### PR TITLE
Electron fuse hardening: OnlyLoadAppFromAsar + strict-require baseline + packaged smoke

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,19 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
+      - name: Run packaged smoke (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npx playwright test tests/e2e/packaged-smoke.e2e.ts --workers=1
+
+      - name: Upload packaged smoke artifacts (Linux)
+        if: runner.os == 'Linux' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-smoke-linux
+          path: |
+            test-results/
+            .planning/artifacts/perf/phase1/baseline/packaged-smoke/
+
   # ── 4. Required-status-check aggregator ────────────────────────────
   # Branch protection should require THIS job (and secrets-scan) only.
   # It succeeds when all upstream jobs succeeded OR were correctly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,13 @@ jobs:
 
       - name: Run packaged smoke (Linux)
         if: runner.os == 'Linux'
+        # The packaged Electron binary ships `chrome-sandbox` unpacked; the
+        # runtime requires it to be root-owned mode 4755, which GitHub Actions
+        # runners do not set up. `VARLENS_E2E_NO_SANDBOX=1` tells the smoke
+        # helper to launch with `--no-sandbox`. The fuse baseline under test
+        # is unaffected by this flag.
+        env:
+          VARLENS_E2E_NO_SANDBOX: '1'
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npx playwright test tests/e2e/packaged-smoke.e2e.ts --workers=1
 
       - name: Upload packaged smoke artifacts (Linux)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,11 +154,29 @@ Test data lives at `tests/test-data/vcf/` (GIAB Chinese Trio, chr22:29M–30.5M,
 ## Security Defaults
 
 - Electron window creation enforces `sandbox: true`, `contextIsolation: true`, `nodeIntegration: false`. See `src/main/index.ts`. **Do not weaken these.**
-- Packaged builds also harden Electron fuses in `package.json` (`build.electronFuses`). Keep `runAsNode` disabled unless the app intentionally adds a main-process `fork()` dependency, and reassess fuses before changing packaging/load behavior.
+- Packaged builds harden Electron fuses via `scripts/configure-fuses.mjs`, invoked from electron-builder's `afterPack` hook. See the "Electron fuse baseline" subsection below.
 - Large renderer-side runtimes such as `pdbe-molstar` should be loaded through Vite's asset graph, not via copied public JS files or raw `file://` script injection. Prefer lazy `import(...)` over bespoke script-tag loaders so Electron packaging stays deterministic across platforms.
 - Renderer talks to main only through the typed `window.api` exposed by `src/preload/index.ts` — no raw `ipcRenderer`. Adding a new IPC channel means adding to the shared contract, preload, main handler, and (ideally) the preload contract test.
 - External URLs are validated before `shell.openExternal`. Do not add a shortcut path that skips that validation.
 - SQLite databases can be encrypted (`better-sqlite3-multiple-ciphers`). User keys are never logged; tests must not commit real user data.
+
+### Electron fuse baseline
+
+`scripts/configure-fuses.mjs` owns the packaged fuse configuration. `strictlyRequireAllFuses: true` forces the baseline to declare every fuse known to the pinned `@electron/fuses` version — an Electron upgrade that introduces a new fuse makes the build fail until the baseline declares an explicit value.
+
+Current baseline (read the script for the authoritative list):
+
+- `RunAsNode: false` — blocks repurposing the packaged binary as a generic Node.js runtime.
+- `EnableCookieEncryption: true` — at-rest cookie encryption for the session.
+- `EnableNodeOptionsEnvironmentVariable: false` — disables `NODE_OPTIONS` injection paths.
+- `EnableNodeCliInspectArguments: false` — disables CLI inspector attachment.
+- `EnableEmbeddedAsarIntegrityValidation: true` — validates the shipped asar against its hash; pairs with `OnlyLoadAppFromAsar` per Electron guidance (see https://www.electronjs.org/docs/latest/tutorial/asar-integrity).
+- `OnlyLoadAppFromAsar: true` — refuses to launch the main app from any location other than `app.asar`.
+- `LoadBrowserProcessSpecificV8Snapshot: false` — current default preserved.
+- `GrantFileProtocolExtraPrivileges: true` — current default preserved; tightening this fuse is a separate, deliberate decision.
+- `resetAdHocDarwinSignature: true` — re-ad-hoc-signs the macOS binary after fuse flipping so local ad-hoc builds remain launchable.
+
+The baseline lives only in `scripts/configure-fuses.mjs`. Do not reintroduce `build.electronFuses` in `package.json`; the hook owns the flip and `doAddElectronFuses` short-circuits when the declarative block is absent.
 
 ## What NOT to do
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help rebuild dev build preview lint lint-check test test-watch test-coverage typecheck dist dist-linux dist-mac dist-win package package-linux package-mac package-win clean clean-all install reinstall all ci ci-full ci-build ci-checks ci-startup-smoke ci-package-linux ci-actions docs docs-dev docs-preview docs-screenshots
+.PHONY: help rebuild dev build preview lint lint-check test test-watch test-coverage typecheck dist dist-linux dist-mac dist-win package package-linux package-mac package-win clean clean-all install reinstall all ci ci-full ci-build ci-checks ci-startup-smoke ci-package-linux ci-packaged-smoke-linux ci-actions docs docs-dev docs-preview docs-screenshots
 
 # Default target - show help
 .DEFAULT_GOAL := help
@@ -174,6 +174,15 @@ ci-package-linux: ## Run the Linux package validation job under Node $(CI_NODE_V
 	@echo ""
 	@echo "=== Package (ubuntu-latest) PASSED ==="
 
+ci-packaged-smoke-linux: ## Run the packaged-binary smoke on Linux (requires a built Linux artifact in release/)
+	@echo "=== Packaged Smoke (Linux) using Node $(CI_NODE_VERSION) ==="
+	$(ensure_ci_node)
+	@echo ""
+	@echo "Step 1/1: Running packaged smoke against release/linux-unpacked/varlens..."
+	$(XVFB_RUN)npx playwright test tests/e2e/packaged-smoke.e2e.ts --workers=1
+	@echo ""
+	@echo "=== Packaged Smoke (Linux) PASSED ==="
+
 ci-full: ci-actions ## Run the local GitHub Actions parity pipeline
 
 ci-actions: ## Run the required local GitHub Actions parity pipeline under Node $(CI_NODE_VERSION)
@@ -181,6 +190,7 @@ ci-actions: ## Run the required local GitHub Actions parity pipeline under Node 
 	$(MAKE) ci-checks
 	$(MAKE) ci-startup-smoke
 	$(MAKE) ci-package-linux
+	$(MAKE) ci-packaged-smoke-linux
 	@echo ""
 	@echo "=== GitHub Actions parity pipeline PASSED ==="
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "devDependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
+        "@electron/fuses": "^1.8.0",
         "@electron/rebuild": "^4.0.3",
         "@eslint/js": "^10.0.1",
         "@mdi/js": "^7.4.47",
@@ -615,7 +616,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@develar/schema-utils": {
@@ -1065,72 +1066,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
@@ -1169,6 +1104,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1185,6 +1121,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1201,6 +1138,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1217,6 +1155,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,6 +1172,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1249,6 +1189,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1265,6 +1206,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1281,6 +1223,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,6 +1240,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,6 +1257,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,6 +1274,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,6 +1291,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1361,6 +1308,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,6 +1325,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1393,6 +1342,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,6 +1359,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,6 +1376,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1441,6 +1393,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1457,6 +1410,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1473,6 +1427,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1489,6 +1444,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1505,6 +1461,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1521,6 +1478,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1537,6 +1495,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1553,6 +1512,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1569,6 +1529,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2706,6 +2667,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2745,6 +2707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2765,6 +2728,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2785,6 +2749,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2805,6 +2770,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2825,6 +2791,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2845,6 +2812,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2865,6 +2833,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2885,6 +2854,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2905,6 +2875,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2925,6 +2896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2945,6 +2917,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2965,6 +2938,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2985,6 +2959,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3002,6 +2977,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3046,6 +3022,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3059,6 +3036,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3072,6 +3050,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3085,6 +3064,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3098,6 +3078,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3111,6 +3092,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3124,6 +3106,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3137,6 +3120,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3150,6 +3134,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3163,6 +3148,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3176,6 +3162,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3189,6 +3176,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3202,6 +3190,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3215,6 +3204,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3228,6 +3218,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3241,6 +3232,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3254,6 +3246,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3267,6 +3260,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3280,6 +3274,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3293,6 +3288,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3306,6 +3302,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3319,6 +3316,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3332,6 +3330,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3345,6 +3344,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3358,6 +3358,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6319,6 +6320,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6484,7 +6486,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -6745,15 +6747,6 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
-    },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9566,6 +9559,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9913,7 +9907,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10526,7 +10520,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10580,7 +10574,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -10941,7 +10935,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13817,36 +13811,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/preact": {
       "version": "10.29.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
@@ -14292,6 +14256,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14793,6 +14758,7 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14814,7 +14780,7 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.99.0.tgz",
       "integrity": "sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
@@ -14862,6 +14828,7 @@
         "!riscv64",
         "!x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14875,6 +14842,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14891,6 +14859,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14907,6 +14876,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14923,6 +14893,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14939,6 +14910,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14955,6 +14927,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14971,6 +14944,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14987,6 +14961,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15003,6 +14978,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15019,6 +14995,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15035,6 +15012,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15051,6 +15029,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15067,6 +15046,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15083,6 +15063,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15096,6 +15077,7 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.99.0.tgz",
       "integrity": "sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15115,6 +15097,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15131,6 +15114,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15144,7 +15128,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16008,7 +15992,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sync-message-port": "^1.0.0"
@@ -16021,7 +16005,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
       "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -16810,7 +16794,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -616,7 +616,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@develar/schema-utils": {
@@ -1066,6 +1066,72 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
@@ -1104,7 +1170,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1121,7 +1186,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1138,7 +1202,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1155,7 +1218,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,7 +1234,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1189,7 +1250,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1206,7 +1266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1223,7 +1282,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1240,7 +1298,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1257,7 +1314,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1274,7 +1330,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1291,7 +1346,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1308,7 +1362,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1325,7 +1378,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,7 +1394,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1359,7 +1410,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1376,7 +1426,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1393,7 +1442,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1410,7 +1458,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,7 +1474,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1444,7 +1490,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1461,7 +1506,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1478,7 +1522,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1495,7 +1538,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1512,7 +1554,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1529,7 +1570,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2667,7 +2707,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2707,7 +2746,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2728,7 +2766,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2749,7 +2786,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2770,7 +2806,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2791,7 +2826,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2812,7 +2846,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2833,7 +2866,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2854,7 +2886,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,7 +2906,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2896,7 +2926,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2917,7 +2946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,7 +2966,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2959,7 +2986,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2977,7 +3003,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3022,7 +3047,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3036,7 +3060,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3050,7 +3073,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3064,7 +3086,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3078,7 +3099,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3092,7 +3112,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3106,7 +3125,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3120,7 +3138,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3134,7 +3151,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3148,7 +3164,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3162,7 +3177,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3176,7 +3190,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3190,7 +3203,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3204,7 +3216,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3218,7 +3229,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3232,7 +3242,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3246,7 +3255,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3260,7 +3268,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3274,7 +3281,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3288,7 +3294,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3302,7 +3307,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,7 +3320,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3330,7 +3333,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3344,7 +3346,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3358,7 +3359,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6320,7 +6320,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6486,7 +6485,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -6747,6 +6746,15 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9559,7 +9567,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9907,7 +9914,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10520,7 +10527,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10574,7 +10581,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -10935,7 +10942,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13811,6 +13818,36 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/preact": {
       "version": "10.29.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
@@ -14256,7 +14293,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14758,7 +14794,6 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14780,7 +14815,7 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.99.0.tgz",
       "integrity": "sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
@@ -14828,7 +14863,6 @@
         "!riscv64",
         "!x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14842,7 +14876,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14859,7 +14892,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14876,7 +14908,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14893,7 +14924,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14910,7 +14940,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14927,7 +14956,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14944,7 +14972,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14961,7 +14988,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14978,7 +15004,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14995,7 +15020,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15012,7 +15036,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15029,7 +15052,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15046,7 +15068,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15063,7 +15084,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15077,7 +15097,6 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.99.0.tgz",
       "integrity": "sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15097,7 +15116,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15114,7 +15132,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15128,7 +15145,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15992,7 +16009,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "sync-message-port": "^1.0.0"
@@ -16005,7 +16022,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
       "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -16794,7 +16811,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@electron/fuses": "^1.8.0",
     "@electron/rebuild": "^4.0.3",
     "@eslint/js": "^10.0.1",
     "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -87,13 +87,7 @@
     "productName": "Varlens",
     "icon": "build/icon.png",
     "npmRebuild": false,
-    "electronFuses": {
-      "runAsNode": false,
-      "enableCookieEncryption": true,
-      "enableNodeOptionsEnvironmentVariable": false,
-      "enableNodeCliInspectArguments": false,
-      "enableEmbeddedAsarIntegrityValidation": true
-    },
+    "afterPack": "scripts/configure-fuses.mjs",
     "extraResources": [
       {
         "from": "resources/gene_reference.db",

--- a/scripts/configure-fuses.mjs
+++ b/scripts/configure-fuses.mjs
@@ -1,0 +1,30 @@
+// Electron fuse baseline for packaged VarLens builds.
+// Invoked by electron-builder via `build.afterPack` in package.json.
+// Owns the flip via `addElectronFuses(...)`; the declarative
+// `build.electronFuses` block in package.json is intentionally absent so
+// electron-builder's internal `doAddElectronFuses` short-circuits.
+//
+// `strictlyRequireAllFuses: true` forces this file to declare every fuse
+// known to the pinned @electron/fuses version. A future Electron upgrade
+// that introduces a new fuse will make builds fail here until the baseline
+// declares an explicit value for it.
+
+import { FuseVersion, FuseV1Options } from '@electron/fuses'
+
+export const FUSE_BASELINE = {
+  version: FuseVersion.V1,
+  strictlyRequireAllFuses: true,
+  resetAdHocDarwinSignature: true,
+  [FuseV1Options.RunAsNode]: false,
+  [FuseV1Options.EnableCookieEncryption]: true,
+  [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+  [FuseV1Options.EnableNodeCliInspectArguments]: false,
+  [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+  [FuseV1Options.OnlyLoadAppFromAsar]: true,
+  [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
+  [FuseV1Options.GrantFileProtocolExtraPrivileges]: true
+}
+
+export default async function configureFuses(context) {
+  await context.packager.addElectronFuses(context, FUSE_BASELINE)
+}

--- a/tests/e2e/helpers/packaged-electron-app.ts
+++ b/tests/e2e/helpers/packaged-electron-app.ts
@@ -4,7 +4,6 @@ import { join, resolve } from 'path'
 import { spawn } from 'child_process'
 
 export interface LaunchPackagedAppResult {
-  pid: number
   isolationRoot: string
   userDataDir: string
   appDataDir: string
@@ -55,6 +54,10 @@ export async function launchPackagedLinuxApp(
 
   const collectedLines: string[] = []
 
+  // --no-sandbox disables Chromium's OS-level renderer sandbox, which is
+  // required on CI containers that lack user-namespace support. This is a
+  // test-only relaxation: real users launch without --no-sandbox and get
+  // the full sandbox. The fuse baseline under test is unaffected.
   const child = spawn(executablePath, ['--no-sandbox'], {
     env: {
       ...process.env,
@@ -136,10 +139,7 @@ export async function launchPackagedLinuxApp(
     child.on('exit', onExit)
   })
 
-  const pid = child.pid ?? 0
-
   return {
-    pid,
     isolationRoot,
     userDataDir,
     appDataDir,

--- a/tests/e2e/helpers/packaged-electron-app.ts
+++ b/tests/e2e/helpers/packaged-electron-app.ts
@@ -1,0 +1,100 @@
+import { _electron as electron, type ElectronApplication, type Page } from '@playwright/test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+export interface LaunchPackagedAppResult {
+  app: ElectronApplication
+  window: Page
+  isolationRoot: string
+  userDataDir: string
+  appDataDir: string
+  executablePath: string
+  consoleMessages: string[]
+  cleanup: () => Promise<void>
+}
+
+export function resolveLinuxPackagedBinary(projectRoot: string = process.cwd()): string {
+  const releaseDir = resolve(projectRoot, 'release')
+  if (!existsSync(releaseDir)) {
+    throw new Error(
+      `release/ does not exist at ${releaseDir} — run 'make dist-linux' before the packaged smoke test.`
+    )
+  }
+  const entries = readdirSync(releaseDir)
+  const appImage = entries.find((f) => f.endsWith('.AppImage'))
+  if (appImage === undefined) {
+    throw new Error(
+      `No .AppImage found under ${releaseDir}. Entries: ${entries.join(', ') || '(empty)'}`
+    )
+  }
+  return join(releaseDir, appImage)
+}
+
+export async function launchPackagedLinuxApp(): Promise<LaunchPackagedAppResult> {
+  const executablePath = resolveLinuxPackagedBinary()
+
+  const isolationRoot = mkdtempSync(join(tmpdir(), 'varlens-packaged-'))
+  const userDataDir = join(isolationRoot, 'user-data')
+  const appDataDir = join(isolationRoot, 'app-data')
+  mkdirSync(userDataDir, { recursive: true })
+  mkdirSync(appDataDir, { recursive: true })
+
+  const app = await electron.launch({
+    executablePath,
+    // --appimage-extract-and-run removes the FUSE dependency; required in CI
+    // containers where FUSE is not mounted. Harmless on developer machines.
+    args: ['--appimage-extract-and-run'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      HOME: isolationRoot,
+      XDG_CONFIG_HOME: appDataDir,
+      XDG_DATA_HOME: appDataDir,
+      VARLENS_APP_DATA_DIR: appDataDir,
+      VARLENS_USER_DATA_DIR: userDataDir,
+      VARLENS_PERF_MODE: '1'
+    }
+  })
+
+  const logFilePath = join(userDataDir, 'logs', 'main.log')
+  let window: Page
+  try {
+    window = await app.firstWindow()
+  } catch (error) {
+    const mainLog = existsSync(logFilePath)
+      ? readFileSync(logFilePath, 'utf8').trim()
+      : 'Main log file was not created before Electron exited.'
+
+    throw new Error(
+      [
+        'Electron app closed before the first window became available.',
+        `Isolation root: ${isolationRoot}`,
+        `Main log: ${logFilePath}`,
+        mainLog
+      ].join('\n\n'),
+      { cause: error }
+    )
+  }
+
+  const consoleMessages: string[] = []
+  window.on('console', (message) => {
+    consoleMessages.push(`[${message.type()}] ${message.text()}`)
+  })
+  window.on('pageerror', (error) => {
+    consoleMessages.push(`[pageerror] ${error.message}`)
+  })
+
+  return {
+    app,
+    window,
+    isolationRoot,
+    userDataDir,
+    appDataDir,
+    executablePath,
+    consoleMessages,
+    cleanup: async () => {
+      await app.close()
+    }
+  }
+}

--- a/tests/e2e/helpers/packaged-electron-app.ts
+++ b/tests/e2e/helpers/packaged-electron-app.ts
@@ -54,11 +54,13 @@ export async function launchPackagedLinuxApp(
 
   const collectedLines: string[] = []
 
-  // --no-sandbox disables Chromium's OS-level renderer sandbox, which is
-  // required on CI containers that lack user-namespace support. This is a
-  // test-only relaxation: real users launch without --no-sandbox and get
-  // the full sandbox. The fuse baseline under test is unaffected.
-  const child = spawn(executablePath, ['--no-sandbox'], {
+  // Gate --no-sandbox behind VARLENS_E2E_NO_SANDBOX=1. Default is the full
+  // Chromium sandbox (matches how real users launch) so the smoke catches
+  // sandbox-related regressions. Set the env var only on environments where
+  // the sandbox cannot initialize (e.g. containers without user-namespace
+  // support).
+  const launchArgs = process.env.VARLENS_E2E_NO_SANDBOX === '1' ? ['--no-sandbox'] : []
+  const child = spawn(executablePath, launchArgs, {
     env: {
       ...process.env,
       NODE_ENV: 'production',
@@ -87,7 +89,19 @@ export async function launchPackagedLinuxApp(
   child.stdout?.on('data', bufferLines)
   child.stderr?.on('data', bufferLines)
 
-  await new Promise<void>((resolveReady, rejectReady) => {
+  async function bestEffortCleanup(): Promise<void> {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+    }
+    try {
+      rmSync(isolationRoot, { recursive: true, force: true })
+    } catch {
+      // best-effort cleanup; ignore failures on long-lived CI mounts
+    }
+  }
+
+  try {
+    await new Promise<void>((resolveReady, rejectReady) => {
     const timer = setTimeout(() => {
       detach()
       rejectReady(
@@ -133,11 +147,18 @@ export async function launchPackagedLinuxApp(
       )
     }
 
-    child.stdout?.on('data', readyWatcher)
-    child.stderr?.on('data', readyWatcher)
-    child.on('error', onError)
-    child.on('exit', onExit)
-  })
+      child.stdout?.on('data', readyWatcher)
+      child.stderr?.on('data', readyWatcher)
+      child.on('error', onError)
+      child.on('exit', onExit)
+    })
+  } catch (err) {
+    // The child is spawned and temp dirs exist before the ready-wait begins,
+    // so a rejection here would otherwise leak both. Clean up then rethrow
+    // so callers see the original failure reason.
+    await bestEffortCleanup()
+    throw err
+  }
 
   return {
     isolationRoot,
@@ -146,7 +167,7 @@ export async function launchPackagedLinuxApp(
     executablePath,
     collectedLines,
     cleanup: async () => {
-      if (!child.killed) {
+      if (child.exitCode === null && child.signalCode === null) {
         child.kill('SIGTERM')
         await new Promise<void>((done) => {
           const t = setTimeout(() => {

--- a/tests/e2e/helpers/packaged-electron-app.ts
+++ b/tests/e2e/helpers/packaged-electron-app.ts
@@ -1,16 +1,15 @@
-import { _electron as electron, type ElectronApplication, type Page } from '@playwright/test'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
+import { spawn } from 'child_process'
 
 export interface LaunchPackagedAppResult {
-  app: ElectronApplication
-  window: Page
+  pid: number
   isolationRoot: string
   userDataDir: string
   appDataDir: string
   executablePath: string
-  consoleMessages: string[]
+  collectedLines: string[]
   cleanup: () => Promise<void>
 }
 
@@ -21,17 +20,31 @@ export function resolveLinuxPackagedBinary(projectRoot: string = process.cwd()):
       `release/ does not exist at ${releaseDir} — run 'make dist-linux' before the packaged smoke test.`
     )
   }
-  const entries = readdirSync(releaseDir)
-  const appImage = entries.find((f) => f.endsWith('.AppImage'))
-  if (appImage === undefined) {
-    throw new Error(
-      `No .AppImage found under ${releaseDir}. Entries: ${entries.join(', ') || '(empty)'}`
-    )
+  // Prefer the unpacked binary: fuses are already applied (it is the binary
+  // that gets wrapped into the AppImage), and it launches without requiring
+  // libfuse2 — which is often missing on CI runners and minimal containers.
+  const unpackedBinary = join(releaseDir, 'linux-unpacked', 'varlens')
+  if (existsSync(unpackedBinary)) {
+    return unpackedBinary
   }
-  return join(releaseDir, appImage)
+  throw new Error(
+    `Expected ${unpackedBinary} to exist after 'make dist-linux'. Contents of ${releaseDir}: ${readdirSync(releaseDir).join(', ') || '(empty)'}`
+  )
 }
 
-export async function launchPackagedLinuxApp(): Promise<LaunchPackagedAppResult> {
+/**
+ * Launches the packaged Linux binary as a child process and waits until the
+ * app emits a known "ready" log line (or the timeout elapses).
+ *
+ * NOTE: Playwright's `_electron.launch({ executablePath })` cannot be used
+ * here because it injects `--inspect=0`, which is blocked by the hardened
+ * `EnableNodeCliInspectArguments: false` fuse.  A direct spawn is the only
+ * reliable way to smoke-test a fuse-hardened Electron binary.
+ */
+export async function launchPackagedLinuxApp(
+  readyPattern: RegExp = /IPC handlers registered/,
+  timeoutMs: number = 30_000
+): Promise<LaunchPackagedAppResult> {
   const executablePath = resolveLinuxPackagedBinary()
 
   const isolationRoot = mkdtempSync(join(tmpdir(), 'varlens-packaged-'))
@@ -40,11 +53,9 @@ export async function launchPackagedLinuxApp(): Promise<LaunchPackagedAppResult>
   mkdirSync(userDataDir, { recursive: true })
   mkdirSync(appDataDir, { recursive: true })
 
-  const app = await electron.launch({
-    executablePath,
-    // --appimage-extract-and-run removes the FUSE dependency; required in CI
-    // containers where FUSE is not mounted. Harmless on developer machines.
-    args: ['--appimage-extract-and-run'],
+  const collectedLines: string[] = []
+
+  const child = spawn(executablePath, ['--no-sandbox'], {
     env: {
       ...process.env,
       NODE_ENV: 'production',
@@ -53,48 +64,106 @@ export async function launchPackagedLinuxApp(): Promise<LaunchPackagedAppResult>
       XDG_DATA_HOME: appDataDir,
       VARLENS_APP_DATA_DIR: appDataDir,
       VARLENS_USER_DATA_DIR: userDataDir,
-      VARLENS_PERF_MODE: '1'
-    }
+      VARLENS_PERF_MODE: '1',
+      // Suppress GPU errors on headless CI
+      DISPLAY: process.env.DISPLAY ?? ':99'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
   })
 
-  const logFilePath = join(userDataDir, 'logs', 'main.log')
-  let window: Page
-  try {
-    window = await app.firstWindow()
-  } catch (error) {
-    const mainLog = existsSync(logFilePath)
-      ? readFileSync(logFilePath, 'utf8').trim()
-      : 'Main log file was not created before Electron exited.'
-
-    throw new Error(
-      [
-        'Electron app closed before the first window became available.',
-        `Isolation root: ${isolationRoot}`,
-        `Main log: ${logFilePath}`,
-        mainLog
-      ].join('\n\n'),
-      { cause: error }
-    )
+  // Keep collecting lines for the entire child lifetime so post-ready crash
+  // patterns are visible to callers.
+  function bufferLines(data: Buffer): void {
+    for (const line of data.toString('utf8').split('\n')) {
+      if (line.trim() !== '') {
+        collectedLines.push(line)
+      }
+    }
   }
 
-  const consoleMessages: string[] = []
-  window.on('console', (message) => {
-    consoleMessages.push(`[${message.type()}] ${message.text()}`)
-  })
-  window.on('pageerror', (error) => {
-    consoleMessages.push(`[pageerror] ${error.message}`)
+  child.stdout?.on('data', bufferLines)
+  child.stderr?.on('data', bufferLines)
+
+  await new Promise<void>((resolveReady, rejectReady) => {
+    const timer = setTimeout(() => {
+      detach()
+      rejectReady(
+        new Error(
+          `Packaged binary did not emit ready pattern ${String(readyPattern)} within ${timeoutMs}ms.\n` +
+            `Output so far:\n${collectedLines.join('\n')}`
+        )
+      )
+    }, timeoutMs)
+
+    function detach(): void {
+      child.stdout?.off('data', readyWatcher)
+      child.stderr?.off('data', readyWatcher)
+      child.off('error', onError)
+      child.off('exit', onExit)
+    }
+
+    function readyWatcher(data: Buffer): void {
+      for (const line of data.toString('utf8').split('\n')) {
+        if (readyPattern.test(line)) {
+          clearTimeout(timer)
+          detach()
+          resolveReady()
+          return
+        }
+      }
+    }
+
+    function onError(err: Error): void {
+      clearTimeout(timer)
+      detach()
+      rejectReady(new Error(`Failed to spawn packaged binary: ${err.message}`))
+    }
+
+    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
+      clearTimeout(timer)
+      detach()
+      rejectReady(
+        new Error(
+          `Packaged binary exited before emitting ready pattern (code=${String(code)}, signal=${String(signal)}).\n` +
+            `Output:\n${collectedLines.join('\n')}`
+        )
+      )
+    }
+
+    child.stdout?.on('data', readyWatcher)
+    child.stderr?.on('data', readyWatcher)
+    child.on('error', onError)
+    child.on('exit', onExit)
   })
 
+  const pid = child.pid ?? 0
+
   return {
-    app,
-    window,
+    pid,
     isolationRoot,
     userDataDir,
     appDataDir,
     executablePath,
-    consoleMessages,
+    collectedLines,
     cleanup: async () => {
-      await app.close()
+      if (!child.killed) {
+        child.kill('SIGTERM')
+        await new Promise<void>((done) => {
+          const t = setTimeout(() => {
+            child.kill('SIGKILL')
+            done()
+          }, 3000)
+          child.on('exit', () => {
+            clearTimeout(t)
+            done()
+          })
+        })
+      }
+      try {
+        rmSync(isolationRoot, { recursive: true, force: true })
+      } catch {
+        // best-effort cleanup; ignore failures on long-lived CI mounts
+      }
     }
   }
 }

--- a/tests/e2e/packaged-smoke.e2e.ts
+++ b/tests/e2e/packaged-smoke.e2e.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import {
+  type LaunchPackagedAppResult,
+  launchPackagedLinuxApp
+} from './helpers/packaged-electron-app'
+import { ensureArtifactDir, writeJsonArtifact } from './helpers/perf-artifacts'
+
+// NOTE: Playwright's `_electron.launch({ executablePath })` cannot be used for
+// fuse-hardened binaries because it injects `--inspect=0`, which is blocked by
+// `EnableNodeCliInspectArguments: false`.  We verify boot by spawning the
+// binary directly and waiting for the "IPC handlers registered" log line.
+test('packaged Linux binary boots with fuses flipped', async ({}, testInfo) => {
+  ensureArtifactDir('packaged-smoke')
+  test.setTimeout(60_000)
+
+  let launched: LaunchPackagedAppResult | undefined
+  const launchStartedAt = Date.now()
+
+  try {
+    launched = await launchPackagedLinuxApp(/IPC handlers registered/, 30_000)
+
+    // The app emitted the ready line — confirm no crash-indicating patterns
+    const crashLines = launched.collectedLines.filter((l) =>
+      /native module.*mismatch|ERR_MODULE_NOT_FOUND|FATAL|Segmentation fault/i.test(l)
+    )
+    expect(crashLines, `Crash indicators in output: ${crashLines.join('\n')}`).toHaveLength(0)
+
+    writeJsonArtifact('packaged-smoke/launch-context.json', {
+      isolationRoot: launched.isolationRoot,
+      executablePath: launched.executablePath,
+      elapsedMs: Date.now() - launchStartedAt,
+      collectedLines: launched.collectedLines
+    })
+  } catch (error) {
+    writeJsonArtifact('packaged-smoke/failure-context.json', {
+      message: error instanceof Error ? error.message : String(error),
+      launchElapsedMs: Date.now() - launchStartedAt,
+      collectedLines: launched?.collectedLines ?? [],
+      testOutputDir: testInfo.outputDir
+    })
+    throw error
+  } finally {
+    if (launched !== undefined) {
+      await launched.cleanup()
+    }
+  }
+})

--- a/tests/main/scripts/configure-fuses.test.ts
+++ b/tests/main/scripts/configure-fuses.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { FuseV1Options, FuseVersion } from '@electron/fuses'
+import { FUSE_BASELINE } from '../../../scripts/configure-fuses.mjs'
+
+describe('FUSE_BASELINE', () => {
+  it('targets fuse wire version V1', () => {
+    expect(FUSE_BASELINE.version).toBe(FuseVersion.V1)
+  })
+
+  it('enables strictlyRequireAllFuses so Electron upgrades fail loudly on new fuses', () => {
+    expect(FUSE_BASELINE.strictlyRequireAllFuses).toBe(true)
+  })
+
+  it('declares every fuse exposed by the pinned @electron/fuses version', () => {
+    const numericFuseKeys = Object.values(FuseV1Options).filter(
+      (v): v is number => typeof v === 'number'
+    )
+    for (const fuseKey of numericFuseKeys) {
+      expect(
+        FUSE_BASELINE,
+        `FUSE_BASELINE is missing a declaration for FuseV1Options=${FuseV1Options[fuseKey]} (${fuseKey})`
+      ).toHaveProperty(String(fuseKey))
+    }
+  })
+
+  it('enables OnlyLoadAppFromAsar', () => {
+    expect(FUSE_BASELINE[FuseV1Options.OnlyLoadAppFromAsar]).toBe(true)
+  })
+
+  it('keeps RunAsNode disabled', () => {
+    expect(FUSE_BASELINE[FuseV1Options.RunAsNode]).toBe(false)
+  })
+
+  it('enables embedded ASAR integrity validation (pairs with OnlyLoadAppFromAsar)', () => {
+    expect(FUSE_BASELINE[FuseV1Options.EnableEmbeddedAsarIntegrityValidation]).toBe(true)
+  })
+
+  it('keeps EnableNodeOptionsEnvironmentVariable and EnableNodeCliInspectArguments disabled', () => {
+    expect(FUSE_BASELINE[FuseV1Options.EnableNodeOptionsEnvironmentVariable]).toBe(false)
+    expect(FUSE_BASELINE[FuseV1Options.EnableNodeCliInspectArguments]).toBe(false)
+  })
+
+  it('enables EnableCookieEncryption', () => {
+    expect(FUSE_BASELINE[FuseV1Options.EnableCookieEncryption]).toBe(true)
+  })
+
+  it('requests resetAdHocDarwinSignature so ad-hoc-signed macOS builds get re-signed post-flip', () => {
+    expect(FUSE_BASELINE.resetAdHocDarwinSignature).toBe(true)
+  })
+})

--- a/tests/main/scripts/packaged-electron-app.test.ts
+++ b/tests/main/scripts/packaged-electron-app.test.ts
@@ -14,21 +14,26 @@ describe('resolveLinuxPackagedBinary', () => {
     createdDirs.length = 0
   })
 
-  function makeReleaseDir(files: string[]): string {
+  function makeReleaseDir(layout: { unpackedBinary?: boolean; otherFiles?: string[] }): string {
     const root = mkdtempSync(join(tmpdir(), 'varlens-packaged-test-'))
     const release = join(root, 'release')
     mkdirSync(release, { recursive: true })
-    for (const name of files) {
+    if (layout.unpackedBinary === true) {
+      const unpackedDir = join(release, 'linux-unpacked')
+      mkdirSync(unpackedDir, { recursive: true })
+      writeFileSync(join(unpackedDir, 'varlens'), 'placeholder')
+    }
+    for (const name of layout.otherFiles ?? []) {
       writeFileSync(join(release, name), 'placeholder')
     }
     createdDirs.push(root)
     return root
   }
 
-  it('returns the path to the AppImage when present', () => {
-    const root = makeReleaseDir(['Varlens-0.56.5.AppImage', 'Varlens-0.56.5.deb'])
+  it('returns the unpacked Electron binary path when present', () => {
+    const root = makeReleaseDir({ unpackedBinary: true, otherFiles: ['Varlens-0.56.5.AppImage'] })
     const resolved = resolveLinuxPackagedBinary(root)
-    expect(resolved).toBe(join(root, 'release', 'Varlens-0.56.5.AppImage'))
+    expect(resolved).toBe(join(root, 'release', 'linux-unpacked', 'varlens'))
   })
 
   it('throws when release/ is missing', () => {
@@ -37,8 +42,8 @@ describe('resolveLinuxPackagedBinary', () => {
     expect(() => resolveLinuxPackagedBinary(root)).toThrow(/release\/ does not exist/)
   })
 
-  it('throws when no AppImage is produced', () => {
-    const root = makeReleaseDir(['Varlens-0.56.5.deb'])
-    expect(() => resolveLinuxPackagedBinary(root)).toThrow(/No \.AppImage found/)
+  it('throws when linux-unpacked/varlens is missing', () => {
+    const root = makeReleaseDir({ unpackedBinary: false, otherFiles: ['Varlens-0.56.5.AppImage'] })
+    expect(() => resolveLinuxPackagedBinary(root)).toThrow(/Expected .*linux-unpacked\/varlens to exist/)
   })
 })

--- a/tests/main/scripts/packaged-electron-app.test.ts
+++ b/tests/main/scripts/packaged-electron-app.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { resolveLinuxPackagedBinary } from '../../e2e/helpers/packaged-electron-app'
+
+describe('resolveLinuxPackagedBinary', () => {
+  const createdDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of createdDirs) {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
+    }
+    createdDirs.length = 0
+  })
+
+  function makeReleaseDir(files: string[]): string {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-packaged-test-'))
+    const release = join(root, 'release')
+    mkdirSync(release, { recursive: true })
+    for (const name of files) {
+      writeFileSync(join(release, name), 'placeholder')
+    }
+    createdDirs.push(root)
+    return root
+  }
+
+  it('returns the path to the AppImage when present', () => {
+    const root = makeReleaseDir(['Varlens-0.56.5.AppImage', 'Varlens-0.56.5.deb'])
+    const resolved = resolveLinuxPackagedBinary(root)
+    expect(resolved).toBe(join(root, 'release', 'Varlens-0.56.5.AppImage'))
+  })
+
+  it('throws when release/ is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-packaged-test-'))
+    createdDirs.push(root)
+    expect(() => resolveLinuxPackagedBinary(root)).toThrow(/release\/ does not exist/)
+  })
+
+  it('throws when no AppImage is produced', () => {
+    const root = makeReleaseDir(['Varlens-0.56.5.deb'])
+    expect(() => resolveLinuxPackagedBinary(root)).toThrow(/No \.AppImage found/)
+  })
+})

--- a/tests/main/scripts/packaged-electron-app.test.ts
+++ b/tests/main/scripts/packaged-electron-app.test.ts
@@ -44,6 +44,8 @@ describe('resolveLinuxPackagedBinary', () => {
 
   it('throws when linux-unpacked/varlens is missing', () => {
     const root = makeReleaseDir({ unpackedBinary: false, otherFiles: ['Varlens-0.56.5.AppImage'] })
-    expect(() => resolveLinuxPackagedBinary(root)).toThrow(/Expected .*linux-unpacked\/varlens to exist/)
+    expect(() => resolveLinuxPackagedBinary(root)).toThrow(
+      /Expected .*linux-unpacked\/varlens to exist/
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Flips `onlyLoadAppFromAsar: true` in packaged builds; moves fuse configuration into an `afterPack` hook (`scripts/configure-fuses.mjs`) that calls `context.packager.addElectronFuses(...)` with `strictlyRequireAllFuses: true` so Electron upgrades that introduce new fuses fail the build until the baseline declares them.
- Adds a Linux packaged-binary smoke test (`tests/e2e/packaged-smoke.e2e.ts`) that launches `release/linux-unpacked/varlens` via `child_process.spawn` and waits for the `IPC handlers registered` log line — catches boot regressions the existing unpacked startup smoke can't see.
- Wires the new smoke into `make ci-packaged-smoke-linux`, `make ci-full`, and the Linux job in `.github/workflows/build.yml`.

## Design docs

- Spec: `.planning/specs/2026-04-22-electron-fuse-hardening-design.md`
- Plan: `.planning/plans/2026-04-22-electron-fuse-hardening-plan.md`
- Addresses Priority A from `.planning/code-review/CODEBASE-REVIEW-2026-04-22.md`.

## Notable design pivots (documented in commits + spec)

1. **Unpacked binary over AppImage** for the smoke target. AppImage requires `libfuse2` even with `--appimage-extract-and-run`; many runners lack it. The unpacked binary has the same flipped fuses (verified via `getCurrentFuseWire`) and launches with zero FUSE dependency.
2. **`child_process.spawn` over Playwright `_electron.launch`.** Playwright injects `--inspect=0` (verified at `node_modules/playwright-core/lib/server/electron/electron.js:131`), which is blocked by `EnableNodeCliInspectArguments: false`. Renderer-interactive assertions are preserved by the existing unpacked `startup-smoke.e2e.ts`.

## Test plan

- [x] `make ci-full` green (checks, startup smoke, package linux, packaged smoke).
- [x] Manual `getCurrentFuseWire` on the packaged binary confirmed `OnlyLoadAppFromAsar: ENABLE`, `RunAsNode: DISABLE`, `EnableEmbeddedAsarIntegrityValidation: ENABLE`.
- [x] `FUSE_BASELINE` unit test — 9/9 pass, covers every `FuseV1Options` key plus strict-require.
- [x] Path-resolution unit test for `resolveLinuxPackagedBinary` — 3/3 pass (happy path, missing release/, missing binary).
- [x] `perf-audit-monkey.e2e.ts` passes against the fuse-flipped build (rapid Case/Cohort switching, cohort pagination stress).
- [ ] CI parity confirms on GitHub Actions runners (Linux + Windows + macOS) once this PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)