### PR TITLE
[codex] add postgres storage session phase 2 scaffold

### DIFF
--- a/.planning/plans/2026-04-23-postgres-storage-session-phase-2-plan.md
+++ b/.planning/plans/2026-04-23-postgres-storage-session-phase-2-plan.md
@@ -1,0 +1,627 @@
+# PostgreSQL Storage Session — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a real PostgreSQL-backed `StorageSession` plus validated config, pool lifecycle, workspace metadata, and health reporting without claiming repository portability.
+
+**Architecture:** This phase keeps SQLite as the operational default and adds PostgreSQL only at the session/lifecycle layer. `PostgresStorageSession` owns a `pg.Pool`, reports redacted workspace identity and explicit capabilities, and exposes structured health checks. Repository migration, worker redesign, renderer backend switching, and schema-path mutation remain out of scope.
+
+**Tech Stack:** Electron 40, TypeScript 6, `pg`, Vitest, existing storage/session boundary, Docker PostgreSQL 18 dev workflow.
+
+---
+
+## File Structure
+
+**Created:**
+- `src/main/storage/postgres/PostgresStorageSession.ts` — PostgreSQL session implementation backed by `pg.Pool`.
+- `tests/main/storage/postgres-storage-session.test.ts` — unit tests for metadata, capabilities, pool lifecycle, unsupported compatibility methods, and health behavior.
+
+**Modified:**
+- `package.json` — add `pg` dependency.
+- `package-lock.json` — lockfile update for `pg`.
+- `src/main/storage/config.ts` — replace minimal dev config parsing with normalized PostgreSQL storage config parsing, pool option shaping, and redaction helpers.
+- `tests/main/storage/config.test.ts` — extend config coverage for defaults, validation, redaction, and `PoolConfig` shaping.
+- `src/shared/ipc/domains/database.ts` — additive storage metadata only if Phase 2 exposes backend info through existing IPC.
+- `src/preload/domains/database.ts` — only if the shared contract changes additively.
+- `src/main/ipc/domains/database.ts` — only if session metadata is exposed through the main IPC registration layer.
+- `src/main/ipc/handlers/database-logic.ts` — only if additive backend/session metadata is surfaced through existing `database:*` handlers.
+
+**Not touched in Phase 2:**
+- Repository implementations under `src/main/database/`.
+- `src/main/database/BaseRepository.ts`.
+- import/export/delete workers.
+- renderer backend selection UI.
+- generic multi-backend `DatabaseManager` switching unless the task requires it explicitly.
+- any `search_path` session mutation.
+
+---
+
+### Task 1: Add the PostgreSQL runtime dependency
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Add `pg` to dependencies**
+
+Update `package.json` dependencies with the current approved `pg` release used by the implementation:
+
+```json
+"pg": "^8.x"
+```
+
+Place it alphabetically with the existing production dependencies.
+
+- [ ] **Step 2: Refresh the lockfile**
+
+Run:
+
+```bash
+npm install
+```
+
+Expected:
+- `package-lock.json` updated with `pg` and its transitive dependencies
+- no other intentional dependency changes beyond the lock refresh
+
+- [ ] **Step 3: Verify the dependency is present**
+
+Run:
+
+```bash
+node -p "require('./package.json').dependencies.pg"
+```
+
+Expected:
+- a `^8.x` `pg` version string
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore(storage): add postgres session runtime dependency"
+```
+
+---
+
+### Task 2: Expand PostgreSQL config parsing, validation, and pool option shaping
+
+**Files:**
+- Modify: `src/main/storage/config.ts`
+- Modify: `tests/main/storage/config.test.ts`
+
+- [ ] **Step 1: Write the failing config and pool-shaping tests**
+
+Add tests to `tests/main/storage/config.test.ts` covering:
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPostgresConnectionLabel,
+  buildPostgresPoolConfig,
+  getPostgresStorageConfig,
+  redactPostgresConnectionUrl
+} from '../../../src/main/storage/config'
+
+describe('getPostgresStorageConfig', () => {
+  it('returns null when postgres env is absent', () => {
+    expect(getPostgresStorageConfig({})).toBeNull()
+  })
+
+  it('returns normalized defaults for schema, application name, timeouts, and pool size', () => {
+    expect(
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev'
+      })
+    ).toEqual({
+      url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      schema: 'public',
+      applicationName: 'varlens-main',
+      sslMode: 'disable',
+      connectionTimeoutMillis: 5000,
+      statementTimeoutMs: 30000,
+      queryTimeoutMs: 30000,
+      lockTimeoutMs: 5000,
+      idleInTransactionSessionTimeoutMs: 10000,
+      poolMax: 4
+    })
+  })
+
+  it('rejects an invalid ssl mode', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SSL_MODE: 'bogus'
+      })
+    ).toThrow('Invalid VARLENS_PG_SSL_MODE')
+  })
+
+  it('rejects a blank schema after trimming', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SCHEMA: '   '
+      })
+    ).toThrow('VARLENS_PG_SCHEMA')
+  })
+
+  it('rejects invalid numeric timeout values', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_QUERY_TIMEOUT_MS: '-1'
+      })
+    ).toThrow('VARLENS_PG_QUERY_TIMEOUT_MS')
+  })
+
+  it('rejects pool sizes smaller than 1', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_POOL_MAX: '0'
+      })
+    ).toThrow('VARLENS_PG_POOL_MAX')
+  })
+})
+
+describe('redactPostgresConnectionUrl', () => {
+  it('removes credentials while preserving the target database', () => {
+    expect(
+      redactPostgresConnectionUrl('postgres://varlens:secret@127.0.0.1:55432/varlens_dev')
+    ).toBe('postgres://127.0.0.1:55432/varlens_dev')
+  })
+})
+
+describe('buildPostgresConnectionLabel', () => {
+  it('formats host, port, database, and schema', () => {
+    expect(
+      buildPostgresConnectionLabel('postgres://127.0.0.1:55432/varlens_dev', 'public')
+    ).toBe('127.0.0.1:55432/varlens_dev (public)')
+  })
+})
+
+describe('buildPostgresPoolConfig', () => {
+  it('maps normalized config into pg pool options without search_path mutation', () => {
+    const config = getPostgresStorageConfig({
+      VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      VARLENS_PG_SCHEMA: 'varlens'
+    })
+
+    expect(buildPostgresPoolConfig(config!)).toMatchObject({
+      connectionString: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      application_name: 'varlens-main',
+      connectionTimeoutMillis: 5000,
+      statement_timeout: 30000,
+      query_timeout: 30000,
+      lock_timeout: 5000,
+      idle_in_transaction_session_timeout: 10000,
+      max: 4
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the config tests and confirm they fail**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/config.test.ts
+```
+
+Expected:
+- FAIL because the new config shape and helper functions do not exist yet
+
+- [ ] **Step 3: Implement normalized config parsing and pool shaping**
+
+Update `src/main/storage/config.ts` to add:
+
+- `PostgresSslMode`
+- `PostgresStorageConfig`
+- explicit defaults for schema, app name, timeouts, and pool size
+- numeric env parsing helper with validation
+- `getPostgresStorageConfig(...)`
+- `redactPostgresConnectionUrl(...)`
+- `buildPostgresConnectionLabel(...)`
+- `buildPostgresPoolConfig(...)`
+
+Implementation requirements:
+
+- `buildPostgresPoolConfig(...)` must map `sslMode` into a deterministic `ssl` setting
+- no support in Phase 2 for mutating `search_path`
+- no support in Phase 2 for mixing conflicting URL SSL parameters with separately managed SSL config
+- config parsing stays side-effect-free and testable
+
+- [ ] **Step 4: Run the config tests and confirm they pass**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/config.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/storage/config.ts tests/main/storage/config.test.ts
+git commit -m "feat(storage): expand postgres session config parsing"
+```
+
+---
+
+### Task 3: Add `PostgresStorageSession`
+
+**Files:**
+- Create: `src/main/storage/postgres/PostgresStorageSession.ts`
+- Test: `tests/main/storage/postgres-storage-session.test.ts`
+
+- [ ] **Step 1: Write the failing PostgreSQL session tests**
+
+Create tests in `tests/main/storage/postgres-storage-session.test.ts` covering:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PostgresStorageConfig } from '../../../src/main/storage/config'
+import { PostgresStorageSession } from '../../../src/main/storage/postgres/PostgresStorageSession'
+
+function makeConfig(overrides: Partial<PostgresStorageConfig> = {}): PostgresStorageConfig {
+  return {
+    url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+    schema: 'public',
+    applicationName: 'varlens-main',
+    sslMode: 'disable',
+    connectionTimeoutMillis: 5000,
+    statementTimeoutMs: 30000,
+    queryTimeoutMs: 30000,
+    lockTimeoutMs: 5000,
+    idleInTransactionSessionTimeoutMs: 10000,
+    poolMax: 4,
+    ...overrides
+  }
+}
+
+describe('PostgresStorageSession', () => {
+  it('exposes redacted workspace metadata and explicit postgres capabilities', () => {
+    const pool = {
+      query: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn()
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never
+    })
+
+    expect(pool.on).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(session.workspace.kind).toBe('postgres')
+    expect(session.workspace.connectionUrlRedacted).toBe(
+      'postgres://127.0.0.1:55432/varlens_dev'
+    )
+    expect(session.workspace.connectionLabel).toBe('127.0.0.1:55432/varlens_dev (public)')
+    expect(session.capabilities).toEqual({
+      backend: 'postgres',
+      supportsEncryptionAtRest: false,
+      supportsLocalFileLifecycle: false,
+      supportsHostedConnectionLifecycle: true,
+      supportsWorkerReadPool: false,
+      supportsFullTextSearch: false
+    })
+  })
+
+  it('returns a healthy result when the round-trip query succeeds', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never
+    })
+
+    await expect(session.health()).resolves.toMatchObject({
+      ok: true,
+      backend: 'postgres'
+    })
+    expect(pool.query).toHaveBeenCalledWith('SELECT 1')
+  })
+
+  it('returns a failed health result when the round-trip query fails', async () => {
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: {
+        query: vi.fn().mockRejectedValue(new Error('connection refused')),
+        end: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn()
+      } as never
+    })
+
+    await expect(session.health()).resolves.toMatchObject({
+      ok: false,
+      backend: 'postgres',
+      message: 'connection refused'
+    })
+  })
+
+  it('throws for sqlite-only compatibility methods', () => {
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: {
+        query: vi.fn(),
+        end: vi.fn(),
+        on: vi.fn()
+      } as never
+    })
+
+    expect(() => session.getDatabaseService()).toThrow('DatabaseService is not available')
+    expect(() => session.getDbPool()).toThrow('DbPool is not available')
+    expect(() => session.rekey('secret')).toThrow('SQLite rekey is not supported')
+  })
+
+  it('closes the underlying pool', async () => {
+    const pool = {
+      query: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never
+    })
+
+    await session.close()
+    expect(pool.end).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run the PostgreSQL session tests and confirm they fail**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/postgres-storage-session.test.ts
+```
+
+Expected:
+- FAIL because `PostgresStorageSession` does not exist yet
+
+- [ ] **Step 3: Implement the session**
+
+Create `src/main/storage/postgres/PostgresStorageSession.ts` with:
+
+- constructor accepting normalized config and a `Pool`
+- workspace metadata derived via the config helpers
+- explicit PostgreSQL capabilities
+- `health()` implemented with `pool.query('SELECT 1')`
+- pool `error` listener registration
+- `close()` implemented with `pool.end()`
+- SQLite-only compatibility methods throwing clear errors
+
+- [ ] **Step 4: Run the PostgreSQL session tests and confirm they pass**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/postgres-storage-session.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/storage/postgres/PostgresStorageSession.ts tests/main/storage/postgres-storage-session.test.ts
+git commit -m "feat(storage): add postgres storage session"
+```
+
+---
+
+### Task 4: Add a small pool factory boundary
+
+**Files:**
+- Modify: `src/main/storage/config.ts`
+- Modify: `tests/main/storage/config.test.ts`
+
+- [ ] **Step 1: Add a focused test for SSL mapping**
+
+Extend `tests/main/storage/config.test.ts` with coverage for:
+
+```ts
+it('maps ssl mode require into a pool ssl object', () => {
+  const config = getPostgresStorageConfig({
+    VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+    VARLENS_PG_SSL_MODE: 'require'
+  })
+
+  expect(buildPostgresPoolConfig(config!)).toMatchObject({
+    ssl: expect.any(Object)
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused config tests**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/config.test.ts
+```
+
+Expected:
+- FAIL if SSL mapping is not implemented yet
+
+- [ ] **Step 3: Finalize the pool helper**
+
+Ensure the helper:
+
+- maps `disable` to no SSL config
+- maps `prefer` and `require` into explicit `ssl` behavior chosen for Phase 2
+- does not set `search_path`
+- keeps all timeout and pool bounds explicit
+
+- [ ] **Step 4: Re-run the focused config tests**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/config.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/storage/config.ts tests/main/storage/config.test.ts
+git commit -m "refactor(storage): add postgres pool config helper"
+```
+
+---
+
+### Task 5: Add additive lifecycle metadata only if needed
+
+**Files:**
+- Modify only if required:
+  - `src/shared/ipc/domains/database.ts`
+  - `src/preload/domains/database.ts`
+  - `src/main/ipc/domains/database.ts`
+  - `src/main/ipc/handlers/database-logic.ts`
+
+- [ ] **Step 1: Inspect whether existing database metadata flows need backend/session info**
+
+Review the current `database:*` contract and choose the smallest additive surface.
+
+Rule:
+- if no current verification or consumer needs PostgreSQL metadata yet, skip this task entirely
+
+- [ ] **Step 2: If needed, add only backend kind and redacted workspace metadata**
+
+Allowed additions:
+- backend kind
+- redacted workspace ref
+- capability flags
+
+Disallowed additions:
+- backend switching commands
+- Postgres repository access
+- raw URLs or credentials
+
+- [ ] **Step 3: Run the affected tests**
+
+Run the smallest relevant suite, for example:
+
+```bash
+npx vitest run tests/main/handlers/database-logic.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/ipc/domains/database.ts src/preload/domains/database.ts src/main/ipc/domains/database.ts src/main/ipc/handlers/database-logic.ts
+git commit -m "feat(storage): expose additive postgres session metadata"
+```
+
+Skip the commit if no files changed because the task was intentionally unnecessary.
+
+---
+
+### Task 6: Verify the slice end-to-end at the unit boundary
+
+**Files:**
+- No new files required
+
+- [ ] **Step 1: Run focused PostgreSQL storage tests**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/config.test.ts tests/main/storage/postgres-storage-session.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 2: Run any adjacent storage/lifecycle tests touched by the implementation**
+
+Run:
+
+```bash
+npx vitest run tests/main/storage/*.test.ts tests/main/services/DatabaseManager.test.ts tests/main/handlers/database-logic.test.ts
+```
+
+Expected:
+- PASS for affected suites
+
+- [ ] **Step 3: Run repo-standard verification**
+
+Run:
+
+```bash
+make ci
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 4: Commit any remaining verification-driven fixes**
+
+```bash
+git add -A
+git commit -m "test(storage): verify postgres session phase 2"
+```
+
+Only do this if verification required a real code change after the earlier commits.
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+This plan covers:
+
+- `pg` adoption
+- normalized config with explicit defaults
+- pool config shaping
+- SSL normalization
+- explicit no-`search_path` rule
+- session lifecycle and `health()`
+- capability and workspace metadata
+- additive IPC only if needed
+- focused verification plus `make ci`
+
+### Placeholder scan
+
+Intended implementation choices remain explicit:
+
+- no repository portability
+- no backend switcher
+- no search-path mutation
+- no raw credential exposure
+- no vague “add validation later” steps
+
+### Type consistency
+
+The plan consistently uses:
+
+- `PostgresStorageConfig`
+- `buildPostgresPoolConfig(...)`
+- `PostgresStorageSession`
+- `health()`
+- existing `StorageSession` compatibility methods
+
+No later task introduces alternative names for the same concepts.

--- a/.planning/specs/2026-04-23-postgres-storage-session-phase-2-design.md
+++ b/.planning/specs/2026-04-23-postgres-storage-session-phase-2-design.md
@@ -1,0 +1,520 @@
+# PostgreSQL Storage Session — Phase 2 Design
+
+**Date:** 2026-04-23  
+**Status:** Draft v2  
+**Depends on:** `2026-04-23-storage-adapter-boundary-design.md`, `2026-04-23-storage-adapter-phase-1-scaffold-plan.md`  
+**Motivation:** Phase 1 created the storage-session boundary and local PostgreSQL development workflow. Phase 2 should add the first real PostgreSQL runtime object behind that boundary without pretending the existing SQLite repositories are already portable.
+
+## Summary
+
+Phase 2 introduces a backend-specific `PostgresStorageSession` and replaces the current PostgreSQL development placeholder config with a real, validated session-level config shape.
+
+This phase is intentionally narrow:
+
+- **Do** add a real PostgreSQL session implementation.
+- **Do** add validated environment-backed PostgreSQL config parsing.
+- **Do** add a `pg.Pool` factory with explicit lifecycle and timeout configuration.
+- **Do** expose PostgreSQL workspace metadata, capability reporting, and health checks.
+- **Do** keep lifecycle and IPC changes additive where needed.
+- **Do not** migrate repositories.
+- **Do not** redesign workers.
+- **Do not** add renderer-facing backend switching UI.
+- **Do not** implicitly mutate PostgreSQL `search_path` in this phase.
+
+This is the first honest PostgreSQL runtime slice after the Phase 1 boundary work. It proves that the new storage seam can carry a second backend at the lifecycle level before any data-access portability work begins.
+
+## Why this is the next step
+
+The 2026-04-22 codebase review kept **Priority C** open: create a real storage boundary before starting PostgreSQL work. That boundary now exists on `main`.
+
+The next safe step is therefore not repository portability. It is session-level backend reality:
+
+- a concrete PostgreSQL session object,
+- a concrete configuration source,
+- explicit pool configuration and lifecycle,
+- concrete backend capability reporting,
+- and a concrete health/readiness signal.
+
+That gives later phases a real target to integrate against without creating false claims that a single query layer already works across SQLite and PostgreSQL.
+
+## Design goals
+
+1. Add a real `PostgresStorageSession` that satisfies the current `StorageSession` contract.
+2. Define a validated PostgreSQL config shape for VarLens main-process lifecycle code.
+3. Own PostgreSQL connection pooling explicitly through `pg.Pool`.
+4. Report PostgreSQL workspace identity without exposing raw credentials.
+5. Provide a reliable `health()` implementation for connection verification.
+6. Keep renderer and IPC changes additive and backward-compatible.
+7. Preserve the rule that repository migration is a later phase.
+
+## Non-goals
+
+- No query portability across SQLite and PostgreSQL.
+- No Postgres-backed repository implementations yet.
+- No `DatabaseManager` default switch from SQLite to PostgreSQL.
+- No worker/executor redesign.
+- No schema migration framework for PostgreSQL in this phase.
+- No renderer settings UI for backend selection.
+- No production secrets-management story beyond explicit environment parsing.
+- No automatic `search_path` manipulation.
+- No claim that PostgreSQL-specific features such as FTS are operationally available yet.
+
+## Current codebase reality
+
+After Phase 1, the relevant storage pieces are:
+
+- [`src/main/storage/session.ts`](<../../src/main/storage/session.ts>) defines the session contract.
+- [`src/main/storage/types.ts`](<../../src/main/storage/types.ts>) defines `StorageCapabilities`, `WorkspaceRef`, and `StorageHealth`.
+- [`src/main/storage/config.ts`](<../../src/main/storage/config.ts>) currently parses only a minimal `{ url, schema }` development config.
+- [`src/main/storage/sqlite/SqliteStorageSession.ts`](<../../src/main/storage/sqlite/SqliteStorageSession.ts>) is the reference implementation of the session contract.
+- [`src/main/services/DatabaseManager.ts`](<../../src/main/services/DatabaseManager.ts>) is now session-backed but remains SQLite-oriented in lifecycle behavior.
+
+That means Phase 2 should add a second session implementation and stronger config parsing without prematurely forcing `DatabaseManager` to become a full multi-backend switchboard.
+
+## Driver choice
+
+Phase 2 uses **`pg`** (`node-postgres`) rather than `postgres` (`postgres.js`).
+
+Reasons:
+
+- it fits the existing Electron main-process service style better,
+- pooled connection lifecycle is explicit,
+- `Pool` is the documented normal mode for application use,
+- health-check behavior is straightforward and unsurprising,
+- it is the more conservative choice for a first backend scaffold.
+
+The design assumes a single long-lived `Pool` owned by `PostgresStorageSession`.
+
+## Proposed architecture
+
+### Core shape
+
+Add:
+
+- `src/main/storage/postgres/PostgresStorageSession.ts`
+- pool/config helpers in `src/main/storage/config.ts`
+
+The session boundary then looks like:
+
+```text
+StorageManager / lifecycle code
+        |
+  StorageSession
+   /         \
+SQLite       Postgres
+session      session
+  |             |
+DatabaseService  pg.Pool
+DbPool           session metadata + health
+```
+
+### Session responsibilities
+
+`PostgresStorageSession` is responsible for:
+
+- owning the PostgreSQL pool,
+- wiring a pool `error` listener,
+- exposing redacted workspace identity,
+- reporting backend capabilities,
+- implementing `health()` via a minimal round-trip query,
+- closing the pool cleanly with `pool.end()`.
+
+It is **not** responsible for:
+
+- repository assembly,
+- SQL portability,
+- import/export execution,
+- worker orchestration,
+- renderer-specific concerns.
+
+## PostgreSQL config design
+
+Phase 1 used:
+
+```ts
+export interface PostgresDevConfig {
+  url: string
+  schema: string
+}
+```
+
+Phase 2 should replace that with a real config shape:
+
+```ts
+export type PostgresSslMode = 'disable' | 'prefer' | 'require'
+
+export interface PostgresStorageConfig {
+  url: string
+  schema: string
+  applicationName: string
+  sslMode: PostgresSslMode
+  connectionTimeoutMillis: number
+  statementTimeoutMs: number
+  queryTimeoutMs: number
+  lockTimeoutMs: number
+  idleInTransactionSessionTimeoutMs: number
+  poolMax: number
+}
+```
+
+### Environment contract
+
+Environment variables:
+
+- `VARLENS_PG_URL` — required to enable PostgreSQL config
+- `VARLENS_PG_SCHEMA` — optional, defaults to `public`
+- `VARLENS_PG_APPLICATION_NAME` — optional, defaults to `varlens-main`
+- `VARLENS_PG_SSL_MODE` — optional, defaults to `disable`
+- `VARLENS_PG_CONNECTION_TIMEOUT_MS` — optional, defaults to a nonzero value
+- `VARLENS_PG_STATEMENT_TIMEOUT_MS` — optional, defaults to a nonzero value
+- `VARLENS_PG_QUERY_TIMEOUT_MS` — optional, defaults to a nonzero value
+- `VARLENS_PG_LOCK_TIMEOUT_MS` — optional, defaults to a nonzero value
+- `VARLENS_PG_IDLE_IN_TX_TIMEOUT_MS` — optional, defaults to a nonzero value
+- `VARLENS_PG_POOL_MAX` — optional, defaults to a small desktop-appropriate pool size
+
+### Recommended defaults
+
+Phase 2 should choose explicit defaults rather than inheriting driver defaults silently:
+
+- `schema`: `public`
+- `applicationName`: `varlens-main`
+- `sslMode`: `disable`
+- `connectionTimeoutMillis`: `5000`
+- `statementTimeoutMs`: `30000`
+- `queryTimeoutMs`: `30000`
+- `lockTimeoutMs`: `5000`
+- `idleInTransactionSessionTimeoutMs`: `10000`
+- `poolMax`: `4`
+
+These values are intentionally conservative for a single-user desktop app. The exact numbers can still be revised during implementation if local verification shows a mismatch, but the design should require explicit, bounded settings.
+
+### Parsing rules
+
+- If `VARLENS_PG_URL` is absent or empty, return `null`.
+- If present, return a fully normalized config object.
+- Reject invalid `sslMode` values.
+- Reject empty schema strings after trimming.
+- Reject non-numeric or negative timeout values.
+- Reject `poolMax < 1`.
+- Keep parsing side-effect-free and testable.
+
+Phase 2 should continue treating PostgreSQL config as opt-in rather than as the default app path.
+
+## Pool option shaping
+
+The session should not pass environment strings directly into `pg.Pool`.
+
+Instead, `src/main/storage/config.ts` should expose a helper that converts `PostgresStorageConfig` into the exact `PoolConfig` shape used by `pg`.
+
+The helper should:
+
+- set `connectionString` from `config.url`,
+- set `application_name` from `config.applicationName`,
+- set `connectionTimeoutMillis`,
+- set `statement_timeout`,
+- set `query_timeout`,
+- set `lock_timeout`,
+- set `idle_in_transaction_session_timeout`,
+- set `max` from `config.poolMax`,
+- map `sslMode` deterministically into a `ssl` setting.
+
+### SSL rule
+
+Phase 2 should avoid ambiguous SSL behavior.
+
+Recommended rule:
+
+- treat `sslMode` as the single source of truth for pool SSL configuration,
+- do not add support in this phase for mixing URL-level SSL parameters with a separate `ssl` object,
+- document that URLs containing libpq-style SSL parameters are unsupported in Phase 2 if they conflict with VarLens-managed SSL configuration.
+
+That avoids the `node-postgres` config collision where URL SSL fields can override or replace the supplied `ssl` object.
+
+## Schema handling
+
+The `schema` field belongs in config and workspace metadata in Phase 2, but it should **not** trigger automatic `search_path` mutation yet.
+
+Reason:
+
+- PostgreSQL treats schemas on `search_path` as trusted resolution targets,
+- a session-level `search_path` policy is a real design decision,
+- VarLens does not yet have PostgreSQL repositories that need this behavior.
+
+Phase 2 rule:
+
+- keep `schema` as validated metadata only,
+- do not run `SET search_path`,
+- do not use `Pool` connect hooks to modify session state,
+- defer any `search_path` strategy to the first repository portability phase.
+
+## Workspace identity and redaction
+
+`WorkspaceRef` for PostgreSQL already exists:
+
+```ts
+{
+  kind: 'postgres'
+  connectionLabel: string
+  connectionUrlRedacted: string
+  schema: string
+}
+```
+
+Phase 2 must define how those fields are populated.
+
+### Redaction rules
+
+The raw URL must never be surfaced in workspace metadata, logs, health output, or IPC payloads.
+
+Recommended redaction behavior:
+
+- preserve protocol, host, port, and database name,
+- strip username and password from the visible URL,
+- if no database name is present, still return a syntactically meaningful redacted target.
+
+Example:
+
+```text
+postgres://varlens:secret@127.0.0.1:55432/varlens_dev
+```
+
+becomes:
+
+```text
+postgres://127.0.0.1:55432/varlens_dev
+```
+
+`connectionLabel` should be human-oriented and stable enough for UI and logs later. In Phase 2 it can be derived from host, port, database, and schema.
+
+Example:
+
+```text
+127.0.0.1:55432/varlens_dev (public)
+```
+
+## Capabilities design
+
+Phase 2 should explicitly report PostgreSQL capabilities rather than guessing from future goals.
+
+Recommended initial PostgreSQL capabilities:
+
+```ts
+{
+  backend: 'postgres',
+  supportsEncryptionAtRest: false,
+  supportsLocalFileLifecycle: false,
+  supportsHostedConnectionLifecycle: true,
+  supportsWorkerReadPool: false,
+  supportsFullTextSearch: false
+}
+```
+
+Rationale:
+
+- `supportsEncryptionAtRest`: VarLens does not control PostgreSQL at-rest encryption in this phase, so claiming `true` would be misleading.
+- `supportsLocalFileLifecycle`: false by definition.
+- `supportsHostedConnectionLifecycle`: true is the main point of the backend.
+- `supportsWorkerReadPool`: false until a PostgreSQL executor strategy actually exists.
+- `supportsFullTextSearch`: PostgreSQL can support FTS in general, but VarLens does not implement it yet, so Phase 2 should report actual app capability, not theoretical database capability.
+
+This keeps capability reporting operationally honest.
+
+## `PostgresStorageSession` contract behavior
+
+`PostgresStorageSession` should satisfy the existing `StorageSession` interface, but some methods are compatibility-only and therefore intentionally unsupported for PostgreSQL in Phase 2.
+
+### Supported methods
+
+- `workspace`
+- `capabilities`
+- `health()`
+- `close()`
+
+### Compatibility methods
+
+- `getDatabaseService()`
+- `getDbPool()`
+- `getEncryptionKey()`
+- `needsStartupRebuild()`
+- `rekey(newPassword: string)`
+
+For Phase 2, SQLite-only methods should fail explicitly and predictably for PostgreSQL rather than returning fake SQLite-shaped values.
+
+Recommended rule:
+
+- methods that only make sense for SQLite should throw a descriptive error such as:
+  - `DatabaseService is not available for postgres sessions`
+  - `DbPool is not available for postgres sessions`
+  - `SQLite rekey is not supported for postgres sessions`
+
+That is preferable to inventing null-like fallback behavior that would hide incorrect call paths.
+
+## Health-check design
+
+`health()` should run a minimal round-trip query through the PostgreSQL pool.
+
+Recommended query:
+
+```sql
+SELECT 1
+```
+
+Recommended behavior:
+
+- use `pool.query('SELECT 1')` directly rather than a checked-out client,
+- measure round-trip latency around the call,
+- return a structured failure payload rather than throwing.
+
+Return:
+
+```ts
+{
+  ok: true,
+  backend: 'postgres',
+  roundTripMs: ...
+}
+```
+
+or on failure:
+
+```ts
+{
+  ok: false,
+  backend: 'postgres',
+  message: ...,
+  roundTripMs: ...
+}
+```
+
+## Lifecycle design
+
+### Pool lifecycle
+
+The pool should be long-lived and session-owned.
+
+Phase 2 rules:
+
+- `PostgresStorageSession` constructs or receives a single `Pool`,
+- the session registers an `error` handler for background idle-client failures,
+- `close()` calls `pool.end()`,
+- `health()` and any future single-query session checks use `pool.query(...)`,
+- transaction behavior remains out of scope for this phase.
+
+### `DatabaseManager`
+
+Do **not** turn `DatabaseManager` into a generic multi-backend switcher yet.
+
+Instead:
+
+- keep existing SQLite open/create/switch behavior as-is,
+- allow other code to construct and inspect a `PostgresStorageSession` directly in tests and targeted lifecycle utilities,
+- only add manager-level PostgreSQL methods if needed by the agreed verification path.
+
+This avoids over-designing a multi-backend orchestration API before the first real vertical slice exists.
+
+### IPC
+
+Any IPC changes should be additive and low-risk.
+
+Good Phase 2 changes:
+
+- expose backend kind in already-existing metadata flows if it can be done additively,
+- expose redacted workspace information if needed for diagnostics,
+- keep existing SQLite flows unchanged.
+
+Bad Phase 2 changes:
+
+- switching the renderer to backend-aware behavior,
+- adding a backend selector,
+- adding Postgres CRUD handlers for repositories that do not exist yet.
+
+## Testing strategy
+
+Phase 2 should stay mostly unit-level.
+
+Required coverage:
+
+- config parsing defaults
+- config parsing validation failures
+- numeric timeout validation
+- `poolMax` validation
+- redacted URL generation
+- label generation
+- pool option shaping from normalized config
+- capability reporting
+- unsupported SQLite-only compatibility methods
+- successful `health()` result
+- failed `health()` result
+- `close()` calling `pool.end()`
+- pool `error` listener registration behavior
+
+Optional integration coverage:
+
+- a local Docker-backed smoke test can be added later if the implementation work reveals value, but it is not required to make Phase 2 honest.
+
+## Verification gate
+
+Minimum verification before Phase 2 is called done:
+
+- focused Vitest coverage for config and PostgreSQL session tests
+- any touched storage-manager or database lifecycle tests
+- `make ci`
+
+`make ci-full` is optional for Phase 2 unless lifecycle integration expands into Electron startup or packaging behavior.
+
+## Risks and mitigations
+
+### Risk: accidental overreach into repository portability
+
+Mitigation:
+
+- keep repository interfaces and implementations out of scope,
+- do not modify `BaseRepository`,
+- do not wire PostgreSQL into case/variant handlers yet.
+
+### Risk: leaking credentials through workspace metadata or logs
+
+Mitigation:
+
+- centralize URL redaction,
+- never expose raw `VARLENS_PG_URL`,
+- test redaction directly.
+
+### Risk: silent pool misconfiguration
+
+Mitigation:
+
+- normalize config before pool creation,
+- validate numeric bounds,
+- test pool option shaping explicitly,
+- use explicit timeout defaults instead of inheriting driver defaults invisibly.
+
+### Risk: future schema behavior becoming inconsistent
+
+Mitigation:
+
+- keep `schema` as metadata only in Phase 2,
+- defer `search_path` policy until a repository phase that can justify it end-to-end.
+
+## Phase 2 exit criteria
+
+Phase 2 is complete when:
+
+- VarLens has a real `PostgresStorageSession` backed by `pg.Pool`,
+- PostgreSQL session config is normalized and validated from environment input,
+- workspace metadata is redacted and stable,
+- capability reporting is explicit and honest,
+- `health()` reports PostgreSQL readiness without throwing,
+- pool lifecycle is explicit and test-covered,
+- no repository portability claims have been introduced.
+
+## Sources
+
+- `pg` Pool API: <https://node-postgres.com/apis/pool>
+- `pg` Client config and timeout fields: <https://node-postgres.com/apis/client>
+- `pg` pooling guidance: <https://node-postgres.com/features/pooling>
+- `pg` transactions guidance: <https://node-postgres.com/features/transactions>
+- `pg` SSL behavior: <https://node-postgres.com/features/ssl>
+- PostgreSQL libpq connection params: <https://www.postgresql.org/docs/current/libpq-connect.html>
+- PostgreSQL client timeout settings: <https://www.postgresql.org/docs/18/runtime-config-client.html>
+- PostgreSQL schema and `search_path` behavior: <https://www.postgresql.org/docs/18/ddl-schemas.html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "markdown-it": "^14.1.0",
         "nanoid": "^5.1.9",
         "pdbe-molstar": "^3.11.0",
+        "pg": "^8.20.0",
         "pinia": "^3.0.4",
         "piscina": "^5.1.4",
         "plotly.js-basic-dist-min": "^3.5.0",
@@ -13136,6 +13137,95 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -13356,6 +13446,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postject": {
@@ -15184,6 +15313,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -17600,6 +17738,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/markdown-it": "^14.1.2",
         "@types/nock": "^11.1.0",
         "@types/node": "^25.6.0",
+        "@types/pg": "^8.20.0",
         "@types/plotly.js": "^3.0.10",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-v8": "^4.1.5",
@@ -4001,6 +4002,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "node_modules/@types/plist": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "markdown-it": "^14.1.0",
     "nanoid": "^5.1.9",
     "pdbe-molstar": "^3.11.0",
+    "pg": "^8.20.0",
     "pinia": "^3.0.4",
     "piscina": "^5.1.4",
     "plotly.js-basic-dist-min": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/markdown-it": "^14.1.2",
     "@types/nock": "^11.1.0",
     "@types/node": "^25.6.0",
+    "@types/pg": "^8.20.0",
     "@types/plotly.js": "^3.0.10",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.5",

--- a/src/main/storage/config.ts
+++ b/src/main/storage/config.ts
@@ -28,6 +28,24 @@ const DEFAULT_PG_POOL_MAX = 4
 const URL_SSL_PARAMS = ['sslmode', 'sslcert', 'sslkey', 'sslrootcert']
 const NON_NEGATIVE_INTEGER_PATTERN = /^\d+$/
 
+function parsePostgresUrl(url: string): URL {
+  let parsed: URL
+
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(
+      'VARLENS_PG_URL must be a valid PostgreSQL connection URL (for example, postgres://user:password@host:5432/database or postgresql://user:password@host:5432/database)'
+    )
+  }
+
+  if (parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:') {
+    throw new Error('VARLENS_PG_URL must use the postgres: or postgresql: scheme')
+  }
+
+  return parsed
+}
+
 function parseNonNegativeInteger(
   value: string | undefined,
   envName: string,
@@ -46,7 +64,7 @@ function parseNonNegativeInteger(
 }
 
 function assertNoManagedSslConflict(url: string): void {
-  const parsed = new URL(url)
+  const parsed = parsePostgresUrl(url)
 
   for (const param of URL_SSL_PARAMS) {
     if (parsed.searchParams.has(param)) {
@@ -135,9 +153,10 @@ export function getPostgresStorageConfig(
 }
 
 export function redactPostgresConnectionUrl(url: string): string {
-  const parsed = new URL(url)
+  const parsed = parsePostgresUrl(url)
   parsed.username = ''
   parsed.password = ''
+  parsed.search = ''
   return parsed.toString()
 }
 
@@ -161,7 +180,7 @@ function buildPostgresSslConfig(sslMode: PostgresSslMode): PoolConfig['ssl'] {
   }
 
   return {
-    rejectUnauthorized: false
+    rejectUnauthorized: true
   }
 }
 

--- a/src/main/storage/config.ts
+++ b/src/main/storage/config.ts
@@ -1,20 +1,169 @@
-export interface PostgresDevConfig {
+import type { PoolConfig } from 'pg'
+
+export type PostgresSslMode = 'disable' | 'prefer' | 'require'
+
+export interface PostgresStorageConfig {
   url: string
   schema: string
+  applicationName: string
+  sslMode: PostgresSslMode
+  connectionTimeoutMillis: number
+  statementTimeoutMs: number
+  queryTimeoutMs: number
+  lockTimeoutMs: number
+  idleInTransactionSessionTimeoutMs: number
+  poolMax: number
 }
 
-export function getPostgresDevConfig(
+const DEFAULT_PG_SCHEMA = 'public'
+const DEFAULT_PG_APPLICATION_NAME = 'varlens-main'
+const DEFAULT_PG_SSL_MODE: PostgresSslMode = 'disable'
+const DEFAULT_PG_CONNECTION_TIMEOUT_MS = 5000
+const DEFAULT_PG_STATEMENT_TIMEOUT_MS = 30000
+const DEFAULT_PG_QUERY_TIMEOUT_MS = 30000
+const DEFAULT_PG_LOCK_TIMEOUT_MS = 5000
+const DEFAULT_PG_IDLE_IN_TX_TIMEOUT_MS = 10000
+const DEFAULT_PG_POOL_MAX = 4
+
+const URL_SSL_PARAMS = ['sslmode', 'sslcert', 'sslkey', 'sslrootcert']
+
+function parseNonNegativeInteger(
+  value: string | undefined,
+  envName: string,
+  fallback: number
+): number {
+  if (value === undefined || value.trim() === '') {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${envName} must be a non-negative integer`)
+  }
+
+  return parsed
+}
+
+function assertNoManagedSslConflict(url: string): void {
+  const parsed = new URL(url)
+
+  for (const param of URL_SSL_PARAMS) {
+    if (parsed.searchParams.has(param)) {
+      throw new Error(
+        `VARLENS_PG_URL must not include ${param} when VarLens manages PostgreSQL SSL configuration`
+      )
+    }
+  }
+}
+
+export function getPostgresStorageConfig(
   env: NodeJS.ProcessEnv = process.env
-): PostgresDevConfig | null {
-  const url = env.VARLENS_PG_URL
-  const schema = env.VARLENS_PG_SCHEMA
+): PostgresStorageConfig | null {
+  const url = env.VARLENS_PG_URL?.trim()
 
   if (url === undefined || url === '') {
     return null
   }
 
+  const schema = env.VARLENS_PG_SCHEMA?.trim() ?? DEFAULT_PG_SCHEMA
+  if (schema === '') {
+    throw new Error('VARLENS_PG_SCHEMA must not be blank')
+  }
+
+  const applicationName =
+    env.VARLENS_PG_APPLICATION_NAME?.trim() || DEFAULT_PG_APPLICATION_NAME
+
+  const sslMode = (env.VARLENS_PG_SSL_MODE?.trim() || DEFAULT_PG_SSL_MODE) as PostgresSslMode
+  if (sslMode !== 'disable' && sslMode !== 'prefer' && sslMode !== 'require') {
+    throw new Error(`Invalid VARLENS_PG_SSL_MODE: ${sslMode}`)
+  }
+
+  assertNoManagedSslConflict(url)
+
+  const connectionTimeoutMillis = parseNonNegativeInteger(
+    env.VARLENS_PG_CONNECTION_TIMEOUT_MS,
+    'VARLENS_PG_CONNECTION_TIMEOUT_MS',
+    DEFAULT_PG_CONNECTION_TIMEOUT_MS
+  )
+  const statementTimeoutMs = parseNonNegativeInteger(
+    env.VARLENS_PG_STATEMENT_TIMEOUT_MS,
+    'VARLENS_PG_STATEMENT_TIMEOUT_MS',
+    DEFAULT_PG_STATEMENT_TIMEOUT_MS
+  )
+  const queryTimeoutMs = parseNonNegativeInteger(
+    env.VARLENS_PG_QUERY_TIMEOUT_MS,
+    'VARLENS_PG_QUERY_TIMEOUT_MS',
+    DEFAULT_PG_QUERY_TIMEOUT_MS
+  )
+  const lockTimeoutMs = parseNonNegativeInteger(
+    env.VARLENS_PG_LOCK_TIMEOUT_MS,
+    'VARLENS_PG_LOCK_TIMEOUT_MS',
+    DEFAULT_PG_LOCK_TIMEOUT_MS
+  )
+  const idleInTransactionSessionTimeoutMs = parseNonNegativeInteger(
+    env.VARLENS_PG_IDLE_IN_TX_TIMEOUT_MS,
+    'VARLENS_PG_IDLE_IN_TX_TIMEOUT_MS',
+    DEFAULT_PG_IDLE_IN_TX_TIMEOUT_MS
+  )
+  const poolMax = parseNonNegativeInteger(
+    env.VARLENS_PG_POOL_MAX,
+    'VARLENS_PG_POOL_MAX',
+    DEFAULT_PG_POOL_MAX
+  )
+
+  if (poolMax < 1) {
+    throw new Error('VARLENS_PG_POOL_MAX must be at least 1')
+  }
+
   return {
     url,
-    schema: schema === undefined || schema === '' ? 'public' : schema
+    schema,
+    applicationName,
+    sslMode,
+    connectionTimeoutMillis,
+    statementTimeoutMs,
+    queryTimeoutMs,
+    lockTimeoutMs,
+    idleInTransactionSessionTimeoutMs,
+    poolMax
+  }
+}
+
+export function redactPostgresConnectionUrl(url: string): string {
+  const parsed = new URL(url)
+  parsed.username = ''
+  parsed.password = ''
+  return parsed.toString()
+}
+
+export function buildPostgresConnectionLabel(redactedUrl: string, schema: string): string {
+  const parsed = new URL(redactedUrl)
+  const databaseName = parsed.pathname.replace(/^\//, '') || '(no-db)'
+  const port = parsed.port || '5432'
+
+  return `${parsed.hostname}:${port}/${databaseName} (${schema})`
+}
+
+function buildPostgresSslConfig(sslMode: PostgresSslMode): PoolConfig['ssl'] {
+  if (sslMode === 'disable') {
+    return undefined
+  }
+
+  return {
+    rejectUnauthorized: false
+  }
+}
+
+export function buildPostgresPoolConfig(config: PostgresStorageConfig): PoolConfig {
+  return {
+    connectionString: config.url,
+    application_name: config.applicationName,
+    connectionTimeoutMillis: config.connectionTimeoutMillis,
+    statement_timeout: config.statementTimeoutMs,
+    query_timeout: config.queryTimeoutMs,
+    lock_timeout: config.lockTimeoutMs,
+    idle_in_transaction_session_timeout: config.idleInTransactionSessionTimeoutMs,
+    max: config.poolMax,
+    ssl: buildPostgresSslConfig(config.sslMode)
   }
 }

--- a/src/main/storage/config.ts
+++ b/src/main/storage/config.ts
@@ -26,6 +26,7 @@ const DEFAULT_PG_IDLE_IN_TX_TIMEOUT_MS = 10000
 const DEFAULT_PG_POOL_MAX = 4
 
 const URL_SSL_PARAMS = ['sslmode', 'sslcert', 'sslkey', 'sslrootcert']
+const NON_NEGATIVE_INTEGER_PATTERN = /^\d+$/
 
 function parseNonNegativeInteger(
   value: string | undefined,
@@ -36,12 +37,12 @@ function parseNonNegativeInteger(
     return fallback
   }
 
-  const parsed = Number.parseInt(value, 10)
-  if (!Number.isInteger(parsed) || parsed < 0) {
+  const normalized = value.trim()
+  if (!NON_NEGATIVE_INTEGER_PATTERN.test(normalized)) {
     throw new Error(`${envName} must be a non-negative integer`)
   }
 
-  return parsed
+  return Number(normalized)
 }
 
 function assertNoManagedSslConflict(url: string): void {
@@ -151,6 +152,12 @@ export function buildPostgresConnectionLabel(redactedUrl: string, schema: string
 function buildPostgresSslConfig(sslMode: PostgresSslMode): PoolConfig['ssl'] {
   if (sslMode === 'disable') {
     return undefined
+  }
+
+  if (sslMode === 'prefer') {
+    throw new Error(
+      'VARLENS_PG_SSL_MODE=prefer is not supported in Phase 2 because pg does not provide safe fallback semantics through this config path'
+    )
   }
 
   return {

--- a/src/main/storage/config.ts
+++ b/src/main/storage/config.ts
@@ -70,10 +70,14 @@ export function getPostgresStorageConfig(
     throw new Error('VARLENS_PG_SCHEMA must not be blank')
   }
 
+  const applicationNameRaw = env.VARLENS_PG_APPLICATION_NAME?.trim()
   const applicationName =
-    env.VARLENS_PG_APPLICATION_NAME?.trim() || DEFAULT_PG_APPLICATION_NAME
+    applicationNameRaw === undefined || applicationNameRaw === ''
+      ? DEFAULT_PG_APPLICATION_NAME
+      : applicationNameRaw
 
-  const sslMode = (env.VARLENS_PG_SSL_MODE?.trim() || DEFAULT_PG_SSL_MODE) as PostgresSslMode
+  const sslModeRaw = env.VARLENS_PG_SSL_MODE?.trim()
+  const sslMode = sslModeRaw === undefined || sslModeRaw === '' ? DEFAULT_PG_SSL_MODE : sslModeRaw
   if (sslMode !== 'disable' && sslMode !== 'prefer' && sslMode !== 'require') {
     throw new Error(`Invalid VARLENS_PG_SSL_MODE: ${sslMode}`)
   }

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -47,7 +47,7 @@ export class PostgresStorageSession implements StorageSession {
       schema: options.config.schema
     }
 
-    this.pool.on('error', error => {
+    this.pool.on('error', (error: Error) => {
       const message = error instanceof Error ? error.message : String(error)
       mainLogger.warn(`Postgres pool error: ${message}`, 'storage')
     })

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -1,0 +1,100 @@
+import type { Pool } from 'pg'
+
+import { mainLogger } from '../../services/MainLogger'
+import type { DatabaseService } from '../../database/DatabaseService'
+import type { DbPool } from '../../database/DbPool'
+import {
+  buildPostgresConnectionLabel,
+  redactPostgresConnectionUrl,
+  type PostgresStorageConfig
+} from '../config'
+import type { StorageSession } from '../session'
+import type { StorageCapabilities, StorageHealth, WorkspaceRef } from '../types'
+
+interface PostgresStorageSessionOptions {
+  config: PostgresStorageConfig
+  pool: Pool
+}
+
+const POSTGRES_CAPABILITIES: StorageCapabilities = {
+  backend: 'postgres',
+  supportsEncryptionAtRest: false,
+  supportsLocalFileLifecycle: false,
+  supportsHostedConnectionLifecycle: true,
+  supportsWorkerReadPool: false,
+  supportsFullTextSearch: false
+}
+
+function unsupported(message: string): never {
+  throw new Error(message)
+}
+
+export class PostgresStorageSession implements StorageSession {
+  readonly capabilities = POSTGRES_CAPABILITIES
+  readonly workspace: WorkspaceRef
+
+  private readonly pool: Pool
+
+  constructor(options: PostgresStorageSessionOptions) {
+    this.pool = options.pool
+
+    const connectionUrlRedacted = redactPostgresConnectionUrl(options.config.url)
+
+    this.workspace = {
+      kind: 'postgres',
+      connectionUrlRedacted,
+      connectionLabel: buildPostgresConnectionLabel(connectionUrlRedacted, options.config.schema),
+      schema: options.config.schema
+    }
+
+    this.pool.on('error', error => {
+      const message = error instanceof Error ? error.message : String(error)
+      mainLogger.warn(`Postgres pool error: ${message}`, 'storage')
+    })
+  }
+
+  getDatabaseService(): DatabaseService {
+    return unsupported('DatabaseService is not available for postgres sessions')
+  }
+
+  getDbPool(): DbPool | null {
+    return unsupported('DbPool is not available for postgres sessions')
+  }
+
+  getEncryptionKey(): string | undefined {
+    return unsupported('Encryption keys are not available for postgres sessions')
+  }
+
+  needsStartupRebuild(): boolean {
+    return unsupported('Startup rebuild is not supported for postgres sessions')
+  }
+
+  rekey(_newPassword: string): void {
+    unsupported('SQLite rekey is not supported for postgres sessions')
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end()
+  }
+
+  async health(): Promise<StorageHealth> {
+    const startedAt = Date.now()
+
+    try {
+      await this.pool.query('SELECT 1')
+
+      return {
+        ok: true,
+        backend: 'postgres',
+        roundTripMs: Date.now() - startedAt
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        backend: 'postgres',
+        message: error instanceof Error ? error.message : String(error),
+        roundTripMs: Date.now() - startedAt
+      }
+    }
+  }
+}

--- a/tests/main/storage/config.test.ts
+++ b/tests/main/storage/config.test.ts
@@ -40,6 +40,22 @@ describe('getPostgresStorageConfig', () => {
     ).toThrow('Invalid VARLENS_PG_SSL_MODE')
   })
 
+  it('rejects a malformed postgres url with a var-specific error', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'not a url'
+      })
+    ).toThrow('VARLENS_PG_URL')
+  })
+
+  it('rejects non-postgres url schemes early', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'https://example.com/not-postgres'
+      })
+    ).toThrow('VARLENS_PG_URL')
+  })
+
   it('rejects a blank schema after trimming', () => {
     expect(() =>
       getPostgresStorageConfig({
@@ -88,6 +104,14 @@ describe('redactPostgresConnectionUrl', () => {
       redactPostgresConnectionUrl('postgres://varlens:secret@127.0.0.1:55432/varlens_dev')
     ).toBe('postgres://127.0.0.1:55432/varlens_dev')
   })
+
+  it('removes query parameters from the redacted url', () => {
+    expect(
+      redactPostgresConnectionUrl(
+        'postgres://varlens:secret@127.0.0.1:55432/varlens_dev?application_name=foo&sslmode=require'
+      )
+    ).toBe('postgres://127.0.0.1:55432/varlens_dev')
+  })
 })
 
 describe('buildPostgresConnectionLabel', () => {
@@ -124,7 +148,9 @@ describe('buildPostgresPoolConfig', () => {
     })
 
     expect(buildPostgresPoolConfig(config!)).toMatchObject({
-      ssl: expect.any(Object)
+      ssl: {
+        rejectUnauthorized: true
+      }
     })
   })
 

--- a/tests/main/storage/config.test.ts
+++ b/tests/main/storage/config.test.ts
@@ -1,16 +1,116 @@
 import { describe, expect, it } from 'vitest'
 
-import { getPostgresDevConfig } from '../../../src/main/storage/config'
+import {
+  buildPostgresConnectionLabel,
+  buildPostgresPoolConfig,
+  getPostgresStorageConfig,
+  redactPostgresConnectionUrl
+} from '../../../src/main/storage/config'
 
-describe('getPostgresDevConfig', () => {
+describe('getPostgresStorageConfig', () => {
   it('returns null when postgres env is absent', () => {
-    expect(getPostgresDevConfig({})).toBeNull()
+    expect(getPostgresStorageConfig({})).toBeNull()
   })
 
-  it('returns the configured url and default schema', () => {
-    expect(getPostgresDevConfig({ VARLENS_PG_URL: 'postgres://x/y' })).toEqual({
-      url: 'postgres://x/y',
-      schema: 'public'
+  it('returns normalized defaults for schema, application name, timeouts, and pool size', () => {
+    expect(
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev'
+      })
+    ).toEqual({
+      url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      schema: 'public',
+      applicationName: 'varlens-main',
+      sslMode: 'disable',
+      connectionTimeoutMillis: 5000,
+      statementTimeoutMs: 30000,
+      queryTimeoutMs: 30000,
+      lockTimeoutMs: 5000,
+      idleInTransactionSessionTimeoutMs: 10000,
+      poolMax: 4
+    })
+  })
+
+  it('rejects an invalid ssl mode', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SSL_MODE: 'bogus'
+      })
+    ).toThrow('Invalid VARLENS_PG_SSL_MODE')
+  })
+
+  it('rejects a blank schema after trimming', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SCHEMA: '   '
+      })
+    ).toThrow('VARLENS_PG_SCHEMA')
+  })
+
+  it('rejects invalid numeric timeout values', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_QUERY_TIMEOUT_MS: '-1'
+      })
+    ).toThrow('VARLENS_PG_QUERY_TIMEOUT_MS')
+  })
+
+  it('rejects pool sizes smaller than 1', () => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_POOL_MAX: '0'
+      })
+    ).toThrow('VARLENS_PG_POOL_MAX')
+  })
+})
+
+describe('redactPostgresConnectionUrl', () => {
+  it('removes credentials while preserving the target database', () => {
+    expect(
+      redactPostgresConnectionUrl('postgres://varlens:secret@127.0.0.1:55432/varlens_dev')
+    ).toBe('postgres://127.0.0.1:55432/varlens_dev')
+  })
+})
+
+describe('buildPostgresConnectionLabel', () => {
+  it('formats host, port, database, and schema', () => {
+    expect(buildPostgresConnectionLabel('postgres://127.0.0.1:55432/varlens_dev', 'public')).toBe(
+      '127.0.0.1:55432/varlens_dev (public)'
+    )
+  })
+})
+
+describe('buildPostgresPoolConfig', () => {
+  it('maps normalized config into pg pool options without search_path mutation', () => {
+    const config = getPostgresStorageConfig({
+      VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      VARLENS_PG_SCHEMA: 'varlens'
+    })
+
+    expect(buildPostgresPoolConfig(config!)).toMatchObject({
+      connectionString: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      application_name: 'varlens-main',
+      connectionTimeoutMillis: 5000,
+      statement_timeout: 30000,
+      query_timeout: 30000,
+      lock_timeout: 5000,
+      idle_in_transaction_session_timeout: 10000,
+      max: 4
+    })
+  })
+
+  it('maps ssl mode require into a pool ssl object', () => {
+    const config = getPostgresStorageConfig({
+      VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      VARLENS_PG_SSL_MODE: 'require'
+    })
+
+    expect(buildPostgresPoolConfig(config!)).toMatchObject({
+      ssl: expect.any(Object)
     })
   })
 })

