### PR TITLE
[codex] add phase 3 cases:list vertical slice

### DIFF
--- a/.planning/plans/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-plan.md
+++ b/.planning/plans/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-plan.md
@@ -1,0 +1,582 @@
+# Storage Session Boundary Phase 3: `cases:list` Vertical Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first real dual-backend storage slice by making `cases:list` run through `StorageSession` for both SQLite and PostgreSQL while keeping SQLite stable and making PostgreSQL testable on this workstation.
+
+**Architecture:** Extend `StorageSession` with one explicit migrated read capability, implement that capability separately in `SqliteStorageSession` and `PostgresStorageSession`, and route the existing `cases:list` IPC handler through the active session. Keep renderer IPC stable, keep PostgreSQL activation explicit and dev-only, and allow only the minimum adjacent compatibility work needed to make the PostgreSQL path usable.
+
+**Tech Stack:** Electron 40, TypeScript 6, Vue 3, Pinia, `better-sqlite3-multiple-ciphers`, `pg`, Vitest, Playwright `_electron`, Docker PostgreSQL dev workflow, `make ci`
+
+---
+
+## File structure
+
+### New files
+
+- `src/main/storage/postgres/PostgresCaseListRepository.ts`
+- `tests/main/storage/postgres-case-list-repository.test.ts`
+- `tests/main/storage/storage-session-cases-list.test.ts`
+- `tests/e2e/postgres-cases-list-dev-mode.e2e.ts`
+- `scripts/postgres/init-db/10-phase3-cases.sql`
+- `scripts/postgres/init-db/20-phase3-seed-cases.sql`
+
+### Modified files
+
+- `src/main/storage/session.ts`
+- `src/main/storage/sqlite/SqliteStorageSession.ts`
+- `src/main/storage/postgres/PostgresStorageSession.ts`
+- `src/main/services/DatabaseManager.ts`
+- `src/main/ipc/handlers/cases.ts`
+- `src/main/ipc/handlers/cases-logic.ts`
+- `src/main/index.ts`
+- `src/renderer/src/stores/databaseStore.ts`
+- `src/shared/ipc/domains/database.ts`
+- `src/shared/types/api.ts`
+- `tests/main/storage/sqlite-storage-session.test.ts`
+- `tests/main/storage/postgres-storage-session.test.ts`
+- `tests/main/handlers/cases-handlers.test.ts`
+
+### Notes on ownership and parallelism
+
+- Task 1 and Task 2 can run in parallel after the slice contract is agreed.
+- Task 3 can run in parallel with Task 2 once the PostgreSQL repository file path is fixed.
+- Task 4 depends on Tasks 1-3 landing.
+- Task 5 depends on the activation path from Task 4.
+- Task 6 is the final verification/documentation pass.
+
+## Task 1: Add the session-level `cases:list` capability
+
+**Files:**
+
+- Modify: `src/main/storage/session.ts`
+- Modify: `src/main/storage/sqlite/SqliteStorageSession.ts`
+- Modify: `src/main/storage/postgres/PostgresStorageSession.ts`
+- Test: `tests/main/storage/sqlite-storage-session.test.ts`
+- Test: `tests/main/storage/postgres-storage-session.test.ts`
+- Test: `tests/main/storage/storage-session-cases-list.test.ts`
+
+- [ ] **Step 1: Write failing session-contract tests for `listCases()`**
+
+Add tests that assert:
+
+- SQLite sessions expose `listCases()` and preserve current ordering
+- PostgreSQL sessions expose `listCases()` and delegate to PostgreSQL query code
+- the method returns the shared `Case[]` shape
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/sqlite-storage-session.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-session-cases-list.test.ts
+```
+
+Expected:
+
+- FAIL because `StorageSession` does not yet define `listCases()`
+
+- [ ] **Step 2: Extend `StorageSession` with the first migrated read slice**
+
+Update `src/main/storage/session.ts` to add:
+
+```ts
+import type { Case } from '../../shared/types/database'
+
+export interface StorageSession {
+  readonly workspace: WorkspaceRef
+  readonly capabilities: StorageCapabilities
+
+  listCases(): Promise<Case[]>
+  getDatabaseService(): DatabaseService
+  getDbPool(): DbPool | null
+  getEncryptionKey(): string | undefined
+  needsStartupRebuild(): boolean
+  rekey(newPassword: string): void
+  close(): Promise<void>
+  health(): Promise<StorageHealth>
+}
+```
+
+- [ ] **Step 3: Implement SQLite `listCases()` with current behavior**
+
+Update `src/main/storage/sqlite/SqliteStorageSession.ts` to add:
+
+```ts
+import type { Case } from '../../../shared/types/database'
+
+async listCases(): Promise<Case[]> {
+  if (this.dbPool !== null) {
+    return (await this.dbPool.run({ type: 'cases:list', params: [] })) as Case[]
+  }
+
+  return this.databaseService.cases.getAllCases()
+}
+```
+
+- [ ] **Step 4: Implement PostgreSQL session delegation**
+
+Update `src/main/storage/postgres/PostgresStorageSession.ts` so the session owns a case-list repository and exposes:
+
+```ts
+import type { Case } from '../../../shared/types/database'
+import { PostgresCaseListRepository } from './PostgresCaseListRepository'
+
+private readonly cases: PostgresCaseListRepository
+
+constructor(options: PostgresStorageSessionOptions) {
+  this.pool = options.pool
+  this.cases = new PostgresCaseListRepository(options.pool, options.config.schema)
+  // existing workspace setup follows
+}
+
+async listCases(): Promise<Case[]> {
+  return await this.cases.listCases()
+}
+```
+
+- [ ] **Step 5: Run the storage-session test set**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/sqlite-storage-session.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-session-cases-list.test.ts
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/storage/session.ts src/main/storage/sqlite/SqliteStorageSession.ts src/main/storage/postgres/PostgresStorageSession.ts tests/main/storage/sqlite-storage-session.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-session-cases-list.test.ts
+git commit -m "feat(storage): add session-level cases list capability"
+```
+
+## Task 2: Route `cases:list` through the active session
+
+**Files:**
+
+- Modify: `src/main/ipc/handlers/cases.ts`
+- Modify: `src/main/ipc/handlers/cases-logic.ts`
+- Test: `tests/main/handlers/cases-handlers.test.ts`
+
+- [ ] **Step 1: Write failing handler tests for session-backed `cases:list`**
+
+Add tests that assert:
+
+- `cases:list` resolves through `getDbManager().getCurrentSession().listCases()`
+- the SQLite fallback still behaves the same through the new path
+- `cases:query` remains unchanged
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/handlers/cases-handlers.test.ts
+```
+
+Expected:
+
+- FAIL because `cases:list` still depends on raw `getDb()` / `getDbPool()`
+
+- [ ] **Step 2: Update cases logic to accept a session**
+
+Refactor `src/main/ipc/handlers/cases-logic.ts` so `listCases` becomes:
+
+```ts
+import type { StorageSession } from '../../storage/session'
+
+export async function listCases(getSession: () => StorageSession): Promise<unknown> {
+  const session = getSession()
+  return await session.listCases()
+}
+```
+
+Keep `queryCases`, `deleteSingleCase`, `deleteAllCases`, and `deleteBatchCases` unchanged in this task.
+
+- [ ] **Step 3: Update the `cases:list` handler only**
+
+Change `src/main/ipc/handlers/cases.ts`:
+
+```ts
+export function registerCaseHandlers({
+  ipcMain,
+  getDb,
+  getDbPool,
+  getDbManager
+}: HandlerDependencies): void {
+  ipcMain.handle('cases:list', async () => {
+    return wrapHandler(() => listCases(() => getDbManager().getCurrentSession()))
+  })
+
+  // leave other handlers as-is
+}
+```
+
+- [ ] **Step 4: Run the handler tests**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/handlers/cases-handlers.test.ts
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ipc/handlers/cases.ts src/main/ipc/handlers/cases-logic.ts tests/main/handlers/cases-handlers.test.ts
+git commit -m "refactor(cases): route cases list through storage session"
+```
+
+## Task 3: Add the PostgreSQL `cases:list` repository and schema bootstrap
+
+**Files:**
+
+- Create: `src/main/storage/postgres/PostgresCaseListRepository.ts`
+- Create: `tests/main/storage/postgres-case-list-repository.test.ts`
+- Create: `scripts/postgres/init-db/10-phase3-cases.sql`
+- Create: `scripts/postgres/init-db/20-phase3-seed-cases.sql`
+
+- [ ] **Step 1: Write a failing PostgreSQL repository test**
+
+The test should seed rows and assert:
+
+- `listCases()` returns rows sorted by `created_at DESC`
+- each row matches the shared `Case` field names exactly
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-case-list-repository.test.ts
+```
+
+Expected:
+
+- FAIL because `PostgresCaseListRepository` does not exist
+
+- [ ] **Step 2: Add minimal PostgreSQL schema bootstrap for the slice**
+
+Create `scripts/postgres/init-db/10-phase3-cases.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS cases (
+  id BIGINT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  file_path TEXT NOT NULL,
+  file_size BIGINT NOT NULL,
+  variant_count BIGINT NOT NULL DEFAULT 0,
+  created_at BIGINT NOT NULL,
+  genome_build TEXT NOT NULL DEFAULT 'GRCh38'
+);
+```
+
+Create `scripts/postgres/init-db/20-phase3-seed-cases.sql` with 2-3 deterministic rows for local verification.
+
+- [ ] **Step 3: Implement the repository**
+
+Create `src/main/storage/postgres/PostgresCaseListRepository.ts`:
+
+```ts
+import type { Pool } from 'pg'
+import type { Case } from '../../../shared/types/database'
+
+export class PostgresCaseListRepository {
+  constructor(
+    private readonly pool: Pool,
+    private readonly schema: string
+  ) {}
+
+  async listCases(): Promise<Case[]> {
+    const query = `
+      SELECT
+        id::bigint AS id,
+        name,
+        file_path,
+        file_size::bigint AS file_size,
+        variant_count::bigint AS variant_count,
+        created_at::bigint AS created_at,
+        genome_build
+      FROM ${this.schema}.cases
+      ORDER BY created_at DESC
+    `
+
+    const result = await this.pool.query(query)
+    return result.rows.map((row) => ({
+      id: Number(row.id),
+      name: row.name,
+      file_path: row.file_path,
+      file_size: Number(row.file_size),
+      variant_count: Number(row.variant_count),
+      created_at: Number(row.created_at),
+      genome_build: row.genome_build
+    }))
+  }
+}
+```
+
+Then replace string interpolation with a schema-safe helper before merging. The engineer implementing this task must not leave raw schema interpolation in the final code.
+
+- [ ] **Step 4: Run the PostgreSQL repository test**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-case-list-repository.test.ts
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/storage/postgres/PostgresCaseListRepository.ts tests/main/storage/postgres-case-list-repository.test.ts scripts/postgres/init-db/10-phase3-cases.sql scripts/postgres/init-db/20-phase3-seed-cases.sql
+git commit -m "feat(storage): add postgres cases list repository"
+```
+
+## Task 4: Add explicit PostgreSQL dev activation and minimal session usability wiring
+
+**Files:**
+
+- Modify: `src/main/services/DatabaseManager.ts`
+- Modify: `src/main/index.ts`
+- Modify: `src/renderer/src/stores/databaseStore.ts`
+- Modify: `src/shared/ipc/domains/database.ts`
+- Modify: `src/shared/types/api.ts`
+- Test: `tests/main/storage/storage-manager-compat.test.ts`
+
+- [ ] **Step 1: Write failing tests for PostgreSQL session activation**
+
+Add tests that assert:
+
+- `DatabaseManager` can hold a PostgreSQL current session
+- startup code can choose PostgreSQL explicitly via environment configuration
+- renderer database info handling remains safe when the active session is not file-backed
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/storage-manager-compat.test.ts
+```
+
+Expected:
+
+- FAIL because `DatabaseManager` only exposes SQLite lifecycle entry points
+
+- [ ] **Step 2: Add an explicit PostgreSQL session-open path**
+
+Extend `DatabaseManager` with a narrow method:
+
+```ts
+async openPostgres(session: StorageSession): Promise<void> {
+  await this.close()
+  this.currentSession = session
+}
+```
+
+Do not add broad backend-switching UI or file-lifecycle semantics in this task.
+
+- [ ] **Step 3: Add startup activation in `src/main/index.ts`**
+
+Introduce an explicit environment gate such as:
+
+```ts
+const experimentalBackend = process.env.VARLENS_EXPERIMENTAL_STORAGE_BACKEND
+if (experimentalBackend === 'postgres') {
+  // build config, pool, PostgresStorageSession, manager.openPostgres(...)
+}
+```
+
+Requirements:
+
+- SQLite remains the default path
+- PostgreSQL startup is explicit and opt-in
+- startup failure logs a structured error and does not silently mutate SQLite behavior
+
+- [ ] **Step 4: Make renderer info handling additive and safe**
+
+If `database:info` remains SQLite-only, update `databaseStore.fetchInfo()` so a `null` response clears stale file-backed state instead of leaving the previous SQLite path visible:
+
+```ts
+if (info) {
+  currentPath.value = info.path
+  currentName.value = info.name
+  isEncrypted.value = info.encrypted
+} else {
+  currentPath.value = null
+  currentName.value = ''
+  isEncrypted.value = false
+}
+```
+
+Do not turn this task into a general backend UI redesign.
+
+- [ ] **Step 5: Run the activation and compatibility tests**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/storage-manager-compat.test.ts tests/main/storage/postgres-storage-session.test.ts
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/services/DatabaseManager.ts src/main/index.ts src/renderer/src/stores/databaseStore.ts src/shared/ipc/domains/database.ts src/shared/types/api.ts tests/main/storage/storage-manager-compat.test.ts tests/main/storage/postgres-storage-session.test.ts
+git commit -m "feat(storage): add explicit postgres dev session activation"
+```
+
+## Task 5: Prove the slice end-to-end in app and local PostgreSQL
+
+**Files:**
+
+- Create: `tests/e2e/postgres-cases-list-dev-mode.e2e.ts`
+- Modify: any shared E2E helper needed for env injection
+
+- [ ] **Step 1: Write the failing E2E smoke test**
+
+The test should:
+
+1. start the app with `VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres`
+2. point it at the local PostgreSQL dev database
+3. call `window.api.cases.list()`
+4. assert the returned rows match the seeded PostgreSQL rows
+
+Run:
+
+```bash
+make build && npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+```
+
+Expected:
+
+- FAIL until the startup activation and repository path are wired
+
+- [ ] **Step 2: Implement any minimal E2E helper changes**
+
+Keep changes narrow:
+
+- env injection for the Electron process
+- optional readiness wait for PostgreSQL dev mode
+
+- [ ] **Step 3: Run the targeted E2E**
+
+Run:
+
+```bash
+make build && npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/postgres-cases-list-dev-mode.e2e.ts tests/e2e/helpers
+git commit -m "test(e2e): verify postgres cases list dev mode"
+```
+
+## Task 6: Final verification and closeout
+
+**Files:**
+
+- Modify: `.planning/specs/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-design.md` if implementation reality requires a tiny clarification
+- Modify: `.planning/plans/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-plan.md` only if task tracking notes need correction
+
+- [ ] **Step 1: Start local PostgreSQL and seed the Phase 3 slice**
+
+Run:
+
+```bash
+make pg-up
+make pg-reset
+```
+
+Expected:
+
+- PostgreSQL container is healthy
+- Phase 3 seed rows are present
+
+- [ ] **Step 2: Run focused verification**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/sqlite-storage-session.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/postgres-case-list-repository.test.ts tests/main/storage/storage-session-cases-list.test.ts tests/main/handlers/cases-handlers.test.ts
+make build && npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+```
+
+Expected:
+
+- all targeted tests PASS
+
+- [ ] **Step 3: Run the required repo gate**
+
+Run:
+
+```bash
+make ci
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 4: Commit final verification note**
+
+```bash
+git add .planning/specs/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-design.md .planning/plans/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-plan.md
+git commit --allow-empty -m "test(storage): verify phase 3 cases list vertical slice"
+```
+
+## Parallel execution recommendation
+
+Use this wave order for maximum safe parallelism without worktrees:
+
+1. Wave 1:
+   - Task 1: session capability
+   - Task 3: PostgreSQL repository + schema bootstrap
+2. Wave 2:
+   - Task 2: handler migration
+   - Task 4: dev activation + compatibility wiring
+3. Wave 3:
+   - Task 5: E2E proof
+4. Wave 4:
+   - Task 6: full verification
+
+Keep write ownership disjoint:
+
+- Worker A owns `src/main/storage/session.ts`, `src/main/storage/sqlite/**`, related storage tests
+- Worker B owns `src/main/storage/postgres/**`, PostgreSQL repository tests, bootstrap SQL
+- Worker C owns `src/main/ipc/handlers/cases*`, related handler tests
+- Worker D owns startup activation, renderer compatibility state, and E2E helper/test files
+
+## Spec coverage check
+
+- Chosen vertical slice: covered by Tasks 1-5
+- SQLite stability: covered by Tasks 1, 2, and 6
+- PostgreSQL workstation testability: covered by Tasks 3, 4, 5, and 6
+- No broad repository portability: enforced by limiting repository work to `PostgresCaseListRepository`
+- No worktrees: enforced by the wave and ownership guidance above
+
+## Placeholder scan
+
+- No `TBD`
+- No hidden “implement later” steps
+- All verification commands are explicit
+
+## Type consistency check
+
+- The plan consistently uses `StorageSession.listCases(): Promise<Case[]>`
+- The renderer-facing IPC contract remains `cases:list`
+- PostgreSQL remains explicit dev activation, not the default runtime path

