### PR TITLE
chore: post-0.56.0 cleanup — docs, CI, macOS, vision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       # Cache ESLint + Prettier results across CI runs. Key on lockfile +
       # lint/format config so stale caches auto-invalidate when rules change.
       - name: Restore lint caches
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .eslintcache
@@ -114,7 +114,7 @@ jobs:
       # because tsc/vue-tsc use content hashes inside .tsbuildinfo to decide
       # what to recheck. Pattern per actions/cache#459 discussion.
       - name: Restore tsbuildinfo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .cache/tsbuildinfo
           key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json') }}-${{ github.sha }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload coverage
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage
           path: coverage/coverage-summary.json
@@ -195,7 +195,7 @@ jobs:
 
       - name: Cache native module for Electron ABI
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/better-sqlite3-multiple-ciphers/build/Release
           key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
         run: xvfb-run --auto-servernum npx playwright test tests/e2e/screenshots.e2e.ts
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: screenshots
           path: docs/public/screenshots/*.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Cache native module for Electron ABI
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/better-sqlite3-multiple-ciphers/build/Release
           key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
@@ -156,7 +156,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-linux
           path: |
@@ -196,7 +196,7 @@ jobs:
 
       - name: Cache native module for Electron ABI
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/better-sqlite3-multiple-ciphers/build/Release
           key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
@@ -211,7 +211,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-macos
           path: |
@@ -252,7 +252,7 @@ jobs:
 
       - name: Cache native module for Electron ABI
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/better-sqlite3-multiple-ciphers/build/Release
           key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
@@ -390,7 +390,7 @@ jobs:
           Set-Content release/latest.yml $yml -NoNewline
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-windows
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
           merge-multiple: true

--- a/.planning/docs/2026-04-11-scoring-via-filters-vision.md
+++ b/.planning/docs/2026-04-11-scoring-via-filters-vision.md
@@ -1,0 +1,113 @@
+# Scoring via Filters — Vision
+
+**Date:** 2026-04-11
+**Status:** Vision document (not a spec, not a plan)
+**Triggered by:** v0.56.0 unified-shortlist release + three documented "Phase-1 scoring gaps"
+**Supersedes:** `.planning/docs/shortlist-scoring-heuristic.md` §10 (Phase-1 limitations section only — §1-9 of that doc still describe the currently-shipped behavior)
+
+## Why this doc exists
+
+The v0.56.0 Shortlist shipped with three documented Phase-1 limitations in the scoring heuristic:
+
+1. **SV / CNV / STR rarity is a hardcoded `rarityPlaceholder: 1.0`** — no real population-frequency source is wired in.
+2. **`inheritanceModes` were silently stripped from the Recessive shortlist preset** because the shared filter translator `buildBaseWhere` (used by `src/main/database/shortlist-query.ts`) doesn't understand inheritance mode — trio/compound-het logic lives only in the Kysely-based `VariantFilterBuilder` and depends on `analysis_group_id` context.
+3. **The `phenotype` score component is always zero** — every scorer reads `row.hpo_sim_score ?? 0` and every built-in preset sets `phenotype: 0` because VarLens has no HPO similarity pipeline.
+
+The natural reaction is to file three spec sheets: one for gnomAD-SV wiring, one for inheritance forwarding, one for HPO. That fixes each gap individually but leaves the scoring module's core architectural flaw in place: **it reads raw database columns through a fixed formula**. Every future scoring improvement — structural constraints, allele-context boosts, gene-panel weighting, compound-het priority — would need to be plumbed through the same `extractFeature(row, dimension)` path, adding feature-specific branches to the scorer and new weight-vector fields to every preset.
+
+This document captures a different direction.
+
+## The mental model
+
+**Today.** Scoring is a fixed formula over extracted raw columns.
+
+```
+score = sum(weights[dimension] * extractFeature(row, dimension))
+        for dimension in [impact, pathogenicity, rarity, clinvar, phenotype]
+```
+
+`extractFeature()` is per-dimension and per-variant-type: it reads `row.consequence`, `row.cadd`, `row.gnomad_af`, etc., and returns a `[0, 1]` sub-score. The preset carries a fixed five-dimension weight vector. Adding a new scoring signal means adding a new `extractFeature` branch, a new weight-vector field, and a migration to update every existing preset's weight vector.
+
+**Tomorrow.** Scoring is a weighted composition of filter-predicate matches.
+
+```
+score = sum(weights[filterName] * filterMatches(variant, filterName))
+        for filterName in preset.scoringFilters
+```
+
+The unit of scoring becomes a **named filter predicate** — the same type of object the user already writes when they build a filter in the UI. A variant is tested against every filter the preset names; matches accumulate weight; totals rank the shortlist. The preset carries a list of `{ filter, weight }` pairs — not a five-dimensional vector. Adding a new scoring signal means registering a new filter predicate; existing presets continue to work unchanged.
+
+## Worked example
+
+A **"Severe recessive"** preset might weight three filters:
+
+| Filter predicate           | Weight |
+|----------------------------|--------|
+| `homozygous`               | +40    |
+| `loss_of_function`         | +40    |
+| `rare_vs_gnomad (af<0.001)`| +20    |
+
+Three variants scored against this preset:
+
+- **Homozygous stop-gain, gnomAD AF = 0.0001** — matches all three filters → **100 points**
+- **Het missense, gnomAD AF = 0.005** — matches zero filters → **0 points**
+- **Homozygous missense, gnomAD AF = 0.02** — matches only `homozygous` → **40 points**
+
+The preset reads like the clinical sentence it models: *"a severe recessive candidate is homozygous, loss-of-function, and rare"*. A clinician editing the preset adjusts weights and filter names, not abstract dimension labels.
+
+## Filter audit (2026-04-11)
+
+This section summarises findings from an Agent-tool audit of the current filter-builder code. Full details live in the spec (`2026-04-11-post-0.56.0-cleanup-design.md` §5.4); the table below captures the architectural gaps that motivate the redesign.
+
+| Predicate family          | SNV          | SV            | CNV           | STR           | Blocker                                                                                      |
+|---------------------------|--------------|---------------|---------------|---------------|----------------------------------------------------------------------------------------------|
+| Gene symbol / consequence | ✅            | ⚠️ partial    | ⚠️ partial    | ⚠️ partial    | annotation-scoped predicates (`starredOnly`, `hasComment`, `acmg`) only surface for SNV via cohort-listing scope |
+| Rarity (`gnomad_af_max`)  | ✅ real       | ❌ no column  | ❌ no column  | ❌ no column  | gnomAD-SV/CNV/STR not wired to schema; scoring uses hardcoded `rarityPlaceholder: 1.0`       |
+| Inheritance mode          | ⚠️ SNV-only SQL special case | ❌ | ❌           | ❌            | Not a first-class predicate. `VariantFilterBuilder.build()` lines 561-694 bake it into `gt_num` SQL, requires `analysis_group_id`, silently skipped when null |
+| Type-specific columns     | —            | ✅ rich        | ✅ rich        | ✅ rich        | Extension tables (`variant_sv`, `variant_cnv`, `variant_str`) expose many type-specific columns but none are composable into score-worthy filter predicates yet |
+| FTS5 search               | ✅            | ✅             | ❌            | ✅             | CNV has `hasFts: false`                                                                      |
+
+### Three root causes
+
+1. **Inheritance is imperative SQL, not a filter predicate.** Trio modes live inside `VariantFilterBuilder.build()` as parameterised subqueries that correlate the proband's `gt_num` against parent/sibling genotypes via the `analysis_group_members` table. Moving them into the filter registry is not a copy-paste — it requires reshaping them as filter predicates that any variant type can be tested against, with explicit handling for the "no analysis group" case.
+
+2. **`shortlist-query.ts` → `buildBaseWhere` shares base columns but not the imperative inheritance branch.** The two filter-building paths in the codebase diverged when the shortlist was added: the older Kysely builder understands inheritance and uses `analysis_group_id` context; the newer shared translator was cloned from the base-column parts only. Unifying them requires the inheritance predicate refactor in (1) as a prerequisite.
+
+3. **Preset JSON shapes differ.** Shortlist presets use `ShortlistConfig` (`baseFilters` + `perTypeOverrides` + `rankConfig` with a fixed 5-dimension weight vector). Classic filter presets use flat `FilterState` with `inheritanceModes`, `columnFilters`, `starredOnly`, etc. A unified preset shape that carries a list of `{ filter, weight }` pairs is a prerequisite for the whole redesign.
+
+## Migration path (high-level)
+
+This is a direction, not a schedule. Each bullet is its own future spec when its turn comes.
+
+1. **Lift inheritance mode out of `VariantFilterBuilder.build()` into a named filter predicate** in the filter registry. The predicate takes `analysis_group_id` as context; shortlist queries supply it from the case record. The old SQL branch in `VariantFilterBuilder` stays until callers migrate, then gets deleted.
+
+2. **Wire per-type rarity data sources as filter predicates** — gnomAD-SV first (it unblocks SV and CNV simultaneously), then an STR-specific source. Rarity becomes a filter predicate named `rare_vs_gnomad`, not a scoring column named `rarity`. Scoring reads the filter-match result; the specific AF cutoff is a filter parameter.
+
+3. **Unify preset JSON shapes** so shortlist and classic filter presets share the same `filter[]` array. The `ShortlistConfig.baseFilters` + `perTypeOverrides` shape dissolves into a flat `filters: FilterPredicate[]` plus `scoringFilters: { filter, weight }[]`. A migration rewrites every existing preset in place.
+
+4. **Rewrite the scoring module as a weighted sum over filter-match booleans.** Drop `extractFeature()` and its per-dimension branches. The scorer takes a `ScoredPreset` and a `Variant`, runs each filter predicate against the variant, and sums `weight * matches`. The existing `consequenceImpact` / `clinvarBoost` lookup tables become parameters of filter predicates (`is_high_impact_consequence`, `is_pathogenic_clinvar`).
+
+5. **HPO phenotype becomes a filter predicate** — `phenotype_similar(patient_hpo, gene, threshold)` — not a separate scoring dimension. Prerequisites: a case-level phenotype entry UI and an HPO similarity algorithm (decided in its own spec). The new "HPO-guided" preset weights this predicate positively; existing presets continue to ignore it.
+
+## Explicitly out of scope
+
+This vision doc names a direction. It does NOT decide:
+
+- **Algorithm choice** for HPO similarity (Resnik vs simGIC vs Phenomizer) — decided in the HPO subsystem spec.
+- **Data source decisions** for gnomAD-SV (bundled vs downloaded on first launch, file size budget, licensing) — decided in the rarity subsystem spec.
+- **Implementation file lists** for any migration step — each step gets its own spec when its turn comes.
+- **Timeline or phase assignment** — none of the five migration steps is scheduled here.
+
+## Not a deprecation of v0.56.0 scoring
+
+The current formula-based scorers (`src/main/services/scoring/score-snv.ts`, `score-sv.ts`, `score-cnv.ts`, `score-str.ts` and the shared `scoring-config.ts`) stay in `main` until their replacement lands. This document is a direction, not a deletion. The next scoring subsystem spec — whichever one lands first — is the first commit that actually changes scoring code.
+
+## References
+
+- v0.56.0 spec: `.planning/specs/2026-04-11-unified-shortlist-ranked-view-design.md`
+- Current scoring heuristic: `.planning/docs/shortlist-scoring-heuristic.md`
+- Post-0.56.0 cleanup spec (source of the filter audit): `.planning/specs/2026-04-11-post-0.56.0-cleanup-design.md` §5.4
+- Filter builder: `src/main/database/VariantFilterBuilder.ts:561-694` (inheritance branch)
+- Shared filter translator: `src/main/database/shortlist-query.ts` → `buildBaseWhere`
+- Built-in shortlist presets: `src/main/database/built-in-shortlist-presets.ts`
+- Classic filter preset shape: `src/shared/types/filter-presets.ts`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Download the latest release for your platform:
 | Platform | Formats |
 |----------|---------|
 | Windows | [Installer / Portable](https://github.com/berntpopp/VarLens/releases/latest) |
-| macOS | [DMG / ZIP](https://github.com/berntpopp/VarLens/releases/latest) |
+| macOS (Apple Silicon only) | [DMG / ZIP](https://github.com/berntpopp/VarLens/releases/latest) |
 | Linux | [AppImage / DEB](https://github.com/berntpopp/VarLens/releases/latest) |
 
 See the [installation guide](https://berntpopp.github.io/VarLens/guide/installation) for system requirements and first-launch steps.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -27,7 +27,7 @@ Download the latest release for your platform from the [GitHub Releases page](ht
 ## System Requirements
 
 - **Windows:** Windows 10 or later
-- **macOS:** macOS 12 (Monterey) or later
+- **macOS:** macOS 12 (Monterey) or later on Apple Silicon (M1 or newer). Intel Macs are not supported.
 - **Linux:** Ubuntu 20.04 or later (or equivalent)
 - **RAM:** 4 GB minimum, 8 GB recommended for large datasets
 - **Disk:** 200 MB for the application, plus space for your variant databases

--- a/package.json
+++ b/package.json
@@ -111,8 +111,18 @@
     "mac": {
       "icon": "build/icon.icns",
       "target": [
-        { "target": "dmg", "arch": ["arm64"] },
-        { "target": "zip", "arch": ["arm64"] }
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64"
+          ]
+        }
       ],
       "artifactName": "${productName}-${version}-${arch}.${ext}"
     },

--- a/package.json
+++ b/package.json
@@ -111,8 +111,8 @@
     "mac": {
       "icon": "build/icon.icns",
       "target": [
-        "dmg",
-        "zip"
+        { "target": "dmg", "arch": ["arm64"] },
+        { "target": "zip", "arch": ["arm64"] }
       ],
       "artifactName": "${productName}-${version}-${arch}.${ext}"
     },


### PR DESCRIPTION
## Summary

Post-release cleanup bundling four loose ends from the v0.56.0 unified-shortlist session. Paired with a separate PR (`fix/restore-coverage-thresholds`) that handles item 2 (threshold restore) on a child branch.

**Items in this PR:**

- **Item 5** (`ci:` × 2) — Bump `actions/cache@v4→v5` and `actions/upload-artifact@v4→v5` across `build.yml`, `release.yml`, `docs.yml`; plus a follow-up commit for the matching `actions/download-artifact@v4→v6` pin in `release.yml` that the first pass missed. All Node-24-compatible majors, ahead of GitHub's June-2026 forced cutover. `gitleaks/gitleaks-action` stays at `@v2` (no v3 upstream; risk documented below).

- **Item 1** (`chore(build):`) — Explicit `arch: ["arm64"]` in `package.json` `build.mac.target` + docs updates in `README.md:49` and `docs/guide/installation.md:30` to formalize Apple-Silicon-only macOS support. v0.56.0 already shipped arm64-only due to the `macos-latest` runner being arm64; this commit makes the intent explicit instead of accidental. Intel Mac support is explicitly dropped per user decision.

- **Item 4** (`docs(planning):`) — New vision document at `.planning/docs/2026-04-11-scoring-via-filters-vision.md` capturing the architectural direction for a future scoring redesign. The three documented Phase-1 scoring gaps (SV/CNV/STR rarity, inheritance forwarding, HPO phenotype) all trace to a single root cause: scoring reads raw DB columns through a fixed formula. The vision is to rewrite it as a weighted composition of filter-predicate matches. NOT a spec, NOT scheduling any implementation — just a direction document for future subsystem specs to reference.

- **Format fixup** (`chore(format):`) — Reformats `package.json` `mac.target` per prettier, following item 1's compact-form edit. `make lint` + `make typecheck` don't run prettier on package.json; only `make ci`'s prettier step catches it. No functional change.

**NOT in this PR:**

- Item 2 (coverage threshold restore) is on `fix/restore-coverage-thresholds` which branches from this PR's tip — see the companion PR.
- Item 3 (Dependabot CVE patches) — aborted per the plan's fail-fast path. The vulnerable `vite`/`esbuild` versions are actually nested inside `vitepress@1.6.4` (not top-level deps), and no clean patch path exists without breaking vitepress 1.x or jumping to the alpha 2.x line. Filed as a follow-up for a future Vite/vitepress upgrade spec.

## Risk notes

**gitleaks-action Node-24 risk:** `gitleaks/gitleaks-action@v2` has no v3 upstream. If GitHub's June-2026 Node-24 cutover breaks the secrets-scan job, two fallback options:
- Replace with `trufflesecurity/trufflehog`
- Run gitleaks as a plain `run:` step from a downloaded binary

Tracking this as a known risk for a future CI resilience pass.

## Test plan

- [ ] CI green on this PR (ubuntu + windows + macos)
- [ ] No regression in docs site build
- [ ] Release workflow still green on the new action versions (verify on next release)

---

Spec: `.planning/specs/2026-04-11-post-0.56.0-cleanup-design.md` (committed as `c785cf9`)
Plan: `.planning/plans/2026-04-11-post-0.56.0-cleanup-plan.md` (committed as `e78ba25`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)