### PR TITLE
feat: integrate SignPath code signing for Windows builds

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -35,21 +35,11 @@ The project uses GitHub Actions to automatically build and release the applicati
 
 **Actions:**
 
-- Builds production-ready installers for all platforms
-- Publishes artifacts to GitHub Releases (as draft)
-- Uploads installers as downloadable assets
+- Builds production-ready installers for all platforms (separate jobs per OS)
+- Signs Windows executables via SignPath (when configured)
+- Uploads all artifacts to the GitHub Release
 
 **Purpose:** Automates the release process when you tag a new version.
-
-#### 3. CodeQL Security Scanning (`.github/workflows/codeql.yml`)
-
-**Triggers:**
-
-- Push to `main`
-- Pull requests to `main`
-- Weekly scheduled scan (Monday 6 AM UTC)
-
-**Purpose:** Performs static analysis security testing (SAST) for JavaScript/TypeScript.
 
 ## Creating a Release
 
@@ -110,43 +100,30 @@ https://github.com/berntpopp/varlens/releases/latest
 - **Linux:** `Varlens-{version}.AppImage` (universal)
 - **Linux (Debian/Ubuntu):** `Varlens-{version}.deb`
 
-## Code Signing (Optional)
+## Code Signing
 
-Currently, releases are built without code signing. To enable code signing:
+Windows executables are signed via [SignPath Foundation](https://signpath.org) (free for open-source projects). See [docs/CODE-SIGNING.md](../docs/CODE-SIGNING.md) for the full code signing policy.
 
-### Windows Code Signing
+### How it works
 
-Add these secrets to your repository:
+The release workflow builds unsigned Windows executables, uploads them as GitHub Actions artifacts, and submits a signing request to SignPath. After the repository owner approves the request on SignPath.io, signed executables are published to the GitHub Release.
 
-- `WINDOWS_CERTS`: Base64-encoded `.pfx` certificate file
-- `WINDOWS_CERTS_PASSWORD`: Certificate password
+### Setup (one-time)
 
-Then uncomment these lines in `.github/workflows/release.yml`:
-
-```yaml
-WIN_CSC_LINK: ${{ secrets.WINDOWS_CERTS }}
-WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERTS_PASSWORD }}
-```
+1. Apply to the [SignPath Foundation OSS program](https://signpath.org)
+2. Install the [SignPath GitHub App](https://github.com/apps/signpath-io) on the repository
+3. Configure the SignPath project with `test-signing` and `release-signing` policies
+4. Add the following to the GitHub repository:
+   - **Secret:** `SIGNPATH_API_TOKEN` -- API token for the submitter user
+   - **Variable:** `SIGNPATH_ORGANIZATION_ID` -- SignPath organization ID
+5. Enable MFA for all team members on GitHub and SignPath
 
 ### macOS Code Signing
 
-Add these secrets to your repository:
+macOS signing is not yet configured. When an Apple Developer certificate becomes available, add these secrets:
 
 - `MAC_CERTS`: Base64-encoded `.p12` certificate file
 - `MAC_CERTS_PASSWORD`: Certificate password
-
-Then uncomment these lines in `.github/workflows/release.yml`:
-
-```yaml
-CSC_LINK: ${{ secrets.MAC_CERTS }}
-CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
-```
-
-**To add secrets:**
-
-1. Go to Settings → Secrets and variables → Actions
-2. Click "New repository secret"
-3. Add each secret with its name and value
 
 ## Local Build Testing
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   secrets-scan:
     name: Secrets Scan
@@ -55,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Rebuild native modules for Node.js (tests need Node-compatible binaries)
+      - name: Rebuild native modules for Node.js
         run: npm run rebuild:node
 
       - name: Run linter
@@ -67,12 +70,10 @@ jobs:
       - name: Run tests
         run: npm run test
 
-      - name: Rebuild native modules for Electron (force compile from source)
+      - name: Rebuild native modules for Electron
         run: npm run rebuild:electron
 
-      - name: Build Electron app (test build)
-        run: npm run dist
+      - name: Build Electron app
+        run: npx electron-vite build && npx electron-builder --publish never
         env:
-          # Disable code signing for test builds
           CSC_IDENTITY_AUTO_DISCOVERY: false
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,14 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
-    name: Release (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+  release-linux:
+    name: Release (Linux)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Configure git line endings
@@ -31,8 +28,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev build-essential
@@ -40,39 +36,163 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Rebuild native modules for Node.js (tests need Node-compatible binaries)
+      - name: Rebuild native modules for Node.js
         run: npm run rebuild:node
 
       - name: Run tests
         run: npm run test
 
-      - name: Rebuild native modules for Electron (force compile from source)
+      - name: Rebuild native modules for Electron
         run: npm run rebuild:electron
 
-      - name: Build and publish
-        run: npm run dist
+      - name: Build
+        run: npx electron-vite build && npx electron-builder --linux --publish never
         env:
-          # GitHub token for publishing releases
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Disable code signing auto-discovery (add secrets for code signing)
           CSC_IDENTITY_AUTO_DISCOVERY: false
-          # Windows code signing (optional - add secrets if you have a certificate)
-          # WIN_CSC_LINK: ${{ secrets.WINDOWS_CERTS }}
-          # WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERTS_PASSWORD }}
-          # macOS code signing (optional - add secrets if you have a certificate)
-          # CSC_LINK: ${{ secrets.MAC_CERTS }}
-          # CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
 
-      - name: Upload artifacts
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release/*
+          file_glob: true
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          prerelease: false
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+  release-macos:
+    name: Release (macOS)
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Configure git line endings
+        run: git config --global core.autocrlf false
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules for Node.js
+        run: npm run rebuild:node
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Rebuild native modules for Electron
+        run: npm run rebuild:electron
+
+      - name: Build
+        run: npx electron-vite build && npx electron-builder --mac --publish never
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release/*
+          file_glob: true
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          prerelease: false
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+  release-windows:
+    name: Release (Windows)
+    runs-on: windows-latest
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Configure git line endings
+        run: git config --global core.autocrlf false
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules for Node.js
+        run: npm run rebuild:node
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Rebuild native modules for Electron
+        run: npm run rebuild:electron
+
+      - name: Build
+        run: npx electron-vite build && npx electron-builder --win --publish never
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload unsigned artifacts for signing
+        if: vars.SIGNPATH_ORGANIZATION_ID != ''
+        id: upload-unsigned
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ matrix.os }}-artifacts
-          path: |
-            release/*.exe
-            release/*.dmg
-            release/*.AppImage
-            release/*.deb
-            release/*.zip
-            release/*.yml
-            release/*.blockmap
-          if-no-files-found: warn
+          name: windows-unsigned
+          path: release/*.exe
+          if-no-files-found: error
+
+      - name: Sign with SignPath
+        if: vars.SIGNPATH_ORGANIZATION_ID != ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'varlens'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: '${{ steps.upload-unsigned.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'release-signed'
+
+      - name: Upload signed executables to release
+        if: vars.SIGNPATH_ORGANIZATION_ID != ''
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release-signed/*.exe
+          file_glob: true
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          prerelease: false
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload remaining artifacts to release
+        if: vars.SIGNPATH_ORGANIZATION_ID != ''
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release/!(*.exe)
+          file_glob: true
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          prerelease: false
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload all artifacts to release (unsigned)
+        if: vars.SIGNPATH_ORGANIZATION_ID == ''
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release/*
+          file_glob: true
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          prerelease: false
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ tests/            Vitest test suite
 docs/             Additional documentation
 ```
 
+## Code signing
+
+Windows installers are signed via [SignPath Foundation](https://signpath.org). See [docs/CODE-SIGNING.md](docs/CODE-SIGNING.md) for the full policy.
+
 ## License
 
 [MIT](LICENSE) -- Labor Berlin

--- a/docs/CODE-SIGNING.md
+++ b/docs/CODE-SIGNING.md
@@ -1,0 +1,29 @@
+# Code Signing Policy
+
+Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+## Signed artifacts
+
+Windows installers (NSIS setup and portable executables) are signed using a certificate issued to SignPath Foundation. Linux and macOS builds are currently unsigned.
+
+## Team roles
+
+- **Committers and reviewers:** [Repository contributors](https://github.com/berntpopp/VarLens/graphs/contributors) with write access
+- **Approvers:** [Repository owner](https://github.com/berntpopp) (Bernt Popp)
+
+All code changes are reviewed via GitHub pull requests. Only approved changes merged into the `main` branch are eligible for signed releases.
+
+## Signing process
+
+1. A version tag (`v*.*.*`) pushed to the `main` branch triggers the release workflow.
+2. The Windows job builds unsigned executables using electron-builder.
+3. Unsigned artifacts are uploaded as GitHub Actions artifacts.
+4. A signing request is submitted to SignPath via the [GitHub Action](https://github.com/SignPath/github-action-submit-signing-request).
+5. The repository owner approves the signing request on SignPath.io.
+6. Signed artifacts are downloaded and attached to the GitHub Release.
+
+## Privacy policy
+
+This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.
+
+VarLens is an offline-first application. Optional network requests occur only when the user explicitly triggers external API lookups (VEP variant annotation, HPO term search, SpliceAI predictions). No telemetry, analytics, or automatic update checks are performed.


### PR DESCRIPTION
## Summary

- Add code signing policy document (`docs/CODE-SIGNING.md`) required by SignPath Foundation terms
- Rewrite `release.yml`: split into per-OS jobs, fix broken `--publish onTag` (electron-builder doesn't detect GitHub Actions), use `svenstaro/upload-release-action` for reliable artifact publishing
- Add conditional SignPath signing to Windows release job (skips gracefully when not configured)
- Fix `build.yml`: use `--publish never` explicitly
- Update `RELEASE.md` with SignPath setup instructions, remove stale CodeQL reference
- Add code signing section to README

## Key fixes

- **`--publish onTag` is broken on GitHub Actions**: electron-builder doesn't include GitHub Actions in its CI detection list, so `--publish onTag` silently does nothing. Changed to explicit `--publish never` + `svenstaro/upload-release-action`
- **SignPath is conditional**: When `SIGNPATH_ORGANIZATION_ID` variable is not set, Windows artifacts are uploaded unsigned. Once SignPath is configured, signing kicks in automatically

## Test plan

- [ ] CI build passes on all 3 platforms
- [ ] Create v0.8.0 release tag to verify release workflow uploads artifacts correctly
- [ ] After SignPath onboarding, test signing with a release candidate tag

Generated with [Claude Code](https://claude.com/claude-code)