--- a/.planning/specs/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-design.md
+++ b/.planning/specs/2026-04-23-storage-adapter-phase-3-cases-list-vertical-slice-design.md
@@ -1,0 +1,350 @@
+# Storage Session Boundary Phase 3: `cases:list` Vertical Slice
+
+**Date:** 2026-04-23  
+**Status:** Proposed Phase 3 spec  
+**Depends on:** [`2026-04-23-storage-adapter-boundary-design.md`](./2026-04-23-storage-adapter-boundary-design.md)  
+**Previous phases:** Phase 1 and Phase 2 complete and archived  
+**Recommendation:** Use `cases:list` as the first dual-backend vertical slice
+
+## Summary
+
+Phase 3 should migrate `cases:list` end-to-end across SQLite and PostgreSQL.
+
+This is the best first vertical slice because it is:
+
+- the first option that is meaningfully user-visible
+- still narrow enough to keep SQLite stable
+- already a real IPC seam in the current app
+- testable on this workstation with the current local PostgreSQL development flow
+- a more honest signal of whether the `StorageSession` boundary can carry backend-specific behavior than `database:info` or `database:overview`
+
+Phase 3 should **not** attempt broad repository portability. It should instead add the first backend-neutral read capability at the session boundary, implement it separately for SQLite and PostgreSQL, and keep the renderer-facing IPC contract stable.
+
+## Why this slice
+
+The active architecture doc leaves three plausible first slices:
+
+1. `database:info`
+2. `database:overview`
+3. `cases:list`
+
+### Option review
+
+#### `database:info`
+
+Pros:
+
+- lowest implementation risk
+- mostly lifecycle/session metadata
+- little SQL portability pressure
+
+Cons:
+
+- too thin for the current goal
+- mostly proves config and session wiring, not a usable backend path
+- likely produces another scaffold phase rather than the first credible migration slice
+
+Conclusion:
+
+- useful compatibility work may still happen around session metadata
+- not strong enough to justify being the primary Phase 3 slice
+
+#### `database:overview`
+
+Pros:
+
+- exercises real query execution
+- touches a mix of aggregates and summary reads
+- could flush out backend-specific SQL assumptions early
+
+Cons:
+
+- less representative of everyday app usage than case listing
+- more likely to force aggregate-query divergence before the boundary pattern is proven
+- lower immediate value than making the basic workspace case list work
+
+Conclusion:
+
+- a viable later slice after the first read-path boundary is proven
+- not the best first candidate
+
+#### `cases:list`
+
+Pros:
+
+- already powers real renderer behavior
+- narrow, read-only, and easy to reason about
+- exercises IPC, session dispatch, backend query code, and renderer consumption
+- useful for internal dev validation immediately
+- forces one honest backend-specific implementation without pretending the whole repository layer is portable
+
+Cons:
+
+- does require a small amount of PostgreSQL workspace usability work
+- may pull in one or two compatibility updates outside the exact `cases:list` handler
+
+Conclusion:
+
+- best balance of user-visible value, scope control, and architectural signal
+- recommended Phase 3 slice
+
+## Design goals
+
+1. Prove one real dual-backend read path through the active `StorageSession` boundary.
+2. Keep SQLite behavior stable and default.
+3. Avoid claiming broad repository portability.
+4. Keep the renderer-facing `cases:list` IPC contract stable.
+5. Make the PostgreSQL path testable end-to-end on this workstation.
+6. Limit incidental compatibility work to what is needed to make the dev PostgreSQL session usable.
+
+## Non-goals
+
+- No migration of `cases:query` in Phase 3.
+- No import, delete, export, or cohort-write migration.
+- No worker/executor redesign.
+- No renderer storage-switcher UI.
+- No general-purpose cross-database repository abstraction.
+- No attempt to make `DatabaseService` itself portable.
+- No broad PostgreSQL schema or migration framework for the whole product.
+
+## Current codebase anchors
+
+The chosen slice is grounded in the existing code:
+
+- [`src/main/ipc/handlers/cases.ts`](../../src/main/ipc/handlers/cases.ts) exposes `cases:list`.
+- [`src/main/ipc/handlers/cases-logic.ts`](../../src/main/ipc/handlers/cases-logic.ts) already centralizes list/query logic and currently branches only on SQLite main-thread vs `DbPool`.
+- [`src/main/storage/session.ts`](../../src/main/storage/session.ts) is the active session seam from Phases 1 and 2.
+- [`src/main/storage/sqlite/SqliteStorageSession.ts`](../../src/main/storage/sqlite/SqliteStorageSession.ts) already owns SQLite-specific runtime access.
+- [`src/main/storage/postgres/PostgresStorageSession.ts`](../../src/main/storage/postgres/PostgresStorageSession.ts) already owns the PostgreSQL pool and session metadata.
+- [`src/main/services/DatabaseManager.ts`](../../src/main/services/DatabaseManager.ts) owns the active session but is still SQLite-oriented at lifecycle boundaries.
+- [`src/renderer/src/stores/databaseStore.ts`](../../src/renderer/src/stores/databaseStore.ts) and renderer callers already consume `cases:list` without needing a new IPC contract.
+
+That is enough structure to add one honest migrated read slice without redesigning the rest of storage.
+
+## Proposed Phase 3 architecture
+
+### 1. Make `cases:list` the first migrated session capability
+
+Phase 1 introduced `StorageSession` as a lifecycle wrapper with SQLite compatibility methods. Phase 3 should evolve it by adding the first real backend-neutral read capability:
+
+```ts
+listCases(): Promise<Case[]>
+```
+
+This is intentionally narrow. It does **not** imply that all case operations or repositories are portable. It only means the session boundary now owns one real vertical slice.
+
+Reasoning:
+
+- adding one explicit slice method is more honest than adding a fake general repository adapter
+- the implementation stays close to the current codebase
+- the compatibility methods from Phase 1 can continue to exist while this first slice is proven
+
+### 2. SQLite keeps its current behavior behind the new method
+
+`SqliteStorageSession.listCases()` should preserve current behavior:
+
+- use `DbPool` when available
+- otherwise read through the wrapped `DatabaseService`
+- preserve current sort order and payload shape from `CaseRepository.getAllCases()`
+
+This keeps SQLite stable while moving ownership of the slice into the session.
+
+### 3. PostgreSQL gets a backend-specific case-list implementation
+
+`PostgresStorageSession.listCases()` should query PostgreSQL directly through the owned `pg.Pool`.
+
+Phase 3 should create a small PostgreSQL-specific read component for this slice only, for example:
+
+- `src/main/storage/postgres/PostgresCaseListRepository.ts`
+
+That repository should:
+
+- query the PostgreSQL `cases` table
+- return rows shaped exactly like the shared `Case` type
+- sort by `created_at DESC` to match SQLite behavior
+- keep SQL intentionally small and local to this slice
+
+This is the first explicit proof that PostgreSQL support is a second implementation, not a driver swap under the SQLite repositories.
+
+### 4. `cases:list` handler becomes session-backed
+
+The `cases:list` handler path should stop reaching around the session boundary.
+
+Near-term rule:
+
+- `cases:list` resolves the active `StorageSession`
+- it calls `session.listCases()`
+- it no longer depends on raw `getDb()` / `getDbPool()` for this slice
+
+`cases:query`, delete operations, and other case handlers remain unchanged in Phase 3.
+
+### 5. Allow small compatibility work required for a usable PostgreSQL dev session
+
+Although `cases:list` is the chosen slice, Phase 3 may include a limited amount of adjacent compatibility work where it is necessary to make the PostgreSQL path usable on this workstation.
+
+Allowed examples:
+
+- a dev-only session-open path for PostgreSQL
+- startup/session selection via explicit environment configuration
+- additive workspace metadata handling so the renderer does not break when the active session is not file-backed
+- minimal bootstrap checks for the PostgreSQL `cases` table or development schema
+
+Disallowed examples:
+
+- broad migration of all `database:*` handlers
+- full workspace-management UI for PostgreSQL
+- broad renderer assumptions that both backends are already equivalent
+
+### 6. Keep PostgreSQL access dev-focused and explicit
+
+Phase 3 should remain an internal/dev milestone, not a user-facing backend switch.
+
+Recommended activation rule:
+
+- SQLite stays the default app path
+- PostgreSQL requires explicit environment-backed activation in dev/test
+
+One acceptable pattern is:
+
+```text
+VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres
+```
+
+with the existing PostgreSQL config env vars from Phase 2.
+
+The important point is not the exact variable name. The important point is that:
+
+- the PostgreSQL path is explicit
+- it is opt-in
+- it is testable locally
+- it does not destabilize normal SQLite startup
+
+### 7. Keep PostgreSQL schema scope intentionally small
+
+Phase 3 should not pretend the full SQLite schema is now portable. It only needs enough PostgreSQL schema support to back `cases:list`.
+
+That means Phase 3 should define and bootstrap only what the slice actually needs:
+
+- `cases` table columns required by the shared `Case` type
+- any minimal constraints needed for realistic data and deterministic tests
+
+The phase may use a dedicated dev bootstrap SQL file or a narrow bootstrap helper, but it should not introduce a fake “full migration parity” story.
+
+## Data contract for the slice
+
+Phase 3 keeps the existing shared `Case` payload contract:
+
+```ts
+interface Case {
+  id: number
+  name: string
+  file_path: string
+  file_size: number
+  variant_count: number
+  created_at: number
+  genome_build: string
+}
+```
+
+The PostgreSQL implementation must return the same field names and value types as the SQLite path.
+
+This is the compatibility line for the slice:
+
+- same IPC channel
+- same renderer contract
+- backend-specific implementation behind it
+
+## Testing strategy
+
+Phase 3 should be test-driven and verifiable locally.
+
+### Unit tests
+
+- session-level tests for `SqliteStorageSession.listCases()`
+- session-level tests for `PostgresStorageSession.listCases()`
+- handler/logic tests proving `cases:list` resolves through the active session
+
+### PostgreSQL integration tests
+
+Run against the local Docker-backed PostgreSQL environment from earlier phases:
+
+- bootstrap a minimal `cases` schema
+- seed known rows
+- verify exact payload shape and ordering
+
+These tests should stay focused on the slice rather than trying to reuse all SQLite integration machinery.
+
+### End-to-end/dev verification
+
+At least one local verification path should prove:
+
+1. app starts in explicit PostgreSQL dev mode
+2. session becomes healthy
+3. `window.api.cases.list()` returns expected rows
+4. the main case list UI can render those rows without IPC or shape regressions
+
+This is what makes the phase meaningful on the workstation rather than purely architectural.
+
+## Risks and mitigations
+
+### Risk: `StorageSession` turns into an unstructured bag of slice methods
+
+Mitigation:
+
+- add only one explicit migrated capability in Phase 3
+- require each future slice to justify itself the same way
+- avoid adding “generic repository” escape hatches
+
+### Risk: PostgreSQL dev activation leaks into normal SQLite startup
+
+Mitigation:
+
+- keep PostgreSQL activation explicit and env-gated
+- keep SQLite as the default startup path
+- keep packaged/release behavior unchanged
+
+### Risk: the slice silently depends on more renderer/database compatibility than planned
+
+Mitigation:
+
+- allow only additive compatibility work needed to keep the dev path usable
+- keep `cases:list` as the only migrated read contract
+- defer general `database:*` redesign
+
+### Risk: the team starts generalizing repository portability from one successful slice
+
+Mitigation:
+
+- write Phase 3 to prove a pattern, not to declare portability solved
+- require later slices to evaluate shared logic based on evidence
+
+## Locked decisions
+
+1. Phase 3 recommends `cases:list`, not `database:info` or `database:overview`, as the first dual-backend slice.
+2. SQLite remains the stable default backend path.
+3. PostgreSQL remains explicit, internal, and workstation-testable in this phase.
+4. The renderer-facing `cases:list` IPC contract stays unchanged.
+5. PostgreSQL implementation is backend-specific and local to the slice.
+6. Small adjacent compatibility work is allowed only when required to make the dev slice usable.
+7. Broad repository portability remains out of scope.
+
+## Acceptance criteria
+
+Phase 3 is successful when all of the following are true:
+
+- `cases:list` resolves through the active `StorageSession`
+- SQLite `cases:list` behavior is unchanged
+- PostgreSQL has a real `cases:list` implementation returning the shared `Case` payload
+- local PostgreSQL dev mode can be activated explicitly on this workstation
+- tests cover both backends for the slice
+- the implementation does not claim that other domains are portable yet
+
+## Relationship to the implementation plan
+
+The corresponding implementation plan should:
+
+- keep the work split into small vertical tasks
+- maximize safe parallelism where file ownership is disjoint
+- avoid worktrees
+- preserve `make ci` as the minimum completion gate
+- treat PostgreSQL dev verification as a required deliverable, not optional polish

