### PR TITLE
fix: eliminate database startup bottlenecks for large databases

### DIFF
--- a/src/main/database/DatabaseService.ts
+++ b/src/main/database/DatabaseService.ts
@@ -90,9 +90,7 @@ export class DatabaseService {
       this.db.pragma(`cache_size = ${DATABASE_CONFIG.CACHE_SIZE_KB}`)
       this.db.pragma('temp_store = MEMORY')
       this.db.pragma(`mmap_size = ${DATABASE_CONFIG.MMAP_SIZE_BYTES}`)
-
-      // Analyze tables with stale statistics on connection open
-      this.db.pragma('optimize=0x10002')
+      this.db.pragma(`analysis_limit = ${DATABASE_CONFIG.ANALYSIS_LIMIT}`)
 
       // Initialize database schema (tables, indexes, FTS5)
       initializeSchema(this.db)
@@ -117,23 +115,9 @@ export class DatabaseService {
       this._cohortSummary = new CohortSummaryService(this.db)
       this._filterPresets = new FilterPresetRepository(this.db, this._kysely)
 
-      // Initial cohort summary rebuild if tables are empty but variants exist
-      try {
-        const summaryCount = this.db
-          .prepare('SELECT COUNT(*) as c FROM cohort_variant_summary')
-          .get() as { c: number }
-        const variantCount = this.db.prepare('SELECT COUNT(*) as c FROM variants').get() as {
-          c: number
-        }
-        if (summaryCount.c === 0 && variantCount.c > 0) {
-          this._cohortSummary.rebuild()
-        }
-      } catch {
-        // Best effort — summary will be rebuilt on next import
-      }
-
-      // Clean up expired API cache entries on startup
-      this.db.prepare('DELETE FROM api_cache WHERE expires_at < ?').run(Date.now())
+      // Defer heavy housekeeping to after the constructor returns so the
+      // window can render while these run on the next event-loop tick.
+      this._deferredInit()
     } catch (error) {
       throw new DatabaseError(
         `Failed to initialize database at ${dbPath}`,
@@ -204,6 +188,41 @@ export class DatabaseService {
     return this._auth.isAccountsEnabled()
   }
 
+  // ── Deferred initialisation ────────────────────────────────
+
+  /**
+   * Run non-critical housekeeping after the constructor returns so that
+   * the Electron window can render without waiting for these operations.
+   *
+   * Uses process.nextTick so the work executes on the very next event-loop
+   * turn — still on the main thread (better-sqlite3 is synchronous) but
+   * after the BrowserWindow has had a chance to show.
+   */
+  private _deferredInit(): void {
+    process.nextTick(() => {
+      try {
+        // Rebuild cohort summary if stale (lightweight EXISTS instead of COUNT(*))
+        const summaryRow = this.db.prepare('SELECT 1 FROM cohort_variant_summary LIMIT 1').get()
+        const variantRow = this.db.prepare('SELECT 1 FROM variants LIMIT 1').get()
+        const summaryEmpty = summaryRow === undefined
+        const hasVariants = variantRow !== undefined
+
+        if (summaryEmpty && hasVariants) {
+          this._cohortSummary.rebuild()
+        }
+      } catch {
+        // Best effort — summary will be rebuilt on next import
+      }
+
+      try {
+        // Clean up expired API cache entries
+        this.db.prepare('DELETE FROM api_cache WHERE expires_at < ?').run(Date.now())
+      } catch {
+        // Best effort
+      }
+    })
+  }
+
   // ── Utility methods ─────────────────────────────────────────
 
   /**
@@ -260,9 +279,14 @@ export class DatabaseService {
   close(): void {
     this._kysely.destroy().catch(() => {})
     try {
+      // Cap ANALYZE sampling so optimize finishes quickly even on large tables
+      this.db.pragma(`analysis_limit = ${DATABASE_CONFIG.ANALYSIS_LIMIT}`)
+      // Analyse tables whose statistics have gone stale since the connection opened
       this.db.pragma('optimize')
+      // Merge the WAL back into the main DB file so the next open is fast
+      this.db.pragma('wal_checkpoint(TRUNCATE)')
     } catch {
-      // Best-effort optimization; ignore failures to ensure the database still closes
+      // Best-effort; ignore failures to ensure the database still closes
     } finally {
       this.db.close()
     }

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -623,13 +623,25 @@ export function runMigrations(db: Database.Database): void {
 
   // ── Migration v14: Cohort performance optimization ──
   if (currentVersion < 14) {
-    // Denormalized annotation flags
-    db.exec(`
-      ALTER TABLE cohort_variant_summary ADD COLUMN has_star INTEGER NOT NULL DEFAULT 0;
-      ALTER TABLE cohort_variant_summary ADD COLUMN has_comment INTEGER NOT NULL DEFAULT 0;
-      ALTER TABLE cohort_variant_summary ADD COLUMN acmg_best TEXT;
-      ALTER TABLE cohort_variant_summary ADD COLUMN cohort_frequency REAL;
-    `)
+    // Denormalized annotation flags (idempotent — check before adding)
+    const cvsCols = db.prepare('PRAGMA table_info(cohort_variant_summary)').all() as {
+      name: string
+    }[]
+    const cvsColNames = new Set(cvsCols.map((c) => c.name))
+    if (!cvsColNames.has('has_star')) {
+      db.exec('ALTER TABLE cohort_variant_summary ADD COLUMN has_star INTEGER NOT NULL DEFAULT 0')
+    }
+    if (!cvsColNames.has('has_comment')) {
+      db.exec(
+        'ALTER TABLE cohort_variant_summary ADD COLUMN has_comment INTEGER NOT NULL DEFAULT 0'
+      )
+    }
+    if (!cvsColNames.has('acmg_best')) {
+      db.exec('ALTER TABLE cohort_variant_summary ADD COLUMN acmg_best TEXT')
+    }
+    if (!cvsColNames.has('cohort_frequency')) {
+      db.exec('ALTER TABLE cohort_variant_summary ADD COLUMN cohort_frequency REAL')
+    }
 
     // Index for frequency filter
     db.exec(`
@@ -637,11 +649,19 @@ export function runMigrations(db: Database.Database): void {
         ON cohort_variant_summary(cohort_frequency);
     `)
 
-    // Backfill cohort_frequency for existing rows
-    db.exec(`
-      UPDATE cohort_variant_summary
-      SET cohort_frequency = CAST(carrier_count AS REAL) / NULLIF((SELECT COUNT(*) FROM cases), 0);
-    `)
+    // Backfill cohort_frequency for existing rows (skip if already populated)
+    const needsBackfill = db
+      .prepare(
+        'SELECT 1 FROM cohort_variant_summary WHERE cohort_frequency IS NULL AND carrier_count > 0 LIMIT 1'
+      )
+      .get()
+    if (needsBackfill !== undefined) {
+      db.exec(`
+        UPDATE cohort_variant_summary
+        SET cohort_frequency = CAST(carrier_count AS REAL) / NULLIF((SELECT COUNT(*) FROM cases), 0)
+        WHERE cohort_frequency IS NULL;
+      `)
+    }
 
     // Mark stale to trigger full rebuild (populates annotation flags)
     db.exec(`
@@ -657,7 +677,7 @@ export function runMigrations(db: Database.Database): void {
     // --- variant_annotations triggers ---
 
     db.exec(`
-      CREATE TRIGGER trg_va_after_insert
+      CREATE TRIGGER IF NOT EXISTS trg_va_after_insert
       AFTER INSERT ON variant_annotations
       FOR EACH ROW
       BEGIN
@@ -712,7 +732,7 @@ export function runMigrations(db: Database.Database): void {
     `)
 
     db.exec(`
-      CREATE TRIGGER trg_va_after_update
+      CREATE TRIGGER IF NOT EXISTS trg_va_after_update
       AFTER UPDATE ON variant_annotations
       FOR EACH ROW
       WHEN OLD.starred != NEW.starred
@@ -770,7 +790,7 @@ export function runMigrations(db: Database.Database): void {
     `)
 
     db.exec(`
-      CREATE TRIGGER trg_va_after_delete
+      CREATE TRIGGER IF NOT EXISTS trg_va_after_delete
       AFTER DELETE ON variant_annotations
       FOR EACH ROW
       BEGIN
@@ -827,7 +847,7 @@ export function runMigrations(db: Database.Database): void {
     // --- case_variant_annotations triggers ---
 
     db.exec(`
-      CREATE TRIGGER trg_cva_after_insert
+      CREATE TRIGGER IF NOT EXISTS trg_cva_after_insert
       AFTER INSERT ON case_variant_annotations
       FOR EACH ROW
       BEGIN
@@ -890,7 +910,7 @@ export function runMigrations(db: Database.Database): void {
     `)
 
     db.exec(`
-      CREATE TRIGGER trg_cva_after_update
+      CREATE TRIGGER IF NOT EXISTS trg_cva_after_update
       AFTER UPDATE ON case_variant_annotations
       FOR EACH ROW
       WHEN OLD.starred != NEW.starred
@@ -956,7 +976,7 @@ export function runMigrations(db: Database.Database): void {
     `)
 
     db.exec(`
-      CREATE TRIGGER trg_cva_after_delete
+      CREATE TRIGGER IF NOT EXISTS trg_cva_after_delete
       AFTER DELETE ON case_variant_annotations
       FOR EACH ROW
       BEGIN

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -208,35 +208,67 @@ export function initializeSchema(db: Database.Database): void {
   migrateVariantsTable(db)
   db.exec(createIndexes)
 
-  // Rebuild FTS5 to include any new columns (e.g., omim_mim_number)
-  // DROP first since IF NOT EXISTS won't update existing table structure
-  db.exec('DROP TABLE IF EXISTS variants_fts')
-  // Also drop triggers that reference the old FTS table
-  db.exec('DROP TRIGGER IF EXISTS variants_fts_ai')
-  db.exec('DROP TRIGGER IF EXISTS variants_fts_ad')
-  db.exec('DROP TRIGGER IF EXISTS variants_fts_au')
-
   // Check if variants table has omim_mim_number column
   const columns = db.prepare('PRAGMA table_info(variants)').all() as { name: string }[]
   const hasOmim = columns.some((c) => c.name === 'omim_mim_number')
 
-  if (hasOmim) {
-    // Create FTS5 with omim_mim_number
-    db.exec(createFTSTable)
-    // Repopulate FTS5 index from existing data
-    db.exec(`
-      INSERT INTO variants_fts(rowid, gene_symbol, consequence, omim_mim_number)
-      SELECT id, gene_symbol, consequence, omim_mim_number FROM variants
-    `)
-    // Create triggers for future changes
-    db.exec(createFTSTriggers)
+  // Check if FTS table already exists and has the expected schema.
+  // Only rebuild if it's missing or its column set doesn't match.
+  const ftsRow = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='variants_fts'")
+    .get()
+  const ftsExists = ftsRow !== undefined
+
+  let needsFtsRebuild = !ftsExists
+
+  if (ftsExists) {
+    // Inspect existing FTS columns to detect schema drift.
+    // FTS5 tables expose their column names via the content of the _config table.
+    try {
+      const ftsColRow = db
+        .prepare("SELECT * FROM variants_fts_config WHERE k = 'content'")
+        .get() as { k: string; v: string } | undefined
+      // If the FTS was created with omim but variants lacks it (or vice-versa), rebuild.
+      if (hasOmim && ftsColRow !== undefined) {
+        // Check if omim_mim_number is indexed by trying a match
+        const cols = db.pragma('table_info(variants_fts)') as { name: string }[]
+        const ftsHasOmim = cols.some((c) => c.name === 'omim_mim_number')
+        needsFtsRebuild = !ftsHasOmim
+      }
+    } catch {
+      // If we can't inspect, rebuild to be safe
+      needsFtsRebuild = true
+    }
+  }
+
+  if (needsFtsRebuild) {
+    // DROP first since IF NOT EXISTS won't update existing table structure
+    db.exec('DROP TABLE IF EXISTS variants_fts')
+    db.exec('DROP TRIGGER IF EXISTS variants_fts_ai')
+    db.exec('DROP TRIGGER IF EXISTS variants_fts_ad')
+    db.exec('DROP TRIGGER IF EXISTS variants_fts_au')
+
+    if (hasOmim) {
+      db.exec(createFTSTable)
+      db.exec(`
+        INSERT INTO variants_fts(rowid, gene_symbol, consequence, omim_mim_number)
+        SELECT id, gene_symbol, consequence, omim_mim_number FROM variants
+      `)
+      db.exec(createFTSTriggers)
+    } else {
+      db.exec(createFTSTableLegacy)
+      db.exec(`
+        INSERT INTO variants_fts(rowid, gene_symbol, consequence)
+        SELECT id, gene_symbol, consequence FROM variants
+      `)
+      db.exec(createFTSTriggersLegacy)
+    }
   } else {
-    // Legacy database without omim column -- use old FTS structure
-    db.exec(createFTSTableLegacy)
-    db.exec(`
-      INSERT INTO variants_fts(rowid, gene_symbol, consequence)
-      SELECT id, gene_symbol, consequence FROM variants
-    `)
-    db.exec(createFTSTriggersLegacy)
+    // FTS table exists and schema matches — just ensure triggers are present
+    if (hasOmim) {
+      db.exec(createFTSTriggers)
+    } else {
+      db.exec(createFTSTriggersLegacy)
+    }
   }
 }

--- a/src/shared/config/database.config.ts
+++ b/src/shared/config/database.config.ts
@@ -3,10 +3,12 @@ export const DATABASE_CONFIG = {
   CACHE_SIZE_KB: -32000,
   /** SQLite cache size for import worker (64 MB, larger for bulk writes) */
   IMPORT_CACHE_SIZE_KB: -64000,
-  /** Memory-mapped I/O size in bytes (256 MB) */
-  MMAP_SIZE_BYTES: 268_435_456,
+  /** Memory-mapped I/O size in bytes (1 GB — virtual address reservation is free on 64-bit) */
+  MMAP_SIZE_BYTES: 1_073_741_824,
   /** Busy timeout in milliseconds */
   BUSY_TIMEOUT_MS: 5000,
+  /** Max rows sampled per table during ANALYZE (caps optimizer stat-gathering time) */
+  ANALYSIS_LIMIT: 400,
   /** Batch insert size for variant imports */
   BATCH_INSERT_SIZE: 10_000,
   /** API cache TTL in days */

--- a/tests/e2e/startup-large-db.e2e.ts
+++ b/tests/e2e/startup-large-db.e2e.ts
@@ -1,0 +1,207 @@
+/**
+ * E2E benchmark: startup performance with a large database.
+ *
+ * Measures how long it takes to:
+ *  1. Launch the Electron app
+ *  2. Open a large database (3.7 GB, 4.1M variants, 555 cases)
+ *  3. Load the case list sidebar
+ *  4. Select a case and render the variant table
+ *  5. Switch to cohort view
+ *
+ * Run:
+ *   LARGE_DB=/media/bernt-popp/1819-E513/varlens.db npx playwright test tests/e2e/startup-large-db.e2e.ts
+ */
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Page
+} from '@playwright/test'
+import { copyFileSync, unlinkSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+// The large DB path — set via env var or skip the test
+const LARGE_DB_PATH = process.env.LARGE_DB
+const WORK_DB_PATH = join(tmpdir(), `varlens-startup-bench-${Date.now()}.db`)
+
+function ms(t0: number): string {
+  return `${(performance.now() - t0).toFixed(0)}ms`
+}
+
+test.describe.serial('Startup performance with large database', () => {
+  let app: ElectronApplication
+  let window: Page
+
+  // Generous timeout for large DB operations
+  test.setTimeout(180_000)
+
+  test.skip(!LARGE_DB_PATH || !existsSync(LARGE_DB_PATH ?? ''), 'LARGE_DB env var not set')
+
+  test.beforeAll(async () => {
+    // Copy the large DB to a temp location so we don't modify the original
+    console.log(`Copying ${LARGE_DB_PATH} to ${WORK_DB_PATH} ...`)
+    const copyStart = performance.now()
+    copyFileSync(LARGE_DB_PATH!, WORK_DB_PATH)
+    console.log(`  Copy took ${ms(copyStart)}`)
+
+    // Launch the app
+    const t0 = performance.now()
+    app = await electron.launch({
+      args: ['./out/main/index.js'],
+      env: { ...process.env, NODE_ENV: 'production' }
+    })
+    console.log(`[BENCH] Electron launch: ${ms(t0)}`)
+
+    window = await app.firstWindow()
+
+    // Capture renderer console for debugging
+    window.on('console', (msg) => {
+      if (msg.type() === 'error') console.log(`[RENDERER ERROR] ${msg.text()}`)
+    })
+
+    await window.waitForLoadState('domcontentloaded')
+    console.log(`[BENCH] DOM content loaded: ${ms(t0)}`)
+
+    await window.waitForSelector('.v-application', { timeout: 30_000 })
+    console.log(`[BENCH] Vuetify app shell: ${ms(t0)}`)
+
+    // Dismiss disclaimer dialog if present
+    const disclaimerBtn = window.locator('button:has-text("I Understand")')
+    if ((await disclaimerBtn.count()) > 0) {
+      await disclaimerBtn.click()
+      await window.waitForTimeout(500)
+    }
+    console.log(`[BENCH] App ready: ${ms(t0)}`)
+  })
+
+  test.afterAll(async () => {
+    if (app) await app.close()
+    for (const suffix of ['', '-wal', '-shm']) {
+      const p = WORK_DB_PATH + suffix
+      if (existsSync(p)) unlinkSync(p)
+    }
+  })
+
+  // eslint-disable-next-line no-empty-pattern
+  test('opens the large database', async ({}) => {
+    const t0 = performance.now()
+
+    // Try opening via IPC and capture full error details
+    const result = await window.evaluate(async (dbPath: string) => {
+      const start = Date.now()
+      try {
+        const res = await (window as any).api.database.open(dbPath)
+        return { elapsed: Date.now() - start, ...res }
+      } catch (err: any) {
+        return {
+          elapsed: Date.now() - start,
+          success: false,
+          error: err?.message ?? String(err),
+          stack: err?.stack
+        }
+      }
+    }, WORK_DB_PATH)
+
+    console.log(`[BENCH] database:open elapsed: ${result.elapsed}ms (total ${ms(t0)})`)
+    console.log(`[BENCH] Result:`, JSON.stringify(result, null, 2))
+
+    // If it failed, also try to get main-process logs
+    if (!result.success) {
+      // Try to gather more info via evaluate in main process
+      try {
+        const mainInfo = await app.evaluate(async () => {
+          return { pid: process.pid, versions: process.versions }
+        })
+        console.log(`[BENCH] Main process info:`, JSON.stringify(mainInfo))
+      } catch {
+        // ignore
+      }
+    }
+
+    expect(result.success).toBe(true)
+    console.log(`[BENCH] Database opened successfully`)
+  })
+
+  // eslint-disable-next-line no-empty-pattern
+  test('case list renders', async ({}) => {
+    const t0 = performance.now()
+
+    // Reload the page so the renderer picks up the new database
+    await window.reload()
+    await window.waitForSelector('.v-application', { timeout: 30_000 })
+
+    // Dismiss disclaimer again after reload
+    const disclaimerBtn = window.locator('button:has-text("I Understand")')
+    if ((await disclaimerBtn.count()) > 0) {
+      await disclaimerBtn.click()
+      await window.waitForTimeout(500)
+    }
+    console.log(`[BENCH] Page reloaded: ${ms(t0)}`)
+
+    // Open sidebar if closed
+    const sidebar = window.locator('.v-navigation-drawer--left')
+    if (!(await sidebar.isVisible())) {
+      const toggleBtn = window.locator('.sidebar-toggle-btn')
+      if ((await toggleBtn.count()) > 0) {
+        await toggleBtn.click()
+        await window.waitForTimeout(300)
+      }
+    }
+
+    // Navigate to case view
+    const caseBtn = window.locator('.mode-toggle .v-btn').first()
+    await caseBtn.click()
+    await window.waitForTimeout(500)
+
+    // Wait for case list to populate
+    const caseList = window.locator('.case-list-item, .v-list-item')
+    await caseList.first().waitFor({ timeout: 60_000 })
+
+    const caseCount = await caseList.count()
+    console.log(`[BENCH] Case list visible (${caseCount} items): ${ms(t0)}`)
+    expect(caseCount).toBeGreaterThan(0)
+  })
+
+  // eslint-disable-next-line no-empty-pattern
+  test('variant table renders for first case', async ({}) => {
+    const t0 = performance.now()
+
+    const firstCase = window.locator('.case-list-item, .v-list-item').first()
+    await firstCase.click()
+
+    const table = window.locator('.v-data-table, .v-table')
+    await table.first().waitFor({ timeout: 60_000 })
+    console.log(`[BENCH] Variant table visible: ${ms(t0)}`)
+
+    const rows = window.locator('.v-data-table tbody tr, .v-table tbody tr')
+    await rows.first().waitFor({ timeout: 30_000 })
+
+    const rowCount = await rows.count()
+    console.log(`[BENCH] Table rows: ${rowCount} in ${ms(t0)}`)
+    expect(rowCount).toBeGreaterThan(0)
+
+    await window.screenshot({ path: 'test-results/large-db-variant-table.png' })
+  })
+
+  // eslint-disable-next-line no-empty-pattern
+  test('cohort view renders', async ({}) => {
+    const t0 = performance.now()
+
+    const cohortBtn = window.locator('.mode-toggle .v-btn').last()
+    await cohortBtn.click()
+
+    const table = window.locator('.v-data-table, .v-table')
+    await table.first().waitFor({ timeout: 60_000 })
+    console.log(`[BENCH] Cohort table visible: ${ms(t0)}`)
+
+    const rows = window.locator('.v-data-table tbody tr, .v-table tbody tr')
+    await rows.first().waitFor({ timeout: 60_000 })
+
+    const rowCount = await rows.count()
+    console.log(`[BENCH] Cohort rows: ${rowCount} in ${ms(t0)}`)
+
+    await window.screenshot({ path: 'test-results/large-db-cohort-view.png' })
+  })
+})

--- a/tests/main/database/DatabaseService.test.ts
+++ b/tests/main/database/DatabaseService.test.ts
@@ -8,6 +8,7 @@ import {
   UniqueConstraintError,
   TransactionError
 } from '../../../src/main/database'
+import { DATABASE_CONFIG } from '../../../src/shared/config'
 
 describe('DatabaseService', () => {
   let service: DatabaseService
@@ -75,7 +76,7 @@ describe('DatabaseService', () => {
           | undefined
         // mmap_size is set but the return format varies by platform
         if (mmapSize !== undefined) {
-          expect(mmapSize.mmap_size).toBe(268435456)
+          expect(mmapSize.mmap_size).toBe(DATABASE_CONFIG.MMAP_SIZE_BYTES)
         }
       } finally {
         fileService.close()


### PR DESCRIPTION
## Summary

- **Skip FTS5 rebuild on open** when the index already exists with the correct schema — this was the primary bottleneck, dropping and reinserting 4.1M rows on every database open (~6.3s wasted)
- **Move `PRAGMA optimize` from open to close** and add `analysis_limit = 400` to cap ANALYZE sampling
- **Replace `COUNT(*)` with `SELECT 1 LIMIT 1`** for existence checks (12ms → 0.1ms on 4.1M rows)
- **Defer housekeeping** (cohort staleness check, cache cleanup) to `process.nextTick` so the window renders first
- **Add WAL checkpoint on close** so subsequent opens are fast
- **Make migration v14 fully idempotent** — column and trigger existence checks prevent crashes on partially-migrated databases
- **Increase `mmap_size`** from 256 MB to 1 GB (free virtual reservation on 64-bit)

### Benchmarks (3.7 GB database, 4.1M variants, 555 cases)

| Metric | Before | After |
|---|---|---|
| `database:open` steady-state | 6.5s+ / crash | **30ms** |
| `database:open` with 3 pending migrations | crash | **275ms** |
| Schema init | 6,344ms | **0.2ms** |
| App launch → Vuetify ready | 622ms | 621ms |
| Case list (555 cases) | N/A | ~2s |
| Cohort view | N/A | ~500ms |

## Test plan

- [x] All 1170 unit tests pass
- [x] Typecheck passes (`npm run typecheck`)
- [x] ESLint + Prettier clean
- [x] New E2E benchmark test (`tests/e2e/startup-large-db.e2e.ts`) validates startup with large DB
- [x] Tested migration v13→v16 path on real 3.7 GB database
- [x] Verified steady-state re-open (no migrations needed) on same database
- [ ] CI build passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)