### PR TITLE
fix(import): cross-platform path handling and batch name stripping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -335,7 +335,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@develar/schema-utils": {
@@ -1854,6 +1854,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1893,6 +1894,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1913,6 +1915,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1933,6 +1936,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1953,6 +1957,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,6 +1978,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,6 +1999,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,6 +2020,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2033,6 +2041,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,6 +2062,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2073,6 +2083,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,6 +2104,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2113,6 +2125,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2133,6 +2146,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2150,6 +2164,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2191,6 +2206,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2204,6 +2220,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2217,6 +2234,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2230,6 +2248,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2243,6 +2262,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2256,6 +2276,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2269,6 +2290,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2282,6 +2304,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2295,6 +2318,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,6 +2332,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,6 +2346,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2334,6 +2360,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2347,6 +2374,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2360,6 +2388,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,6 +2402,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2386,6 +2416,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2399,6 +2430,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2412,6 +2444,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,6 +2458,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,6 +2472,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,6 +2486,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2464,6 +2500,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,6 +2514,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,6 +2528,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2503,6 +2542,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2698,7 +2738,7 @@
       "version": "25.2.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
       "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4308,6 +4348,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4459,7 +4500,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -6007,6 +6048,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6301,7 +6343,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6523,7 +6565,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -6591,7 +6633,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6611,7 +6653,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6762,7 +6804,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8314,6 +8356,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8495,7 +8538,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -8542,6 +8585,7 @@
       "version": "1.97.3",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8563,7 +8607,7 @@
       "version": "1.97.3",
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.3.tgz",
       "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
@@ -8611,6 +8655,7 @@
         "!riscv64",
         "!x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8624,6 +8669,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8640,6 +8686,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8656,6 +8703,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8672,6 +8720,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8688,6 +8737,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8704,6 +8754,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8720,6 +8771,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8736,6 +8788,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8752,6 +8805,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8768,6 +8822,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8784,6 +8839,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8800,6 +8856,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8816,6 +8873,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8832,6 +8890,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8845,6 +8904,7 @@
       "version": "1.97.3",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.3.tgz",
       "integrity": "sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8864,6 +8924,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8880,6 +8941,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8893,7 +8955,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9345,7 +9407,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sync-message-port": "^1.0.0"
@@ -9358,7 +9420,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
       "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -9616,7 +9678,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
