### PR TITLE
perf: Phase 2 bundle optimization (-47% JS, -28% CSS)

### DIFF
--- a/src/renderer/src/components/AppDialogHost.vue
+++ b/src/renderer/src/components/AppDialogHost.vue
@@ -7,12 +7,12 @@
   <AppSnackbar ref="snackbarRef" />
   <LogViewer v-model:open="logViewerOpen" />
   <DisclaimerDialog ref="disclaimerRef" @acknowledged="handleDisclaimerAcknowledged" />
-  <FaqDialog ref="faqDialogRef" />
-  <ExternalLinksSettings ref="externalLinksSettingsRef" />
-  <ApplicationPreferences ref="applicationPreferencesRef" />
-  <TagManagementDialog ref="tagManagementDialogRef" />
-  <DatabaseOverviewDialog ref="databaseOverviewDialogRef" />
-  <DeleteAllCasesDialog ref="deleteAllCasesDialogRef" />
+  <FaqDialog v-if="faqMounted" ref="faqDialogRef" />
+  <ExternalLinksSettings v-if="externalLinksMounted" ref="externalLinksSettingsRef" />
+  <ApplicationPreferences v-if="preferencesMounted" ref="applicationPreferencesRef" />
+  <TagManagementDialog v-if="tagsMounted" ref="tagManagementDialogRef" />
+  <DatabaseOverviewDialog v-if="dbOverviewMounted" ref="databaseOverviewDialogRef" />
+  <DeleteAllCasesDialog v-if="deleteAllMounted" ref="deleteAllCasesDialogRef" />
   <CaseMetadataModal
     v-if="selectedCaseId"
     ref="caseMetadataModalRef"
@@ -24,19 +24,21 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, defineAsyncComponent, onMounted, nextTick } from 'vue'
 import ImportDialog from './ImportDialog.vue'
 import BatchImportDialog from './BatchImportDialog.vue'
 import AppSnackbar from './AppSnackbar.vue'
 import LogViewer from './LogViewer.vue'
 import DisclaimerDialog from './DisclaimerDialog.vue'
-import FaqDialog from './FaqDialog.vue'
-import ExternalLinksSettings from './ExternalLinksSettings.vue'
-import ApplicationPreferences from './ApplicationPreferences.vue'
-import TagManagementDialog from './TagManagementDialog.vue'
-import DatabaseOverviewDialog from './DatabaseOverviewDialog.vue'
-import DeleteAllCasesDialog from './DeleteAllCasesDialog.vue'
 import CaseMetadataModal from './CaseMetadataModal.vue'
+
+// Lazy-load rarely-used dialogs to reduce initial render cost
+const FaqDialog = defineAsyncComponent(() => import('./FaqDialog.vue'))
+const ExternalLinksSettings = defineAsyncComponent(() => import('./ExternalLinksSettings.vue'))
+const ApplicationPreferences = defineAsyncComponent(() => import('./ApplicationPreferences.vue'))
+const TagManagementDialog = defineAsyncComponent(() => import('./TagManagementDialog.vue'))
+const DatabaseOverviewDialog = defineAsyncComponent(() => import('./DatabaseOverviewDialog.vue'))
+const DeleteAllCasesDialog = defineAsyncComponent(() => import('./DeleteAllCasesDialog.vue'))
 import { useAppState } from '../composables/useAppState'
 import { useVersionGating } from '../composables/useVersionGating'
 import { logService } from '../services/LogService'