--- a/tests/main/storage/config.test.ts
+++ b/tests/main/storage/config.test.ts
@@ -58,6 +58,20 @@ describe('getPostgresStorageConfig', () => {
     ).toThrow('VARLENS_PG_QUERY_TIMEOUT_MS')
   })
 
+  it.each([
+    ['VARLENS_PG_QUERY_TIMEOUT_MS', '1.5'],
+    ['VARLENS_PG_QUERY_TIMEOUT_MS', '10ms'],
+    ['VARLENS_PG_QUERY_TIMEOUT_MS', '1e3'],
+    ['VARLENS_PG_POOL_MAX', '2.5']
+  ])('rejects malformed integer env values for %s=%s', (envName, value) => {
+    expect(() =>
+      getPostgresStorageConfig({
+        VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+        [envName]: value
+      })
+    ).toThrow(envName)
+  })
+
   it('rejects pool sizes smaller than 1', () => {
     expect(() =>
       getPostgresStorageConfig({
@@ -112,5 +126,14 @@ describe('buildPostgresPoolConfig', () => {
     expect(buildPostgresPoolConfig(config!)).toMatchObject({
       ssl: expect.any(Object)
     })
+  })
+
+  it('rejects ssl mode prefer until fallback semantics are implemented correctly', () => {
+    const config = getPostgresStorageConfig({
+      VARLENS_PG_URL: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      VARLENS_PG_SSL_MODE: 'prefer'
+    })
+
+    expect(() => buildPostgresPoolConfig(config!)).toThrow('VARLENS_PG_SSL_MODE=prefer')
   })
 })

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PostgresStorageConfig } from '../../../src/main/storage/config'
+import { PostgresStorageSession } from '../../../src/main/storage/postgres/PostgresStorageSession'
+
+function makeConfig(overrides: Partial<PostgresStorageConfig> = {}): PostgresStorageConfig {
+  return {
+    url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+    schema: 'public',
+    applicationName: 'varlens-main',
+    sslMode: 'disable',
+    connectionTimeoutMillis: 5000,
+    statementTimeoutMs: 30000,
+    queryTimeoutMs: 30000,
+    lockTimeoutMs: 5000,
+    idleInTransactionSessionTimeoutMs: 10000,
+    poolMax: 4,
+    ...overrides
+  }
+}
+
+describe('PostgresStorageSession', () => {
+  it('exposes redacted workspace metadata and explicit postgres capabilities', () => {
+    const pool = {
+      query: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn()
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never
+    })
+
+    expect(pool.on).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(session.workspace.kind).toBe('postgres')
+    expect(session.workspace.connectionUrlRedacted).toBe(
+      'postgres://127.0.0.1:55432/varlens_dev'
+    )
+    expect(session.workspace.connectionLabel).toBe('127.0.0.1:55432/varlens_dev (public)')
+    expect(session.capabilities).toEqual({
+      backend: 'postgres',
+      supportsEncryptionAtRest: false,
+      supportsLocalFileLifecycle: false,
+      supportsHostedConnectionLifecycle: true,
+      supportsWorkerReadPool: false,
+      supportsFullTextSearch: false
+    })
+  })
+
+  it('returns a healthy result when the round-trip query succeeds', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never
+    })
+
+    await expect(session.health()).resolves.toMatchObject({
+      ok: true,
+      backend: 'postgres'
+    })
+    expect(pool.query).toHaveBeenCalledWith('SELECT 1')
+  })
+
+  it('returns a failed health result when the round-trip query fails', async () => {
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: {
+        query: vi.fn().mockRejectedValue(new Error('connection refused')),
+        end: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn()
+      } as never
+    })
+
+    await expect(session.health()).resolves.toMatchObject({
+      ok: false,
+      backend: 'postgres',
+      message: 'connection refused'
+    })
+  })
+
+  it('throws for sqlite-only compatibility methods', () => {
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: {
+        query: vi.fn(),
+        end: vi.fn(),
+        on: vi.fn()
+      } as never
+    })
+
+    expect(() => session.getDatabaseService()).toThrow('DatabaseService is not available')
+    expect(() => session.getDbPool()).toThrow('DbPool is not available')
+    expect(() => session.rekey('secret')).toThrow('SQLite rekey is not supported')
+  })
+
+  it('closes the underlying pool', async () => {
+    const pool = {
+      query: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never
+    })
+
+    await session.close()
+    expect(pool.end).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -34,9 +34,7 @@ describe('PostgresStorageSession', () => {
 
     expect(pool.on).toHaveBeenCalledWith('error', expect.any(Function))
     expect(session.workspace.kind).toBe('postgres')
-    expect(session.workspace.connectionUrlRedacted).toBe(
-      'postgres://127.0.0.1:55432/varlens_dev'
-    )
+    expect(session.workspace.connectionUrlRedacted).toBe('postgres://127.0.0.1:55432/varlens_dev')
     expect(session.workspace.connectionLabel).toBe('127.0.0.1:55432/varlens_dev (public)')
     expect(session.capabilities).toEqual({
       backend: 'postgres',


### PR DESCRIPTION
## Summary
- add the Phase 2 PostgreSQL storage-session design and implementation plan under `.planning/`
- add `pg`-backed PostgreSQL session scaffolding with validated config parsing, connection redaction, pool shaping, and explicit backend capabilities
- add focused PostgreSQL storage tests and complete local verification fixes needed to satisfy lint, typecheck, and Node ABI rebuild requirements

## Why
Phase 1 created the storage boundary and local PostgreSQL development workflow. This PR implements the first real PostgreSQL runtime slice at the session/lifecycle layer without pretending the existing SQLite repositories are portable yet.

## Impact
- PostgreSQL configuration is now normalized and validated from env input
- VarLens can construct a real `PostgresStorageSession` with redacted workspace metadata and structured `health()` reporting
- repository portability, worker redesign, and backend switching UI remain intentionally out of scope

## Test Plan
- [x] `npx vitest run tests/main/storage/config.test.ts tests/main/storage/postgres-storage-session.test.ts`
- [x] `npx vitest run tests/main/storage/*.test.ts tests/main/services/DatabaseManager.test.ts tests/main/handlers/database-logic.test.ts`
- [x] `make ci`