--- a/scripts/postgres/init-db/10-phase3-cases.sql
+++ b/scripts/postgres/init-db/10-phase3-cases.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS cases (
+  id BIGINT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  file_path TEXT NOT NULL,
+  file_size BIGINT NOT NULL,
+  variant_count BIGINT NOT NULL DEFAULT 0,
+  created_at BIGINT NOT NULL,
+  genome_build TEXT NOT NULL DEFAULT 'GRCh38'
+);

--- a/scripts/postgres/init-db/20-phase3-seed-cases.sql
+++ b/scripts/postgres/init-db/20-phase3-seed-cases.sql
@@ -1,0 +1,5 @@
+INSERT INTO cases (id, name, file_path, file_size, variant_count, created_at, genome_build)
+VALUES
+  (1, 'Oldest Case', '/data/oldest.vcf.gz', 1024, 0, 1714060800000, 'GRCh38'),
+  (2, 'Middle Case', '/data/middle.vcf.gz', 2048, 21, 1714060801000, 'GRCh37'),
+  (3, 'Newest Case', '/data/newest.vcf.gz', 4096, 42, 1714060802000, 'GRCh38');

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -9,6 +9,7 @@ import { DatabaseManager } from '../services/DatabaseManager'
 import { RecentDatabasesService } from '../services/RecentDatabasesService'
 import { app } from 'electron'
 import { join } from 'path'