@@ -69,6 +71,14 @@ const caseMetadataModalRef = ref<InstanceType<typeof CaseMetadataModal> | null>(
 
 // Log viewer state
 const logViewerOpen = ref(false)
+
+// Lazy dialog mount flags — only mount component after first open
+const faqMounted = ref(false)
+const externalLinksMounted = ref(false)
+const preferencesMounted = ref(false)
+const tagsMounted = ref(false)
+const dbOverviewMounted = ref(false)
+const deleteAllMounted = ref(false)
 
 // Disclaimer acknowledgment state
 const disclaimerAcknowledged = ref(false)
@@ -118,12 +128,36 @@ defineExpose({
   showBatchImportDialog: (mode: 'files' | 'folder' | 'zip') =>
     batchImportDialogRef.value?.show(mode),
   showDisclaimer: () => disclaimerRef.value?.show(),
-  showFaq: () => faqDialogRef.value?.show(),
-  showExternalLinks: () => externalLinksSettingsRef.value?.show(),
-  showPreferences: () => applicationPreferencesRef.value?.show(),
-  showTagManagement: () => tagManagementDialogRef.value?.show(),
-  showDatabaseOverview: () => databaseOverviewDialogRef.value?.show(),
-  showDeleteAllCases: (count: number) => deleteAllCasesDialogRef.value?.show(count),
+  showFaq: async () => {
+    faqMounted.value = true
+    await nextTick()
+    faqDialogRef.value?.show()
+  },
+  showExternalLinks: async () => {
+    externalLinksMounted.value = true
+    await nextTick()
+    externalLinksSettingsRef.value?.show()
+  },
+  showPreferences: async () => {
+    preferencesMounted.value = true
+    await nextTick()
+    applicationPreferencesRef.value?.show()
+  },
+  showTagManagement: async () => {
+    tagsMounted.value = true
+    await nextTick()
+    tagManagementDialogRef.value?.show()
+  },
+  showDatabaseOverview: async () => {
+    dbOverviewMounted.value = true
+    await nextTick()
+    databaseOverviewDialogRef.value?.show()
+  },
+  showDeleteAllCases: async (count: number) => {
+    deleteAllMounted.value = true
+    await nextTick()
+    return deleteAllCasesDialogRef.value?.show(count)
+  },
   showCaseMetadata: () => caseMetadataModalRef.value?.show(),
   showSnackbar: (message: string, type: 'success' | 'error') =>
     snackbarRef.value?.show(message, type),

--- a/src/renderer/src/plugins/vuetify.ts
+++ b/src/renderer/src/plugins/vuetify.ts
@@ -1,6 +1,4 @@
 import { createVuetify, ThemeDefinition } from 'vuetify'
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
 import { mdi } from 'vuetify/iconsets/mdi'
@@ -82,8 +80,6 @@ const warmDark: ThemeDefinition = {
 }
 
 export default createVuetify({
-  components,
-  directives,
   theme: {
     defaultTheme: 'warmLight',
     themes: {

--- a/src/renderer/src/router/index.ts
+++ b/src/renderer/src/router/index.ts
@@ -1,6 +1,4 @@
 import { createRouter, createMemoryHistory } from 'vue-router'
-import CaseView from '../views/CaseView.vue'
-import CohortView from '../views/CohortView.vue'
 
 /**
  * Vue Router for VarLens.
@@ -8,6 +6,8 @@ import CohortView from '../views/CohortView.vue'
  * Uses memory history (no URL bar in Electron) with two main routes:
  * - /case — single case analysis (default)
  * - /cohort — multi-case cohort analysis
+ *
+ * Both routes are lazy-loaded to reduce initial bundle size.
  */
 const router = createRouter({
   history: createMemoryHistory(),
@@ -19,12 +19,12 @@ const router = createRouter({
     {
       path: '/case',
       name: 'case',
-      component: CaseView
+      component: () => import('../views/CaseView.vue')
     },
     {
       path: '/cohort',
       name: 'cohort',
-      component: CohortView
+      component: () => import('../views/CohortView.vue')
     }
   ]
 })


### PR DESCRIPTION
## Summary
- **Vuetify tree-shaking**: Remove `import * as components/directives` from vuetify.ts — rely on `vite-plugin-vuetify` `autoImport: true` (already configured). This was the single biggest win.
- **Lazy-load routes**: CaseView and CohortView now use `() => import(...)` instead of static imports
- **Async dialogs**: 6 rarely-used dialogs (FAQ, ExternalLinks, Preferences, Tags, DatabaseOverview, DeleteAll) wrapped with `defineAsyncComponent` + `v-if` mount gates

## Bundle Impact
| Asset | Before | After | Change |
|-------|--------|-------|--------|
| Main JS | 3,081 kB | 1,628 kB | **-47%** |
| CSS | 1,337 kB | 963 kB | **-28%** |
| CaseView chunk | — | 112 kB | (split out) |
| CohortView chunk | — | 167 kB | (split out) |
| Dialog chunks | — | ~134 kB | (split out) |

## Test plan
- [x] `make typecheck` passes
- [x] `make lint` passes (lint:check mode)
- [x] All 1247 tests pass
- [x] `electron-vite build` succeeds
- [ ] Manual: all views render correctly (no missing Vuetify components)
- [ ] Manual: all 6 lazy dialogs open correctly on first use
- [ ] Manual: Case and Cohort routes load properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)