@@ -9706,7 +9768,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {
@@ -9814,7 +9876,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/verror": {
@@ -9935,6 +9997,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9951,6 +10014,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9967,6 +10031,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9983,6 +10048,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9999,6 +10065,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10015,6 +10082,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10031,6 +10099,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10047,6 +10116,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10063,6 +10133,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10079,6 +10150,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10095,6 +10167,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10111,6 +10184,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10127,6 +10201,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10143,6 +10218,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10159,6 +10235,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10175,6 +10252,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10191,6 +10269,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10207,6 +10286,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10223,6 +10303,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10239,6 +10320,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10255,6 +10337,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10271,6 +10354,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10287,6 +10371,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10303,6 +10388,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10319,6 +10405,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10335,6 +10422,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "author": "Bernt Popp <bernt.popp@gmail.com>",

--- a/src/main/import/BatchImportService.ts
+++ b/src/main/import/BatchImportService.ts
@@ -1,3 +1,4 @@
+import { basename } from 'path'
 import { DatabaseService } from '../database/DatabaseService'
 import { ImportService } from './ImportService'
 import { NotFoundError } from '../database/errors'
@@ -46,13 +47,16 @@ export class BatchImportService {
    * Check which files have duplicate case names in the database.
    * Call this BEFORE processBatch() so the user can review and choose a strategy.
    */
-  checkDuplicates(filePaths: string[]): { files: DuplicateCheckItem[]; duplicateCount: number } {
+  checkDuplicates(
+    filePaths: string[],
+    stripText?: string
+  ): { files: DuplicateCheckItem[]; duplicateCount: number } {
     const files: DuplicateCheckItem[] = []
     let duplicateCount = 0
 
     for (const filePath of filePaths) {
       const fileName = this.extractFileName(filePath)
-      const caseName = this.extractCaseName(fileName)
+      const caseName = this.extractCaseName(fileName, stripText)
 
       let isDuplicate = false
       try {
@@ -105,7 +109,7 @@ export class BatchImportService {
 
       const filePath = filePaths[i]
       const fileName = this.extractFileName(filePath)
-      const caseName = this.extractCaseName(fileName)
+      const caseName = this.extractCaseName(fileName, options.stripText)
 
       // Emit batch progress
       const overallPercent = Math.round((i / filePaths.length) * 100)
@@ -184,25 +188,22 @@ export class BatchImportService {
    * Extract file name from path
    */
   private extractFileName(filePath: string): string {
-    const parts = filePath.split('/')
-    const lastPart = parts[parts.length - 1]
-    if (lastPart !== undefined && lastPart !== '') {
-      return lastPart
-    }
-    const backslashParts = filePath.split('\\')
-    return backslashParts[backslashParts.length - 1] ?? 'unknown'
+    return basename(filePath) || 'unknown'
   }
 
   /**
-   * Extract case name from file name (strip .gz and .json extensions)
+   * Extract case name from file name (strip extensions and optional user text)
    */
-  private extractCaseName(fileName: string): string {
+  private extractCaseName(fileName: string, stripText?: string): string {
     let name = fileName
     if (name.endsWith('.gz') === true) {
       name = name.slice(0, -3)
     }
     if (name.endsWith('.json') === true) {
       name = name.slice(0, -5)
+    }
+    if (stripText !== undefined && stripText !== '') {
+      name = name.split(stripText).join('').trim()
     }
     return name
   }

--- a/src/main/import/types.ts
+++ b/src/main/import/types.ts
@@ -53,6 +53,7 @@ export type DuplicateChoice = 'skip' | 'overwrite'
 
 export interface BatchImportOptions {
   duplicateStrategy: DuplicateChoice
+  stripText?: string
   onBatchProgress?: (progress: {
     currentIndex: number
     totalFiles: number

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -1,5 +1,5 @@
 import { ipcMain, dialog, BrowserWindow, app } from 'electron'
-import { join } from 'path'
+import { join, dirname, basename } from 'path'
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs'
 import { getDatabaseService } from '../../database'
 import { ImportService, BatchImportService, ZipExtractor, TempDirectoryManager } from '../../import'
@@ -75,8 +75,7 @@ ipcMain.handle('batch-import:selectFiles', async () => {
 
   // Save directory for next time (use first file's directory)
   const firstFile = result.filePaths[0]
-  const directory = firstFile.substring(0, firstFile.lastIndexOf('/'))
-  saveSettings({ ...settings, lastImportDirectory: directory })
+  saveSettings({ ...settings, lastImportDirectory: dirname(firstFile) })
 
   return result.filePaths
 })
@@ -129,35 +128,38 @@ ipcMain.handle('batch-import:selectFolder', async () => {
  * Check which files have duplicate case names in the database.
  * Called before start() so user can review duplicates and choose a strategy.
  */
-ipcMain.handle('batch-import:checkDuplicates', async (_event, filePaths: string[]) => {
-  try {
-    const db = getDatabaseService()
-    const importService = new ImportService(db)
-    const batchImportService = new BatchImportService(db, importService)
-    const result = batchImportService.checkDuplicates(filePaths)
+ipcMain.handle(
+  'batch-import:checkDuplicates',
+  async (_event, filePaths: string[], stripText?: string) => {
+    try {
+      const db = getDatabaseService()
+      const importService = new ImportService(db)
+      const batchImportService = new BatchImportService(db, importService)
+      const result = batchImportService.checkDuplicates(filePaths, stripText)
 
-    // Return plain object (class instances may fail structured clone)
-    return {
-      files: result.files.map((f) => ({
-        filePath: f.filePath,
-        fileName: f.fileName,
-        caseName: f.caseName,
-        isDuplicate: f.isDuplicate
-      })),
-      duplicateCount: result.duplicateCount
+      // Return plain object (class instances may fail structured clone)
+      return {
+        files: result.files.map((f) => ({
+          filePath: f.filePath,
+          fileName: f.fileName,
+          caseName: f.caseName,
+          isDuplicate: f.isDuplicate
+        })),
+        duplicateCount: result.duplicateCount
+      }
+    } catch (error) {
+      mainLogger.error(`checkDuplicates error: ${error}`, 'import')
+      return { files: [], duplicateCount: 0 }
     }
-  } catch (error) {
-    mainLogger.error(`checkDuplicates error: ${error}`, 'import')
-    return { files: [], duplicateCount: 0 }
   }
-})
+)
 
 /**
  * Start batch import with a pre-determined duplicate strategy
  */
 ipcMain.handle(
   'batch-import:start',
-  async (_event, filePaths: string[], duplicateStrategy: DuplicateChoice) => {
+  async (_event, filePaths: string[], duplicateStrategy: DuplicateChoice, stripText?: string) => {
     try {
       const db = getDatabaseService()
       const importService = new ImportService(db)
@@ -225,6 +227,7 @@ ipcMain.handle(
 
       const result = await batchImportService.processBatch(filePaths, {
         duplicateStrategy,
+        stripText,
         onBatchProgress,
         onFileProgress,
         signal: currentBatchAbortController.signal
@@ -251,7 +254,7 @@ ipcMain.handle(
         cancelled: false,
         details: filePaths.map((fp) => ({
           filePath: fp,
-          fileName: fp.split('/').pop() ?? fp.split('\\').pop() ?? 'unknown',
+          fileName: basename(fp) || 'unknown',
           status: 'failed' as const,
           error: error instanceof Error ? error.message : 'Unknown error'
         }))
@@ -295,8 +298,7 @@ ipcMain.handle('batch-import:selectZip', async () => {
     const filePath = result.filePaths[0]
 
     // Save directory for next time
-    const directory = filePath.substring(0, filePath.lastIndexOf('/'))
-    saveSettings({ ...settings, lastImportDirectory: directory })
+    saveSettings({ ...settings, lastImportDirectory: dirname(filePath) })
 
     const isEncrypted = zipExtractor.isEncrypted(filePath)
 

--- a/src/main/ipc/handlers/import.ts
+++ b/src/main/ipc/handlers/import.ts
@@ -1,5 +1,5 @@
 import { ipcMain, dialog, BrowserWindow, app } from 'electron'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { wrapHandler } from '../errorHandler'
 import { getDatabaseService } from '../../database'
@@ -63,8 +63,7 @@ ipcMain.handle('import:selectFile', async () => {
 
   // Save directory for next time
   const filePath = result.filePaths[0]
-  const directory = filePath.substring(0, filePath.lastIndexOf('/'))
-  saveSettings({ ...settings, lastImportDirectory: directory })
+  saveSettings({ ...settings, lastImportDirectory: dirname(filePath) })
 
   return filePath
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -110,10 +110,10 @@ const api = {
   batchImport: {
     selectFiles: () => ipcRenderer.invoke('batch-import:selectFiles'),
     selectFolder: () => ipcRenderer.invoke('batch-import:selectFolder'),
-    checkDuplicates: (filePaths: string[]): Promise<DuplicateCheckResult> =>
-      ipcRenderer.invoke('batch-import:checkDuplicates', filePaths),
-    start: (filePaths: string[], duplicateStrategy: DuplicateChoice) =>
-      ipcRenderer.invoke('batch-import:start', filePaths, duplicateStrategy),
+    checkDuplicates: (filePaths: string[], stripText?: string): Promise<DuplicateCheckResult> =>
+      ipcRenderer.invoke('batch-import:checkDuplicates', filePaths, stripText),
+    start: (filePaths: string[], duplicateStrategy: DuplicateChoice, stripText?: string) =>
+      ipcRenderer.invoke('batch-import:start', filePaths, duplicateStrategy, stripText),
     cancel: () => ipcRenderer.invoke('batch-import:cancel'),
 
     selectZip: () => ipcRenderer.invoke('batch-import:selectZip'),

--- a/src/renderer/src/components/BatchImportDialog.vue
+++ b/src/renderer/src/components/BatchImportDialog.vue
@@ -1,45 +1,59 @@
 <template>
-  <v-dialog v-model="dialog" max-width="650" :persistent="phase === 'importing'">
+  <v-dialog v-model="dialog" max-width="700" :persistent="phase === 'importing'">
     <v-card>
       <v-card-title>Batch Import</v-card-title>
 
       <v-card-text>
-        <!-- Duplicate review phase (shown before import if duplicates found) -->
-        <div v-if="phase === 'duplicate-review'">
-          <v-alert type="warning" variant="tonal" class="mb-4">
-            {{ duplicateCount }} of {{ fileCount }} selected files already exist as cases in the
-            database.
+        <!-- Review phase (always shown before import) -->
+        <div v-if="phase === 'review'">
+          <v-text-field
+            v-model="stripText"
+            label="Remove from names"
+            placeholder="e.g. _results, LB24-"
+            variant="outlined"
+            density="compact"
+            clearable
+            hide-details
+            class="mb-3"
+            prepend-inner-icon="mdi-text-search-variant"
+          />
+
+          <v-alert v-if="duplicateCount > 0" type="warning" variant="tonal" class="mb-3">
+            {{ duplicateCount }} of {{ fileCount }} files already exist as cases.
           </v-alert>
 
-          <div class="text-body-2 font-weight-medium mb-2">How should duplicates be handled?</div>
-          <v-radio-group v-model="duplicateStrategy" class="mb-4">
-            <v-radio value="skip" color="primary">
-              <template #label>
-                <div>
-                  <strong>Skip duplicates</strong>
-                  <div class="text-caption text-medium-emphasis">
-                    Only import new files, leave existing cases unchanged
+          <div v-if="duplicateCount > 0">
+            <v-radio-group v-model="duplicateStrategy" class="mb-3" hide-details>
+              <v-radio value="skip" color="primary">
+                <template #label>
+                  <div>
+                    <strong>Skip duplicates</strong>
+                    <div class="text-caption text-medium-emphasis">
+                      Only import new files, leave existing cases unchanged
+                    </div>
                   </div>
-                </div>
-              </template>
-            </v-radio>
-            <v-radio value="overwrite" color="warning">
-              <template #label>
-                <div>
-                  <strong>Overwrite duplicates</strong>
-                  <div class="text-caption text-medium-emphasis">
-                    Replace existing cases with data from the selected files
+                </template>
+              </v-radio>
+              <v-radio value="overwrite" color="warning">
+                <template #label>
+                  <div>
+                    <strong>Overwrite duplicates</strong>
+                    <div class="text-caption text-medium-emphasis">
+                      Replace existing cases with data from the selected files
+                    </div>
                   </div>
-                </div>
-              </template>
-            </v-radio>
-          </v-radio-group>
+                </template>
+              </v-radio>
+            </v-radio-group>
+            <v-divider class="mb-3" />
+          </div>
 
-          <v-divider class="mb-3" />
-          <div class="text-caption text-medium-emphasis mb-2">Files to import:</div>
-          <v-list density="compact" class="pa-0">
+          <div class="text-caption text-medium-emphasis mb-2">
+            {{ fileCount }} file{{ fileCount !== 1 ? 's' : '' }} to import:
+          </div>
+          <v-list density="compact" class="pa-0" max-height="300" style="overflow-y: auto">
             <v-list-item
-              v-for="(file, i) in duplicateCheckFiles"
+              v-for="(file, i) in reviewFiles"
               :key="i"
               :class="file.isDuplicate ? 'text-warning' : ''"
             >
@@ -50,13 +64,26 @@
                 <v-icon v-else color="success" size="small"> mdi-new-box </v-icon>
               </template>
               <v-list-item-title class="text-body-2">
-                {{ file.fileName }}
+                {{ file.caseName }}
                 <span v-if="file.isDuplicate" class="text-caption text-warning ml-1">
                   (exists)
                 </span>
               </v-list-item-title>
+              <v-list-item-subtitle v-if="file.caseName !== file.fileName" class="text-caption">
+                {{ file.fileName }}
+              </v-list-item-subtitle>
             </v-list-item>
           </v-list>
+
+          <v-alert
+            v-if="hasEmptyCaseNames"
+            type="error"
+            variant="tonal"
+            density="compact"
+            class="mt-3"
+          >
+            Some case names are empty after stripping. Adjust the text to remove.
+          </v-alert>
         </div>
 
         <!-- ZIP password phase -->
@@ -72,35 +99,6 @@
             @click:append-inner="showZipPassword = !showZipPassword"
             @keyup.enter="handleZipUnlock"
           />
-        </div>
-
-        <!-- ZIP preview phase -->
-        <div v-if="phase === 'zip-preview'">
-          <div class="text-body-2 mb-2">
-            {{ extractedFilePaths.length }} file{{ extractedFilePaths.length !== 1 ? 's' : '' }}
-            ready to import:
-          </div>
-          <v-list density="compact" class="pa-0 mb-3" max-height="300" style="overflow-y: auto">
-            <v-list-item v-for="(fp, i) in extractedFilePaths" :key="i">
-              <template #prepend>
-                <v-icon color="success" size="small">mdi-file-check</v-icon>
-              </template>
-              <v-list-item-title class="text-body-2">
-                {{ fp.split('/').pop() ?? fp.split('\\').pop() ?? fp }}
-              </v-list-item-title>
-            </v-list-item>
-          </v-list>
-          <v-alert
-            v-if="zipExtractionErrors.length > 0"
-            type="warning"
-            variant="tonal"
-            class="mb-3"
-          >
-            <div class="text-body-2 font-weight-medium mb-1">Extraction warnings:</div>
-            <div v-for="(err, i) in zipExtractionErrors" :key="i" class="text-caption">
-              {{ err }}
-            </div>
-          </v-alert>
         </div>
 
         <!-- Importing phase -->
@@ -171,13 +169,12 @@
 
       <v-card-actions>
         <v-spacer />
-        <v-btn v-if="phase === 'duplicate-review'" variant="text" @click="closeDialog">
-          Cancel
-        </v-btn>
+        <v-btn v-if="phase === 'review'" variant="text" @click="closeDialog"> Cancel </v-btn>
         <v-btn
-          v-if="phase === 'duplicate-review'"
+          v-if="phase === 'review'"
           color="primary"
           variant="flat"
+          :disabled="hasEmptyCaseNames"
           @click="confirmAndStartImport"
         >
           Start Import
@@ -194,17 +191,6 @@
         >
           Unlock
         </v-btn>
-        <v-btn v-if="phase === 'zip-preview'" variant="text" @click="handleZipCancel">
-          Cancel
-        </v-btn>
-        <v-btn
-          v-if="phase === 'zip-preview'"
-          color="primary"
-          variant="flat"
-          @click="startZipImport"
-        >
-          Start Import
-        </v-btn>
         <v-btn v-if="phase === 'importing'" @click="handleCancel"> Cancel </v-btn>
         <v-btn v-if="phase === 'summary'" @click="handleCancel"> Close </v-btn>
       </v-card-actions>
@@ -213,7 +199,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import type {
   BatchProgress,
   BatchResult,
@@ -221,7 +207,7 @@ import type {
   DuplicateCheckItem
 } from '../../../shared/types/api'
 
-type Phase = 'idle' | 'duplicate-review' | 'importing' | 'summary' | 'zip-password' | 'zip-preview'
+type Phase = 'idle' | 'review' | 'importing' | 'summary' | 'zip-password'
 
 const dialog = ref(false)
 const phase = ref<Phase>('idle')
@@ -229,11 +215,13 @@ const phase = ref<Phase>('idle')
 // File selection state
 const selectedFilePaths = ref<string[]>([])
 
-// Duplicate check state
+// Review state
 const duplicateCheckFiles = ref<DuplicateCheckItem[]>([])
 const duplicateCount = ref(0)
 const fileCount = ref(0)
 const duplicateStrategy = ref<DuplicateChoice>('skip')
+const stripText = ref('')
+const isZipImport = ref(false)
 
 // ZIP state
 const zipPath = ref('')
@@ -241,8 +229,6 @@ const zipPassword = ref('')
 const showZipPassword = ref(false)
 const zipErrorMessage = ref('')
 const testingPassword = ref(false)
-const extractedFilePaths = ref<string[]>([])
-const zipExtractionErrors = ref<string[]>([])
 
 // Progress state
 const currentIndex = ref(0)
@@ -264,10 +250,56 @@ const summary = ref<BatchResult>({
 let cleanupProgress: (() => void) | null = null
 
 /**
+ * Derive case name from file name (mirrors backend logic for live preview)
+ */
+const deriveCaseName = (fileName: string, strip: string): string => {
+  let name = fileName
+  if (name.endsWith('.gz') === true) name = name.slice(0, -3)
+  if (name.endsWith('.json') === true) name = name.slice(0, -5)
+  if (strip !== '') {
+    name = name.split(strip).join('').trim()
+  }
+  return name
+}
+
+/**
+ * Computed review files with live case name preview
+ */
+const reviewFiles = computed(() =>
+  duplicateCheckFiles.value.map((file) => ({
+    ...file,
+    caseName: deriveCaseName(file.fileName, stripText.value)
+  }))
+)
+
+const hasEmptyCaseNames = computed(() => reviewFiles.value.some((f) => f.caseName === ''))
+
+/**
+ * Re-check duplicates when stripText changes (debounced via watch)
+ */
+// eslint-disable-next-line no-undef
+let recheckTimeout: ReturnType<typeof setTimeout> | null = null
+
+watch(stripText, () => {
+  // eslint-disable-next-line no-undef
+  if (recheckTimeout !== null) clearTimeout(recheckTimeout)
+  // eslint-disable-next-line no-undef
+  recheckTimeout = setTimeout(async () => {
+    if (selectedFilePaths.value.length === 0) return
+    // eslint-disable-next-line no-undef
+    const checkResult = await window.api.batchImport.checkDuplicates(
+      [...selectedFilePaths.value],
+      stripText.value || undefined
+    )
+    duplicateCheckFiles.value = checkResult.files
+    duplicateCount.value = checkResult.duplicateCount
+  }, 300)
+})
+
+/**
  * Show dialog and start the batch import flow
  */
 const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
-  // Reset all state
   resetState()
 
   if (mode === 'zip') {
@@ -276,19 +308,19 @@ const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
     if (result === null) return
 
     zipPath.value = result.filePath
+    isZipImport.value = true
     dialog.value = true
 
     if (result.isEncrypted === true) {
       phase.value = 'zip-password'
     } else {
-      await extractAndPreview(result.filePath)
+      await extractAndShowReview(result.filePath)
     }
     return
   }
 
   let filePaths: string[] = []
 
-  // Select files based on mode
   if (mode === 'files') {
     // eslint-disable-next-line no-undef
     filePaths = await window.api.batchImport.selectFiles()
@@ -297,49 +329,76 @@ const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
     filePaths = await window.api.batchImport.selectFolder()
   }
 
-  // User cancelled or no files found
-  if (filePaths.length === 0) {
-    return
-  }
+  if (filePaths.length === 0) return
 
   selectedFilePaths.value = filePaths
   fileCount.value = filePaths.length
   dialog.value = true
 
-  // Check for duplicates before importing
   // eslint-disable-next-line no-undef
   const checkResult = await window.api.batchImport.checkDuplicates(filePaths)
+  duplicateCheckFiles.value = checkResult.files
+  duplicateCount.value = checkResult.duplicateCount
+  phase.value = 'review'
+}
 
-  if (checkResult.duplicateCount > 0) {
-    // Duplicates found — show review phase
+/**
+ * Extract ZIP and show review phase
+ */
+const extractAndShowReview = async (zipFilePath: string, password?: string): Promise<void> => {
+  try {
+    // eslint-disable-next-line no-undef
+    const result = await window.api.batchImport.extractZip(zipFilePath, password)
+
+    if (result.files.length === 0) {
+      zipErrorMessage.value = 'No importable files found in archive.'
+      if (result.errors.length > 0) {
+        zipErrorMessage.value += ' Errors: ' + result.errors.join('; ')
+      }
+      // eslint-disable-next-line no-undef
+      await window.api.batchImport.cleanupZipTemp()
+      return
+    }
+
+    selectedFilePaths.value = result.files
+    fileCount.value = result.files.length
+
+    // eslint-disable-next-line no-undef
+    const checkResult = await window.api.batchImport.checkDuplicates(result.files)
     duplicateCheckFiles.value = checkResult.files
     duplicateCount.value = checkResult.duplicateCount
-    phase.value = 'duplicate-review'
-  } else {
-    // No duplicates — start importing immediately
-    phase.value = 'importing'
-    await startImport(filePaths, 'skip')
+    phase.value = 'review'
+  } catch (error) {
+    zipErrorMessage.value = error instanceof Error ? error.message : 'Failed to extract archive'
+    // eslint-disable-next-line no-undef
+    await window.api.batchImport.cleanupZipTemp()
   }
 }
 
 /**
- * User confirmed strategy in duplicate-review phase, start import
+ * User confirmed in review phase, start import
  */
 const confirmAndStartImport = async (): Promise<void> => {
   phase.value = 'importing'
-  // Spread to plain array — Vue reactive Proxy can't be structured-cloned by Electron IPC
-  await startImport([...selectedFilePaths.value], duplicateStrategy.value)
+  const filePaths = [...selectedFilePaths.value]
+  const strategy = duplicateCount.value > 0 ? duplicateStrategy.value : 'skip'
+  const strip = stripText.value || undefined
+  await startImport(filePaths, strategy, strip)
 }
 
 /**
  * Start the batch import process
  */
-const startImport = async (filePaths: string[], strategy: DuplicateChoice): Promise<void> => {
+const startImport = async (
+  filePaths: string[],
+  strategy: DuplicateChoice,
+  strip?: string
+): Promise<void> => {
   totalFiles.value = filePaths.length
 
   try {
     // eslint-disable-next-line no-undef
-    const result = await window.api.batchImport.start(filePaths, strategy)
+    const result = await window.api.batchImport.start(filePaths, strategy, strip)
 
     summary.value = result
     phase.value = 'summary'
@@ -363,34 +422,6 @@ const startImport = async (filePaths: string[], strategy: DuplicateChoice): Prom
 }
 
 /**
- * Extract ZIP and show preview of files
- */
-const extractAndPreview = async (zipFilePath: string, password?: string): Promise<void> => {
-  try {
-    // eslint-disable-next-line no-undef
-    const result = await window.api.batchImport.extractZip(zipFilePath, password)
-    extractedFilePaths.value = result.files
-    zipExtractionErrors.value = result.errors
-
-    if (result.files.length === 0) {
-      zipErrorMessage.value = 'No importable files found in archive.'
-      if (result.errors.length > 0) {
-        zipErrorMessage.value += ' Errors: ' + result.errors.join('; ')
-      }
-      // eslint-disable-next-line no-undef
-      await window.api.batchImport.cleanupZipTemp()
-      return
-    }
-
-    phase.value = 'zip-preview'
-  } catch (error) {
-    zipErrorMessage.value = error instanceof Error ? error.message : 'Failed to extract archive'
-    // eslint-disable-next-line no-undef
-    await window.api.batchImport.cleanupZipTemp()
-  }
-}
-
-/**
  * Test ZIP password and extract if correct
  */
 const handleZipUnlock = async (): Promise<void> => {
@@ -401,7 +432,7 @@ const handleZipUnlock = async (): Promise<void> => {
     // eslint-disable-next-line no-undef
     const result = await window.api.batchImport.testZipPassword(zipPath.value, zipPassword.value)
     if (result.success === true) {
-      await extractAndPreview(zipPath.value, zipPassword.value)
+      await extractAndShowReview(zipPath.value, zipPassword.value)
     } else {
       zipErrorMessage.value = 'Incorrect password. Please try again.'
     }
@@ -409,45 +440,6 @@ const handleZipUnlock = async (): Promise<void> => {
     zipErrorMessage.value = error instanceof Error ? error.message : 'Failed to test password'
   } finally {
     testingPassword.value = false
-  }
-}
-
-/**
- * Start importing extracted ZIP files
- */
-const startZipImport = async (): Promise<void> => {
-  phase.value = 'importing'
-  totalFiles.value = extractedFilePaths.value.length
-
-  try {
-    // Spread to plain array to avoid Vue reactive Proxy IPC issue
-    // eslint-disable-next-line no-undef
-    const batchResult = await window.api.batchImport.start(
-      [...extractedFilePaths.value],
-      'skip' // ZIP files are freshly extracted, no duplicates expected - default to skip
-    )
-    summary.value = batchResult
-    phase.value = 'summary'
-  } catch (error) {
-    summary.value = {
-      succeeded: 0,
-      failed: 1,
-      skipped: 0,
-      cancelled: false,
-      details: [
-        {
-          filePath: '',
-          fileName: 'ZIP Import',
-          status: 'failed',
-          error: error instanceof Error ? error.message : 'Unknown error'
-        }
-      ]
-    }
-    phase.value = 'summary'
-  } finally {
-    // Always clean up temp directory
-    // eslint-disable-next-line no-undef
-    await window.api.batchImport.cleanupZipTemp()
   }
 }
 
@@ -469,9 +461,10 @@ const handleCancel = async (): Promise<void> => {
     await window.api.batchImport.cancel()
   } else if (phase.value === 'summary') {
     dialog.value = false
-    // Cleanup temp directory in case it's a ZIP import (idempotent)
-    // eslint-disable-next-line no-undef
-    await window.api.batchImport.cleanupZipTemp()
+    if (isZipImport.value === true) {
+      // eslint-disable-next-line no-undef
+      await window.api.batchImport.cleanupZipTemp()
+    }
 
     if (summary.value.succeeded > 0) {
       emit('batch-import-complete', { totalImported: summary.value.succeeded })
@@ -482,7 +475,11 @@ const handleCancel = async (): Promise<void> => {
 /**
  * Close dialog without importing
  */
-const closeDialog = (): void => {
+const closeDialog = async (): Promise<void> => {
+  if (isZipImport.value === true) {
+    // eslint-disable-next-line no-undef
+    await window.api.batchImport.cleanupZipTemp()
+  }
   dialog.value = false
 }
 
@@ -496,6 +493,8 @@ const resetState = (): void => {
   duplicateCount.value = 0
   fileCount.value = 0
   duplicateStrategy.value = 'skip'
+  stripText.value = ''
+  isZipImport.value = false
   currentIndex.value = 0
   totalFiles.value = 0
   currentFileName.value = ''
@@ -507,8 +506,6 @@ const resetState = (): void => {
   showZipPassword.value = false
   zipErrorMessage.value = ''
   testingPassword.value = false
-  extractedFilePaths.value = []
-  zipExtractionErrors.value = []
 }
 
 // Setup IPC listeners
@@ -529,6 +526,8 @@ onMounted(() => {
 // Cleanup IPC listeners
 onUnmounted(() => {
   cleanupProgress?.()
+  // eslint-disable-next-line no-undef
+  if (recheckTimeout !== null) clearTimeout(recheckTimeout)
 })
 
 // Define emits

--- a/src/renderer/src/components/ImportDialog.vue
+++ b/src/renderer/src/components/ImportDialog.vue
@@ -113,14 +113,10 @@ const progressText = computed(() => {
   return `${phaseLabel}... ${count}`
 })
 
-// Extract case name from file path
+// Extract case name from file path (cross-platform)
 const extractCaseName = (path: string): string => {
-  const parts = path.split('/')
-  let name = parts[parts.length - 1]
-  if (name === undefined || name === '') {
-    const backslashParts = path.split('\\')
-    name = backslashParts[backslashParts.length - 1] ?? 'import'
-  }
+  const parts = path.split(/[/\\]/)
+  let name = parts[parts.length - 1] ?? 'import'
   if (name.endsWith('.gz') === true) name = name.slice(0, -3)
   if (name.endsWith('.json') === true) name = name.slice(0, -5)
   return name

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -194,8 +194,12 @@ export interface DuplicateCheckResult {
 export interface BatchImportAPI {
   selectFiles: () => Promise<string[]>
   selectFolder: () => Promise<string[]>
-  checkDuplicates: (filePaths: string[]) => Promise<DuplicateCheckResult>
-  start: (filePaths: string[], duplicateStrategy: DuplicateChoice) => Promise<BatchResult>
+  checkDuplicates: (filePaths: string[], stripText?: string) => Promise<DuplicateCheckResult>
+  start: (
+    filePaths: string[],
+    duplicateStrategy: DuplicateChoice,
+    stripText?: string
+  ) => Promise<BatchResult>
   cancel: () => Promise<void>
   onProgress: (callback: (progress: BatchProgress) => void) => () => void
   selectZip: () => Promise<{ filePath: string; isEncrypted: boolean } | null>


### PR DESCRIPTION
## Summary
- **Bug fix**: Windows paths were used as case names instead of just filenames during import (both single and batch). Replaced manual `split('/')` logic with `path.basename()`/`dirname()` in main process and regex split `/[/\\]/` in renderer.
- **Feature**: Added "Remove from names" text field to batch import review phase — lets users strip common substrings (e.g. `_results`, `LB24-`) from auto-derived case names with live preview and debounced duplicate re-checking.
- **UX improvement**: Unified ZIP and file/folder batch imports into a single review phase that always shows before importing, giving users a chance to review case names and configure stripping.
- **Version bump**: 0.9.1 → 0.9.2

## Changed files
- `BatchImportService.ts` — `path.basename()`, `stripText` parameter
- `ImportDialog.vue` — cross-platform regex path split
- `batch-import.ts` / `import.ts` — `path.dirname()`, pass `stripText` through IPC
- `BatchImportDialog.vue` — unified review phase with strip-text UI
- `api.ts` / `preload/index.ts` / `types.ts` — updated API signatures

## Test plan
- [x] Lint passes
- [x] TypeScript check passes
- [x] All 523 tests pass (27/28 test files, 1 skipped perf test)
- [ ] Manual: batch import files → verify case names show filename only (not full path)
- [ ] Manual: type text in "Remove from names" → verify case names update live
- [ ] Manual: ZIP import routes through review phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)