### PR TITLE
refactor(storage): migrate available builds to storage executor

### DIFF
--- a/src/main/database/CaseRepository.ts
+++ b/src/main/database/CaseRepository.ts
@@ -1,5 +1,6 @@
 import { BaseRepository } from './BaseRepository'
 import type {
+  AvailableBuild,
   Case,
   CaseWithCohorts,
   CaseSearchParams,
@@ -108,15 +109,19 @@ export class CaseRepository extends BaseRepository {
    * Sorted so the most-represented build appears first — the renderer uses
    * the first entry as the default selection in the cohort view.
    */
-  getAvailableGenomeBuilds(): Array<{ build: string; caseCount: number }> {
-    const compiled = this.kysely
-      .selectFrom('cases')
-      .select(['genome_build as build'])
-      .select((eb) => eb.fn.countAll<number>().as('caseCount'))
-      .groupBy('genome_build')
-      .orderBy('caseCount', 'desc')
-      .compile()
-    const rows = this.db.prepare(compiled.sql).all(...compiled.parameters) as Array<{
+  getAvailableGenomeBuilds(): AvailableBuild[] {
+    const rows = this.db
+      .prepare(
+        `
+          SELECT
+            COALESCE(genome_build, 'GRCh38') AS build,
+            COUNT(*) AS caseCount
+          FROM cases
+          GROUP BY build
+          ORDER BY caseCount DESC
+        `
+      )
+      .all() as Array<{
       build: string | null
       caseCount: number
     }>

--- a/src/main/database/DbPool.ts
+++ b/src/main/database/DbPool.ts
@@ -19,14 +19,29 @@ import { DATABASE_CONFIG } from '../../shared/config'
 // Use require() to load piscina — avoids Vite's static import analysis
 // which cannot resolve Node.js-only modules during test transforms
 
-let PiscinaClass: (new (opts: Record<string, unknown>) => PiscinaInstance) | null = null
-
 interface PiscinaInstance {
   run: (task: DbTask) => Promise<unknown>
   destroy: () => Promise<void>
 }
 
-function getPiscina(): new (opts: Record<string, unknown>) => PiscinaInstance {
+interface DbPoolInitOptions {
+  filename: string
+  minThreads: number
+  maxThreads: number
+  idleTimeout: number
+  workerData: {
+    dbPath: string
+    encryptionKey?: string
+    geneRefDbPath?: string
+  }
+  execArgv?: string[]
+}
+
+type PiscinaConstructor = new (opts: DbPoolInitOptions) => PiscinaInstance
+
+let PiscinaClass: PiscinaConstructor | null = null
+
+function getPiscina(): PiscinaConstructor {
   if (PiscinaClass === null) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     PiscinaClass = require('piscina') as typeof PiscinaClass
@@ -36,6 +51,7 @@ function getPiscina(): new (opts: Record<string, unknown>) => PiscinaInstance {
 
 export class DbPool {
   private pool: PiscinaInstance | null = null
+  private initOptions: DbPoolInitOptions | null = null
 
   /**
    * Initialise the worker pool.
@@ -55,34 +71,39 @@ export class DbPool {
       geneRefDbPath?: string
     }
   ): void {
-    if (this.pool !== null) return // already initialised
+    if (this.initOptions !== null) return // already initialised
 
     const filename = options?.workerPath ?? resolve(__dirname, 'db-worker.js')
-    const Piscina = getPiscina()
     const maxThreads = options?.maxThreads ?? Math.max(1, os.cpus().length - 1)
 
-    this.pool = new Piscina({
+    this.initOptions = {
       filename,
       minThreads: 1,
       maxThreads,
       idleTimeout: DATABASE_CONFIG.WORKER_IDLE_TIMEOUT_MS,
       workerData: { dbPath, encryptionKey, geneRefDbPath: options?.geneRefDbPath },
       ...(options?.execArgv !== undefined ? { execArgv: options.execArgv } : {})
-    })
+    }
   }
 
   /**
    * Check whether the pool has been initialised.
    */
   isInitialised(): boolean {
-    return this.pool !== null
+    return this.initOptions !== null
   }
 
   /**
    * Dispatch a read-only task to the pool.
    */
   async run<T>(task: DbTask): Promise<T> {
-    if (this.pool === null) throw new Error('DbPool not initialized — call init() first')
+    if (this.initOptions === null) throw new Error('DbPool not initialized — call init() first')
+
+    if (this.pool === null) {
+      const Piscina = getPiscina()
+      this.pool = new Piscina(this.initOptions)
+    }
+
     return this.pool.run(task) as Promise<T>
   }
 
@@ -94,5 +115,7 @@ export class DbPool {
       await this.pool.destroy()
       this.pool = null
     }
+
+    this.initOptions = null
   }
 }

--- a/src/main/ipc/handlers/cases-logic.ts
+++ b/src/main/ipc/handlers/cases-logic.ts
@@ -9,9 +9,10 @@ import { Worker } from 'worker_threads'
 import { resolve } from 'node:path'
 import { mainLogger } from '../../services/MainLogger'
 import type { DatabaseService } from '../../database/DatabaseService'
-import type { AvailableBuild, StorageReadTask } from '../../storage/read-executor'
+import type { StorageReadTask } from '../../storage/read-executor'
 import type { StorageSession } from '../../storage/session'
 import type { DeleteWorkerRequest, DeleteWorkerResponse } from '../../workers/delete-worker'
+import type { AvailableBuild } from '../../../shared/types/database'
 import type { ValidatedCaseSearchParams } from '../../../shared/types/ipc-schemas'
 
 /** Callbacks for emitting events to the renderer during delete operations. */

--- a/src/main/ipc/handlers/cases-logic.ts
+++ b/src/main/ipc/handlers/cases-logic.ts
@@ -9,8 +9,7 @@ import { Worker } from 'worker_threads'
 import { resolve } from 'node:path'
 import { mainLogger } from '../../services/MainLogger'
 import type { DatabaseService } from '../../database/DatabaseService'
-import type { DbPool } from '../../database/DbPool'
-import type { StorageReadTask } from '../../storage/read-executor'
+import type { AvailableBuild, StorageReadTask } from '../../storage/read-executor'
 import type { StorageSession } from '../../storage/session'
 import type { DeleteWorkerRequest, DeleteWorkerResponse } from '../../workers/delete-worker'
 import type { ValidatedCaseSearchParams } from '../../../shared/types/ipc-schemas'
@@ -106,18 +105,14 @@ export async function queryCases(
  * Used by the cohort view to populate the genome build selector.
  */
 export async function getAvailableBuilds(
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
-): Promise<Array<{ build: string; caseCount: number }>> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return (await pool.run({ type: 'cases:availableBuilds', params: [] })) as Array<{
-      build: string
-      caseCount: number
-    }>
+  getSession: () => StorageSession
+): Promise<AvailableBuild[]> {
+  const task: StorageReadTask = {
+    type: 'cases:availableBuilds',
+    params: []
   }
-  const db = getDb()
-  return db.cases.getAvailableGenomeBuilds()
+
+  return (await getSession().getReadExecutor().execute(task)) as AvailableBuild[]
 }
 
 /**

--- a/src/main/ipc/handlers/cases.ts
+++ b/src/main/ipc/handlers/cases.ts
@@ -37,18 +37,13 @@ function assertFileBackedWorkerWritesSupported(
  * Cases IPC handlers
  * Channels: cases:list, cases:query, cases:delete, cases:deleteAll, cases:deleteBatch
  */
-export function registerCaseHandlers({
-  ipcMain,
-  getDb,
-  getDbPool,
-  getDbManager
-}: HandlerDependencies): void {
+export function registerCaseHandlers({ ipcMain, getDb, getDbManager }: HandlerDependencies): void {
   ipcMain.handle('cases:list', async () => {
     return wrapHandler(() => listCases(() => getDbManager().getCurrentSession()))
   })
 
   ipcMain.handle('cases:availableBuilds', async () => {
-    return wrapHandler(() => getAvailableBuilds(getDb, getDbPool))
+    return wrapHandler(() => getAvailableBuilds(() => getDbManager().getCurrentSession()))
   })
 
   ipcMain.handle('cases:query', async (_event, params: unknown) => {

--- a/src/main/storage/postgres/PostgresAvailableBuildsRepository.ts
+++ b/src/main/storage/postgres/PostgresAvailableBuildsRepository.ts
@@ -1,6 +1,6 @@
 import type { Pool } from 'pg'
 
-import type { AvailableBuild } from '../read-executor'
+import type { AvailableBuild } from '../../../shared/types/database'
 import { quoteIdentifier } from './identifiers'
 
 interface AvailableBuildRow {
@@ -18,10 +18,10 @@ export class PostgresAvailableBuildsRepository {
     const schemaName = quoteIdentifier(this.schema)
     const query = `
       SELECT
-        genome_build AS build,
+        COALESCE(genome_build, 'GRCh38') AS build,
         COUNT(*)::int AS case_count
       FROM ${schemaName}."cases"
-      GROUP BY genome_build
+      GROUP BY 1
       ORDER BY case_count DESC
     `
 

--- a/src/main/storage/postgres/PostgresAvailableBuildsRepository.ts
+++ b/src/main/storage/postgres/PostgresAvailableBuildsRepository.ts
@@ -1,0 +1,35 @@
+import type { Pool } from 'pg'
+
+import type { AvailableBuild } from '../read-executor'
+import { quoteIdentifier } from './identifiers'
+
+interface AvailableBuildRow {
+  build: unknown
+  case_count: unknown
+}
+
+export class PostgresAvailableBuildsRepository {
+  constructor(
+    private readonly pool: Pick<Pool, 'query'>,
+    private readonly schema: string
+  ) {}
+
+  async getAvailableGenomeBuilds(): Promise<AvailableBuild[]> {
+    const schemaName = quoteIdentifier(this.schema)
+    const query = `
+      SELECT
+        genome_build AS build,
+        COUNT(*)::int AS case_count
+      FROM ${schemaName}."cases"
+      GROUP BY genome_build
+      ORDER BY case_count DESC
+    `
+
+    const result = await this.pool.query<AvailableBuildRow>(query)
+
+    return result.rows.map((row) => ({
+      build: row.build === null || row.build === undefined ? 'GRCh38' : String(row.build),
+      caseCount: Number(row.case_count)
+    }))
+  }
+}

--- a/src/main/storage/postgres/PostgresCasesQueryRepository.ts
+++ b/src/main/storage/postgres/PostgresCasesQueryRepository.ts
@@ -2,10 +2,7 @@ import type { Pool } from 'pg'
 
 import type { CaseWithCohorts, PaginatedResult } from '../../../shared/types/database'
 import type { ValidatedCaseSearchParams } from '../../../shared/types/ipc-schemas'
-
-function quoteIdentifier(identifier: string): string {
-  return `"${identifier.split('"').join('""')}"`
-}
+import { quoteIdentifier } from './identifiers'
 
 export class PostgresCasesQueryRepository {
   constructor(

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -1,13 +1,22 @@
 import type { StorageReadExecutor, StorageReadTask } from '../read-executor'
+import type { PostgresAvailableBuildsRepository } from './PostgresAvailableBuildsRepository'
 import type { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 
+interface PostgresReadExecutorRepositories {
+  casesQuery: Pick<PostgresCasesQueryRepository, 'queryCases'>
+  availableBuilds: Pick<PostgresAvailableBuildsRepository, 'getAvailableGenomeBuilds'>
+}
+
 export class PostgresReadExecutor implements StorageReadExecutor {
-  constructor(private readonly casesQuery: Pick<PostgresCasesQueryRepository, 'queryCases'>) {}
+  constructor(private readonly repositories: PostgresReadExecutorRepositories) {}
 
   async execute(task: StorageReadTask): Promise<unknown> {
     switch (task.type) {
       case 'cases:query':
-        return await this.casesQuery.queryCases(task.params)
+        return await this.repositories.casesQuery.queryCases(task.params)
+
+      case 'cases:availableBuilds':
+        return await this.repositories.availableBuilds.getAvailableGenomeBuilds()
     }
   }
 }

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -18,5 +18,8 @@ export class PostgresReadExecutor implements StorageReadExecutor {
       case 'cases:availableBuilds':
         return await this.repositories.availableBuilds.getAvailableGenomeBuilds()
     }
+
+    const _exhaustive: never = task
+    throw new Error(`Unhandled read task: ${JSON.stringify(_exhaustive)}`)
   }
 }

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -4,6 +4,7 @@ import { mainLogger } from '../../services/MainLogger'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
 import type { Case } from '../../../shared/types/database'
+import { PostgresAvailableBuildsRepository } from './PostgresAvailableBuildsRepository'
 import { PostgresCaseListRepository } from './PostgresCaseListRepository'
 import { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 import { PostgresReadExecutor } from './PostgresReadExecutor'
@@ -50,9 +51,10 @@ export class PostgresStorageSession implements StorageSession {
 
   constructor(options: PostgresStorageSessionOptions) {
     this.pool = options.pool
-    this.readExecutor = new PostgresReadExecutor(
-      new PostgresCasesQueryRepository(options.pool, options.config.schema)
-    )
+    this.readExecutor = new PostgresReadExecutor({
+      casesQuery: new PostgresCasesQueryRepository(options.pool, options.config.schema),
+      availableBuilds: new PostgresAvailableBuildsRepository(options.pool, options.config.schema)
+    })
     this.createCaseListRepository =
       options.createCaseListRepository ??
       ((pool: Pool, schema: string) => new PostgresCaseListRepository(pool, schema))

--- a/src/main/storage/postgres/identifiers.ts
+++ b/src/main/storage/postgres/identifiers.ts
@@ -1,0 +1,3 @@
+export function quoteIdentifier(identifier: string): string {
+  return `"${identifier.split('"').join('""')}"`
+}

--- a/src/main/storage/read-executor.ts
+++ b/src/main/storage/read-executor.ts
@@ -1,9 +1,19 @@
 import type { ValidatedCaseSearchParams } from '../../shared/types/ipc-schemas'
 
-export type StorageReadTask = {
-  type: 'cases:query'
-  params: ValidatedCaseSearchParams
+export interface AvailableBuild {
+  build: string
+  caseCount: number
 }
+
+export type StorageReadTask =
+  | {
+      type: 'cases:query'
+      params: ValidatedCaseSearchParams
+    }
+  | {
+      type: 'cases:availableBuilds'
+      params: []
+    }
 
 export interface StorageReadExecutor {
   execute(task: StorageReadTask): Promise<unknown>

--- a/src/main/storage/read-executor.ts
+++ b/src/main/storage/read-executor.ts
@@ -1,9 +1,6 @@
 import type { ValidatedCaseSearchParams } from '../../shared/types/ipc-schemas'
 
-export interface AvailableBuild {
-  build: string
-  caseCount: number
-}
+export type { AvailableBuild } from '../../shared/types/database'
 
 export type StorageReadTask =
   | {

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -19,6 +19,16 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         }
 
         return this.databaseService.cases.queryCases(task.params)
+
+      case 'cases:availableBuilds':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'cases:availableBuilds',
+            params: []
+          })
+        }
+
+        return this.databaseService.cases.getAvailableGenomeBuilds()
     }
   }
 }

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -30,5 +30,8 @@ export class SqliteReadExecutor implements StorageReadExecutor {
 
         return this.databaseService.cases.getAvailableGenomeBuilds()
     }
+
+    const _exhaustive: never = task
+    throw new Error(`Unhandled read task: ${JSON.stringify(_exhaustive)}`)
   }
 }

--- a/src/renderer/src/composables/useCohortData.ts
+++ b/src/renderer/src/composables/useCohortData.ts
@@ -20,16 +20,11 @@ import type { Ref, ShallowRef, InjectionKey } from 'vue'
 import type { CohortVariant, CohortSummary } from '../../../shared/types/cohort'
 import type { ColumnFilterMeta } from '../../../shared/types/column-filters'
 import type { ColumnFiltersParam } from '../../../shared/types/column-filters'
+import type { AvailableBuild } from '../../../shared/types/database'
 import { useApiService } from './useApiService'
 import { cloneForIpc } from '../utils/cloneForIpc'
 import { logService } from '../services/LogService'
 import { isIpcError, unwrapIpcResult } from '../../../shared/types/errors'
-
-/** A single entry in the available genome builds list returned by cases:availableBuilds */
-export interface AvailableBuild {
-  build: string
-  caseCount: number
-}
 
 /**
  * Query parameters for cohort variant fetching

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -32,6 +32,12 @@ export interface CaseSearchParams {
   _count_needed?: boolean
 }
 
+/** Genome build option returned by cases:availableBuilds. */
+export interface AvailableBuild {
+  build: string
+  caseCount: number
+}
+
 /**
  * Database entity types for Varlens
  *

--- a/tests/main/database/case-query.test.ts
+++ b/tests/main/database/case-query.test.ts
@@ -27,6 +27,27 @@ describe('CaseRepository.queryCases', () => {
     return result.lastInsertRowid as number
   }
 
+  /** Insert a case with an explicit genome build value, including null. */
+  const insertCaseWithBuild = (
+    name: string,
+    genomeBuild: string | null,
+    variantCount = 0,
+    createdAt?: number
+  ): number => {
+    const stmt = db.prepare(
+      'INSERT INTO cases (name, file_path, file_size, variant_count, created_at, genome_build) VALUES (?, ?, ?, ?, ?, ?)'
+    )
+    const result = stmt.run(
+      name,
+      `/test/${name}.json`,
+      1000,
+      variantCount,
+      createdAt ?? Date.now(),
+      genomeBuild
+    )
+    return result.lastInsertRowid as number
+  }
+
   /** Insert case_metadata for a case */
   const insertMetadata = (
     caseId: number,
@@ -221,6 +242,19 @@ describe('CaseRepository.queryCases', () => {
 
       const result = caseRepo.queryCases({ limit: 50 })
       expect(result.total_count).toBe(5)
+    })
+  })
+
+  describe('available genome builds', () => {
+    it('merges null genome_build rows into the GRCh38 bucket before counting', () => {
+      insertCaseWithBuild('GRCh38 Case', 'GRCh38')
+      insertCaseWithBuild('Legacy Null Case', null)
+      insertCaseWithBuild('GRCh37 Case', 'GRCh37')
+
+      expect(caseRepo.getAvailableGenomeBuilds()).toEqual([
+        { build: 'GRCh38', caseCount: 2 },
+        { build: 'GRCh37', caseCount: 1 }
+      ])
     })
   })
 

--- a/tests/main/database/dbpool-lazy.test.ts
+++ b/tests/main/database/dbpool-lazy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('DbPool lazy initialization', () => {
+  it('does not load a missing worker during init-only lifecycle', async () => {
+    vi.resetModules()
+    const { DbPool } = await import('../../../src/main/database/DbPool')
+    const pool = new DbPool()
+
+    pool.init('/tmp/varlens-lazy.db', undefined, {
+      workerPath: '/tmp/varlens-missing-db-worker.js',
+      maxThreads: 1
+    })
+
+    expect(pool.isInitialised()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    await pool.destroy()
+  })
+})

--- a/tests/main/handlers/cases-handlers.test.ts
+++ b/tests/main/handlers/cases-handlers.test.ts
@@ -205,6 +205,46 @@ describe('cases IPC handlers', () => {
     })
   })
 
+  it('routes cases:availableBuilds through the active storage read executor', async () => {
+    const expected = [{ build: 'GRCh38', caseCount: 2 }]
+    const execute = vi.fn().mockResolvedValue(expected)
+    const currentSession = {
+      getReadExecutor: () => ({ execute })
+    }
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler)
+      })
+    }
+
+    const { registerCaseHandlers } = await import('../../../src/main/ipc/handlers/cases')
+
+    registerCaseHandlers({
+      ipcMain: ipcMain as never,
+      getDb: (() => {
+        throw new Error('getDb should not be called for cases:availableBuilds')
+      }) as never,
+      getDbManager: (() => ({
+        getCurrentSession: () => currentSession
+      })) as never,
+      getDbPool: (() => {
+        throw new Error('getDbPool should not be called for cases:availableBuilds')
+      }) as never
+    })
+
+    const handler = handlers.get('cases:availableBuilds')
+    expect(handler).toBeTypeOf('function')
+
+    const result = await handler!()
+
+    expect(result).toBe(expected)
+    expect(execute).toHaveBeenCalledWith({
+      type: 'cases:availableBuilds',
+      params: []
+    })
+  })
+
   it('rejects worker-backed case deletes for postgres sessions before sqlite access', async () => {
     const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
     const ipcMain = {

--- a/tests/main/storage/postgres-available-builds-repository.test.ts
+++ b/tests/main/storage/postgres-available-builds-repository.test.ts
@@ -6,19 +6,19 @@ describe('PostgresAvailableBuildsRepository', () => {
   it('returns available genome builds with numeric counts and null-build fallback', async () => {
     const query = vi.fn().mockResolvedValue({
       rows: [
-        { build: 'GRCh38', case_count: '3' },
-        { build: null, case_count: 1 }
+        { build: 'GRCh38', case_count: '4' },
+        { build: 'GRCh37', case_count: 1 }
       ]
     })
     const repository = new PostgresAvailableBuildsRepository({ query } as never, 'public')
 
     await expect(repository.getAvailableGenomeBuilds()).resolves.toEqual([
-      { build: 'GRCh38', caseCount: 3 },
-      { build: 'GRCh38', caseCount: 1 }
+      { build: 'GRCh38', caseCount: 4 },
+      { build: 'GRCh37', caseCount: 1 }
     ])
   })
 
-  it('quotes the configured schema and groups by the stored genome build', async () => {
+  it('quotes the configured schema and groups by the normalized genome build', async () => {
     const query = vi.fn().mockResolvedValue({
       rows: [{ build: 'GRCh38', case_count: 1 }]
     })
@@ -29,7 +29,8 @@ describe('PostgresAvailableBuildsRepository', () => {
     expect(query).toHaveBeenCalledTimes(1)
     const sql = query.mock.calls[0][0] as string
     expect(sql).toContain('"tenant""schema"."cases"')
-    expect(sql).toContain('GROUP BY genome_build')
+    expect(sql).toContain("COALESCE(genome_build, 'GRCh38') AS build")
+    expect(sql).toContain('GROUP BY 1')
     expect(sql).toContain('ORDER BY case_count DESC')
   })
 })

--- a/tests/main/storage/postgres-available-builds-repository.test.ts
+++ b/tests/main/storage/postgres-available-builds-repository.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PostgresAvailableBuildsRepository } from '../../../src/main/storage/postgres/PostgresAvailableBuildsRepository'
+
+describe('PostgresAvailableBuildsRepository', () => {
+  it('returns available genome builds with numeric counts and null-build fallback', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        { build: 'GRCh38', case_count: '3' },
+        { build: null, case_count: 1 }
+      ]
+    })
+    const repository = new PostgresAvailableBuildsRepository({ query } as never, 'public')
+
+    await expect(repository.getAvailableGenomeBuilds()).resolves.toEqual([
+      { build: 'GRCh38', caseCount: 3 },
+      { build: 'GRCh38', caseCount: 1 }
+    ])
+  })
+
+  it('quotes the configured schema and groups by the stored genome build', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{ build: 'GRCh38', case_count: 1 }]
+    })
+    const repository = new PostgresAvailableBuildsRepository({ query } as never, 'tenant"schema')
+
+    await repository.getAvailableGenomeBuilds()
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const sql = query.mock.calls[0][0] as string
+    expect(sql).toContain('"tenant""schema"."cases"')
+    expect(sql).toContain('GROUP BY genome_build')
+    expect(sql).toContain('ORDER BY case_count DESC')
+  })
+})

--- a/tests/main/storage/postgres-identifiers.test.ts
+++ b/tests/main/storage/postgres-identifiers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { quoteIdentifier } from '../../../src/main/storage/postgres/identifiers'
+
+describe('postgres identifier helpers', () => {
+  it('wraps identifiers in double quotes', () => {
+    expect(quoteIdentifier('public')).toBe('"public"')
+  })
+
+  it('escapes embedded double quotes by doubling them', () => {
+    expect(quoteIdentifier('tenant"schema')).toBe('"tenant""schema"')
+  })
+})

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -8,15 +8,36 @@ describe('PostgresReadExecutor', () => {
     const casesQuery = {
       queryCases: vi.fn().mockResolvedValue(expected)
     }
+    const availableBuilds = {
+      getAvailableGenomeBuilds: vi.fn()
+    }
     const params = {
       limit: 25,
       offset: 0,
       sort_by: 'created_at' as const,
       sort_order: 'desc' as const
     }
-    const executor = new PostgresReadExecutor(casesQuery)
+    const executor = new PostgresReadExecutor({ casesQuery, availableBuilds })
 
     await expect(executor.execute({ type: 'cases:query', params })).resolves.toBe(expected)
     expect(casesQuery.queryCases).toHaveBeenCalledWith(params)
+    expect(availableBuilds.getAvailableGenomeBuilds).not.toHaveBeenCalled()
+  })
+
+  it('dispatches cases:availableBuilds to the postgres available-builds repository', async () => {
+    const expected = [{ build: 'GRCh38', caseCount: 2 }]
+    const casesQuery = {
+      queryCases: vi.fn()
+    }
+    const availableBuilds = {
+      getAvailableGenomeBuilds: vi.fn().mockResolvedValue(expected)
+    }
+    const executor = new PostgresReadExecutor({ casesQuery, availableBuilds })
+
+    await expect(executor.execute({ type: 'cases:availableBuilds', params: [] })).resolves.toBe(
+      expected
+    )
+    expect(availableBuilds.getAvailableGenomeBuilds).toHaveBeenCalledWith()
+    expect(casesQuery.queryCases).not.toHaveBeenCalled()
   })
 })

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -197,4 +197,28 @@ describe('PostgresStorageSession', () => {
       total_count: 1
     })
   })