+import { openConfiguredDatabase } from './startup'
 
 // Singleton instance of DatabaseManager
 let databaseManager: DatabaseManager | null = null
@@ -28,9 +29,10 @@ export async function initDatabaseManager(): Promise<DatabaseManager> {
     const recentDatabases = new RecentDatabasesService(settingsPath)
     databaseManager = new DatabaseManager(recentDatabases)
 
-    // Open default database
-    const dbPath = join(app.getPath('userData'), 'varlens.db')
-    await databaseManager.open(dbPath)
+    await openConfiguredDatabase(databaseManager, {
+      env: process.env,
+      userDataPath: app.getPath('userData')
+    })
   }
   return databaseManager
 }

--- a/src/main/database/startup.ts
+++ b/src/main/database/startup.ts
@@ -1,0 +1,57 @@
+import { join } from 'node:path'
+import { Pool } from 'pg'
+
+import type { DatabaseManager } from '../services/DatabaseManager'
+import {
+  buildPostgresPoolConfig,
+  getPostgresStorageConfig,
+  type PostgresStorageConfig
+} from '../storage/config'
+import { PostgresStorageSession } from '../storage/postgres/PostgresStorageSession'
+import type { StorageSession } from '../storage/session'
+
+interface OpenConfiguredDatabaseOptions {
+  env?: NodeJS.ProcessEnv
+  userDataPath: string
+  getPostgresConfig?: (env: NodeJS.ProcessEnv) => PostgresStorageConfig | null
+  createPostgresPool?: (config: PostgresStorageConfig) => Pool
+  createPostgresSession?: (config: PostgresStorageConfig, pool: Pool) => StorageSession
+}
+
+function getExperimentalBackend(env: NodeJS.ProcessEnv): string | null {
+  const backend = env.VARLENS_EXPERIMENTAL_STORAGE_BACKEND?.trim()
+  return backend === undefined || backend === '' ? null : backend
+}
+
+export async function openConfiguredDatabase(
+  manager: DatabaseManager,
+  options: OpenConfiguredDatabaseOptions
+): Promise<void> {
+  const env = options.env ?? process.env
+  const requestedBackend = getExperimentalBackend(env)
+
+  if (requestedBackend === 'postgres') {
+    const config = (options.getPostgresConfig ?? getPostgresStorageConfig)(env)
+
+    if (config === null) {
+      throw new Error(
+        'VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres requires PostgreSQL configuration, including VARLENS_PG_URL'
+      )
+    }
+
+    const poolFactory =
+      options.createPostgresPool ??
+      ((pgConfig: PostgresStorageConfig) => new Pool(buildPostgresPoolConfig(pgConfig)))
+    const sessionFactory =
+      options.createPostgresSession ??
+      ((pgConfig: PostgresStorageConfig, pool: Pool) =>
+        new PostgresStorageSession({ config: pgConfig, pool }))
+
+    const pool = poolFactory(config)
+    const session = sessionFactory(config, pool)
+    await manager.openPostgresSession(session)
+    return
+  }
+
+  await manager.open(join(options.userDataPath, 'varlens.db'))
+}