+
+  it('routes cases:availableBuilds through the session-owned postgres read executor', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ build: 'GRCh38', case_count: 2 }]
+      }),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+    const session = new PostgresStorageSession({
+      config: makeConfig({ schema: 'phase5_cases' }),
+      pool: pool as never
+    })
+
+    await expect(
+      session.getReadExecutor().execute({
+        type: 'cases:availableBuilds',
+        params: []
+      })
+    ).resolves.toEqual([{ build: 'GRCh38', caseCount: 2 }])
+
+    expect(pool.query).toHaveBeenCalledTimes(1)
+    expect(pool.query.mock.calls[0][0]).toContain('"phase5_cases"."cases"')
+  })
 })

--- a/tests/main/storage/read-executor-contract.test.ts
+++ b/tests/main/storage/read-executor-contract.test.ts
@@ -1,7 +1,11 @@
 import { describe, expectTypeOf, it } from 'vitest'
 
 import type { ValidatedCaseSearchParams } from '../../../src/shared/types/ipc-schemas'
-import type { StorageReadExecutor, StorageReadTask } from '../../../src/main/storage/read-executor'
+import type {
+  AvailableBuild,
+  StorageReadExecutor,
+  StorageReadTask
+} from '../../../src/main/storage/read-executor'
 
 describe('StorageReadExecutor contract', () => {
   it('accepts the narrow Phase 4 cases:query task union', () => {
@@ -18,6 +22,17 @@ describe('StorageReadExecutor contract', () => {
     } satisfies StorageReadTask
 
     expectTypeOf(queryTask).toMatchTypeOf<StorageReadTask>()
+    expectTypeOf<StorageReadExecutor['execute']>().returns.toEqualTypeOf<Promise<unknown>>()
+  })
+
+  it('supports cases:availableBuilds as a typed read task', () => {
+    const task = {
+      type: 'cases:availableBuilds',
+      params: []
+    } satisfies StorageReadTask
+
+    expectTypeOf(task.params).toEqualTypeOf<[]>()
+    expectTypeOf<AvailableBuild>().toEqualTypeOf<{ build: string; caseCount: number }>()
     expectTypeOf<StorageReadExecutor['execute']>().returns.toEqualTypeOf<Promise<unknown>>()
   })
 })

--- a/tests/main/storage/read-executor-contract.test.ts
+++ b/tests/main/storage/read-executor-contract.test.ts
@@ -1,11 +1,8 @@
 import { describe, expectTypeOf, it } from 'vitest'
 
+import type { AvailableBuild } from '../../../src/shared/types/database'
 import type { ValidatedCaseSearchParams } from '../../../src/shared/types/ipc-schemas'
-import type {
-  AvailableBuild,
-  StorageReadExecutor,
-  StorageReadTask
-} from '../../../src/main/storage/read-executor'
+import type { StorageReadExecutor, StorageReadTask } from '../../../src/main/storage/read-executor'
 
 describe('StorageReadExecutor contract', () => {
   it('accepts the narrow Phase 4 cases:query task union', () => {

--- a/tests/main/storage/sqlite-read-executor.test.ts
+++ b/tests/main/storage/sqlite-read-executor.test.ts
@@ -43,4 +43,41 @@ describe('SqliteReadExecutor', () => {
     await expect(executor.execute({ type: 'cases:query', params })).resolves.toBe(expected)
     expect(databaseService.cases.queryCases).toHaveBeenCalledWith(params)
   })
+
+  it('uses the worker read pool for cases:availableBuilds when a pool exists', async () => {
+    const expected = [{ build: 'GRCh38', caseCount: 2 }]
+    const dbPool = {
+      run: vi.fn().mockResolvedValue(expected)
+    }
+    const databaseService = {
+      cases: {
+        getAvailableGenomeBuilds: vi.fn()
+      }
+    }
+    const executor = new SqliteReadExecutor(databaseService as never, dbPool as never)
+
+    await expect(executor.execute({ type: 'cases:availableBuilds', params: [] })).resolves.toBe(
+      expected
+    )
+    expect(dbPool.run).toHaveBeenCalledWith({
+      type: 'cases:availableBuilds',
+      params: []
+    })
+    expect(databaseService.cases.getAvailableGenomeBuilds).not.toHaveBeenCalled()
+  })
+
+  it('falls back to DatabaseService for cases:availableBuilds when no pool exists', async () => {
+    const expected = [{ build: 'GRCh37', caseCount: 1 }]
+    const databaseService = {
+      cases: {
+        getAvailableGenomeBuilds: vi.fn().mockReturnValue(expected)
+      }
+    }
+    const executor = new SqliteReadExecutor(databaseService as never, null)
+
+    await expect(executor.execute({ type: 'cases:availableBuilds', params: [] })).resolves.toBe(
+      expected
+    )
+    expect(databaseService.cases.getAvailableGenomeBuilds).toHaveBeenCalledWith()
+  })
 })


### PR DESCRIPTION
## Summary

- Add `cases:availableBuilds` to the session-owned storage read executor contract.
- Preserve SQLite behavior through the worker pool/direct `DatabaseService` fallback paths.
- Add PostgreSQL available-builds execution and route the IPC handler through the active storage session.

## Phase 5 Scope

Backend-aware Phase 5 coverage is included in normal CI through Vitest:

- `tests/main/storage/sqlite-read-executor.test.ts`
- `tests/main/storage/postgres-identifiers.test.ts`
- `tests/main/storage/postgres-cases-query-repository.test.ts`
- `tests/main/storage/postgres-available-builds-repository.test.ts`
- `tests/main/storage/postgres-read-executor.test.ts`
- `tests/main/storage/postgres-storage-session.test.ts`
- `tests/main/handlers/cases-handlers.test.ts`

No Docker-backed PostgreSQL CI service is added in this phase. The PostgreSQL coverage uses mocked `pg.Pool` calls and runs under the existing `npm run test` step. `database:overview` remains on the legacy SQLite pool/direct path by design and should be evaluated as a later cross-domain read slice.

## Validation

- `make rebuild-node && npx vitest run tests/main/storage/read-executor-contract.test.ts tests/main/storage/sqlite-read-executor.test.ts tests/main/storage/postgres-identifiers.test.ts tests/main/storage/postgres-cases-query-repository.test.ts tests/main/storage/postgres-available-builds-repository.test.ts tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/handlers/cases-handlers.test.ts`
- `make typecheck`
- `make ci`