--- a/src/main/database/startup.ts
+++ b/src/main/database/startup.ts
@@ -48,9 +48,20 @@ export async function openConfiguredDatabase(
         new PostgresStorageSession({ config: pgConfig, pool }))
 
     const pool = poolFactory(config)
-    const session = sessionFactory(config, pool)
-    await manager.openPostgresSession(session)
-    return
+    let session: StorageSession | undefined
+
+    try {
+      session = sessionFactory(config, pool)
+      await manager.openPostgresSession(session)
+      return
+    } catch (error) {
+      if (session !== undefined) {
+        await session.close()
+      } else {
+        await pool.end()
+      }
+      throw error
+    }
   }
 
   await manager.open(join(options.userDataPath, 'varlens.db'))

--- a/src/main/ipc/handlers/cases-logic.ts
+++ b/src/main/ipc/handlers/cases-logic.ts
@@ -76,7 +76,10 @@ export function runDeleteWorker(request: DeleteWorkerRequest): Promise<number> {
 }
 
 /**
- * List all cases. Uses pool if available, otherwise direct db access.
+ * List all cases through the active storage session.
+ *
+ * Backend-specific dispatch lives at the session layer so SQLite and PostgreSQL
+ * can implement the slice differently without changing the IPC surface.
  */
 export async function listCases(getSession: () => StorageSession): Promise<unknown> {
   return await getSession().listCases()

--- a/src/main/ipc/handlers/cases-logic.ts
+++ b/src/main/ipc/handlers/cases-logic.ts
@@ -10,6 +10,7 @@ import { resolve } from 'node:path'
 import { mainLogger } from '../../services/MainLogger'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
+import type { StorageSession } from '../../storage/session'
 import type { DeleteWorkerRequest, DeleteWorkerResponse } from '../../workers/delete-worker'
 import type { ValidatedCaseSearchParams } from '../../../shared/types/ipc-schemas'
 
@@ -77,16 +78,8 @@ export function runDeleteWorker(request: DeleteWorkerRequest): Promise<number> {
 /**
  * List all cases. Uses pool if available, otherwise direct db access.
  */
-export async function listCases(
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
-): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'cases:list', params: [] })
-  }
-  const db = getDb()
-  return db.cases.getAllCases()
+export async function listCases(getSession: () => StorageSession): Promise<unknown> {
+  return await getSession().listCases()
 }
 
 /**

--- a/src/main/ipc/handlers/cases.ts
+++ b/src/main/ipc/handlers/cases.ts
@@ -27,9 +27,14 @@ const deleteCallbacks: DeleteCallbacks = {
  * Cases IPC handlers
  * Channels: cases:list, cases:query, cases:delete, cases:deleteAll, cases:deleteBatch
  */
-export function registerCaseHandlers({ ipcMain, getDb, getDbPool }: HandlerDependencies): void {
+export function registerCaseHandlers({
+  ipcMain,
+  getDb,
+  getDbPool,
+  getDbManager
+}: HandlerDependencies): void {
   ipcMain.handle('cases:list', async () => {
-    return wrapHandler(() => listCases(getDb, getDbPool))
+    return wrapHandler(() => listCases(() => getDbManager().getCurrentSession()))
   })
 
   ipcMain.handle('cases:availableBuilds', async () => {

--- a/src/main/services/DatabaseManager.ts
+++ b/src/main/services/DatabaseManager.ts
@@ -199,6 +199,11 @@ export class DatabaseManager {
     await this.switchDatabase(path, key)
   }
 
+  async openPostgresSession(session: StorageSession): Promise<void> {
+    await this.close()
+    this.currentSession = session
+  }
+
   /**
    * Close the current database
    *

--- a/src/main/services/DatabaseManager.ts
+++ b/src/main/services/DatabaseManager.ts
@@ -200,6 +200,13 @@ export class DatabaseManager {
   }
 
   async openPostgresSession(session: StorageSession): Promise<void> {
+    const isPostgresSession =
+      session.workspace.kind === 'postgres' && session.capabilities.backend === 'postgres'
+
+    if (!isPostgresSession) {
+      throw new DatabaseError('openPostgresSession requires a postgres-backed session')
+    }
+
     await this.close()
     this.currentSession = session
   }

--- a/src/main/storage/postgres/PostgresCaseListRepository.ts
+++ b/src/main/storage/postgres/PostgresCaseListRepository.ts
@@ -1,0 +1,42 @@
+import type { Pool } from 'pg'
+
+import type { Case } from '../../../shared/types/database'
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.split('"').join('""')}"`
+}
+
+export class PostgresCaseListRepository {
+  constructor(
+    private readonly pool: Pool,
+    private readonly schema: string
+  ) {}
+
+  async listCases(): Promise<Case[]> {
+    const schemaName = quoteIdentifier(this.schema)
+    const query = `
+      SELECT
+        id,
+        name,
+        file_path,
+        file_size,
+        variant_count,
+        created_at,
+        genome_build
+      FROM ${schemaName}."cases"
+      ORDER BY created_at DESC
+    `
+
+    const result = await this.pool.query(query)
+
+    return result.rows.map((row) => ({
+      id: Number(row.id),
+      name: String(row.name),
+      file_path: String(row.file_path),
+      file_size: Number(row.file_size),
+      variant_count: Number(row.variant_count),
+      created_at: Number(row.created_at),
+      genome_build: String(row.genome_build)
+    }))
+  }
+}

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -3,6 +3,8 @@ import type { Pool } from 'pg'
 import { mainLogger } from '../../services/MainLogger'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
+import type { Case } from '../../../shared/types/database'
+import { PostgresCaseListRepository } from './PostgresCaseListRepository'
 import {
   buildPostgresConnectionLabel,
   redactPostgresConnectionUrl,
@@ -14,6 +16,7 @@ import type { StorageCapabilities, StorageHealth, WorkspaceRef } from '../types'
 interface PostgresStorageSessionOptions {
   config: PostgresStorageConfig
   pool: Pool
+  createCaseListRepository?: (pool: Pool, schema: string) => PostgresCaseListRepository
 }
 
 const POSTGRES_CAPABILITIES: StorageCapabilities = {
@@ -33,10 +36,18 @@ export class PostgresStorageSession implements StorageSession {
   readonly capabilities = POSTGRES_CAPABILITIES
   readonly workspace: WorkspaceRef
 
+  private readonly createCaseListRepository: (
+    pool: Pool,
+    schema: string
+  ) => PostgresCaseListRepository
   private readonly pool: Pool
+  private cases: PostgresCaseListRepository | null = null
 
   constructor(options: PostgresStorageSessionOptions) {
     this.pool = options.pool
+    this.createCaseListRepository =
+      options.createCaseListRepository ??
+      ((pool: Pool, schema: string) => new PostgresCaseListRepository(pool, schema))
 
     const connectionUrlRedacted = redactPostgresConnectionUrl(options.config.url)
 
@@ -51,6 +62,17 @@ export class PostgresStorageSession implements StorageSession {
       const message = error instanceof Error ? error.message : String(error)
       mainLogger.warn(`Postgres pool error: ${message}`, 'storage')
     })
+  }
+
+  async listCases(): Promise<Case[]> {
+    if (this.cases === null) {
+      this.cases = this.createCaseListRepository(
+        this.pool,
+        this.workspace.kind === 'postgres' ? this.workspace.schema : 'public'
+      )
+    }
+
+    return await this.cases.listCases()
   }
 
   getDatabaseService(): DatabaseService {

--- a/src/main/storage/session.ts
+++ b/src/main/storage/session.ts
@@ -1,11 +1,13 @@
 import type { DatabaseService } from '../database/DatabaseService'
 import type { DbPool } from '../database/DbPool'
+import type { Case } from '../../shared/types/database'
 import type { StorageCapabilities, StorageHealth, WorkspaceRef } from './types'
 
 export interface StorageSession {
   readonly workspace: WorkspaceRef
   readonly capabilities: StorageCapabilities
 
+  listCases(): Promise<Case[]>
   getDatabaseService(): DatabaseService
   getDbPool(): DbPool | null
   getEncryptionKey(): string | undefined

--- a/src/main/storage/sqlite/SqliteStorageSession.ts
+++ b/src/main/storage/sqlite/SqliteStorageSession.ts
@@ -1,5 +1,6 @@
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
+import type { Case } from '../../../shared/types/database'
 import type { StorageSession } from '../session'
 import type { StorageCapabilities, StorageHealth, WorkspaceRef } from '../types'
 
@@ -40,6 +41,14 @@ export class SqliteStorageSession implements StorageSession {
 
   getDatabaseService(): DatabaseService {
     return this.databaseService
+  }
+
+  async listCases(): Promise<Case[]> {
+    if (this.dbPool !== null) {
+      return (await this.dbPool.run({ type: 'cases:list', params: [] })) as Case[]
+    }
+
+    return this.databaseService.cases.getAllCases()
   }
 
   getDbPool(): DbPool | null {

--- a/src/renderer/src/stores/databaseStore.ts
+++ b/src/renderer/src/stores/databaseStore.ts
@@ -34,6 +34,10 @@ export const useDatabaseStore = defineStore('database', () => {
       currentPath.value = info.path
       currentName.value = info.name
       isEncrypted.value = info.encrypted
+    } else {
+      currentPath.value = null
+      currentName.value = ''
+      isEncrypted.value = false
     }
     await fetchRecent()
   }

--- a/tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+++ b/tests/e2e/postgres-cases-list-dev-mode.e2e.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  dismissDisclaimerIfPresent,
+  launchElectronApp,
+  waitForAppShell
+} from './helpers/electron-app'
+
+test('postgres dev mode exposes seeded cases through cases:list', async () => {
+  test.skip(
+    process.env.VARLENS_RUN_POSTGRES_E2E !== '1',
+    'Set VARLENS_RUN_POSTGRES_E2E=1 after starting the local postgres container to run this test.'
+  )
+
+  let launched:
+    | Awaited<ReturnType<typeof launchElectronApp>>
+    | undefined
+
+  try {
+    launched = await launchElectronApp({
+      env: {
+        VARLENS_EXPERIMENTAL_STORAGE_BACKEND: 'postgres',
+        VARLENS_PG_URL:
+          process.env.VARLENS_PG_URL ??
+          'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SCHEMA: process.env.VARLENS_PG_SCHEMA ?? 'public'
+      }
+    })
+
+    await waitForAppShell(launched.window)
+    await dismissDisclaimerIfPresent(launched.window)
+
+    const cases = await launched.window.evaluate(async () => {
+      return await window.api.cases.list()
+    })
+
+    expect(cases).toEqual([
+      expect.objectContaining({ id: 3, name: 'Newest Case' }),
+      expect.objectContaining({ id: 2, name: 'Middle Case' }),
+      expect.objectContaining({ id: 1, name: 'Oldest Case' })
+    ])
+  } finally {
+    if (launched !== undefined) {
+      await launched.cleanup()
+    }
+  }
+})

--- a/tests/main/database/database-startup.test.ts
+++ b/tests/main/database/database-startup.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { StorageSession } from '../../../src/main/storage/session'
+import type { PostgresStorageConfig } from '../../../src/main/storage/config'
+
+describe('openConfiguredDatabase', () => {
+  it('opens the default sqlite database when no experimental backend is requested', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data'
+    })
+
+    expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+    expect(manager.openPostgresSession).not.toHaveBeenCalled()
+  })
+
+  it('opens a postgres session when the experimental backend is explicitly requested', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const config: PostgresStorageConfig = {
+      url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      schema: 'public',
+      applicationName: 'varlens-main',
+      sslMode: 'disable',
+      connectionTimeoutMillis: 5000,
+      statementTimeoutMs: 30000,
+      queryTimeoutMs: 30000,
+      lockTimeoutMs: 5000,
+      idleInTransactionSessionTimeoutMs: 10000,
+      poolMax: 4
+    }
+    const pool = { end: vi.fn(), on: vi.fn(), query: vi.fn() }
+    const session = {
+      workspace: {
+        kind: 'postgres',
+        connectionLabel: '127.0.0.1:55432/varlens_dev (public)',
+        connectionUrlRedacted: 'postgres://127.0.0.1:55432/varlens_dev',
+        schema: 'public'
+      },
+      capabilities: {
+        backend: 'postgres',
+        supportsEncryptionAtRest: false,
+        supportsLocalFileLifecycle: false,
+        supportsHostedConnectionLifecycle: true,
+        supportsWorkerReadPool: false,
+        supportsFullTextSearch: false
+      },
+      listCases: async () => [],
+      getDatabaseService: () => {
+        throw new Error('not available')
+      },
+      getDbPool: () => {
+        throw new Error('not available')
+      },
+      getEncryptionKey: () => undefined,
+      needsStartupRebuild: () => false,
+      rekey: () => {
+        throw new Error('not available')
+      },
+      close: async () => undefined,
+      health: async () => ({ ok: true, backend: 'postgres' as const })
+    } satisfies StorageSession
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {
+        VARLENS_EXPERIMENTAL_STORAGE_BACKEND: 'postgres'
+      },
+      userDataPath: '/tmp/varlens-user-data',
+      getPostgresConfig: () => config,
+      createPostgresPool: vi.fn().mockReturnValue(pool),
+      createPostgresSession: vi.fn().mockReturnValue(session)
+    })
+
+    expect(manager.open).not.toHaveBeenCalled()
+    expect(manager.openPostgresSession).toHaveBeenCalledWith(session)
+  })
+
+  it('fails fast when postgres mode is requested without postgres config', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await expect(
+      openConfiguredDatabase(manager as never, {
+        env: {
+          VARLENS_EXPERIMENTAL_STORAGE_BACKEND: 'postgres'
+        },
+        userDataPath: '/tmp/varlens-user-data',
+        getPostgresConfig: () => null
+      })
+    ).rejects.toThrow('VARLENS_PG_URL')
+  })
+})

--- a/tests/main/database/database-startup.test.ts
+++ b/tests/main/database/database-startup.test.ts
@@ -104,4 +104,71 @@ describe('openConfiguredDatabase', () => {
       })
     ).rejects.toThrow('VARLENS_PG_URL')
   })
+
+  it('closes the postgres session when handoff to DatabaseManager fails', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockRejectedValue(new Error('close failed'))
+    }
+    const config: PostgresStorageConfig = {
+      url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+      schema: 'public',
+      applicationName: 'varlens-main',
+      sslMode: 'disable',
+      connectionTimeoutMillis: 5000,
+      statementTimeoutMs: 30000,
+      queryTimeoutMs: 30000,
+      lockTimeoutMs: 5000,
+      idleInTransactionSessionTimeoutMs: 10000,
+      poolMax: 4
+    }
+    const pool = { end: vi.fn().mockResolvedValue(undefined), on: vi.fn(), query: vi.fn() }
+    const session = {
+      workspace: {
+        kind: 'postgres',
+        connectionLabel: '127.0.0.1:55432/varlens_dev (public)',
+        connectionUrlRedacted: 'postgres://127.0.0.1:55432/varlens_dev',
+        schema: 'public'
+      },
+      capabilities: {
+        backend: 'postgres',
+        supportsEncryptionAtRest: false,
+        supportsLocalFileLifecycle: false,
+        supportsHostedConnectionLifecycle: true,
+        supportsWorkerReadPool: false,
+        supportsFullTextSearch: false
+      },
+      listCases: async () => [],
+      getDatabaseService: () => {
+        throw new Error('not available')
+      },
+      getDbPool: () => {
+        throw new Error('not available')
+      },
+      getEncryptionKey: () => undefined,
+      needsStartupRebuild: () => false,
+      rekey: () => {
+        throw new Error('not available')
+      },
+      close: vi.fn().mockResolvedValue(undefined),
+      health: async () => ({ ok: true, backend: 'postgres' as const })
+    } satisfies StorageSession
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await expect(
+      openConfiguredDatabase(manager as never, {
+        env: {
+          VARLENS_EXPERIMENTAL_STORAGE_BACKEND: 'postgres'
+        },
+        userDataPath: '/tmp/varlens-user-data',
+        getPostgresConfig: () => config,
+        createPostgresPool: vi.fn().mockReturnValue(pool),
+        createPostgresSession: vi.fn().mockReturnValue(session)
+      })
+    ).rejects.toThrow('close failed')
+
+    expect(session.close).toHaveBeenCalledTimes(1)
+    expect(pool.end).not.toHaveBeenCalled()
+  })
 })

--- a/tests/main/handlers/cases-handlers.test.ts
+++ b/tests/main/handlers/cases-handlers.test.ts
@@ -102,6 +102,58 @@ describe('cases IPC handlers', () => {
     })
   })
   /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  it('routes cases:list through the active storage session', async () => {
+    const listCases = vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        name: 'Postgres Case',
+        file_path: '/tmp/postgres-case.vcf',
+        file_size: 123,
+        variant_count: 5,
+        created_at: 100,
+        genome_build: 'GRCh38'
+      }
+    ])
+
+    const currentSession = {
+      listCases
+    }
+
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler)
+      })
+    }
+
+    const { registerCaseHandlers } = await import('../../../src/main/ipc/handlers/cases')
+
+    registerCaseHandlers({
+      ipcMain: ipcMain as never,
+      getDb: (() => {
+        throw new Error('getDb should not be called for cases:list')
+      }) as never,
+      getDbManager: (() => ({
+        getCurrentSession: () => currentSession
+      })) as never,
+      getDbPool: (() => {
+        throw new Error('getDbPool should not be called for cases:list')
+      }) as never
+    })
+
+    const handler = handlers.get('cases:list')
+    expect(handler).toBeTypeOf('function')
+
+    const result = await handler!()
+
+    expect(listCases).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: 'Postgres Case'
+      })
+    ])
+  })
 })
 
 describe('database:overview handler', () => {

--- a/tests/main/storage/postgres-case-list-repository.test.ts
+++ b/tests/main/storage/postgres-case-list-repository.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Case } from '../../../src/shared/types/database'
+
+const seededRows = [
+  {
+    id: '3',
+    name: 'Newest Case',
+    file_path: '/data/newest.vcf.gz',
+    file_size: '4096',
+    variant_count: '42',
+    created_at: '1714060802000',
+    genome_build: 'GRCh38'
+  },
+  {
+    id: '2',
+    name: 'Middle Case',
+    file_path: '/data/middle.vcf.gz',
+    file_size: '2048',
+    variant_count: '21',
+    created_at: '1714060801000',
+    genome_build: 'GRCh37'
+  },
+  {
+    id: '1',
+    name: 'Oldest Case',
+    file_path: '/data/oldest.vcf.gz',
+    file_size: '1024',
+    variant_count: '0',
+    created_at: '1714060800000',
+    genome_build: 'GRCh38'
+  }
+] as const
+
+const expectedCases: Case[] = [
+  {
+    id: 3,
+    name: 'Newest Case',
+    file_path: '/data/newest.vcf.gz',
+    file_size: 4096,
+    variant_count: 42,
+    created_at: 1714060802000,
+    genome_build: 'GRCh38'
+  },
+  {
+    id: 2,
+    name: 'Middle Case',
+    file_path: '/data/middle.vcf.gz',
+    file_size: 2048,
+    variant_count: 21,
+    created_at: 1714060801000,
+    genome_build: 'GRCh37'
+  },
+  {
+    id: 1,
+    name: 'Oldest Case',
+    file_path: '/data/oldest.vcf.gz',
+    file_size: 1024,
+    variant_count: 0,
+    created_at: 1714060800000,
+    genome_build: 'GRCh38'
+  }
+]
+
+async function loadSubject(): Promise<{
+  PostgresCaseListRepository: new (
+    pool: { query: (sql: string) => Promise<{ rows: unknown[] }> },
+    schema: string
+  ) => {
+    listCases(): Promise<Case[]>
+  }
+}> {
+  const module =
+    await import('../../../src/main/storage/postgres/PostgresCaseListRepository').catch(() => null)
+
+  expect(module).not.toBeNull()
+  return module!
+}
+
+describe('PostgresCaseListRepository', () => {
+  it('lists cases in created_at descending order using the shared Case shape', async () => {
+    const { PostgresCaseListRepository } = await loadSubject()
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: seededRows
+      })
+    }
+
+    const repository = new PostgresCaseListRepository(pool, 'phase3_cases')
+
+    await expect(repository.listCases()).resolves.toStrictEqual(expectedCases)
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('FROM "phase3_cases"."cases"'))
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY created_at DESC'))
+  })
+
+  it('quotes the schema identifier before building the cases query', async () => {
+    const { PostgresCaseListRepository } = await loadSubject()
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: []
+      })
+    }
+
+    const repository = new PostgresCaseListRepository(pool, 'phase3"cases')
+
+    await repository.listCases()
+
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('FROM "phase3""cases"."cases"'))
+  })
+})

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { Case } from '../../../src/shared/types/database'
 import type { PostgresStorageConfig } from '../../../src/main/storage/config'
 import { PostgresStorageSession } from '../../../src/main/storage/postgres/PostgresStorageSession'
 
@@ -111,5 +112,38 @@ describe('PostgresStorageSession', () => {
 
     await session.close()
     expect(pool.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('delegates listCases to a repository created from the pool and schema', async () => {
+    const pool = {
+      query: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+    const expectedCases: Case[] = [
+      {
+        id: 1,
+        name: 'postgres-case',
+        file_path: '/postgres.vcf',
+        file_size: 1024,
+        variant_count: 2,
+        created_at: 1_000,
+        genome_build: 'GRCh38'
+      }
+    ]
+    const repository = {
+      listCases: vi.fn().mockResolvedValue(expectedCases)
+    }
+    const createCaseListRepository = vi.fn().mockReturnValue(repository)
+
+    const session = new PostgresStorageSession({
+      config: makeConfig({ schema: 'varlens_app' }),
+      pool: pool as never,
+      createCaseListRepository
+    })
+
+    await expect(session.listCases()).resolves.toEqual(expectedCases)
+    expect(createCaseListRepository).toHaveBeenCalledWith(pool, 'varlens_app')
+    expect(repository.listCases).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/main/storage/sqlite-storage-session.test.ts
+++ b/tests/main/storage/sqlite-storage-session.test.ts
@@ -53,4 +53,57 @@ describe('SqliteStorageSession', () => {
       backend: 'sqlite'
     })
   })
+
+  it('lists cases in descending created_at order from the database service', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-storage-session-'))
+    const dbPath = join(tempDir, 'session.db')
+    const db = new DatabaseService(dbPath)
+
+    const olderCaseId = db.cases.createCase('older-case', '/older.vcf', 100)
+    const newerCaseId = db.cases.createCase('newer-case', '/newer.vcf', 200)
+
+    db.database.prepare('UPDATE cases SET created_at = ? WHERE id = ?').run(1_000, olderCaseId)
+    db.database.prepare('UPDATE cases SET created_at = ? WHERE id = ?').run(2_000, newerCaseId)
+
+    const session = new SqliteStorageSession({
+      databaseService: db,
+      dbPool: null
+    })
+
+    const cases = await session.listCases()
+
+    expect(cases.map((entry) => entry.name)).toEqual(['newer-case', 'older-case'])
+
+    await session.close()
+  })
+
+  it('uses the worker read pool for listCases when one is available', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-storage-session-'))
+    const dbPath = join(tempDir, 'session.db')
+    const db = new DatabaseService(dbPath)
+    const pooledCases = [
+      {
+        id: 2,
+        name: 'pooled-case',
+        file_path: '/pooled.vcf',
+        file_size: 512,
+        variant_count: 4,
+        created_at: 2_000,
+        genome_build: 'GRCh38'
+      }
+    ]
+    const dbPool = {
+      run: async () => pooledCases,
+      destroy: async () => undefined
+    }
+
+    const session = new SqliteStorageSession({
+      databaseService: db,
+      dbPool: dbPool as never
+    })
+
+    await expect(session.listCases()).resolves.toEqual(pooledCases)
+
+    await session.close()
+  })
 })

--- a/tests/main/storage/storage-manager-compat.test.ts
+++ b/tests/main/storage/storage-manager-compat.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 
 import { DatabaseManager } from '../../../src/main/services/DatabaseManager'
 import { RecentDatabasesService } from '../../../src/main/services/RecentDatabasesService'
+import type { StorageSession } from '../../../src/main/storage/session'
 
 let tempDir: string | null = null
 
@@ -30,6 +31,55 @@ describe('DatabaseManager storage-session compatibility', () => {
 
     const current = manager.getCurrent()
     expect(current.getPath()).toBe(dbPath)
+
+    await manager.close()
+  })
+
+  it('can adopt a postgres-backed current session without exposing a sqlite path', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-storage-manager-'))
+    const settingsPath = join(tempDir, 'settings.json')
+    const manager = new DatabaseManager(new RecentDatabasesService(settingsPath))
+
+    const session = {
+      workspace: {
+        kind: 'postgres',
+        connectionLabel: '127.0.0.1:55432/varlens_dev (public)',
+        connectionUrlRedacted: 'postgres://127.0.0.1:55432/varlens_dev',
+        schema: 'public'
+      },
+      capabilities: {
+        backend: 'postgres',
+        supportsEncryptionAtRest: false,
+        supportsLocalFileLifecycle: false,
+        supportsHostedConnectionLifecycle: true,
+        supportsWorkerReadPool: false,
+        supportsFullTextSearch: false
+      },
+      listCases: async () => [],
+      getDatabaseService: () => {
+        throw new Error('DatabaseService is not available for postgres sessions')
+      },
+      getDbPool: () => {
+        throw new Error('DbPool is not available for postgres sessions')
+      },
+      getEncryptionKey: () => {
+        throw new Error('Encryption keys are not available for postgres sessions')
+      },
+      needsStartupRebuild: () => {
+        throw new Error('Startup rebuild is not supported for postgres sessions')
+      },
+      rekey: () => {
+        throw new Error('SQLite rekey is not supported for postgres sessions')
+      },
+      close: async () => undefined,
+      health: async () => ({ ok: true, backend: 'postgres' as const })
+    } satisfies StorageSession
+
+    await manager.openPostgresSession(session)
+
+    expect(manager.getCurrentSession()).toBe(session)
+    expect(manager.getCurrentPath()).toBeNull()
+    expect(manager.getCurrentInfo()).toBeNull()
 
     await manager.close()
   })

--- a/tests/main/storage/storage-manager-compat.test.ts
+++ b/tests/main/storage/storage-manager-compat.test.ts
@@ -83,4 +83,22 @@ describe('DatabaseManager storage-session compatibility', () => {
 
     await manager.close()
   })
+
+  it('rejects sqlite-backed sessions passed to openPostgresSession', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-storage-manager-'))
+    const settingsPath = join(tempDir, 'settings.json')
+    const dbPath = join(tempDir, 'test.db')
+    const manager = new DatabaseManager(new RecentDatabasesService(settingsPath))
+
+    await manager.open(dbPath)
+    const sqliteSession = manager.getCurrentSession()
+
+    await expect(manager.openPostgresSession(sqliteSession)).rejects.toThrow(
+      'openPostgresSession requires a postgres-backed session'
+    )
+
+    expect(manager.getCurrentSession()).toBe(sqliteSession)
+
+    await manager.close()
+  })
 })

--- a/tests/main/storage/storage-session-cases-list.test.ts
+++ b/tests/main/storage/storage-session-cases-list.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { DatabaseService } from '../../../src/main/database/DatabaseService'
+import type { Case } from '../../../src/shared/types/database'
+import type { PostgresStorageConfig } from '../../../src/main/storage/config'
+import { PostgresStorageSession } from '../../../src/main/storage/postgres/PostgresStorageSession'
+import { SqliteStorageSession } from '../../../src/main/storage/sqlite/SqliteStorageSession'
+
+let tempDir: string | null = null
+
+function makeConfig(overrides: Partial<PostgresStorageConfig> = {}): PostgresStorageConfig {
+  return {
+    url: 'postgres://varlens:secret@127.0.0.1:55432/varlens_dev',
+    schema: 'public',
+    applicationName: 'varlens-main',
+    sslMode: 'disable',
+    connectionTimeoutMillis: 5000,
+    statementTimeoutMs: 30000,
+    queryTimeoutMs: 30000,
+    lockTimeoutMs: 5000,
+    idleInTransactionSessionTimeoutMs: 10000,
+    poolMax: 4,
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  if (tempDir !== null) {
+    rmSync(tempDir, { recursive: true, force: true })
+    tempDir = null
+  }
+})
+
+describe('StorageSession listCases contract', () => {
+  it('returns SQLite cases in the shared Case shape', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-storage-session-'))
+    const dbPath = join(tempDir, 'session.db')
+    const db = new DatabaseService(dbPath)
+    const caseId = db.cases.createCase('sqlite-case', '/sqlite.vcf', 123)
+
+    const session = new SqliteStorageSession({
+      databaseService: db,
+      dbPool: null
+    })
+
+    const cases = await session.listCases()
+
+    expect(cases).toHaveLength(1)
+    expect(cases[0]).toMatchObject({
+      id: caseId,
+      name: 'sqlite-case',
+      file_path: '/sqlite.vcf',
+      file_size: 123,
+      variant_count: 0,
+      created_at: expect.any(Number),
+      genome_build: 'GRCh38'
+    })
+
+    await session.close()
+  })
+
+  it('returns PostgreSQL cases in the shared Case shape', async () => {
+    const expectedCases: Case[] = [
+      {
+        id: 7,
+        name: 'postgres-case',
+        file_path: '/postgres.vcf',
+        file_size: 456,
+        variant_count: 8,
+        created_at: 3_000,
+        genome_build: 'GRCh38'
+      }
+    ]
+    const pool = {
+      query: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+    const repository = {
+      listCases: vi.fn().mockResolvedValue(expectedCases)
+    }
+
+    const session = new PostgresStorageSession({
+      config: makeConfig(),
+      pool: pool as never,
+      createCaseListRepository: vi.fn().mockReturnValue(repository)
+    })
+
+    await expect(session.listCases()).resolves.toEqual(expectedCases)
+  })
+})

--- a/tests/renderer/stores/databaseStore.test.ts
+++ b/tests/renderer/stores/databaseStore.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useDatabaseStore } from '../../../src/renderer/src/stores/databaseStore'
+
+describe('databaseStore.fetchInfo', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        database: {
+          info: vi.fn().mockResolvedValue(null),
+          recentList: vi.fn().mockResolvedValue([])
+        }
+      }
+    })
+  })
+
+  it('clears stale sqlite metadata when database:info returns null', async () => {
+    const store = useDatabaseStore()
+
+    store.currentPath = '/tmp/old.db'
+    store.currentName = 'old.db'
+    store.isEncrypted = true
+
+    await store.fetchInfo()
+
+    expect(store.currentPath).toBeNull()
+    expect(store.currentName).toBe('')
+    expect(store.isEncrypted).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Implement the Phase 3 storage-session vertical slice around `cases:list`.

- add `StorageSession.listCases()` and route `cases:list` through the active session
- add a PostgreSQL-specific `cases:list` repository, startup selection helper, and minimal dev bootstrap SQL
- add planning docs, focused unit coverage, renderer compatibility coverage, and a PostgreSQL Electron smoke test

## Why
This is the first honest dual-backend slice from the storage-session design. It keeps SQLite stable while making explicit PostgreSQL dev mode testable on a real workstation path.

## Validation
- `make rebuild-node && npx vitest run tests/main/database/database-startup.test.ts tests/main/storage/sqlite-storage-session.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-session-cases-list.test.ts tests/main/storage/postgres-case-list-repository.test.ts tests/main/storage/storage-manager-compat.test.ts tests/main/handlers/cases-handlers.test.ts tests/renderer/stores/databaseStore.test.ts`
- `make build`
- `make pg-reset && make pg-up`
- `docker compose -f docker-compose.postgres.yml --env-file .env.postgres.local exec postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT id, name, created_at FROM cases ORDER BY created_at DESC;"'`
- `make rebuild && VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts`
- `make ci`

## Notes
This PR keeps PostgreSQL explicitly dev-only and does not claim broader repository portability beyond the `cases:list` slice.
