### PR TITLE
refactor(storage): add postgres case metadata parity

### DIFF
--- a/.planning/artifacts/postgres-parity-phase-6-wgs-readiness.md
+++ b/.planning/artifacts/postgres-parity-phase-6-wgs-readiness.md
@@ -1,0 +1,51 @@
+# PostgreSQL WGS-readiness Inventory
+
+**Date:** 2026-04-24
+**Scope:** Planning artifact only; no runtime code changes.
+
+## Variant Tables Required
+
+- `variants`
+- `variant_transcripts`
+- `variant_frequency`
+- `variant_sv`
+- `variant_cnv`
+- `variant_str`
+- PostgreSQL replacement for SQLite FTS tables
+
+## First Variant-read Slice
+
+Implement `variants:typeCounts`, `variants:typesPresent`, and `variants:geneSymbols` before full `variants:query`.
+
+Reason: these are small, user-visible, case-scoped queries that validate variant table shape and indexes before porting the full filter builder.
+
+## Indexes To Evaluate
+
+- `variants(case_id, variant_type)`
+- `variants(case_id, gene_symbol)`
+- `variants(case_id, chr, pos)`
+- `variants(case_id, consequence)`
+- `variants(case_id, func)`
+- `variant_frequency(chr, pos, ref, alt)`
+- extension table indexes on `variant_id`
+
+## PostgreSQL Full-text Options
+
+- `to_tsvector` generated/search column plus GIN index for basic text search
+- trigram index for gene/HGVS-ish prefix/fuzzy lookups
+- explicit degraded mode only if search is excluded from early PG beta
+
+## Import Scale Blockers
+
+- current import worker accepts `dbPath` and SQLite key
+- current import SQL is synchronous better-sqlite3 statements
+- current FTS trigger teardown/rebuild is SQLite-specific
+- PostgreSQL bulk path needs `COPY` or batched `INSERT ... ON CONFLICT`
+
+## Measurement Commands For Phase 7
+
+```bash
+make pg-reset
+make pg-up
+VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-*.e2e.ts
+```

--- a/.planning/plans/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md
+++ b/.planning/plans/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md
@@ -1,0 +1,1705 @@
+# PostgreSQL Parity Phase 6: Case Metadata and Cases Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete PostgreSQL parity for cases-query metadata filters and the `case-metadata:*` domain, validate it early against a running Docker PostgreSQL backend, and keep renderer PostgreSQL settings hidden.
+
+**Architecture:** Use a Docker-first loop, then add a small backend-aware write executor beside the existing read executor and migrate one domain vertically. SQLite executors delegate to existing `DatabaseService` repositories; PostgreSQL executors delegate to a focused `PostgresCaseMetadataRepository`. `database:overview`, broad variants, import, export, delete, and summary rebuild remain deferred, but Phase 6 also produces the WGS-readiness notes needed to start Phase 7 immediately.
+
+**Tech Stack:** Electron 40 main process IPC, TypeScript 6, `pg`, `better-sqlite3-multiple-ciphers`, Vitest, gated Docker PostgreSQL dev workflow, Playwright Electron E2E, `make rebuild-node`, `make typecheck`, `make ci`
+
+---
+
+## Reference Checks
+
+Implementation details in this plan are pinned to primary documentation:
+
+- Docker PostgreSQL init scripts in `/docker-entrypoint-initdb.d/` run on first database initialization in alphabetical order, so Phase 6 FK DDL must sort after `10-phase3-cases.sql`: https://docs.docker.com/guides/postgresql/advanced-configuration-and-initialization/
+- node-postgres transactions must use one checked-out client; do not implement multi-statement transactions with separate `pool.query(...)` calls: https://node-postgres.com/features/transactions
+- PostgreSQL sequences are independent objects; deterministic explicit-ID seed data must reset affected `BIGSERIAL` sequences with `setval(...)`: https://www.postgresql.org/docs/current/functions-sequence.html
+
+## Parallelization Note
+
+This plan is designed for maximum safe parallelism. When implementation starts, use `superpowers:subagent-driven-development` and dispatch workers by lane after Task 1 lands. Do not dispatch implementation agents during planning.
+
+| Lane | Can start after | Write set | Commit prefix |
+|---|---|---|---|
+| A Docker/schema/E2E | Task 0 and Task 0A baseline smoke | `scripts/postgres/init-db/`, `tests/e2e/postgres-*.e2e.ts` | `test(e2e): ...` |
+| B PostgreSQL repository | Task 1 | `src/main/storage/postgres/PostgresCaseMetadataRepository.ts`, repository tests | `feat(storage): ...` |
+| C SQLite executors | Task 1; merge only with matching Task 4 session interface work | `src/main/storage/sqlite/`, SQLite storage tests | `refactor(storage): ...` |
+| D PostgreSQL executor/session | Tasks 1 and 2 | `src/main/storage/postgres/PostgresReadExecutor.ts`, `PostgresWriteExecutor.ts`, `PostgresStorageSession.ts` | `refactor(storage): ...` |
+| E IPC routing | Tasks 1, 3, and 4 | `src/main/ipc/handlers/case-metadata*`, handler tests | `refactor(ipc): ...` |
+| F Cases filters | Task 2 Step 3 schema file exists | `PostgresCasesQueryRepository.ts`, cases query tests | `feat(storage): ...` |
+| G WGS readiness notes | Task 2 schema/repository decisions are known | `.planning/artifacts/` or `.planning/docs/` only | `docs(planning): ...` |
+
+The fastest implementation order is:
+
+1. Land Task 0 and run Task 0A baseline Docker smoke.
+2. Land Task 1 contract work.
+3. Split Task 2 schema and repository work where useful; schema must use `11-phase6-case-metadata.sql`.
+4. Run Task 3 and Task 4 in parallel, but merge them together or only after both backends implement `getWriteExecutor()`.
+5. Run Task 5 IPC routing and Task 6 cases-filter parity in parallel after Task 2; Task 6 does not depend on IPC routing.
+6. Run Task 0B/Lane G after Task 2 so WGS notes are grounded in the Phase 6 PostgreSQL schema/repository choices.
+7. Run focused tests after every lane merge, then Docker E2E, then `make ci`.
+
+## File Structure
+
+### New Files
+
+- `src/main/storage/case-metadata-types.ts` - backend-neutral case metadata parameter/result types shared by storage and IPC logic.
+- `src/main/storage/write-executor.ts` - typed backend-neutral write task contract.
+- `src/main/storage/sqlite/SqliteWriteExecutor.ts` - SQLite write executor delegating to `DatabaseService`.
+- `src/main/storage/postgres/PostgresWriteExecutor.ts` - PostgreSQL write executor delegating to PostgreSQL repositories.
+- `src/main/storage/postgres/PostgresCaseMetadataRepository.ts` - PostgreSQL implementation of case metadata reads and writes.
+- `tests/main/storage/write-executor-contract.test.ts` - type contract tests for write tasks.
+- `tests/main/storage/sqlite-write-executor.test.ts` - SQLite write executor tests.
+- `tests/main/storage/postgres-case-metadata-repository.test.ts` - PostgreSQL repository tests using mocked `pg.Pool`.
+- `tests/main/storage/postgres-write-executor.test.ts` - PostgreSQL write dispatch tests.
+- `tests/main/handlers/case-metadata-routing.test.ts` - IPC registration tests that prove PostgreSQL routing uses the active storage session.
+- `tests/e2e/postgres-case-metadata-dev-mode.e2e.ts` - gated Docker-backed E2E for case metadata.
+- `scripts/postgres/init-db/11-phase6-case-metadata.sql` - Phase 6 PostgreSQL dev DDL that runs after `10-phase3-cases.sql` creates `cases`.
+
+### Modified Files
+
+- `src/main/storage/read-executor.ts` - add case metadata read tasks.
+- `src/main/storage/session.ts` - expose `getWriteExecutor()`.
+- `src/main/storage/sqlite/SqliteReadExecutor.ts` - dispatch case metadata read tasks.
+- `src/main/storage/sqlite/SqliteStorageSession.ts` - construct the SQLite write executor.
+- `src/main/storage/postgres/PostgresReadExecutor.ts` - dispatch case metadata read tasks.
+- `src/main/storage/postgres/PostgresStorageSession.ts` - construct case metadata repository and write executor.
+- `src/main/storage/postgres/PostgresCasesQueryRepository.ts` - support `cohort_ids` and `hpo_ids`.
+- `src/main/ipc/handlers/case-metadata-logic.ts` - use storage session executors.
+- `src/main/ipc/handlers/case-metadata.ts` - pass active session into logic functions.
+- `scripts/postgres/init-db/20-phase3-seed-cases.sql` - seed metadata rows used by gated Docker E2E.
+- `scripts/postgres/init-db/README.md` - document the Phase 6 init file and fresh-volume ordering.
+- `tests/main/storage/read-executor-contract.test.ts` - add case metadata read task coverage.
+- `tests/main/storage/sqlite-read-executor.test.ts` - add SQLite read dispatch coverage.
+- `tests/main/storage/postgres-read-executor.test.ts` - add PostgreSQL read dispatch coverage.
+- `tests/main/storage/postgres-storage-session.test.ts` - assert read/write executor routing.
+- `tests/main/storage/storage-manager-compat.test.ts` - update mock sessions with `getWriteExecutor`.
+- `tests/main/handlers/case-metadata-logic.test.ts` - update logic tests for executor dependencies.
+- `tests/main/storage/postgres-cases-query-repository.test.ts` - replace unsupported-filter tests with parity tests.
+
+### Explicitly Unchanged
+
+- `src/main/ipc/handlers/database-logic.ts` - `database:overview` remains legacy SQLite pool/direct logic.
+- `src/main/workers/import-worker.ts` - import remains SQLite-file-backed.
+- `src/main/workers/export-worker.ts` - export remains SQLite-file-backed.
+- `src/main/workers/delete-worker.ts` - delete remains SQLite-file-backed.
+- `src/main/workers/rebuild-summary-worker.ts` - summary rebuild remains SQLite-file-backed.
+- Renderer and preload storage settings - no PostgreSQL settings UI in Phase 6.
+
+## Task 0: Start the Implementation Branch
+
+**Files:**
+
+- No source files
+
+- [ ] **Step 1: Confirm base state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -5
+```
+
+Expected:
+
+- Work starts from an understood branch.
+- Existing local changes, including planning docs, are not overwritten.
+- Implementation does not commit directly to `main`.
+
+- [ ] **Step 2: Create the implementation branch**
+
+Run:
+
+```bash
+git switch -c refactor/postgres-parity-phase-6-case-metadata
+```
+
+Expected:
+
+- New branch `refactor/postgres-parity-phase-6-case-metadata`.
+- All Phase 6 implementation commits are made on this branch.
+
+## Task 0A: Docker-first Baseline Smoke
+
+**Files:**
+
+- No source files unless the existing Docker smoke is broken
+
+Run this immediately after Task 0 has created the implementation branch.
+
+- [ ] **Step 1: Reset and start the local PostgreSQL backend**
+
+Run:
+
+```bash
+make pg-reset
+make pg-up
+```
+
+Expected:
+
+- Docker starts `docker-compose.postgres.yml`.
+- PostgreSQL listens on `127.0.0.1:${VARLENS_PG_PORT:-55432}`.
+- If Docker is unavailable, record this and continue with unit tests; do not mark Docker verification complete.
+
+- [ ] **Step 2: Run the current gated PostgreSQL E2E**
+
+Run:
+
+```bash
+VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+```
+
+Expected:
+
+- PASS against the running Docker PostgreSQL backend.
+- This proves the branch starts from a working PostgreSQL runtime before Phase 6 expands schema and IPC coverage.
+
+- [ ] **Step 3: Stop the local backend**
+
+Run:
+
+```bash
+make pg-down
+```
+
+Expected:
+
+- Docker PostgreSQL is stopped.
+
+- [ ] **Step 4: Commit only if a baseline fix was required**
+
+Run this only if Step 2 required a test or Docker bootstrap fix, and only on the implementation branch from Task 0:
+
+```bash
+git add docker-compose.postgres.yml scripts/postgres tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+git commit -m "test(e2e): keep postgres docker smoke runnable"
+```
+
+Expected:
+
+- No commit if the existing Docker smoke already passes.
+
+## Task 0B: WGS-readiness Inventory Artifact
+
+**Files:**
+
+- Create: `.planning/artifacts/postgres-parity-phase-6-wgs-readiness.md`
+
+Run this artifact task after Task 2 schema/repository decisions are known, even though it is numbered with the branch/bootstrap work. It is planning-only and must not touch runtime files.
+
+- [ ] **Step 1: Write the WGS-readiness artifact**
+
+Create `.planning/artifacts/postgres-parity-phase-6-wgs-readiness.md` with these sections:
+
+```markdown
+# PostgreSQL WGS-readiness Inventory
+
+**Date:** 2026-04-24
+**Scope:** Planning artifact only; no runtime code changes.
+
+## Variant Tables Required
+
+- `variants`
+- `variant_transcripts`
+- `variant_frequency`
+- `variant_sv`
+- `variant_cnv`
+- `variant_str`
+- PostgreSQL replacement for SQLite FTS tables
+
+## First Variant-read Slice
+
+Implement `variants:typeCounts`, `variants:typesPresent`, and `variants:geneSymbols` before full `variants:query`.
+
+Reason: these are small, user-visible, case-scoped queries that validate variant table shape and indexes before porting the full filter builder.
+
+## Indexes To Evaluate
+
+- `variants(case_id, variant_type)`
+- `variants(case_id, gene_symbol)`
+- `variants(case_id, chr, pos)`
+- `variants(case_id, consequence)`
+- `variants(case_id, func)`
+- `variant_frequency(chr, pos, ref, alt)`
+- extension table indexes on `variant_id`
+
+## PostgreSQL Full-text Options
+
+- `to_tsvector` generated/search column plus GIN index for basic text search
+- trigram index for gene/HGVS-ish prefix/fuzzy lookups
+- explicit degraded mode only if search is excluded from early PG beta
+
+## Import Scale Blockers
+
+- current import worker accepts `dbPath` and SQLite key
+- current import SQL is synchronous better-sqlite3 statements
+- current FTS trigger teardown/rebuild is SQLite-specific
+- PostgreSQL bulk path needs `COPY` or batched `INSERT ... ON CONFLICT`
+
+## Measurement Commands For Phase 7
+
+```bash
+make pg-reset
+make pg-up
+VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-*.e2e.ts
+```
+```
+
+- [ ] **Step 2: Commit the inventory artifact**
+
+Run:
+
+```bash
+git add .planning/artifacts/postgres-parity-phase-6-wgs-readiness.md
+git commit -m "docs(planning): inventory postgres wgs readiness"
+```
+
+Expected:
+
+- The artifact exists for Phase 7 planning and does not change runtime code.
+
+## Task 1: Add Read and Write Executor Contracts
+
+**Files:**
+
+- Create: `src/main/storage/case-metadata-types.ts`
+- Create: `src/main/storage/write-executor.ts`
+- Modify: `src/main/storage/read-executor.ts`
+- Modify: `src/main/storage/session.ts`
+- Test: `tests/main/storage/read-executor-contract.test.ts`
+- Test: `tests/main/storage/write-executor-contract.test.ts`
+
+- [ ] **Step 1: Write failing read contract tests**
+
+Append these cases to `tests/main/storage/read-executor-contract.test.ts`:
+
+```ts
+it('supports case metadata read tasks', () => {
+  const tasks = [
+    { type: 'case-metadata:get', params: [1] },
+    { type: 'case-metadata:listCohorts', params: [] },
+    { type: 'case-metadata:getCohortByName', params: ['research'] },
+    { type: 'case-metadata:getCaseCohorts', params: [1] },
+    { type: 'case-metadata:getHpoTerms', params: [1] },
+    { type: 'case-metadata:getDataInfo', params: [1] },
+    { type: 'case-metadata:listExternalIds', params: [1] },
+    { type: 'case-metadata:distinctHpoTerms', params: [] },
+    { type: 'case-metadata:distinctPlatforms', params: [] },
+    { type: 'case-metadata:distinctExternalIdTypes', params: [] },
+    { type: 'case-metadata:getFullMetadata', params: [1] }
+  ] satisfies StorageReadTask[]
+
+  expect(tasks).toHaveLength(11)
+})
+```
+
+- [ ] **Step 2: Write failing write contract tests**
+
+Create `tests/main/storage/write-executor-contract.test.ts`:
+
+```ts
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import type { StorageWriteExecutor, StorageWriteTask } from '../../../src/main/storage/write-executor'
+
+describe('StorageWriteExecutor contract', () => {
+  it('supports case metadata write tasks', () => {
+    const tasks = [
+      { type: 'case-metadata:upsert', params: [1, { affected_status: 'affected', age: 42, date_of_birth: '1984-01-02' }] },
+      { type: 'case-metadata:createCohort', params: [{ name: 'research', description: null }] },
+      { type: 'case-metadata:updateCohort', params: [2, { name: 'updated' }] },
+      { type: 'case-metadata:deleteCohort', params: [2] },
+      { type: 'case-metadata:assignCohort', params: [1, 2] },
+      { type: 'case-metadata:removeCohort', params: [1, 2] },
+      { type: 'case-metadata:setCohorts', params: [1, [2, 3]] },
+      { type: 'case-metadata:assignHpoTerm', params: [1, 'HP:0001250', 'Seizure'] },
+      { type: 'case-metadata:removeHpoTerm', params: [1, 'HP:0001250'] },
+      { type: 'case-metadata:upsertDataInfo', params: [1, { platform: 'WGS' }] },
+      { type: 'case-metadata:upsertExternalId', params: [1, 'MRN', '12345'] },
+      { type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] }
+    ] satisfies StorageWriteTask[]
+
+    expect(tasks).toHaveLength(12)
+    expectTypeOf<StorageWriteExecutor['execute']>().returns.toEqualTypeOf<Promise<unknown>>()
+  })
+})
+```
+
+- [ ] **Step 3: Run focused tests and typecheck to confirm failure**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/read-executor-contract.test.ts tests/main/storage/write-executor-contract.test.ts
+make typecheck
+```
+
+Expected:
+
+- Vitest or typecheck fails because the new task unions and write executor do not exist.
+
+- [ ] **Step 4: Add backend-neutral case metadata storage types**
+
+Create `src/main/storage/case-metadata-types.ts`:
+
+```ts
+export interface MetadataUpdates {
+  affected_status?: string | null
+  sex?: string | null
+  notes?: string | null
+  age?: number | null
+  date_of_birth?: string | null
+}
+
+export interface CohortCreateParams {
+  name: string
+  description?: string | null
+}
+
+export interface CohortUpdateParams {
+  name?: string
+  description?: string | null
+}
+
+export interface DataInfoUpdates {
+  platform?: string | null
+  platform_details?: string | null
+  af_filter?: string | null
+  gene_list_filter?: string | null
+  region_filter?: string | null
+  quality_filter?: string | null
+  data_notes?: string | null
+  gene_list_id?: number | null
+  region_file_id?: number | null
+}
+
+export interface FullCaseMetadataResult {
+  metadata: unknown
+  cohorts: unknown[]
+  hpoTerms: unknown[]
+  comments: unknown[]
+  metrics: unknown[]
+  dataInfo: unknown
+  externalIds: unknown[]
+}
+```
+
+These types intentionally live in storage, not `src/main/ipc/handlers/`, so storage code does not import IPC handler internals.
+
+- [ ] **Step 5: Add the write executor contract**
+
+Create `src/main/storage/write-executor.ts` with this shape:
+
+```ts
+import type {
+  CohortCreateParams,
+  CohortUpdateParams,
+  DataInfoUpdates,
+  MetadataUpdates
+} from './case-metadata-types'
+
+export type StorageWriteTask =
+  | { type: 'case-metadata:upsert'; params: [caseId: number, updates: MetadataUpdates] }
+  | { type: 'case-metadata:createCohort'; params: [params: CohortCreateParams] }
+  | {
+      type: 'case-metadata:updateCohort'
+      params: [cohortId: number, updates: CohortUpdateParams]
+    }
+  | { type: 'case-metadata:deleteCohort'; params: [cohortId: number] }
+  | { type: 'case-metadata:assignCohort'; params: [caseId: number, cohortId: number] }
+  | { type: 'case-metadata:removeCohort'; params: [caseId: number, cohortId: number] }
+  | { type: 'case-metadata:setCohorts'; params: [caseId: number, cohortIds: number[]] }
+  | { type: 'case-metadata:assignHpoTerm'; params: [caseId: number, hpoId: string, hpoLabel: string] }
+  | { type: 'case-metadata:removeHpoTerm'; params: [caseId: number, hpoId: string] }
+  | { type: 'case-metadata:upsertDataInfo'; params: [caseId: number, updates: DataInfoUpdates] }
+  | { type: 'case-metadata:upsertExternalId'; params: [caseId: number, idType: string, idValue: string] }
+  | { type: 'case-metadata:deleteExternalId'; params: [caseId: number, idType: string] }
+
+export interface StorageWriteExecutor {
+  execute(task: StorageWriteTask): Promise<unknown>
+}
+```
+
+- [ ] **Step 6: Extend the read executor contract**
+
+Update `src/main/storage/read-executor.ts` so `StorageReadTask` includes the eleven `case-metadata:*` read tasks from Step 1. Keep the existing cases tasks unchanged.
+
+- [ ] **Step 7: Expose the write executor on sessions**
+
+Update `src/main/storage/session.ts`:
+
+```ts
+import type { StorageWriteExecutor } from './write-executor'
+```
+
+Add to `StorageSession`:
+
+```ts
+getWriteExecutor(): StorageWriteExecutor
+```
+
+- [ ] **Step 8: Verify contracts**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/read-executor-contract.test.ts tests/main/storage/write-executor-contract.test.ts
+make typecheck
+```
+
+Expected:
+
+- Focused tests pass.
+- Typecheck may fail because concrete session classes do not yet implement `getWriteExecutor()`; do not merge this checkpoint into another lane until Task 3 and Task 4 are green.
+
+- [ ] **Step 9: Commit contract work**
+
+Run:
+
+```bash
+git add src/main/storage/case-metadata-types.ts src/main/storage/read-executor.ts src/main/storage/write-executor.ts src/main/storage/session.ts tests/main/storage/read-executor-contract.test.ts tests/main/storage/write-executor-contract.test.ts
+git commit -m "refactor(storage): add case metadata executor contracts"
+```
+
+## Task 2: Add PostgreSQL Schema and Case Metadata Repository
+
+**Files:**
+
+- Create: `scripts/postgres/init-db/11-phase6-case-metadata.sql`
+- Modify: `scripts/postgres/init-db/20-phase3-seed-cases.sql`
+- Modify: `scripts/postgres/init-db/README.md`
+- Create: `src/main/storage/postgres/PostgresCaseMetadataRepository.ts`
+- Test: `tests/main/storage/postgres-case-metadata-repository.test.ts`
+
+- [ ] **Step 1: Write failing PostgreSQL repository tests**
+
+Create `tests/main/storage/postgres-case-metadata-repository.test.ts`. The test file must cover the complete IPC result shape for this phase, including comments and metrics returned by current SQLite `MetadataRepository.getFullCaseMetadata()`.
+
+Use this helper at the top of the test file:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PostgresCaseMetadataRepository } from '../../../src/main/storage/postgres/PostgresCaseMetadataRepository'
+
+const makePool = () => {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn()
+  }
+
+  return {
+    pool: {
+      query: vi.fn(),
+      connect: vi.fn().mockResolvedValue(client)
+    },
+    client
+  }
+}
+
+describe('PostgresCaseMetadataRepository', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-24T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+})
+```
+
+Add these concrete tests inside the `describe` block:
+
+```ts
+it('reads case metadata and normalizes numeric ids', async () => {
+  const { pool } = makePool()
+  pool.query.mockResolvedValueOnce({
+    rows: [{ id: '7', case_id: '1', affected_status: 'affected', sex: 'female', notes: 'index case' }]
+  })
+  const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+  await expect(repository.getCaseMetadata(1)).resolves.toStrictEqual({
+    id: 7,
+    case_id: 1,
+    affected_status: 'affected',
+    sex: 'female',
+    notes: 'index case'
+  })
+  expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('"public"."case_metadata"'), [1])
+})
+
+it('upserts case metadata with conflict on case_id', async () => {
+  const { pool } = makePool()
+  pool.query.mockResolvedValueOnce({
+    rows: [{ id: '8', case_id: '1', affected_status: 'affected', sex: 'female', notes: null, age: 42, date_of_birth: '1984-01-02' }]
+  })
+  const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+  await repository.upsertCaseMetadata(1, {
+    affected_status: 'affected',
+    sex: 'female',
+    age: 42,
+    date_of_birth: '1984-01-02'
+  })
+
+  expect(pool.query).toHaveBeenCalledWith(
+    expect.stringContaining('ON CONFLICT (case_id) DO UPDATE'),
+    expect.arrayContaining([1, 'affected', 'female', 42, '1984-01-02'])
+  )
+})
+
+it('sets case cohorts transactionally on one checked-out client', async () => {
+  const { pool, client } = makePool()
+  const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+  await repository.setCaseCohorts(1, [2, 3])
+
+  expect(pool.connect).toHaveBeenCalledTimes(1)
+  expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+  expect(client.query).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM "public"."case_cohort_links"'), [1])
+  expect(client.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO "public"."case_cohort_links"'), [1, [2, 3]])
+  expect(client.query).toHaveBeenLastCalledWith('COMMIT')
+  expect(client.release).toHaveBeenCalledTimes(1)
+})
+
+it('rolls back setCaseCohorts when an insert fails', async () => {
+  const { pool, client } = makePool()
+  client.query.mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('insert failed'))
+  const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+  await expect(repository.setCaseCohorts(1, [2])).rejects.toThrow('insert failed')
+
+  expect(client.query).toHaveBeenCalledWith('ROLLBACK')
+  expect(client.release).toHaveBeenCalledTimes(1)
+})
+
+it('returns full case metadata with comments and metrics included', async () => {
+  const { pool } = makePool()
+  pool.query
+    .mockResolvedValueOnce({ rows: [{ id: '1', case_id: '1', affected_status: 'affected' }] })
+    .mockResolvedValueOnce({ rows: [{ id: '2', name: 'rare disease' }] })
+    .mockResolvedValueOnce({ rows: [{ id: '3', hpo_id: 'HP:0001250', hpo_label: 'Seizure' }] })
+    .mockResolvedValueOnce({ rows: [{ id: '4', category: 'clinical', content: 'reviewed' }] })
+    .mockResolvedValueOnce({ rows: [{ id: '5', metric_id: '6', name: 'Age', value_type: 'numeric', numeric_value: 42 }] })
+    .mockResolvedValueOnce({ rows: [{ id: '7', platform: 'WGS' }] })
+    .mockResolvedValueOnce({ rows: [{ id: '8', id_type: 'MRN', id_value: '12345' }] })
+  const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+  await expect(repository.getFullCaseMetadata(1)).resolves.toStrictEqual({
+    metadata: { id: 1, case_id: 1, affected_status: 'affected' },
+    cohorts: [{ id: 2, name: 'rare disease' }],
+    hpoTerms: [{ id: 3, hpo_id: 'HP:0001250', hpo_label: 'Seizure' }],
+    comments: [{ id: 4, category: 'clinical', content: 'reviewed' }],
+    metrics: [{ id: 5, metric_id: 6, name: 'Age', value_type: 'numeric', numeric_value: 42 }],
+    dataInfo: { id: 7, platform: 'WGS' },
+    externalIds: [{ id: 8, id_type: 'MRN', id_value: '12345' }]
+  })
+})
+
+it('returns stable distinct HPO terms by hpo_id and hpo_label', async () => {
+  const { pool } = makePool()
+  pool.query.mockResolvedValueOnce({ rows: [{ hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: '2' }] })
+  const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+  await expect(repository.getDistinctHpoTerms()).resolves.toStrictEqual([
+    { hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: 2 }
+  ])
+  expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('GROUP BY hpo_id, hpo_label'), [])
+})
+```
+
+- [ ] **Step 2: Run the repository test and confirm failure**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-case-metadata-repository.test.ts
+```
+
+Expected:
+
+- FAIL because `PostgresCaseMetadataRepository` does not exist.
+
+- [ ] **Step 3: Add PostgreSQL metadata schema**
+
+Create `scripts/postgres/init-db/11-phase6-case-metadata.sql` to create these tables with `BIGSERIAL` primary keys and foreign keys to `cases(id)`.
+
+Do not put this DDL in `001-create-varlens-schema.sql`: Docker runs `/docker-entrypoint-initdb.d` files in alphabetical order on fresh-volume initialization, and `10-phase3-cases.sql` must create `cases` before Phase 6 tables can reference `cases(id)`.
+
+```sql
+CREATE TABLE IF NOT EXISTS case_metadata (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL UNIQUE REFERENCES cases(id) ON DELETE CASCADE,
+  affected_status TEXT,
+  notes TEXT,
+  created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT,
+  updated_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT,
+  sex TEXT,
+  age DOUBLE PRECISION,
+  date_of_birth TEXT
+);
+
+CREATE TABLE IF NOT EXISTS cohort_groups (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  created_at BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS case_cohort_links (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  cohort_id BIGINT NOT NULL REFERENCES cohort_groups(id) ON DELETE CASCADE,
+  UNIQUE(case_id, cohort_id)
+);
+
+CREATE TABLE IF NOT EXISTS case_hpo_terms (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  hpo_id TEXT NOT NULL,
+  hpo_label TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  UNIQUE(case_id, hpo_id)
+);
+
+CREATE TABLE IF NOT EXISTS case_data_info (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL UNIQUE REFERENCES cases(id) ON DELETE CASCADE,
+  import_file_name TEXT,
+  import_file_type TEXT,
+  platform TEXT,
+  platform_details TEXT,
+  af_filter TEXT,
+  gene_list_filter TEXT,
+  region_filter TEXT,
+  quality_filter TEXT,
+  data_notes TEXT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  gene_list_id BIGINT,
+  region_file_id BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS case_external_ids (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  id_type TEXT NOT NULL,
+  id_value TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  UNIQUE(case_id, id_type)
+);
+
+CREATE TABLE IF NOT EXISTS case_comments (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS metric_definitions (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  value_type TEXT NOT NULL,
+  unit TEXT NOT NULL DEFAULT '',
+  category TEXT NOT NULL,
+  is_predefined INTEGER NOT NULL DEFAULT 0,
+  created_at BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS case_metrics (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  metric_id BIGINT NOT NULL REFERENCES metric_definitions(id) ON DELETE CASCADE,
+  numeric_value DOUBLE PRECISION,
+  text_value TEXT,
+  date_value TEXT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  UNIQUE(case_id, metric_id)
+);
+```
+
+Add indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_case_metadata_case_id ON case_metadata(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_cohort_links_case_id ON case_cohort_links(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_cohort_links_cohort_id ON case_cohort_links(cohort_id);
+CREATE INDEX IF NOT EXISTS idx_case_hpo_terms_case_id ON case_hpo_terms(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_hpo_terms_hpo_id ON case_hpo_terms(hpo_id);
+CREATE INDEX IF NOT EXISTS idx_case_data_info_case_id ON case_data_info(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_external_ids_case_id ON case_external_ids(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_comments_case_created ON case_comments(case_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_case_comments_case_category ON case_comments(case_id, category);
+CREATE INDEX IF NOT EXISTS idx_case_metrics_case ON case_metrics(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_metrics_metric ON case_metrics(metric_id);
+```
+
+- [ ] **Step 4: Seed PostgreSQL metadata fixtures**
+
+Append deterministic seed rows to `scripts/postgres/init-db/20-phase3-seed-cases.sql`:
+
+```sql
+INSERT INTO case_metadata (case_id, affected_status, sex, notes)
+VALUES
+  (1, 'affected', 'female', 'index case'),
+  (2, 'unaffected', 'male', 'control case')
+ON CONFLICT (case_id) DO UPDATE SET
+  affected_status = EXCLUDED.affected_status,
+  sex = EXCLUDED.sex,
+  notes = EXCLUDED.notes;
+
+INSERT INTO cohort_groups (id, name, description, created_at)
+VALUES
+  (1, 'rare disease', 'Rare disease cohort', 1714060803000),
+  (2, 'controls', 'Control cohort', 1714060804000)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description;
+
+INSERT INTO case_cohort_links (case_id, cohort_id)
+VALUES (1, 1), (2, 2), (3, 1)
+ON CONFLICT (case_id, cohort_id) DO NOTHING;
+
+INSERT INTO case_hpo_terms (case_id, hpo_id, hpo_label, created_at)
+VALUES
+  (1, 'HP:0001250', 'Seizure', 1714060805000),
+  (3, 'HP:0004322', 'Short stature', 1714060806000)
+ON CONFLICT (case_id, hpo_id) DO UPDATE SET hpo_label = EXCLUDED.hpo_label;
+
+INSERT INTO case_comments (id, case_id, category, content, created_at)
+VALUES
+  (1, 1, 'clinical', 'Reviewed for PostgreSQL parity smoke', 1714060807000)
+ON CONFLICT (id) DO UPDATE SET
+  category = EXCLUDED.category,
+  content = EXCLUDED.content;
+
+INSERT INTO metric_definitions (id, name, value_type, unit, category, is_predefined, created_at)
+VALUES
+  (1, 'Age at analysis', 'numeric', 'years', 'clinical', 1, 1714060808000)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  value_type = EXCLUDED.value_type,
+  unit = EXCLUDED.unit,
+  category = EXCLUDED.category,
+  is_predefined = EXCLUDED.is_predefined;
+
+INSERT INTO case_metrics (id, case_id, metric_id, numeric_value, created_at, updated_at)
+VALUES
+  (1, 1, 1, 42, 1714060809000, 1714060809000)
+ON CONFLICT (id) DO UPDATE SET
+  numeric_value = EXCLUDED.numeric_value,
+  updated_at = EXCLUDED.updated_at;
+
+SELECT setval(pg_get_serial_sequence('public.case_metadata', 'id'), COALESCE((SELECT MAX(id) FROM case_metadata), 1), true);
+SELECT setval(pg_get_serial_sequence('public.cohort_groups', 'id'), COALESCE((SELECT MAX(id) FROM cohort_groups), 1), true);
+SELECT setval(pg_get_serial_sequence('public.case_comments', 'id'), COALESCE((SELECT MAX(id) FROM case_comments), 1), true);
+SELECT setval(pg_get_serial_sequence('public.metric_definitions', 'id'), COALESCE((SELECT MAX(id) FROM metric_definitions), 1), true);
+SELECT setval(pg_get_serial_sequence('public.case_metrics', 'id'), COALESCE((SELECT MAX(id) FROM case_metrics), 1), true);
+```
+
+The explicit `setval` calls are required because the seed data supplies IDs for deterministic E2E fixtures and `BIGSERIAL` sequences are not advanced by explicit ID inserts.
+
+- [ ] **Step 5: Update init-db README**
+
+Modify `scripts/postgres/init-db/README.md` so it no longer says the bootstrap is only Phase 1/minimal. It must document:
+
+```markdown
+- `001-create-varlens-schema.sql` creates the schema only.
+- `10-phase3-cases.sql` creates the base `cases` table.
+- `11-phase6-case-metadata.sql` creates Phase 6 metadata/cohort/HPO/comment/metric tables that depend on `cases`.
+- `20-phase3-seed-cases.sql` seeds deterministic development rows and resets sequences after explicit-ID seed inserts.
+```
+
+- [ ] **Step 6: Implement the PostgreSQL repository**
+
+Create `src/main/storage/postgres/PostgresCaseMetadataRepository.ts`. Use `quoteIdentifier` from `src/main/storage/postgres/identifiers.ts`; do not define a second quoting helper. The constructor must accept `Pick<Pool, 'query' | 'connect'>` so `setCaseCohorts()` can run a real transaction on one checked-out client.
+
+Import `MetadataUpdates`, `CohortUpdateParams`, `DataInfoUpdates`, and `FullCaseMetadataResult` from `src/main/storage/case-metadata-types.ts`.
+
+Required implementation details:
+
+- Normalize PostgreSQL integer strings to JavaScript numbers for `id`, `case_id`, `cohort_id`, `metric_id`, and `case_count`.
+- Return `null` when singular read queries have no row, matching current SQLite behavior.
+- Preserve SQLite ordering semantics: `listCohortGroups()` by `name`; `getCaseCohorts()` by cohort group `name`; `getCaseHpoTerms()` by `hpo_id`; `listCaseExternalIds()` by `id_type`; `listCaseComments()` by `created_at DESC, id DESC`; `listCaseMetrics()` by metric `category`, then metric `name`; `getDistinctHpoTerms()` by `hpo_label`.
+- `getFullCaseMetadata()` must return exactly:
+
+```ts
+{
+  metadata,
+  cohorts,
+  hpoTerms,
+  comments,
+  metrics,
+  dataInfo,
+  externalIds
+}
+```
+
+- `getDistinctHpoTerms()` must use `GROUP BY hpo_id, hpo_label` so PostgreSQL is deterministic and legal.
+- `setCaseCohorts()` must use `const client = await this.pool.connect()`, then `BEGIN`, delete existing links, insert the new links with `UNNEST($2::bigint[])`, `COMMIT`, `ROLLBACK` on error, and `client.release()` in `finally`.
+
+The repository class must include these public methods with the same names as `MetadataRepository`:
+
+```ts
+getCaseMetadata(caseId: number): Promise<unknown | null>
+upsertCaseMetadata(caseId: number, updates: MetadataUpdates): Promise<unknown>
+listCohortGroups(): Promise<unknown[]>
+createCohortGroup(name: string, description?: string | null): Promise<unknown>
+updateCohortGroup(cohortId: number, updates: CohortUpdateParams): Promise<unknown>
+deleteCohortGroup(cohortId: number): Promise<void>
+getCohortGroupByName(name: string): Promise<unknown | null>
+getCaseCohorts(caseId: number): Promise<unknown[]>
+assignCaseCohort(caseId: number, cohortId: number): Promise<void>
+removeCaseCohort(caseId: number, cohortId: number): Promise<void>
+setCaseCohorts(caseId: number, cohortIds: number[]): Promise<void>
+getCaseHpoTerms(caseId: number): Promise<unknown[]>
+assignCaseHpoTerm(caseId: number, hpoId: string, hpoLabel: string): Promise<unknown>
+removeCaseHpoTerm(caseId: number, hpoId: string): Promise<void>
+getCaseDataInfo(caseId: number): Promise<unknown | null>
+upsertCaseDataInfo(caseId: number, updates: DataInfoUpdates): Promise<unknown>
+listCaseExternalIds(caseId: number): Promise<unknown[]>
+upsertCaseExternalId(caseId: number, idType: string, idValue: string): Promise<unknown>
+deleteCaseExternalId(caseId: number, idType: string): Promise<void>
+listCaseComments(caseId: number): Promise<unknown[]>
+listCaseMetrics(caseId: number): Promise<unknown[]>
+getDistinctHpoTerms(): Promise<unknown[]>
+getDistinctPlatforms(): Promise<string[]>
+getDistinctExternalIdTypes(): Promise<string[]>
+getFullCaseMetadata(caseId: number): Promise<FullCaseMetadataResult>
+```
+
+- [ ] **Step 7: Verify PostgreSQL repository tests**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-case-metadata-repository.test.ts
+make typecheck
+```
+
+Expected:
+
+- Repository tests pass.
+- Typecheck may still fail until session classes implement write executor methods in later tasks; treat this as a local red checkpoint and do not merge or hand it to another lane as green.
+
+- [ ] **Step 8: Commit PostgreSQL repository and schema**
+
+Run:
+
+```bash
+git add scripts/postgres/init-db/11-phase6-case-metadata.sql scripts/postgres/init-db/20-phase3-seed-cases.sql scripts/postgres/init-db/README.md src/main/storage/postgres/PostgresCaseMetadataRepository.ts tests/main/storage/postgres-case-metadata-repository.test.ts
+git commit -m "feat(storage): add postgres case metadata repository"
+```
+
+## Task 3: Add SQLite Read and Write Executors for Case Metadata
+
+**Files:**
+
+- Modify: `src/main/storage/sqlite/SqliteReadExecutor.ts`
+- Create: `src/main/storage/sqlite/SqliteWriteExecutor.ts`
+- Modify: `src/main/storage/sqlite/SqliteStorageSession.ts`
+- Test: `tests/main/storage/sqlite-read-executor.test.ts`
+- Test: `tests/main/storage/sqlite-write-executor.test.ts`
+- Test: `tests/main/storage/sqlite-storage-session.test.ts`
+
+- [ ] **Step 1: Write failing SQLite read executor tests**
+
+Append tests to `tests/main/storage/sqlite-read-executor.test.ts` proving:
+
+```ts
+await executor.execute({ type: 'case-metadata:get', params: [1] })
+await executor.execute({ type: 'case-metadata:listCohorts', params: [] })
+await executor.execute({ type: 'case-metadata:getFullMetadata', params: [1] })
+```
+
+Expected:
+
+- With `dbPool`, each call forwards to `dbPool.run({ type, params })`.
+- Without `dbPool`, each call delegates to `databaseService.metadata`.
+
+- [ ] **Step 2: Write failing SQLite write executor tests**
+
+Create `tests/main/storage/sqlite-write-executor.test.ts` with tests proving:
+
+```ts
+await executor.execute({ type: 'case-metadata:upsert', params: [1, { sex: 'female' }] })
+await executor.execute({ type: 'case-metadata:setCohorts', params: [1, [2, 3]] })
+await executor.execute({ type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] })
+```
+
+Expected:
+
+- Each call delegates to the matching `databaseService.metadata` method.
+- The executor returns repository results for upsert/create methods.
+- Delete/remove methods resolve to `undefined`.
+
+- [ ] **Step 3: Run focused SQLite executor tests and confirm failure**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/sqlite-read-executor.test.ts tests/main/storage/sqlite-write-executor.test.ts tests/main/storage/sqlite-storage-session.test.ts
+```
+
+Expected:
+
+- FAIL because the SQLite write executor does not exist and read dispatch is missing.
+
+- [ ] **Step 4: Implement SQLite read dispatch**
+
+Update `src/main/storage/sqlite/SqliteReadExecutor.ts` with one switch case per case metadata read task. These eleven read task types already exist in `DbTask` and `src/main/workers/db-worker-dispatch.ts`, so forwarding to `dbPool.run(...)` is a dispatch change only; do not extend `DbTask` in this task.
+
+Use the existing pattern:
+
+```ts
+case 'case-metadata:get':
+  if (this.dbPool !== null) {
+    return await this.dbPool.run({ type: 'case-metadata:get', params: task.params })
+  }
+  return this.databaseService.metadata.getCaseMetadata(task.params[0])
+```
+
+Repeat the mapping for all eleven read tasks listed in Task 1.
+
+- [ ] **Step 5: Implement SQLite write executor**
+
+Create `src/main/storage/sqlite/SqliteWriteExecutor.ts`:
+
+```ts
+import type { DatabaseService } from '../../database/DatabaseService'
+import type { StorageWriteExecutor, StorageWriteTask } from '../write-executor'
+
+export class SqliteWriteExecutor implements StorageWriteExecutor {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async execute(task: StorageWriteTask): Promise<unknown> {
+    switch (task.type) {
+      case 'case-metadata:upsert':
+        return this.databaseService.metadata.upsertCaseMetadata(task.params[0], task.params[1])
+      case 'case-metadata:createCohort':
+        return this.databaseService.metadata.createCohortGroup(task.params[0].name, task.params[0].description)
+      case 'case-metadata:updateCohort':
+        return this.databaseService.metadata.updateCohortGroup(task.params[0], task.params[1])
+      case 'case-metadata:deleteCohort':
+        this.databaseService.metadata.deleteCohortGroup(task.params[0])
+        return undefined
+      case 'case-metadata:assignCohort':
+        this.databaseService.metadata.assignCaseCohort(task.params[0], task.params[1])
+        return undefined
+      case 'case-metadata:removeCohort':
+        this.databaseService.metadata.removeCaseCohort(task.params[0], task.params[1])
+        return undefined
+      case 'case-metadata:setCohorts':
+        this.databaseService.metadata.setCaseCohorts(task.params[0], task.params[1])
+        return undefined
+      case 'case-metadata:assignHpoTerm':
+        return this.databaseService.metadata.assignCaseHpoTerm(task.params[0], task.params[1], task.params[2])
+      case 'case-metadata:removeHpoTerm':
+        this.databaseService.metadata.removeCaseHpoTerm(task.params[0], task.params[1])
+        return undefined
+      case 'case-metadata:upsertDataInfo':
+        return this.databaseService.metadata.upsertCaseDataInfo(task.params[0], task.params[1])
+      case 'case-metadata:upsertExternalId':
+        return this.databaseService.metadata.upsertCaseExternalId(task.params[0], task.params[1], task.params[2])
+      case 'case-metadata:deleteExternalId':
+        this.databaseService.metadata.deleteCaseExternalId(task.params[0], task.params[1])
+        return undefined
+      default: {
+        const exhaustive: never = task
+        throw new Error(`Unsupported storage write task: ${JSON.stringify(exhaustive)}`)
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Wire SQLite session**
+
+Modify `src/main/storage/sqlite/SqliteStorageSession.ts`:
+
+```ts
+import { SqliteWriteExecutor } from './SqliteWriteExecutor'
+import type { StorageWriteExecutor } from '../write-executor'
+```
+
+Add:
+
+```ts
+private readonly writeExecutor: StorageWriteExecutor
+```
+
+Initialize:
+
+```ts
+this.writeExecutor = new SqliteWriteExecutor(this.databaseService)
+```
+
+Expose:
+
+```ts
+getWriteExecutor(): StorageWriteExecutor {
+  return this.writeExecutor
+}
+```
+
+- [ ] **Step 7: Verify SQLite executor behavior**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/sqlite-read-executor.test.ts tests/main/storage/sqlite-write-executor.test.ts tests/main/storage/sqlite-storage-session.test.ts
+make typecheck
+```
+
+Expected:
+
+- Focused SQLite tests pass.
+- Typecheck may still fail because PostgreSQL session lacks `getWriteExecutor()`; treat this as a local red checkpoint and do not merge or hand it to another lane as green.
+
+- [ ] **Step 8: Commit SQLite executor work**
+
+Run:
+
+```bash
+git add src/main/storage/sqlite/SqliteReadExecutor.ts src/main/storage/sqlite/SqliteWriteExecutor.ts src/main/storage/sqlite/SqliteStorageSession.ts tests/main/storage/sqlite-read-executor.test.ts tests/main/storage/sqlite-write-executor.test.ts tests/main/storage/sqlite-storage-session.test.ts
+git commit -m "refactor(storage): route sqlite case metadata through executors"
+```
+
+## Task 4: Wire PostgreSQL Executors and Session
+
+**Files:**
+
+- Modify: `src/main/storage/postgres/PostgresReadExecutor.ts`
+- Create: `src/main/storage/postgres/PostgresWriteExecutor.ts`
+- Modify: `src/main/storage/postgres/PostgresStorageSession.ts`
+- Test: `tests/main/storage/postgres-read-executor.test.ts`
+- Test: `tests/main/storage/postgres-write-executor.test.ts`
+- Test: `tests/main/storage/postgres-storage-session.test.ts`
+- Test: `tests/main/storage/storage-manager-compat.test.ts`
+
+- [ ] **Step 1: Write failing PostgreSQL executor tests**
+
+Add read executor tests to `tests/main/storage/postgres-read-executor.test.ts`:
+
+```ts
+it('routes case metadata read tasks to the postgres repository', async () => {
+  const caseMetadata = {
+    getCaseMetadata: vi.fn().mockResolvedValue({ case_id: 1 }),
+    listCohortGroups: vi.fn().mockResolvedValue([]),
+    getFullCaseMetadata: vi.fn().mockResolvedValue({
+      metadata: null,
+      cohorts: [],
+      hpoTerms: [],
+      comments: [],
+      metrics: [],
+      dataInfo: null,
+      externalIds: []
+    })
+  }
+  const executor = new PostgresReadExecutor({
+    casesQuery: {} as never,
+    availableBuilds: {} as never,
+    caseMetadata: caseMetadata as never
+  })
+
+  await executor.execute({ type: 'case-metadata:get', params: [1] })
+  await executor.execute({ type: 'case-metadata:listCohorts', params: [] })
+  await executor.execute({ type: 'case-metadata:getFullMetadata', params: [1] })
+
+  expect(caseMetadata.getCaseMetadata).toHaveBeenCalledWith(1)
+  expect(caseMetadata.listCohortGroups).toHaveBeenCalledWith()
+  expect(caseMetadata.getFullCaseMetadata).toHaveBeenCalledWith(1)
+})
+```
+
+Create write executor tests in `tests/main/storage/postgres-write-executor.test.ts`:
+
+```ts
+it('routes case metadata write tasks to the postgres repository', async () => {
+  const repository = {
+    upsertCaseMetadata: vi.fn().mockResolvedValue({ case_id: 1 }),
+    setCaseCohorts: vi.fn().mockResolvedValue(undefined),
+    deleteCaseExternalId: vi.fn().mockResolvedValue(undefined)
+  }
+  const executor = new PostgresWriteExecutor(repository as never)
+
+  await executor.execute({ type: 'case-metadata:upsert', params: [1, { sex: 'female' }] })
+  await executor.execute({ type: 'case-metadata:setCohorts', params: [1, [2, 3]] })
+  await executor.execute({ type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] })
+
+  expect(repository.upsertCaseMetadata).toHaveBeenCalledWith(1, { sex: 'female' })
+  expect(repository.setCaseCohorts).toHaveBeenCalledWith(1, [2, 3])
+  expect(repository.deleteCaseExternalId).toHaveBeenCalledWith(1, 'MRN')
+})
+```
+
+- [ ] **Step 2: Run focused PostgreSQL executor tests and confirm failure**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-write-executor.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-manager-compat.test.ts
+```
+
+Expected:
+
+- FAIL because PostgreSQL write executor and read dispatch are missing.
+
+- [ ] **Step 3: Extend PostgreSQL read executor**
+
+Modify `src/main/storage/postgres/PostgresReadExecutor.ts` so repository dependencies include:
+
+```ts
+caseMetadata: Pick<PostgresCaseMetadataRepository,
+  | 'getCaseMetadata'
+  | 'listCohortGroups'
+  | 'getCohortGroupByName'
+  | 'getCaseCohorts'
+  | 'getCaseHpoTerms'
+  | 'getCaseDataInfo'
+  | 'listCaseExternalIds'
+  | 'getDistinctHpoTerms'
+  | 'getDistinctPlatforms'
+  | 'getDistinctExternalIdTypes'
+  | 'getFullCaseMetadata'
+>
+```
+
+Add switch cases for all eleven case metadata read tasks.
+
+- [ ] **Step 4: Implement PostgreSQL write executor**
+
+Create `src/main/storage/postgres/PostgresWriteExecutor.ts`:
+
+```ts
+import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
+import type { StorageWriteExecutor, StorageWriteTask } from '../write-executor'
+
+export class PostgresWriteExecutor implements StorageWriteExecutor {
+  constructor(private readonly caseMetadata: PostgresCaseMetadataRepository) {}
+
+  async execute(task: StorageWriteTask): Promise<unknown> {
+    switch (task.type) {
+      case 'case-metadata:upsert':
+        return await this.caseMetadata.upsertCaseMetadata(task.params[0], task.params[1])
+      case 'case-metadata:createCohort':
+        return await this.caseMetadata.createCohortGroup(task.params[0].name, task.params[0].description)
+      case 'case-metadata:updateCohort':
+        return await this.caseMetadata.updateCohortGroup(task.params[0], task.params[1])
+      case 'case-metadata:deleteCohort':
+        return await this.caseMetadata.deleteCohortGroup(task.params[0])
+      case 'case-metadata:assignCohort':
+        return await this.caseMetadata.assignCaseCohort(task.params[0], task.params[1])
+      case 'case-metadata:removeCohort':
+        return await this.caseMetadata.removeCaseCohort(task.params[0], task.params[1])
+      case 'case-metadata:setCohorts':
+        return await this.caseMetadata.setCaseCohorts(task.params[0], task.params[1])
+      case 'case-metadata:assignHpoTerm':
+        return await this.caseMetadata.assignCaseHpoTerm(task.params[0], task.params[1], task.params[2])
+      case 'case-metadata:removeHpoTerm':
+        return await this.caseMetadata.removeCaseHpoTerm(task.params[0], task.params[1])
+      case 'case-metadata:upsertDataInfo':
+        return await this.caseMetadata.upsertCaseDataInfo(task.params[0], task.params[1])
+      case 'case-metadata:upsertExternalId':
+        return await this.caseMetadata.upsertCaseExternalId(task.params[0], task.params[1], task.params[2])
+      case 'case-metadata:deleteExternalId':
+        return await this.caseMetadata.deleteCaseExternalId(task.params[0], task.params[1])
+      default: {
+        const exhaustive: never = task
+        throw new Error(`Unsupported storage write task: ${JSON.stringify(exhaustive)}`)
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Wire PostgreSQL session**
+
+Modify `src/main/storage/postgres/PostgresStorageSession.ts`:
+
+- construct one `PostgresCaseMetadataRepository`
+- pass it into `PostgresReadExecutor`
+- pass it into `PostgresWriteExecutor`
+- implement `getWriteExecutor()`
+
+- [ ] **Step 6: Update mock sessions**
+
+Update tests that build mock `StorageSession` objects, especially `tests/main/storage/storage-manager-compat.test.ts`, to include:
+
+```ts
+getWriteExecutor: () => ({
+  execute: vi.fn()
+})
+```
+
+- [ ] **Step 7: Verify PostgreSQL executor wiring**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-write-executor.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-manager-compat.test.ts
+make typecheck
+```
+
+Expected:
+
+- Focused tests pass.
+- Typecheck passes for session interface implementations.
+
+- [ ] **Step 8: Commit PostgreSQL executor wiring**
+
+Run:
+
+```bash
+git add src/main/storage/postgres/PostgresReadExecutor.ts src/main/storage/postgres/PostgresWriteExecutor.ts src/main/storage/postgres/PostgresStorageSession.ts tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-write-executor.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/storage-manager-compat.test.ts
+git commit -m "refactor(storage): wire postgres case metadata executors"
+```
+
+## Task 5: Route Case Metadata IPC Through Storage Sessions
+
+**Files:**
+
+- Modify: `src/main/ipc/handlers/case-metadata.ts`
+- Modify: `src/main/ipc/handlers/case-metadata-logic.ts`
+- Create: `tests/main/handlers/case-metadata-routing.test.ts`
+- Test: `tests/main/handlers/case-metadata-logic.test.ts`
+
+- [ ] **Step 1: Write failing handler tests**
+
+Create `tests/main/handlers/case-metadata-routing.test.ts` with PostgreSQL routing tests for:
+
+```ts
+case-metadata:get
+case-metadata:upsert
+case-metadata:listCohorts
+case-metadata:assignHpoTerm
+case-metadata:getFullMetadata
+```
+
+Mock `getDb` and `getDbPool` to throw:
+
+```ts
+const getDb = () => {
+  throw new Error('getDb should not be called for postgres case metadata')
+}
+const getDbPool = () => {
+  throw new Error('getDbPool should not be called for postgres case metadata')
+}
+```
+
+Expected:
+
+- Each handler resolves through `getDbManager().getCurrentSession().getReadExecutor()` or `getWriteExecutor()`.
+- The test captures handlers through a fake `ipcMain.handle` registry and invokes the registered function directly, so it proves IPC registration routing rather than only repository helpers.
+- Keep the existing `tests/main/handlers/case-metadata-handlers.test.ts` focused on its current SQLite-backed integration coverage; do not force the new mocked routing tests into that file.
+
+Use this fake IPC shape:
+
+```ts
+const registered = new Map<string, (...args: unknown[]) => unknown>()
+const ipcMain = {
+  handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+    registered.set(channel, handler)
+  })
+} as never
+```
+
+- [ ] **Step 2: Run handler tests and confirm failure**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/handlers/case-metadata-routing.test.ts tests/main/handlers/case-metadata-logic.test.ts
+```
+
+Expected:
+
+- FAIL because handlers still call `getDb()` directly.
+
+- [ ] **Step 3: Verify domain registration already exposes `getDbManager`**
+
+Read `src/main/ipc/domains/case-metadata.ts` and `src/main/ipc/types.ts`. The current domain registration already passes `getDbManager`, and `HandlerDependencies` already includes it. Do not create a needless diff in `src/main/ipc/domains/case-metadata.ts` unless the live code has changed.
+
+Expected current shape:
+
+```ts
+registerCaseMetadataHandlers({
+  ipcMain,
+  getDb,
+  getDbManager,
+  getDbPool
+})
+```
+
+- [ ] **Step 4: Update case metadata logic functions**
+
+Change `src/main/ipc/handlers/case-metadata-logic.ts` so `MetadataUpdates`, `CohortCreateParams`, `CohortUpdateParams`, and `DataInfoUpdates` are imported from `src/main/storage/case-metadata-types.ts` instead of being declared in the IPC logic file. Then change read functions to take `getSession: () => StorageSession` and execute `StorageReadTask`.
+
+`MetadataUpdates` must include `age?: number | null` and `date_of_birth?: string | null` through the storage type, matching `CaseMetadataUpdates` in `src/shared/types/api.ts` and the existing SQLite `MetadataRepository.upsertCaseMetadata()` behavior.
+
+Example:
+
+```ts
+export async function getMetadata(
+  caseId: number,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({
+    type: 'case-metadata:get',
+    params: [caseId]
+  })
+}
+```
+
+Change write functions to execute `StorageWriteTask`.
+
+Example:
+
+```ts
+export async function upsertMetadata(
+  caseId: number,
+  updates: MetadataUpdates,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession().getWriteExecutor().execute({
+    type: 'case-metadata:upsert',
+    params: [caseId, updates]
+  })
+}
+```
+
+Apply the same pattern to every function exported from `case-metadata-logic.ts`.
+
+- [ ] **Step 5: Update case metadata handlers**
+
+Modify `src/main/ipc/handlers/case-metadata.ts`:
+
+```ts
+export function registerCaseMetadataHandlers({
+  ipcMain,
+  getDbManager
+}: HandlerDependencies): void {
+  const getSession = () => getDbManager().getCurrentSession()
+}
+```
+
+Pass `getSession` into all logic functions.
+
+Also widen `MetadataUpsertSchema` in `src/main/ipc/handlers/case-metadata.ts` so age/date-of-birth are not stripped before either backend sees them:
+
+```ts
+const MetadataUpsertSchema = z.object({
+  affected_status: z.string().nullish(),
+  sex: z.string().nullish(),
+  notes: z.string().nullish(),
+  age: z.number().nullish(),
+  date_of_birth: z.string().nullish()
+})
+```
+
+- [ ] **Step 6: Verify handler routing**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/handlers/case-metadata-routing.test.ts tests/main/handlers/case-metadata-logic.test.ts
+make typecheck
+```
+
+Expected:
+
+- Focused handler tests pass.
+- Typecheck passes.
+
+- [ ] **Step 7: Commit IPC routing**
+
+Run:
+
+```bash
+git add src/main/ipc/handlers/case-metadata.ts src/main/ipc/handlers/case-metadata-logic.ts tests/main/handlers/case-metadata-routing.test.ts tests/main/handlers/case-metadata-logic.test.ts
+git commit -m "refactor(ipc): route case metadata through storage sessions"
+```
+
+## Task 6: Complete PostgreSQL Cases Query Metadata Filters
+
+**Files:**
+
+- Modify: `src/main/storage/postgres/PostgresCasesQueryRepository.ts`
+- Test: `tests/main/storage/postgres-cases-query-repository.test.ts`
+
+- [ ] **Step 1: Replace unsupported-filter tests with failing parity tests**
+
+Update `tests/main/storage/postgres-cases-query-repository.test.ts`:
+
+```ts
+it('filters postgres cases by cohort ids', async () => {
+  const pool = {
+    query: vi.fn().mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [{ total_count: 0 }] })
+  }
+  const repository = new PostgresCasesQueryRepository(pool as never, 'public')
+
+  await repository.queryCases({ limit: 25, offset: 0, cohort_ids: [1, 2] })
+
+  expect(pool.query).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('ccl_filter.cohort_id = ANY'),
+    [[1, 2], 25, 0]
+  )
+})
+
+it('filters postgres cases by hpo ids', async () => {
+  const pool = {
+    query: vi.fn().mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [{ total_count: 0 }] })
+  }
+  const repository = new PostgresCasesQueryRepository(pool as never, 'public')
+
+  await repository.queryCases({ limit: 25, offset: 0, hpo_ids: ['HP:0001250'] })
+
+  expect(pool.query).toHaveBeenNthCalledWith(
+    1,
+    expect.stringContaining('cht_filter.hpo_id = ANY'),
+    [['HP:0001250'], 25, 0]
+  )
+})
+```
+
+- [ ] **Step 2: Run cases query repository tests and confirm failure**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-cases-query-repository.test.ts
+```
+
+Expected:
+
+- FAIL because the repository still throws unsupported-filter errors.
+
+- [ ] **Step 3: Implement cohort and HPO filters**
+
+Modify `src/main/storage/postgres/PostgresCasesQueryRepository.ts`:
+
+- remove the explicit unsupported-filter throws
+- add `EXISTS` clauses for filter-only joins
+- keep display joins for `cohort_names` and `cohort_ids`
+- keep filter and display cohort IDs consistently typed as `bigint[]`; if current display SQL casts `cohort_ids` to `int[]`, update it to `bigint[]`
+- include the same filter conditions in the count query
+
+Use this condition shape:
+
+```sql
+EXISTS (
+  SELECT 1
+  FROM "schema"."case_cohort_links" ccl_filter
+  WHERE ccl_filter.case_id = c.id
+    AND ccl_filter.cohort_id = ANY($n::bigint[])
+)
+```
+
+and:
+
+```sql
+EXISTS (
+  SELECT 1
+  FROM "schema"."case_hpo_terms" cht_filter
+  WHERE cht_filter.case_id = c.id
+    AND cht_filter.hpo_id = ANY($n::text[])
+)
+```
+
+- [ ] **Step 4: Verify cases query repository parity**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run tests/main/storage/postgres-cases-query-repository.test.ts tests/main/storage/postgres-case-metadata-repository.test.ts
+make typecheck
+```
+
+Expected:
+
+- Focused repository tests pass.
+- Typecheck passes.
+
+- [ ] **Step 5: Commit cases query filters**
+
+Run:
+
+```bash
+git add src/main/storage/postgres/PostgresCasesQueryRepository.ts tests/main/storage/postgres-cases-query-repository.test.ts
+git commit -m "feat(storage): support postgres cases metadata filters"
+```
+
+## Task 7: Add Gated Docker-backed PostgreSQL Integration Coverage
+
+**Files:**
+
+- Create: `tests/e2e/postgres-case-metadata-dev-mode.e2e.ts`
+- Modify: `tests/e2e/postgres-cases-list-dev-mode.e2e.ts` if shared helper extraction is needed
+
+- [ ] **Step 1: Write gated E2E tests**
+
+Create `tests/e2e/postgres-case-metadata-dev-mode.e2e.ts` with the same skip gate as the existing PostgreSQL E2E:
+
+```ts
+test.skip(
+  process.env.VARLENS_RUN_POSTGRES_E2E !== '1',
+  'Set VARLENS_RUN_POSTGRES_E2E=1 after starting the local postgres container to run this test.'
+)
+```
+
+Add tests that call renderer APIs:
+
+```ts
+await window.api.cases.query({ limit: 25, offset: 0, cohort_ids: [1] })
+await window.api.cases.query({ limit: 25, offset: 0, hpo_ids: ['HP:0001250'] })
+await window.api.caseMetadata.getFullMetadata(1)
+await window.api.caseMetadata.assignHpoTerm(2, 'HP:0000707', 'Abnormality of the nervous system')
+```
+
+Expected:
+
+- Tests are skipped unless `VARLENS_RUN_POSTGRES_E2E=1`.
+- They are not part of default CI unless explicitly enabled.
+
+- [ ] **Step 2: Run skipped E2E without Docker**
+
+Run:
+
+```bash
+npx playwright test tests/e2e/postgres-case-metadata-dev-mode.e2e.ts
+```
+
+Expected:
+
+- Tests are skipped with the PostgreSQL E2E gate message.
+
+- [ ] **Step 3: Run Docker-backed E2E locally when Docker is available**
+
+Run:
+
+```bash
+make pg-reset
+make pg-up
+VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts tests/e2e/postgres-case-metadata-dev-mode.e2e.ts
+make pg-down
+```
+
+Expected:
+
+- PostgreSQL E2E tests pass when Docker is available.
+- This remains outside default CI, but it is required local verification for Phase 6 implementation branches when Docker is available.
+- If Docker is unavailable locally, record that the gated Docker E2E was not run and keep default CI verification as the required non-Docker gate.
+
+- [ ] **Step 4: Commit gated E2E**
+
+Run:
+
+```bash
+git add tests/e2e/postgres-case-metadata-dev-mode.e2e.ts tests/e2e/postgres-cases-list-dev-mode.e2e.ts
+git commit -m "test(e2e): cover postgres case metadata dev mode"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+
+- All files touched in prior tasks
+
+- [ ] **Step 1: Run focused Phase 6 unit tests**
+
+Run:
+
+```bash
+make rebuild-node && npx vitest run \
+  tests/main/storage/read-executor-contract.test.ts \
+  tests/main/storage/write-executor-contract.test.ts \
+  tests/main/storage/sqlite-read-executor.test.ts \
+  tests/main/storage/sqlite-write-executor.test.ts \
+  tests/main/storage/postgres-read-executor.test.ts \
+  tests/main/storage/postgres-write-executor.test.ts \
+  tests/main/storage/postgres-case-metadata-repository.test.ts \
+  tests/main/storage/postgres-cases-query-repository.test.ts \
+  tests/main/storage/postgres-storage-session.test.ts \
+  tests/main/handlers/case-metadata-routing.test.ts \
+  tests/main/handlers/case-metadata-logic.test.ts
+```
+
+Expected:
+
+- All focused tests pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+make typecheck
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 3: Run default CI**
+
+Run:
+
+```bash
+make ci
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 4: Gated PostgreSQL E2E**
+
+Run only when Docker is available:
+
+```bash
+make pg-reset
+make pg-up
+VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts tests/e2e/postgres-case-metadata-dev-mode.e2e.ts
+make pg-down
+```
+
+Expected:
+
+- PASS when Docker is available.
+- If skipped because Docker is unavailable, state that explicitly in the final implementation report.
+
+- [ ] **Step 5: Confirm no catch-all commit is needed**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+- Working tree is clean except for unrelated pre-existing local changes.
+- Prior tasks already committed their focused slices; do not make a broad catch-all commit that could capture opportunistic or unrelated edits.
+- No renderer storage settings were added.
+- `database:overview` remains unmigrated.
+
+## Self-review Checklist
+
+- [ ] Spec requirement 1 covered: remaining SQLite-only paths are inventoried in the Phase 6 spec matrix.
+- [ ] Spec requirement 2 covered: parity matrix includes SQLite implementation, worker path, PostgreSQL status, required work, tests, and user-facing blocker status.
+- [ ] Spec requirement 3 covered: next smallest high-leverage slice is case metadata plus cases-query filters.
+- [ ] Spec requirement 4 covered: implementation is one backend/domain vertical slice, not broad task-union expansion.
+- [ ] Spec requirement 5 covered: `database:overview` is explicitly deferred.
+- [ ] Spec requirement 6 covered: Docker-backed PostgreSQL integration is gated outside default CI and required locally when Docker is available.
+- [ ] Spec requirement 7 covered: import, export, delete, rebuild, summary rebuild, lifecycle/open/close/health/config appear in the matrix.
+- [ ] Spec requirement 8 covered: renderer storage settings remain out of scope.

--- a/.planning/specs/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md
+++ b/.planning/specs/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md
@@ -1,0 +1,304 @@
+# PostgreSQL Parity Phase 6: Case Metadata and Cases Filters
+
+**Date:** 2026-04-24  
+**Status:** Proposed  
+**Depends on:** [Storage Session Boundary Design](./2026-04-23-storage-adapter-boundary-design.md)  
+**Previous phase:** [Storage Session Boundary Phase 5: Cases Available Builds](../archive/completed-specs/2026-04-24-storage-session-phase-5-cases-available-builds.md)  
+**Goal:** Move the next high-leverage backend slice toward honest PostgreSQL parity, make Docker PostgreSQL validation runnable early, and keep renderer PostgreSQL settings hidden until runtime support is honest.
+
+## Summary
+
+Phase 5 left VarLens with real but narrow PostgreSQL support:
+
+- `cases:list`
+- `cases:query`
+- `cases:availableBuilds`
+- startup via `VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres`
+- PostgreSQL config, health, and capability scaffolding
+
+The code inventory shows that `cases:query` is still partial: PostgreSQL rejects `cohort_ids` and `hpo_ids` filters, and the Docker bootstrap schema only seeds the cases-era table. The next smallest high-leverage Phase 6 slice should therefore complete the case metadata surface and the remaining cases-query filters. However, speed to a usable running backend matters more than a tidy sequential plan, so Phase 6 should be executed as a Docker-first, parallel-lane phase:
+
+- bring up Docker PostgreSQL and run a gated smoke test immediately,
+- land the backend executor contract once,
+- split independent implementation lanes across PostgreSQL schema/repository work, SQLite executor compatibility, IPC routing, and Docker E2E,
+- keep each lane small enough to merge or abandon independently,
+- start WGS-scale variant-read design and fixture preparation in parallel only where it does not share write sets with the case metadata slice.
+
+Phase 6 should implement:
+
+1. PostgreSQL schema and repositories for case metadata, cohort groups, case-cohort links, HPO terms, data info, and external IDs.
+2. Backend-aware read and write executor coverage for the `case-metadata:*` domain.
+3. PostgreSQL support for `cases:query` `cohort_ids` and `hpo_ids` filters.
+4. Docker-backed PostgreSQL integration coverage for the new slice, gated outside default CI but runnable as soon as the first Phase 6 checkpoint lands.
+5. A parallel WGS-readiness inventory for variants/import scale so Phase 7 can start immediately after Phase 6 without another discovery-only phase.
+
+Renderer storage settings remain out of scope. The fast path is an environment-gated running backend first, then UI exposure after import/export/delete/rebuild and variant/cohort reads are real.
+
+## Fast Iteration Strategy
+
+Phase 6 should optimize for frequent runnable checkpoints:
+
+1. **Checkpoint A: Docker backend boots.** `make pg-reset && make pg-up` initializes the schema and the existing PostgreSQL E2E still passes.
+2. **Checkpoint B: Metadata schema is visible in Docker.** The dev container includes metadata/cohort/HPO/data-info/external-ID tables and deterministic seed data.
+3. **Checkpoint C: Unit parity is green.** Mocked `pg.Pool` tests cover SQL shape and executor dispatch.
+4. **Checkpoint D: IPC works against Docker.** A gated Electron E2E reads and writes metadata through `window.api` while running with `VARLENS_EXPERIMENTAL_STORAGE_BACKEND=postgres`.
+5. **Checkpoint E: Next WGS work is unblocked.** Variant schema/read-spine and import-scale findings are captured as immediate Phase 7 inputs.
+
+Default CI should not require Docker in Phase 6, but every implementation branch should run the gated Docker path locally when Docker is available. If Docker is unavailable, the implementer must say so explicitly.
+
+## Parallel Work Lanes
+
+After the executor contract lands, implementation can split into independent write sets:
+
+| Lane | Ownership | Write set | Output |
+|---|---|---|---|
+| A | Docker/schema | `scripts/postgres/init-db/`, `tests/e2e/postgres-*.e2e.ts` | running Docker backend with seeded metadata |
+| B | PostgreSQL repositories | `src/main/storage/postgres/PostgresCaseMetadataRepository.ts`, PostgreSQL repository tests | backend SQL and row normalization |
+| C | SQLite compatibility executors | `src/main/storage/sqlite/`, SQLite executor tests | unchanged SQLite behavior through new contracts |
+| D | IPC/domain routing | `src/main/ipc/handlers/case-metadata*`, handler tests | renderer API reaches active session, not `getDb()` |
+| E | Cases filter parity | `PostgresCasesQueryRepository.ts`, cases query tests | `cohort_ids` and `hpo_ids` no longer throw |
+| F | WGS-readiness prep | `.planning/artifacts/` notes only, later Phase 7 plan inputs | variant schema/import scale blockers identified without touching runtime code |
+
+Lane F is deliberately planning/artifact-only in Phase 6. It may inspect code and write notes, but it must not start broad variants/import implementation in the same files as the case metadata slice.
+
+## Inventory Method
+
+Inventory was taken from:
+
+- `src/shared/types/db-task.ts`
+- `src/main/workers/db-worker-dispatch.ts`
+- `src/main/storage/read-executor.ts`
+- `src/main/storage/postgres/`
+- `src/main/storage/sqlite/`
+- `src/main/ipc/handlers/`
+- `src/main/ipc/dbPoolManager.ts`
+- `src/main/services/DatabaseManager.ts`
+- `src/main/database/startup.ts`
+- `src/main/workers/import-worker.ts`
+- `src/main/workers/export-worker.ts`
+- `src/main/workers/delete-worker.ts`
+- `src/main/workers/rebuild-summary-worker.ts`
+
+## Current PostgreSQL Status
+
+Implemented:
+
+- `PostgresStorageSession`
+- `PostgresReadExecutor`
+- `PostgresCaseListRepository`
+- `PostgresCasesQueryRepository`
+- `PostgresAvailableBuildsRepository`
+- environment-gated PostgreSQL startup
+- gated Docker dev workflow through `make pg-up`, `make pg-down`, `make pg-reset`, `make pg-psql`
+- gated PostgreSQL E2E path through `VARLENS_RUN_POSTGRES_E2E=1`
+
+Important current gaps:
+
+- `PostgresCasesQueryRepository` rejects `cohort_ids` and `hpo_ids`.
+- `StorageReadTask` only covers `cases:query` and `cases:availableBuilds`.
+- There is no `StorageWriteExecutor`.
+- PostgreSQL sessions intentionally throw for `getDatabaseService()`, `getDbPool()`, `getEncryptionKey()`, `needsStartupRebuild()`, and `rekey()`.
+- `database:info` returns `null` for PostgreSQL sessions because `DatabaseManager.getCurrentInfo()` is still SQLite file-shaped.
+- Docker PostgreSQL bootstrap only creates/seeds the cases table.
+
+## Parity Matrix
+
+| IPC channel or storage operation | Current SQLite implementation | Current worker/pool path | PostgreSQL status | Required repository/service/executor work | Required tests | Blocks user-facing PostgreSQL mode |
+|---|---|---|---|---|---|---|
+| `cases:list` | `CaseRepository.getAllCases()` | `DbTask` `cases:list`; also `SqliteStorageSession.listCases()` | Implemented through `PostgresCaseListRepository` | Keep as-is; verify against expanded schema | Existing unit and gated Docker E2E | No |
+| `cases:query` basic search/sort/page | `CaseRepository.queryCases()` | `DbTask` `cases:query`; `StorageReadTask` `cases:query` | Partially implemented | Keep existing basic PostgreSQL implementation | Existing unit tests | No for basic browsing |
+| `cases:query` `cohort_ids` filter | `CaseRepository.queryCases()` joins metadata/cohort tables | `DbTask` `cases:query` | Explicitly unsupported | Extend `PostgresCasesQueryRepository` with cohort filter SQL | Mocked repository tests plus gated Docker E2E | Yes |
+| `cases:query` `hpo_ids` filter | `CaseRepository.queryCases()` joins HPO tables | `DbTask` `cases:query` | Explicitly unsupported | Extend `PostgresCasesQueryRepository` with HPO filter SQL | Mocked repository tests plus gated Docker E2E | Yes |
+| `cases:availableBuilds` | `CaseRepository.getAvailableGenomeBuilds()` | `DbTask` `cases:availableBuilds`; `StorageReadTask` `cases:availableBuilds` | Implemented through `PostgresAvailableBuildsRepository` | Keep as-is | Existing tests | No |
+| `cases:delete` | `deleteSingleCase()` plus `delete-worker.ts` and frequency updates | File-backed worker write with `dbPath` and key | Guarded as SQLite-only | Later backend-aware delete executor with frequency and summary semantics | Delete unit tests, PostgreSQL integration tests | Yes |
+| `cases:deleteAll` | `deleteAllCases()` plus `delete-worker.ts` | File-backed worker write | Guarded as SQLite-only | Later backend-aware bulk delete executor | Delete worker parity tests | Yes |
+| `cases:deleteBatch` | `deleteBatchCases()` plus `delete-worker.ts` | File-backed worker write | Guarded as SQLite-only | Later backend-aware bulk delete executor | Delete worker parity tests | Yes |
+| `case-metadata:get` | `MetadataRepository.getCaseMetadata()` | `DbTask` `case-metadata:get` | Not implemented | Add PostgreSQL case metadata read repository and `StorageReadTask` | Repository, executor, handler tests | Yes |
+| `case-metadata:upsert` | `MetadataRepository.upsertCaseMetadata()` | Direct `DatabaseService` | Not implemented | Add `StorageWriteExecutor` and PostgreSQL write method | Write executor and handler tests | Yes |
+| `case-metadata:listCohorts` | `MetadataRepository.listCohortGroups()` | `DbTask` `case-metadata:listCohorts` | Not implemented | PostgreSQL cohort group reads | Repository, executor, handler tests | Yes |
+| `case-metadata:createCohort` | `MetadataRepository.createCohortGroup()` | Direct `DatabaseService` | Not implemented | PostgreSQL cohort group insert | Write repository and handler tests | Yes |
+| `case-metadata:updateCohort` | `MetadataRepository.updateCohortGroup()` | Direct `DatabaseService` | Not implemented | PostgreSQL cohort group update | Write repository and handler tests | Yes |
+| `case-metadata:deleteCohort` | `MetadataRepository.deleteCohortGroup()` | Direct `DatabaseService` | Not implemented | PostgreSQL cohort group delete | Write repository and handler tests | Yes |
+| `case-metadata:getCohortByName` | `MetadataRepository.getCohortGroupByName()` | `DbTask` `case-metadata:getCohortByName` | Not implemented | PostgreSQL query by name | Repository and executor tests | Yes |
+| `case-metadata:getCaseCohorts` | `MetadataRepository.getCaseCohorts()` | `DbTask` `case-metadata:getCaseCohorts` | Not implemented | PostgreSQL case cohort reads | Repository and handler tests | Yes |
+| `case-metadata:assignCohort` | `MetadataRepository.assignCaseCohort()` | Direct `DatabaseService` | Not implemented | PostgreSQL insert link | Write repository and handler tests | Yes |
+| `case-metadata:removeCohort` | `MetadataRepository.removeCaseCohort()` | Direct `DatabaseService` | Not implemented | PostgreSQL delete link | Write repository and handler tests | Yes |
+| `case-metadata:setCohorts` | `MetadataRepository.setCaseCohorts()` | Direct `DatabaseService` | Not implemented | PostgreSQL transactional replace | Write repository and handler tests | Yes |
+| `case-metadata:getHpoTerms` | `MetadataRepository.getCaseHpoTerms()` | `DbTask` `case-metadata:getHpoTerms` | Not implemented | PostgreSQL HPO reads | Repository and handler tests | Yes |
+| `case-metadata:assignHpoTerm` | `MetadataRepository.assignCaseHpoTerm()` | Direct `DatabaseService` | Not implemented | PostgreSQL HPO insert | Write repository and handler tests | Yes |
+| `case-metadata:removeHpoTerm` | `MetadataRepository.removeCaseHpoTerm()` | Direct `DatabaseService` | Not implemented | PostgreSQL HPO delete | Write repository and handler tests | Yes |
+| `case-metadata:getDataInfo` | `MetadataRepository.getCaseDataInfo()` | `DbTask` `case-metadata:getDataInfo` | Not implemented | PostgreSQL data info reads | Repository and handler tests | Yes |
+| `case-metadata:upsertDataInfo` | `MetadataRepository.upsertCaseDataInfo()` | Direct `DatabaseService` | Not implemented | PostgreSQL upsert | Write repository and handler tests | Yes |
+| `case-metadata:listExternalIds` | `MetadataRepository.listCaseExternalIds()` | `DbTask` `case-metadata:listExternalIds` | Not implemented | PostgreSQL external ID reads | Repository and handler tests | Yes |
+| `case-metadata:upsertExternalId` | `MetadataRepository.upsertCaseExternalId()` | Direct `DatabaseService` | Not implemented | PostgreSQL upsert | Write repository and handler tests | Yes |
+| `case-metadata:deleteExternalId` | `MetadataRepository.deleteCaseExternalId()` | Direct `DatabaseService` | Not implemented | PostgreSQL delete | Write repository and handler tests | Yes |
+| `case-metadata:distinctHpoTerms` | `MetadataRepository.getDistinctHpoTerms()` | `DbTask` `case-metadata:distinctHpoTerms` | Not implemented | PostgreSQL distinct HPO query | Repository and handler tests | Yes |
+| `case-metadata:distinctPlatforms` | `MetadataRepository.getDistinctPlatforms()` | `DbTask` `case-metadata:distinctPlatforms` | Not implemented | PostgreSQL distinct platform query | Repository and handler tests | Yes |
+| `case-metadata:distinctExternalIdTypes` | `MetadataRepository.getDistinctExternalIdTypes()` | `DbTask` `case-metadata:distinctExternalIdTypes` | Not implemented | PostgreSQL distinct external ID query | Repository and handler tests | Yes |
+| `case-metadata:getFullMetadata` | `MetadataRepository.getFullCaseMetadata()` returns metadata, cohorts, HPO terms, comments, metrics, data info, and external IDs | `DbTask` `case-metadata:getFullMetadata` | Not implemented | PostgreSQL aggregate metadata method with comments and metrics included | Repository and handler tests | Yes |
+| `variants:query` | `VariantRepository.getVariants()` and `VariantFilterBuilder` | `DbTask` `variants:query` | Not implemented | PostgreSQL variant query repository, filter builder, panel interval strategy | Unit, Docker integration, renderer workflow tests | Yes |
+| `variants:filterOptions` | `VariantRepository.getFilterOptions()` | `DbTask` `variants:filterOptions` | Not implemented | PostgreSQL column metadata/filter options | Unit and integration tests | Yes |
+| `variants:search` | `VariantSearchService` with SQLite FTS5 | `DbTask` `variants:search` | Not implemented; PostgreSQL capability says no FTS | PostgreSQL full-text design or explicit degraded-mode contract | Search parity tests | Yes |
+| `variants:geneSymbols` | `VariantSearchService.getGeneSymbols()` | `DbTask` `variants:geneSymbols` | Not implemented | PostgreSQL prefix query | Repository and handler tests | Yes |
+| `variants:typeCounts` | `VariantRepository.getVariantTypeCounts()` | `DbTask` `variants:typeCounts` | Not implemented | PostgreSQL count query | Repository and handler tests | Yes |
+| `variants:columnMeta` | `VariantRepository.getColumnMeta()` | `DbTask` `variants:columnMeta` | Not implemented | PostgreSQL column metadata repository | Unit and integration tests | Yes |
+| `variants:typesPresent` | `VariantRepository.getVariantTypesPresent()` | `DbTask` `variants:typesPresent` | Not implemented | PostgreSQL distinct type query | Unit and handler tests | Yes |
+| `variants:shortlist` | `ShortlistService.query()` | Direct `DatabaseService` | Not implemented | PostgreSQL shortlist query or defer until variant query parity | Repository and handler tests | Yes |
+| `cohort:variants` | `CohortService.getCohortVariants()` | `DbTask` `cohort:variants` | Not implemented | PostgreSQL cohort summary/variant query path | Unit, integration, perf checks | Yes |
+| `cohort:columnMeta` | `CohortService.getColumnMeta()` | `DbTask` `cohort:columnMeta` | Not implemented | PostgreSQL cohort metadata query | Unit and integration tests | Yes |
+| `cohort:summary` | `CohortService.getCohortSummary()` | `DbTask` `cohort:summary` | Not implemented | PostgreSQL cohort summary service | Unit and integration tests | Yes |
+| `cohort:carriers` | `CohortService.getCarriers()` | `DbTask` `cohort:carriers` | Not implemented | PostgreSQL carrier query | Unit and integration tests | Yes |
+| `cohort:geneBurden` | `CohortService.getGeneBurden()` | `DbTask` `cohort:geneBurden` | Not implemented | PostgreSQL gene burden query | Unit and integration tests | Yes |
+| `cohort:geneBurdenCompare` | `AssociationEngine` with `AssociationDataBuilder` | `DbTask` `association:build` for off-thread build | Not implemented | PostgreSQL association data builder or backend-neutral export of data build | Statistics parity tests | Yes |
+| `cohort:summaryStatus` | `CohortSummaryService.getStatus()` | `DbTask` `cohort:summaryStatus` | Not implemented | PostgreSQL summary metadata status | Unit and integration tests | Yes |
+| `cohort:rebuildSummary` | `rebuild-summary-worker.ts` | File-backed SQLite worker | Not implemented | PostgreSQL summary rebuild executor | Worker/executor integration tests | Yes |
+| `annotations:getGlobal` | `AnnotationRepository.getGlobalAnnotation()` | `DbTask` `annotations:getGlobal` | Not implemented | PostgreSQL annotation read repository | Unit and handler tests | Yes |
+| `annotations:upsertGlobal` | `AnnotationRepository.upsertGlobalAnnotation()` plus audit log | Direct `DatabaseService` | Not implemented | PostgreSQL annotation write plus audit write | Unit and handler tests | Yes |
+| `annotations:deleteGlobal` | `AnnotationRepository.deleteGlobalAnnotation()` | Direct `DatabaseService` | Not implemented | PostgreSQL delete | Unit and handler tests | Yes |
+| `annotations:getPerCase` | `AnnotationRepository.getPerCaseAnnotation()` | `DbTask` `annotations:getPerCase` | Not implemented | PostgreSQL per-case annotation reads | Unit and handler tests | Yes |
+| `annotations:upsertPerCase` | `AnnotationRepository.upsertPerCaseAnnotation()` plus audit log | Direct `DatabaseService` | Not implemented | PostgreSQL write plus audit write | Unit and handler tests | Yes |
+| `annotations:deletePerCase` | `AnnotationRepository.deletePerCaseAnnotation()` | Direct `DatabaseService` | Not implemented | PostgreSQL delete | Unit and handler tests | Yes |
+| `annotations:getForVariant` | `AnnotationRepository.getAnnotationsForVariant()` | `DbTask` `annotations:getForVariant` | Not implemented | PostgreSQL combined read | Unit and handler tests | Yes |
+| `annotations:batchGet` | `AnnotationRepository.getBatch()` | `DbTask` `annotations:batchGet` | Not implemented | PostgreSQL batch read | Unit and handler tests | Yes |
+| `tags:list` | `TagRepository.listTags()` | `DbTask` `tags:list` | Not implemented | PostgreSQL tag reads | Unit and handler tests | Yes |
+| `tags:create`, `tags:update`, `tags:delete` | `TagRepository` writes | Direct `DatabaseService` | Not implemented | PostgreSQL tag writes | Unit and handler tests | Yes |
+| `tags:getUsageCount` | `TagRepository.getTagUsageCount()` | `DbTask` `tags:getUsageCount` | Not implemented | PostgreSQL usage count | Unit and handler tests | Yes |
+| `tags:getVariantTags` | `TagRepository.getVariantTags()` | `DbTask` `tags:getVariantTags` | Not implemented | PostgreSQL variant tag reads | Unit and handler tests | Yes |
+| `tags:assignVariantTag`, `tags:removeVariantTag`, `tags:setVariantTags` | `TagRepository` writes | Direct `DatabaseService` | Not implemented | PostgreSQL variant tag writes | Unit and handler tests | Yes |
+| `transcripts:list` | `TranscriptRepository.getVariantTranscripts()` | `DbTask` `transcripts:list` | Not implemented | PostgreSQL transcript read repository | Unit and handler tests | Yes |
+| `transcripts:switch`, `transcripts:insertAndSwitch` | `TranscriptRepository` writes | Direct `DatabaseService` | Not implemented | PostgreSQL transcript writes | Unit and handler tests | Yes |
+| `gene-lists:list`, `gene-lists:getGenes` | `GeneListRepository` reads | `DbTask` `gene-lists:list`, `gene-lists:getGenes` | Not implemented | PostgreSQL gene list reads | Unit and handler tests | Yes |
+| `gene-lists:create`, `gene-lists:delete`, `gene-lists:setGenes` | `GeneListRepository` writes | Direct `DatabaseService` | Not implemented | PostgreSQL gene list writes | Unit and handler tests | Yes |
+| `region-files:list` | `GeneListRepository.listRegionFiles()` | `DbTask` `region-files:list` | Not implemented | PostgreSQL region file reads | Unit and handler tests | Yes |
+| `region-files:create`, `region-files:delete`, `region-files:importBed` | `GeneListRepository` writes plus BED file parse | Direct `DatabaseService` | Not implemented | PostgreSQL region file writes and import | Unit and handler tests | Yes |
+| `panels:*` | `PanelRepository` reads/writes and gene reference computations | Direct `DatabaseService`; panel interval helper can run in db-worker for variants/cohort | Not implemented | PostgreSQL panel repository or deliberate local-only reference split | Unit, handler, interval tests | Yes for panel filters |
+| `analysisGroups:*` | `AnalysisGroupRepository` reads/writes | Direct `DatabaseService` | Not implemented | PostgreSQL analysis group repository | Unit and handler tests | No for basic browsing, yes for analysis group feature |
+| `auth:*` | `AuthService` | Direct `DatabaseService` | Not implemented | PostgreSQL auth repository or keep account mode disabled for PG | Unit and handler tests | No if accounts disabled |
+| `case-comments:*` | Case comments repository methods on `DatabaseService`; `getFullCaseMetadata()` includes comment reads | Direct `DatabaseService` | Phase 6 includes read support only for `getFullMetadata`; standalone comment CRUD remains not implemented | PostgreSQL comment tables and read methods needed for full metadata shape; standalone CRUD deferred | Repository full-metadata tests | No for basic browsing; yes for honest full metadata |
+| `case-metrics:*` | Clinical metrics repository methods on `DatabaseService`; `getFullCaseMetadata()` includes metric reads | Direct `DatabaseService` | Phase 6 includes read support only for `getFullMetadata`; standalone metric CRUD remains not implemented | PostgreSQL metric tables and read methods needed for full metadata shape; standalone CRUD deferred | Repository full-metadata tests | No for basic browsing; yes for honest full metadata |
+| `audit:*` | `AuditLogRepository` | Direct `DatabaseService` | Not implemented | PostgreSQL audit log repository | Unit and handler tests | Yes once writes are enabled |
+| `presets:*` | `FilterPresetRepository` and `ShortlistService` | Direct `DatabaseService` | Not implemented | PostgreSQL preset repository or local-settings decision | Unit and handler tests | Yes for full filter UX |
+| `database:overview` | `DatabaseOverviewService.getDatabaseOverview()` | `DbTask` `database:overview` | Not implemented | Defer until cases metadata, tags, cohort summary, phenotypes are PostgreSQL-backed | Overview service tests after components exist | Yes, but not next |
+| `database:open`, `database:create`, `database:selectFile`, `database:selectSaveLocation`, `database:deleteFile`, `database:showInFolder` | SQLite file lifecycle | Mostly direct `DatabaseManager` and file system | SQLite file-only | Keep SQLite-only; PostgreSQL lifecycle is env-gated until UI support is honest | Existing database lifecycle tests plus later storage lifecycle tests | Yes for renderer settings |
+| `database:info`, `database:recentList`, `database:removeRecent`, `database:rekey` | SQLite workspace/recent DB/encryption | Direct `DatabaseManager` | PostgreSQL info returns `null`; rekey unsupported | Later backend-neutral workspace info and capability-aware UI | Database handler tests | Yes for renderer settings |
+| startup open/close/health/config | SQLite default open plus env-gated PostgreSQL startup | `DatabaseManager`, `openConfiguredDatabase`, `PostgresStorageSession.health()` | Partial; no renderer-facing PG lifecycle | Later storage lifecycle domain and `database:info` shape update | Startup, config, health tests | Yes for renderer settings |
+| import single-file JSON/VCF | `ImportWorkerClient` plus `import-worker.ts` | File-backed worker write | Not implemented | Backend-aware import executor; PostgreSQL bulk insert path | Worker and integration tests | Yes |
+| import multi-file append | First file worker, later appends on main thread with `VariantRepository` | Mixed worker and direct SQLite write | Not implemented | Backend-aware append and finalization path | Import integration tests | Yes |
+| export variants | `prepareVariantExport()` plus `export-worker.ts` | File-backed read worker with compiled SQLite SQL | Not implemented | Backend-aware export executor that does not ship SQLite SQL to PostgreSQL | Export worker tests | Yes |
+| export cohort | `CohortService` and XLSX write in main process | Direct SQLite read | Not implemented | PostgreSQL cohort export query path | Export tests | Yes |
+| delete all/batch/single | `delete-worker.ts`, `delete-operations.ts`, frequency rebuilds | File-backed worker write | Not implemented | Backend-aware delete executor | Delete tests | Yes |
+| summary rebuild | `CohortSummaryService` and `rebuild-summary-worker.ts` | File-backed worker | Not implemented | PostgreSQL summary rebuild SQL and executor | Rebuild tests | Yes |
+| external API caches (`vep`, `gnomad`, `myvariant`, `spliceai`, `protein`, `hpo`) | `ApiCache` on `getDb().database` | Direct SQLite cache | Not implemented | Decide local cache vs PostgreSQL cache storage | Cache tests | No for variant data parity, yes for full feature parity |
+| local reference data (`gene-ref:*`) | Gene reference DB/resource | No case DB worker | Backend-independent local resource | Keep out of PostgreSQL storage parity | Existing tests | No |
+| non-storage domains (`shell:*`, `system:*`, `updater:*`) | OS/Electron services | No database path | Not applicable | None | Existing tests | No |
+
+## Phase 6 Slice Decision
+
+Use Phase 6 for **case metadata and cases-query filter parity**.
+
+Reasons:
+
+- It closes a known gap in the current `cases:query` PostgreSQL implementation.
+- It creates PostgreSQL schema for tables that current `PostgresCasesQueryRepository` already joins.
+- It introduces backend-aware write execution on a contained domain before larger write paths such as import/delete/rebuild.
+- It is smaller than variants or cohort parity but still materially improves user-facing PostgreSQL honesty.
+- It supports later `database:overview`, because overview depends on cases, cohort groups, tags, and top phenotypes.
+
+Do not use Phase 6 for variants yet. The variants domain is the largest read surface and includes SQLite FTS5, extension tables, panel interval resolution, internal allele frequency, type tabs, column metadata, and export query compilation. It should be Phase 7 or later after Phase 6 proves write executor shape on a smaller domain.
+
+## `database:overview` Decision
+
+Defer `database:overview`.
+
+`database:overview` should not be next because its component data sources are not yet PostgreSQL-backed:
+
+- cases list is backed
+- case metadata and HPO terms are not backed yet
+- cohort groups are not backed yet
+- tags are not backed yet
+- cohort summary is not backed yet
+- BigInt conversion behavior must remain stable
+
+After Phase 6, `database:overview` can be reconsidered only if it is implemented as a thin aggregator over PostgreSQL-backed component services. It should not become a one-off monolithic PostgreSQL summary query while its components remain unsupported elsewhere.
+
+## Docker-backed PostgreSQL Integration Strategy
+
+The Docker workflow exists and should remain gated outside default CI:
+
+- `make pg-up`
+- `make pg-down`
+- `make pg-reset`
+- `make pg-psql`
+- `VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-*.e2e.ts`
+
+Phase 6 should add Docker-backed integration coverage early, not at the end, for:
+
+- seeded case metadata
+- `cases:query` with `cohort_ids`
+- `cases:query` with `hpo_ids`
+- `case-metadata:getFullMetadata`
+- at least one metadata write round trip, such as `case-metadata:assignHpoTerm`
+
+Do not require Docker in default CI in Phase 6. The current default CI should stay fast and deterministic through mocked `pg.Pool` unit tests. Docker-backed PostgreSQL should be a local required verification when Docker is available and can become a scheduled or manual GitHub Actions job once schema coverage is broad enough to justify service-container maintenance.
+
+Recommended local Docker loop:
+
+```bash
+make pg-reset
+make pg-up
+VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts tests/e2e/postgres-case-metadata-dev-mode.e2e.ts
+make pg-down
+```
+
+For WGS-scale work, Phase 6 should not import WGS data into PostgreSQL yet. It should prepare the next phase by identifying:
+
+- tables required for SNV/indel/SV/CNV/STR variant rows,
+- indexes needed for case-scoped pagination, gene lookup, type counts, and cohort filtering,
+- PostgreSQL full-text strategy to replace SQLite FTS5,
+- bulk insert path requirements for JSON and VCF,
+- query-plan capture commands to use once variant data is loaded.
+
+## Renderer Storage Settings
+
+Renderer storage settings remain out of scope.
+
+PostgreSQL runtime support is still not honest enough for a user-facing settings UI because:
+
+- import is SQLite-file-backed
+- export is SQLite-file-backed or direct SQLite service-backed
+- delete is SQLite-file-backed
+- summary rebuild is SQLite-file-backed
+- variants and cohort views are not PostgreSQL-backed
+- `database:info` is still SQLite-shaped
+- `database:open`, `database:create`, `database:rekey`, and recent database UX are local-file concepts
+
+Phase 6 may improve backend capability reporting in tests, but it must not expose renderer PostgreSQL settings.
+
+## Acceptance Criteria
+
+Phase 6 is complete when:
+
+- Docker PostgreSQL can be reset, started, and used by the gated PostgreSQL E2E path when Docker is available.
+- PostgreSQL dev schema includes case metadata, cohort group, case-cohort link, HPO term, data info, external ID, case comment, metric definition, and case metric tables required by full metadata parity.
+- `case-metadata:*` reads and writes route through active `StorageSession` executors instead of `DatabaseService` for migrated paths.
+- SQLite behavior for `case-metadata:*` remains unchanged.
+- PostgreSQL `case-metadata:*` behavior has mocked unit coverage.
+- `cases:query` supports `cohort_ids` and `hpo_ids` for PostgreSQL sessions.
+- Handler tests prove PostgreSQL case metadata paths do not call `getDb()` or `getDbPool()`.
+- PostgreSQL handlers resolve through `getCurrentSession()`; SQLite read paths may continue using the session-owned worker pool through `SqliteReadExecutor`.
+- Gated Docker PostgreSQL tests cover the new slice, stay skipped unless `VARLENS_RUN_POSTGRES_E2E=1`, and are required local verification when Docker is available.
+- A Phase 7 WGS-readiness artifact exists under `.planning/artifacts/` or `.planning/docs/` with concrete variant/import scale blockers and recommended first variant-read slice.
+- `database:overview` remains deferred and documented as dependent on component parity.
+- No renderer storage settings are added.
+
+## Follow-up Ordering
+
+Recommended order after Phase 6:
+
+1. Phase 7: variants read parity, including variant query, type counts, gene symbols, basic filter options, and explicit FTS strategy.
+2. Phase 8: cohort read parity and summary status.
+3. Phase 9: tags, annotations, transcripts, and audit-backed writes.
+4. Phase 10: import/delete/summary rebuild write executors.
+5. Phase 11: export parity.
+6. Phase 12: `database:overview` once component services are backed.
+7. Phase 13: renderer storage settings and backend lifecycle UX.

--- a/scripts/postgres/init-db/11-phase6-case-metadata.sql
+++ b/scripts/postgres/init-db/11-phase6-case-metadata.sql
@@ -1,0 +1,104 @@
+CREATE TABLE IF NOT EXISTS case_metadata (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL UNIQUE REFERENCES cases(id) ON DELETE CASCADE,
+  affected_status TEXT,
+  notes TEXT,
+  created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT,
+  updated_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT,
+  sex TEXT,
+  age DOUBLE PRECISION,
+  date_of_birth TEXT
+);
+
+CREATE TABLE IF NOT EXISTS cohort_groups (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  created_at BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS case_cohort_links (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  cohort_id BIGINT NOT NULL REFERENCES cohort_groups(id) ON DELETE CASCADE,
+  UNIQUE(case_id, cohort_id)
+);
+
+CREATE TABLE IF NOT EXISTS case_hpo_terms (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  hpo_id TEXT NOT NULL,
+  hpo_label TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  UNIQUE(case_id, hpo_id)
+);
+
+CREATE TABLE IF NOT EXISTS case_data_info (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL UNIQUE REFERENCES cases(id) ON DELETE CASCADE,
+  import_file_name TEXT,
+  import_file_type TEXT,
+  platform TEXT,
+  platform_details TEXT,
+  af_filter TEXT,
+  gene_list_filter TEXT,
+  region_filter TEXT,
+  quality_filter TEXT,
+  data_notes TEXT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  gene_list_id BIGINT,
+  region_file_id BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS case_external_ids (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  id_type TEXT NOT NULL,
+  id_value TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  UNIQUE(case_id, id_type)
+);
+
+CREATE TABLE IF NOT EXISTS case_comments (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS metric_definitions (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  value_type TEXT NOT NULL,
+  unit TEXT NOT NULL DEFAULT '',
+  category TEXT NOT NULL,
+  is_predefined INTEGER NOT NULL DEFAULT 0,
+  created_at BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS case_metrics (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  metric_id BIGINT NOT NULL REFERENCES metric_definitions(id) ON DELETE CASCADE,
+  numeric_value DOUBLE PRECISION,
+  text_value TEXT,
+  date_value TEXT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  UNIQUE(case_id, metric_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_case_metadata_case_id ON case_metadata(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_cohort_links_case_id ON case_cohort_links(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_cohort_links_cohort_id ON case_cohort_links(cohort_id);
+CREATE INDEX IF NOT EXISTS idx_case_hpo_terms_case_id ON case_hpo_terms(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_hpo_terms_hpo_id ON case_hpo_terms(hpo_id);
+CREATE INDEX IF NOT EXISTS idx_case_data_info_case_id ON case_data_info(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_external_ids_case_id ON case_external_ids(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_comments_case_created ON case_comments(case_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_case_comments_case_category ON case_comments(case_id, category);
+CREATE INDEX IF NOT EXISTS idx_case_metrics_case ON case_metrics(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_metrics_metric ON case_metrics(metric_id);

--- a/scripts/postgres/init-db/20-phase3-seed-cases.sql
+++ b/scripts/postgres/init-db/20-phase3-seed-cases.sql
@@ -3,3 +3,60 @@ VALUES
   (1, 'Oldest Case', '/data/oldest.vcf.gz', 1024, 0, 1714060800000, 'GRCh38'),
   (2, 'Middle Case', '/data/middle.vcf.gz', 2048, 21, 1714060801000, 'GRCh37'),
   (3, 'Newest Case', '/data/newest.vcf.gz', 4096, 42, 1714060802000, 'GRCh38');
+
+INSERT INTO case_metadata (case_id, affected_status, sex, notes)
+VALUES
+  (1, 'affected', 'female', 'index case'),
+  (2, 'unaffected', 'male', 'control case')
+ON CONFLICT (case_id) DO UPDATE SET
+  affected_status = EXCLUDED.affected_status,
+  sex = EXCLUDED.sex,
+  notes = EXCLUDED.notes;
+
+INSERT INTO cohort_groups (id, name, description, created_at)
+VALUES
+  (1, 'rare disease', 'Rare disease cohort', 1714060803000),
+  (2, 'controls', 'Control cohort', 1714060804000)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description;
+
+INSERT INTO case_cohort_links (case_id, cohort_id)
+VALUES (1, 1), (2, 2), (3, 1)
+ON CONFLICT (case_id, cohort_id) DO NOTHING;
+
+INSERT INTO case_hpo_terms (case_id, hpo_id, hpo_label, created_at)
+VALUES
+  (1, 'HP:0001250', 'Seizure', 1714060805000),
+  (3, 'HP:0004322', 'Short stature', 1714060806000)
+ON CONFLICT (case_id, hpo_id) DO UPDATE SET hpo_label = EXCLUDED.hpo_label;
+
+INSERT INTO case_comments (id, case_id, category, content, created_at)
+VALUES
+  (1, 1, 'clinical', 'Reviewed for PostgreSQL parity smoke', 1714060807000)
+ON CONFLICT (id) DO UPDATE SET
+  category = EXCLUDED.category,
+  content = EXCLUDED.content;
+
+INSERT INTO metric_definitions (id, name, value_type, unit, category, is_predefined, created_at)
+VALUES
+  (1, 'Age at analysis', 'numeric', 'years', 'clinical', 1, 1714060808000)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  value_type = EXCLUDED.value_type,
+  unit = EXCLUDED.unit,
+  category = EXCLUDED.category,
+  is_predefined = EXCLUDED.is_predefined;
+
+INSERT INTO case_metrics (id, case_id, metric_id, numeric_value, created_at, updated_at)
+VALUES
+  (1, 1, 1, 42, 1714060809000, 1714060809000)
+ON CONFLICT (id) DO UPDATE SET
+  numeric_value = EXCLUDED.numeric_value,
+  updated_at = EXCLUDED.updated_at;
+
+SELECT setval(pg_get_serial_sequence('public.case_metadata', 'id'), COALESCE((SELECT MAX(id) FROM case_metadata), 1), true);
+SELECT setval(pg_get_serial_sequence('public.cohort_groups', 'id'), COALESCE((SELECT MAX(id) FROM cohort_groups), 1), true);
+SELECT setval(pg_get_serial_sequence('public.case_comments', 'id'), COALESCE((SELECT MAX(id) FROM case_comments), 1), true);
+SELECT setval(pg_get_serial_sequence('public.metric_definitions', 'id'), COALESCE((SELECT MAX(id) FROM metric_definitions), 1), true);
+SELECT setval(pg_get_serial_sequence('public.case_metrics', 'id'), COALESCE((SELECT MAX(id) FROM case_metrics), 1), true);

--- a/scripts/postgres/init-db/README.md
+++ b/scripts/postgres/init-db/README.md
@@ -19,8 +19,14 @@ Developers can override the host port in their untracked `.env.postgres.local`
 file. If the port changes, update `VARLENS_PG_URL` in the same local env file so
 client tools keep pointing at the correct endpoint.
 
-Phase 1 keeps this bootstrap SQL intentionally minimal. The local development
-workflow only needs a stable schema baseline for early PostgreSQL session work.
+Current init files:
+
+- `001-create-varlens-schema.sql` creates the schema only.
+- `10-phase3-cases.sql` creates the base `cases` table.
+- `11-phase6-case-metadata.sql` creates Phase 6 metadata/cohort/HPO/comment/metric
+  tables that depend on `cases`.
+- `20-phase3-seed-cases.sql` seeds deterministic development rows and resets
+  sequences after explicit-ID seed inserts.
 
 Future phases may add development-only helper objects here if they improve local
 iteration. Production migrations must not depend on this folder because these

--- a/src/main/ipc/handlers/case-metadata-logic.ts
+++ b/src/main/ipc/handlers/case-metadata-logic.ts
@@ -1,44 +1,17 @@
 /**
  * Pure business logic for case-metadata IPC handlers.
  *
- * All functions take explicit dependencies (db, pool) as parameters
- * and never touch IPC/Electron APIs directly. This makes them testable
- * without mocking Electron internals.
+ * All functions take an explicit storage session dependency and never touch
+ * IPC/Electron APIs directly. This makes them testable without mocking
+ * Electron internals.
  */
-import type { DatabaseService } from '../../database/DatabaseService'
-import type { DbPool } from '../../database/DbPool'
-
-// ============================================================
-// Validated input types (after Zod parsing in handler)
-// ============================================================
-
-export interface MetadataUpdates {
-  affected_status?: string | null
-  sex?: string | null
-  notes?: string | null
-}
-
-export interface CohortCreateParams {
-  name: string
-  description?: string | null
-}
-
-export interface CohortUpdateParams {
-  name?: string
-  description?: string | null
-}
-
-export interface DataInfoUpdates {
-  platform?: string | null
-  platform_details?: string | null
-  af_filter?: string | null
-  gene_list_filter?: string | null
-  region_filter?: string | null
-  quality_filter?: string | null
-  data_notes?: string | null
-  gene_list_id?: number | null
-  region_file_id?: number | null
-}
+import type { StorageSession } from '../../storage/session'
+import type {
+  CohortCreateParams,
+  CohortUpdateParams,
+  DataInfoUpdates,
+  MetadataUpdates
+} from '../../storage/case-metadata-types'
 
 // ============================================================
 // Case Metadata
@@ -49,27 +22,30 @@ export interface DataInfoUpdates {
  */
 export async function getMetadata(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:get', params: [caseId] })
-  }
-  const db = getDb()
-  return db.metadata.getCaseMetadata(caseId)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:get',
+      params: [caseId]
+    })
 }
 
 /**
  * Upsert case metadata.
  */
-export function upsertMetadata(
+export async function upsertMetadata(
   caseId: number,
   updates: MetadataUpdates,
-  getDb: () => DatabaseService
-): unknown {
-  const db = getDb()
-  return db.metadata.upsertCaseMetadata(caseId, updates)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:upsert',
+      params: [caseId, updates]
+    })
 }
 
 // ============================================================
@@ -79,44 +55,57 @@ export function upsertMetadata(
 /**
  * List all cohort groups.
  */
-export async function listCohorts(
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
-): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:listCohorts', params: [] })
-  }
-  const db = getDb()
-  return db.metadata.listCohortGroups()
+export async function listCohorts(getSession: () => StorageSession): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({
+    type: 'case-metadata:listCohorts',
+    params: []
+  })
 }
 
 /**
  * Create a new cohort group.
  */
-export function createCohort(params: CohortCreateParams, getDb: () => DatabaseService): unknown {
-  const db = getDb()
-  return db.metadata.createCohortGroup(params.name, params.description)
+export async function createCohort(
+  params: CohortCreateParams,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:createCohort',
+      params: [params]
+    })
 }
 
 /**
  * Update a cohort group.
  */
-export function updateCohort(
+export async function updateCohort(
   cohortId: number,
   updates: CohortUpdateParams,
-  getDb: () => DatabaseService
-): unknown {
-  const db = getDb()
-  return db.metadata.updateCohortGroup(cohortId, updates)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:updateCohort',
+      params: [cohortId, updates]
+    })
 }
 
 /**
  * Delete a cohort group.
  */
-export function deleteCohort(cohortId: number, getDb: () => DatabaseService): void {
-  const db = getDb()
-  db.metadata.deleteCohortGroup(cohortId)
+export async function deleteCohort(
+  cohortId: number,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:deleteCohort',
+      params: [cohortId]
+    })
 }
 
 /**
@@ -124,15 +113,14 @@ export function deleteCohort(cohortId: number, getDb: () => DatabaseService): vo
  */
 export async function getCohortByName(
   name: string,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:getCohortByName', params: [name] })
-  }
-  const db = getDb()
-  return db.metadata.getCohortGroupByName(name)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:getCohortByName',
+      params: [name]
+    })
 }
 
 // ============================================================
@@ -144,43 +132,62 @@ export async function getCohortByName(
  */
 export async function getCaseCohorts(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:getCaseCohorts', params: [caseId] })
-  }
-  const db = getDb()
-  return db.metadata.getCaseCohorts(caseId)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:getCaseCohorts',
+      params: [caseId]
+    })
 }
 
 /**
  * Assign a case to a cohort.
  */
-export function assignCohort(caseId: number, cohortId: number, getDb: () => DatabaseService): void {
-  const db = getDb()
-  db.metadata.assignCaseCohort(caseId, cohortId)
+export async function assignCohort(
+  caseId: number,
+  cohortId: number,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:assignCohort',
+      params: [caseId, cohortId]
+    })
 }
 
 /**
  * Remove a case from a cohort.
  */
-export function removeCohort(caseId: number, cohortId: number, getDb: () => DatabaseService): void {
-  const db = getDb()
-  db.metadata.removeCaseCohort(caseId, cohortId)
+export async function removeCohort(
+  caseId: number,
+  cohortId: number,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:removeCohort',
+      params: [caseId, cohortId]
+    })
 }
 
 /**
  * Replace all cohort assignments for a case.
  */
-export function setCohorts(
+export async function setCohorts(
   caseId: number,
   cohortIds: number[],
-  getDb: () => DatabaseService
-): void {
-  const db = getDb()
-  db.metadata.setCaseCohorts(caseId, cohortIds)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:setCohorts',
+      params: [caseId, cohortIds]
+    })
 }
 
 // ============================================================
@@ -192,36 +199,47 @@ export function setCohorts(
  */
 export async function getHpoTerms(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:getHpoTerms', params: [caseId] })
-  }
-  const db = getDb()
-  return db.metadata.getCaseHpoTerms(caseId)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:getHpoTerms',
+      params: [caseId]
+    })
 }
 
 /**
  * Assign HPO term to case.
  */
-export function assignHpoTerm(
+export async function assignHpoTerm(
   caseId: number,
   hpoId: string,
   hpoLabel: string,
-  getDb: () => DatabaseService
-): unknown {
-  const db = getDb()
-  return db.metadata.assignCaseHpoTerm(caseId, hpoId, hpoLabel)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:assignHpoTerm',
+      params: [caseId, hpoId, hpoLabel]
+    })
 }
 
 /**
  * Remove HPO term from case.
  */
-export function removeHpoTerm(caseId: number, hpoId: string, getDb: () => DatabaseService): void {
-  const db = getDb()
-  db.metadata.removeCaseHpoTerm(caseId, hpoId)
+export async function removeHpoTerm(
+  caseId: number,
+  hpoId: string,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:removeHpoTerm',
+      params: [caseId, hpoId]
+    })
 }
 
 // ============================================================
@@ -233,27 +251,30 @@ export function removeHpoTerm(caseId: number, hpoId: string, getDb: () => Databa
  */
 export async function getDataInfo(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:getDataInfo', params: [caseId] })
-  }
-  const db = getDb()
-  return db.metadata.getCaseDataInfo(caseId)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:getDataInfo',
+      params: [caseId]
+    })
 }
 
 /**
  * Upsert case data info.
  */
-export function upsertDataInfo(
+export async function upsertDataInfo(
   caseId: number,
   updates: DataInfoUpdates,
-  getDb: () => DatabaseService
-): unknown {
-  const db = getDb()
-  return db.metadata.upsertCaseDataInfo(caseId, updates)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:upsertDataInfo',
+      params: [caseId, updates]
+    })
 }
 
 // ============================================================
@@ -265,40 +286,47 @@ export function upsertDataInfo(
  */
 export async function listExternalIds(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:listExternalIds', params: [caseId] })
-  }
-  const db = getDb()
-  return db.metadata.listCaseExternalIds(caseId)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:listExternalIds',
+      params: [caseId]
+    })
 }
 
 /**
  * Upsert an external ID for a case.
  */
-export function upsertExternalId(
+export async function upsertExternalId(
   caseId: number,
   idType: string,
   idValue: string,
-  getDb: () => DatabaseService
-): unknown {
-  const db = getDb()
-  return db.metadata.upsertCaseExternalId(caseId, idType, idValue)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:upsertExternalId',
+      params: [caseId, idType, idValue]
+    })
 }
 
 /**
  * Delete an external ID for a case.
  */
-export function deleteExternalId(
+export async function deleteExternalId(
   caseId: number,
   idType: string,
-  getDb: () => DatabaseService
-): void {
-  const db = getDb()
-  db.metadata.deleteCaseExternalId(caseId, idType)
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession()
+    .getWriteExecutor()
+    .execute({
+      type: 'case-metadata:deleteExternalId',
+      params: [caseId, idType]
+    })
 }
 
 // ============================================================
@@ -308,46 +336,31 @@ export function deleteExternalId(
 /**
  * Get distinct HPO terms across all cases.
  */
-export async function distinctHpoTerms(
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
-): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:distinctHpoTerms', params: [] })
-  }
-  const db = getDb()
-  return db.metadata.getDistinctHpoTerms()
+export async function distinctHpoTerms(getSession: () => StorageSession): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({
+    type: 'case-metadata:distinctHpoTerms',
+    params: []
+  })
 }
 
 /**
  * Get distinct platforms across all cases.
  */
-export async function distinctPlatforms(
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
-): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:distinctPlatforms', params: [] })
-  }
-  const db = getDb()
-  return db.metadata.getDistinctPlatforms()
+export async function distinctPlatforms(getSession: () => StorageSession): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({
+    type: 'case-metadata:distinctPlatforms',
+    params: []
+  })
 }
 
 /**
  * Get distinct external ID types across all cases.
  */
-export async function distinctExternalIdTypes(
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
-): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:distinctExternalIdTypes', params: [] })
-  }
-  const db = getDb()
-  return db.metadata.getDistinctExternalIdTypes()
+export async function distinctExternalIdTypes(getSession: () => StorageSession): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({
+    type: 'case-metadata:distinctExternalIdTypes',
+    params: []
+  })
 }
 
 // ============================================================
@@ -359,13 +372,12 @@ export async function distinctExternalIdTypes(
  */
 export async function getFullMetadata(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSession: () => StorageSession
 ): Promise<unknown> {
-  const pool = getDbPool?.()
-  if (pool) {
-    return await pool.run({ type: 'case-metadata:getFullMetadata', params: [caseId] })
-  }
-  const db = getDb()
-  return db.metadata.getFullCaseMetadata(caseId)
+  return await getSession()
+    .getReadExecutor()
+    .execute({
+      type: 'case-metadata:getFullMetadata',
+      params: [caseId]
+    })
 }

--- a/src/main/ipc/handlers/case-metadata.ts
+++ b/src/main/ipc/handlers/case-metadata.ts
@@ -106,7 +106,10 @@ const ExternalIdDeleteSchema = z.object({
  *           case-metadata:createCohort, case-metadata:updateCohort, case-metadata:deleteCohort, case-metadata:getCohortByName,
  *           case-metadata:getCaseCohorts, case-metadata:assignCohort, case-metadata:removeCohort,
  *           case-metadata:setCohorts, case-metadata:getHpoTerms, case-metadata:assignHpoTerm,
- *           case-metadata:removeHpoTerm, case-metadata:getFullMetadata
+ *           case-metadata:removeHpoTerm, case-metadata:getDataInfo, case-metadata:upsertDataInfo,
+ *           case-metadata:listExternalIds, case-metadata:upsertExternalId, case-metadata:deleteExternalId,
+ *           case-metadata:distinctHpoTerms, case-metadata:distinctPlatforms,
+ *           case-metadata:distinctExternalIdTypes, case-metadata:getFullMetadata
  */
 export function registerCaseMetadataHandlers({ ipcMain, getDbManager }: HandlerDependencies): void {
   const getSession = () => getDbManager().getCurrentSession()

--- a/src/main/ipc/handlers/case-metadata.ts
+++ b/src/main/ipc/handlers/case-metadata.ts
@@ -38,7 +38,9 @@ const CohortIdSchema = z.number().int().positive()
 const MetadataUpsertSchema = z.object({
   affected_status: z.string().nullish(),
   sex: z.string().nullish(),
-  notes: z.string().nullish()
+  notes: z.string().nullish(),
+  age: z.number().nullish(),
+  date_of_birth: z.string().nullish()
 })
 
 const CohortCreateSchema = z.object({
@@ -106,11 +108,9 @@ const ExternalIdDeleteSchema = z.object({
  *           case-metadata:setCohorts, case-metadata:getHpoTerms, case-metadata:assignHpoTerm,
  *           case-metadata:removeHpoTerm, case-metadata:getFullMetadata
  */
-export function registerCaseMetadataHandlers({
-  ipcMain,
-  getDb,
-  getDbPool
-}: HandlerDependencies): void {
+export function registerCaseMetadataHandlers({ ipcMain, getDbManager }: HandlerDependencies): void {
+  const getSession = () => getDbManager().getCurrentSession()
+
   // ============================================================
   // Case Metadata Handlers
   // ============================================================
@@ -125,7 +125,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return getMetadata(validated.data, getDb, getDbPool)
+      return getMetadata(validated.data, getSession)
     })
   })
 
@@ -149,7 +149,7 @@ export function registerCaseMetadataHandlers({
         throw new Error('Invalid parameters')
       }
 
-      return upsertMetadata(validatedId.data, validatedUpdates.data, getDb)
+      return upsertMetadata(validatedId.data, validatedUpdates.data, getSession)
     })
   })
 
@@ -159,7 +159,7 @@ export function registerCaseMetadataHandlers({
 
   ipcMain.handle('case-metadata:listCohorts', async () => {
     return wrapHandler(async () => {
-      return listCohorts(getDb, getDbPool)
+      return listCohorts(getSession)
     })
   })
 
@@ -175,7 +175,7 @@ export function registerCaseMetadataHandlers({
           )
           throw new Error('Invalid parameters')
         }
-        return createCohort(validated.data, getDb)
+        return createCohort(validated.data, getSession)
       })
     }
   )
@@ -202,7 +202,7 @@ export function registerCaseMetadataHandlers({
           throw new Error('Invalid parameters')
         }
 
-        return updateCohort(validatedId.data, validatedUpdates.data, getDb)
+        return updateCohort(validatedId.data, validatedUpdates.data, getSession)
       })
     }
   )
@@ -218,8 +218,7 @@ export function registerCaseMetadataHandlers({
         throw new Error('Invalid parameters')
       }
 
-      deleteCohort(validatedId.data, getDb)
-      return undefined
+      return deleteCohort(validatedId.data, getSession)
     })
   })
 
@@ -233,7 +232,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return getCohortByName(validated.data, getDb, getDbPool)
+      return getCohortByName(validated.data, getSession)
     })
   })
 
@@ -251,7 +250,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return getCaseCohorts(validated.data, getDb, getDbPool)
+      return getCaseCohorts(validated.data, getSession)
     })
   })
 
@@ -268,8 +267,7 @@ export function registerCaseMetadataHandlers({
           throw new Error('Invalid parameters')
         }
 
-        assignCohort(validated.data.caseId, validated.data.cohortId, getDb)
-        return undefined
+        return assignCohort(validated.data.caseId, validated.data.cohortId, getSession)
       })
     }
   )
@@ -287,8 +285,7 @@ export function registerCaseMetadataHandlers({
           throw new Error('Invalid parameters')
         }
 
-        removeCohort(validated.data.caseId, validated.data.cohortId, getDb)
-        return undefined
+        return removeCohort(validated.data.caseId, validated.data.cohortId, getSession)
       })
     }
   )
@@ -306,8 +303,7 @@ export function registerCaseMetadataHandlers({
           throw new Error('Invalid parameters')
         }
 
-        setCohorts(validated.data.caseId, validated.data.cohortIds, getDb)
-        return undefined
+        return setCohorts(validated.data.caseId, validated.data.cohortIds, getSession)
       })
     }
   )
@@ -326,7 +322,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return getHpoTerms(validated.data, getDb, getDbPool)
+      return getHpoTerms(validated.data, getSession)
     })
   })
 
@@ -347,7 +343,7 @@ export function registerCaseMetadataHandlers({
           validated.data.caseId,
           validated.data.hpoId,
           validated.data.hpoLabel,
-          getDb
+          getSession
         )
       })
     }
@@ -364,8 +360,7 @@ export function registerCaseMetadataHandlers({
         throw new Error('Invalid parameters')
       }
 
-      removeHpoTerm(validated.data.caseId, validated.data.hpoId, getDb)
-      return undefined
+      return removeHpoTerm(validated.data.caseId, validated.data.hpoId, getSession)
     })
   })
 
@@ -383,7 +378,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return getDataInfo(validated.data, getDb, getDbPool)
+      return getDataInfo(validated.data, getSession)
     })
   })
 
@@ -409,7 +404,7 @@ export function registerCaseMetadataHandlers({
           throw new Error('Invalid parameters')
         }
 
-        return upsertDataInfo(validatedId.data, validatedUpdates.data, getDb)
+        return upsertDataInfo(validatedId.data, validatedUpdates.data, getSession)
       })
     }
   )
@@ -428,7 +423,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return listExternalIds(validated.data, getDb, getDbPool)
+      return listExternalIds(validated.data, getSession)
     })
   })
 
@@ -449,7 +444,7 @@ export function registerCaseMetadataHandlers({
           validated.data.caseId,
           validated.data.idType,
           validated.data.idValue,
-          getDb
+          getSession
         )
       })
     }
@@ -468,8 +463,7 @@ export function registerCaseMetadataHandlers({
           throw new Error('Invalid parameters')
         }
 
-        deleteExternalId(validated.data.caseId, validated.data.idType, getDb)
-        return undefined
+        return deleteExternalId(validated.data.caseId, validated.data.idType, getSession)
       })
     }
   )
@@ -480,19 +474,19 @@ export function registerCaseMetadataHandlers({
 
   ipcMain.handle('case-metadata:distinctHpoTerms', async () => {
     return wrapHandler(async () => {
-      return distinctHpoTerms(getDb, getDbPool)
+      return distinctHpoTerms(getSession)
     })
   })
 
   ipcMain.handle('case-metadata:distinctPlatforms', async () => {
     return wrapHandler(async () => {
-      return distinctPlatforms(getDb, getDbPool)
+      return distinctPlatforms(getSession)
     })
   })
 
   ipcMain.handle('case-metadata:distinctExternalIdTypes', async () => {
     return wrapHandler(async () => {
-      return distinctExternalIdTypes(getDb, getDbPool)
+      return distinctExternalIdTypes(getSession)
     })
   })
 
@@ -510,7 +504,7 @@ export function registerCaseMetadataHandlers({
         )
         throw new Error('Invalid parameters')
       }
-      return getFullMetadata(validated.data, getDb, getDbPool)
+      return getFullMetadata(validated.data, getSession)
     })
   })
 }

--- a/src/main/storage/case-metadata-types.ts
+++ b/src/main/storage/case-metadata-types.ts
@@ -1,0 +1,39 @@
+export interface MetadataUpdates {
+  affected_status?: string | null
+  sex?: string | null
+  notes?: string | null
+  age?: number | null
+  date_of_birth?: string | null
+}
+
+export interface CohortCreateParams {
+  name: string
+  description?: string | null
+}
+
+export interface CohortUpdateParams {
+  name?: string
+  description?: string | null
+}
+
+export interface DataInfoUpdates {
+  platform?: string | null
+  platform_details?: string | null
+  af_filter?: string | null
+  gene_list_filter?: string | null
+  region_filter?: string | null
+  quality_filter?: string | null
+  data_notes?: string | null
+  gene_list_id?: number | null
+  region_file_id?: number | null
+}
+
+export interface FullCaseMetadataResult {
+  metadata: unknown
+  cohorts: unknown[]
+  hpoTerms: unknown[]
+  comments: unknown[]
+  metrics: unknown[]
+  dataInfo: unknown
+  externalIds: unknown[]
+}

--- a/src/main/storage/postgres/PostgresCaseMetadataRepository.ts
+++ b/src/main/storage/postgres/PostgresCaseMetadataRepository.ts
@@ -11,7 +11,17 @@ import { quoteIdentifier } from './identifiers'
 type Queryable = Pick<Pool, 'query' | 'connect'>
 type Row = Record<string, unknown>
 
-const integerFields = new Set(['id', 'case_id', 'cohort_id', 'metric_id', 'case_count'])
+const integerFields = new Set([
+  'id',
+  'case_id',
+  'cohort_id',
+  'metric_id',
+  'case_count',
+  'created_at',
+  'updated_at',
+  'gene_list_id',
+  'region_file_id'
+])
 
 function normalizeRow<T extends Row>(row: T): Row {
   const normalized: Row = { ...row }
@@ -364,9 +374,9 @@ export class PostgresCaseMetadataRepository {
   async getDistinctHpoTerms(): Promise<unknown[]> {
     const result = await this.pool.query<Row>(
       `
-        SELECT hpo_id, hpo_label, COUNT(DISTINCT case_id)::int AS case_count
+        SELECT hpo_id, MIN(hpo_label) AS hpo_label, COUNT(DISTINCT case_id)::int AS case_count
         FROM ${this.table('case_hpo_terms')}
-        GROUP BY hpo_id, hpo_label
+        GROUP BY hpo_id
         ORDER BY hpo_label
       `,
       []

--- a/src/main/storage/postgres/PostgresCaseMetadataRepository.ts
+++ b/src/main/storage/postgres/PostgresCaseMetadataRepository.ts
@@ -374,7 +374,7 @@ export class PostgresCaseMetadataRepository {
   async getDistinctHpoTerms(): Promise<unknown[]> {
     const result = await this.pool.query<Row>(
       `
-        SELECT hpo_id, MIN(hpo_label) AS hpo_label, COUNT(DISTINCT case_id)::int AS case_count
+        SELECT hpo_id, MIN(hpo_label) AS hpo_label
         FROM ${this.table('case_hpo_terms')}
         GROUP BY hpo_id
         ORDER BY hpo_label

--- a/src/main/storage/postgres/PostgresCaseMetadataRepository.ts
+++ b/src/main/storage/postgres/PostgresCaseMetadataRepository.ts
@@ -1,0 +1,428 @@
+import type { Pool, QueryResult } from 'pg'
+
+import type {
+  CohortUpdateParams,
+  DataInfoUpdates,
+  FullCaseMetadataResult,
+  MetadataUpdates
+} from '../case-metadata-types'
+import { quoteIdentifier } from './identifiers'
+
+type Queryable = Pick<Pool, 'query' | 'connect'>
+type Row = Record<string, unknown>
+
+const integerFields = new Set(['id', 'case_id', 'cohort_id', 'metric_id', 'case_count'])
+
+function normalizeRow<T extends Row>(row: T): Row {
+  const normalized: Row = { ...row }
+  for (const field of integerFields) {
+    const value = normalized[field]
+    if (typeof value === 'string') {
+      normalized[field] = Number(value)
+    }
+  }
+  return normalized
+}
+
+function firstNormalized(result: QueryResult<Row>): Row | null {
+  const row = result.rows[0]
+  return row === undefined ? null : normalizeRow(row)
+}
+
+function allNormalized(result: QueryResult<Row>): Row[] {
+  return result.rows.map((row) => normalizeRow(row))
+}
+
+export class PostgresCaseMetadataRepository {
+  constructor(
+    private readonly pool: Queryable,
+    private readonly schema: string
+  ) {}
+
+  async getCaseMetadata(caseId: number): Promise<unknown | null> {
+    const result = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('case_metadata')} WHERE case_id = $1`,
+      [caseId]
+    )
+    return firstNormalized(result)
+  }
+
+  async upsertCaseMetadata(caseId: number, updates: MetadataUpdates): Promise<unknown> {
+    const now = Date.now()
+    const result = await this.pool.query<Row>(
+      `
+        INSERT INTO ${this.table('case_metadata')} (
+          case_id,
+          affected_status,
+          sex,
+          notes,
+          age,
+          date_of_birth,
+          created_at,
+          updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+        ON CONFLICT (case_id) DO UPDATE SET
+          affected_status = CASE WHEN $8 THEN EXCLUDED.affected_status ELSE case_metadata.affected_status END,
+          sex = CASE WHEN $9 THEN EXCLUDED.sex ELSE case_metadata.sex END,
+          notes = CASE WHEN $10 THEN EXCLUDED.notes ELSE case_metadata.notes END,
+          age = CASE WHEN $11 THEN EXCLUDED.age ELSE case_metadata.age END,
+          date_of_birth = CASE WHEN $12 THEN EXCLUDED.date_of_birth ELSE case_metadata.date_of_birth END,
+          updated_at = EXCLUDED.updated_at
+        RETURNING *
+      `,
+      [
+        caseId,
+        updates.affected_status ?? null,
+        updates.sex ?? null,
+        updates.notes ?? null,
+        updates.age ?? null,
+        updates.date_of_birth ?? null,
+        now,
+        'affected_status' in updates,
+        'sex' in updates,
+        'notes' in updates,
+        'age' in updates,
+        'date_of_birth' in updates
+      ]
+    )
+    return firstNormalized(result)
+  }
+
+  async listCohortGroups(): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('cohort_groups')} ORDER BY name`,
+      []
+    )
+    return allNormalized(result)
+  }
+
+  async createCohortGroup(name: string, description?: string | null): Promise<unknown> {
+    const result = await this.pool.query<Row>(
+      `
+        INSERT INTO ${this.table('cohort_groups')} (name, description, created_at)
+        VALUES ($1, $2, $3)
+        RETURNING *
+      `,
+      [name, description ?? null, Date.now()]
+    )
+    return firstNormalized(result)
+  }
+
+  async updateCohortGroup(cohortId: number, updates: CohortUpdateParams): Promise<unknown> {
+    const existing = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('cohort_groups')} WHERE id = $1`,
+      [cohortId]
+    )
+    if (existing.rows[0] === undefined) {
+      return null
+    }
+
+    const result = await this.pool.query<Row>(
+      `
+        UPDATE ${this.table('cohort_groups')}
+        SET
+          name = CASE WHEN $2 THEN $3 ELSE name END,
+          description = CASE WHEN $4 THEN $5 ELSE description END
+        WHERE id = $1
+        RETURNING *
+      `,
+      [
+        cohortId,
+        'name' in updates,
+        updates.name ?? null,
+        'description' in updates,
+        updates.description ?? null
+      ]
+    )
+    return firstNormalized(result)
+  }
+
+  async deleteCohortGroup(cohortId: number): Promise<void> {
+    await this.pool.query(`DELETE FROM ${this.table('cohort_groups')} WHERE id = $1`, [cohortId])
+  }
+
+  async getCohortGroupByName(name: string): Promise<unknown | null> {
+    const result = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('cohort_groups')} WHERE name = $1`,
+      [name]
+    )
+    return firstNormalized(result)
+  }
+
+  async getCaseCohorts(caseId: number): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `
+        SELECT cg.*
+        FROM ${this.table('cohort_groups')} cg
+        INNER JOIN ${this.table('case_cohort_links')} ccl ON ccl.cohort_id = cg.id
+        WHERE ccl.case_id = $1
+        ORDER BY cg.name
+      `,
+      [caseId]
+    )
+    return allNormalized(result)
+  }
+
+  async assignCaseCohort(caseId: number, cohortId: number): Promise<void> {
+    await this.pool.query(
+      `
+        INSERT INTO ${this.table('case_cohort_links')} (case_id, cohort_id)
+        VALUES ($1, $2)
+        ON CONFLICT (case_id, cohort_id) DO NOTHING
+      `,
+      [caseId, cohortId]
+    )
+  }
+
+  async removeCaseCohort(caseId: number, cohortId: number): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM ${this.table('case_cohort_links')} WHERE case_id = $1 AND cohort_id = $2`,
+      [caseId, cohortId]
+    )
+  }
+
+  async setCaseCohorts(caseId: number, cohortIds: number[]): Promise<void> {
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(`DELETE FROM ${this.table('case_cohort_links')} WHERE case_id = $1`, [
+        caseId
+      ])
+      await client.query(
+        `
+          INSERT INTO ${this.table('case_cohort_links')} (case_id, cohort_id)
+          SELECT $1, cohort_id
+          FROM UNNEST($2::bigint[]) AS cohort_id
+          ON CONFLICT (case_id, cohort_id) DO NOTHING
+        `,
+        [caseId, cohortIds]
+      )
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async getCaseHpoTerms(caseId: number): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('case_hpo_terms')} WHERE case_id = $1 ORDER BY hpo_id`,
+      [caseId]
+    )
+    return allNormalized(result)
+  }
+
+  async assignCaseHpoTerm(caseId: number, hpoId: string, hpoLabel: string): Promise<unknown> {
+    const result = await this.pool.query<Row>(
+      `
+        INSERT INTO ${this.table('case_hpo_terms')} (case_id, hpo_id, hpo_label, created_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (case_id, hpo_id) DO UPDATE SET hpo_label = EXCLUDED.hpo_label
+        RETURNING *
+      `,
+      [caseId, hpoId, hpoLabel, Date.now()]
+    )
+    return firstNormalized(result)
+  }
+
+  async removeCaseHpoTerm(caseId: number, hpoId: string): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM ${this.table('case_hpo_terms')} WHERE case_id = $1 AND hpo_id = $2`,
+      [caseId, hpoId]
+    )
+  }
+
+  async getCaseDataInfo(caseId: number): Promise<unknown | null> {
+    const result = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('case_data_info')} WHERE case_id = $1`,
+      [caseId]
+    )
+    return firstNormalized(result)
+  }
+
+  async upsertCaseDataInfo(caseId: number, updates: DataInfoUpdates): Promise<unknown> {
+    const now = Date.now()
+    const result = await this.pool.query<Row>(
+      `
+        INSERT INTO ${this.table('case_data_info')} (
+          case_id,
+          platform,
+          platform_details,
+          af_filter,
+          gene_list_filter,
+          region_filter,
+          quality_filter,
+          data_notes,
+          gene_list_id,
+          region_file_id,
+          created_at,
+          updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $11)
+        ON CONFLICT (case_id) DO UPDATE SET
+          platform = CASE WHEN $12 THEN EXCLUDED.platform ELSE case_data_info.platform END,
+          platform_details = CASE WHEN $13 THEN EXCLUDED.platform_details ELSE case_data_info.platform_details END,
+          af_filter = CASE WHEN $14 THEN EXCLUDED.af_filter ELSE case_data_info.af_filter END,
+          gene_list_filter = CASE WHEN $15 THEN EXCLUDED.gene_list_filter ELSE case_data_info.gene_list_filter END,
+          region_filter = CASE WHEN $16 THEN EXCLUDED.region_filter ELSE case_data_info.region_filter END,
+          quality_filter = CASE WHEN $17 THEN EXCLUDED.quality_filter ELSE case_data_info.quality_filter END,
+          data_notes = CASE WHEN $18 THEN EXCLUDED.data_notes ELSE case_data_info.data_notes END,
+          gene_list_id = CASE WHEN $19 THEN EXCLUDED.gene_list_id ELSE case_data_info.gene_list_id END,
+          region_file_id = CASE WHEN $20 THEN EXCLUDED.region_file_id ELSE case_data_info.region_file_id END,
+          updated_at = EXCLUDED.updated_at
+        RETURNING *
+      `,
+      [
+        caseId,
+        updates.platform ?? null,
+        updates.platform_details ?? null,
+        updates.af_filter ?? null,
+        updates.gene_list_filter ?? null,
+        updates.region_filter ?? null,
+        updates.quality_filter ?? null,
+        updates.data_notes ?? null,
+        updates.gene_list_id ?? null,
+        updates.region_file_id ?? null,
+        now,
+        'platform' in updates,
+        'platform_details' in updates,
+        'af_filter' in updates,
+        'gene_list_filter' in updates,
+        'region_filter' in updates,
+        'quality_filter' in updates,
+        'data_notes' in updates,
+        'gene_list_id' in updates,
+        'region_file_id' in updates
+      ]
+    )
+    return firstNormalized(result)
+  }
+
+  async listCaseExternalIds(caseId: number): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `SELECT * FROM ${this.table('case_external_ids')} WHERE case_id = $1 ORDER BY id_type`,
+      [caseId]
+    )
+    return allNormalized(result)
+  }
+
+  async upsertCaseExternalId(caseId: number, idType: string, idValue: string): Promise<unknown> {
+    const result = await this.pool.query<Row>(
+      `
+        INSERT INTO ${this.table('case_external_ids')} (case_id, id_type, id_value, created_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (case_id, id_type) DO UPDATE SET id_value = EXCLUDED.id_value
+        RETURNING *
+      `,
+      [caseId, idType, idValue, Date.now()]
+    )
+    return firstNormalized(result)
+  }
+
+  async deleteCaseExternalId(caseId: number, idType: string): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM ${this.table('case_external_ids')} WHERE case_id = $1 AND id_type = $2`,
+      [caseId, idType]
+    )
+  }
+
+  async listCaseComments(caseId: number): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `
+        SELECT *
+        FROM ${this.table('case_comments')}
+        WHERE case_id = $1
+        ORDER BY created_at DESC, id DESC
+      `,
+      [caseId]
+    )
+    return allNormalized(result)
+  }
+
+  async listCaseMetrics(caseId: number): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `
+        SELECT
+          cm.*,
+          md.name,
+          md.value_type,
+          md.unit,
+          md.category AS metric_category
+        FROM ${this.table('case_metrics')} cm
+        INNER JOIN ${this.table('metric_definitions')} md ON md.id = cm.metric_id
+        WHERE cm.case_id = $1
+        ORDER BY md.category, md.name
+      `,
+      [caseId]
+    )
+    return allNormalized(result)
+  }
+
+  async getDistinctHpoTerms(): Promise<unknown[]> {
+    const result = await this.pool.query<Row>(
+      `
+        SELECT hpo_id, hpo_label, COUNT(DISTINCT case_id)::int AS case_count
+        FROM ${this.table('case_hpo_terms')}
+        GROUP BY hpo_id, hpo_label
+        ORDER BY hpo_label
+      `,
+      []
+    )
+    return allNormalized(result)
+  }
+
+  async getDistinctPlatforms(): Promise<string[]> {
+    const result = await this.pool.query<{ platform: string }>(
+      `
+        SELECT DISTINCT platform
+        FROM ${this.table('case_data_info')}
+        WHERE platform IS NOT NULL
+        ORDER BY platform
+      `,
+      []
+    )
+    return result.rows.map((row) => row.platform)
+  }
+
+  async getDistinctExternalIdTypes(): Promise<string[]> {
+    const result = await this.pool.query<{ id_type: string }>(
+      `
+        SELECT DISTINCT id_type
+        FROM ${this.table('case_external_ids')}
+        ORDER BY id_type
+      `,
+      []
+    )
+    return result.rows.map((row) => row.id_type)
+  }
+
+  async getFullCaseMetadata(caseId: number): Promise<FullCaseMetadataResult> {
+    const [metadata, cohorts, hpoTerms, comments, metrics, dataInfo, externalIds] =
+      await Promise.all([
+        this.getCaseMetadata(caseId),
+        this.getCaseCohorts(caseId),
+        this.getCaseHpoTerms(caseId),
+        this.listCaseComments(caseId),
+        this.listCaseMetrics(caseId),
+        this.getCaseDataInfo(caseId),
+        this.listCaseExternalIds(caseId)
+      ])
+
+    return {
+      metadata,
+      cohorts,
+      hpoTerms,
+      comments,
+      metrics,
+      dataInfo,
+      externalIds
+    }
+  }
+
+  private table(name: string): string {
+    return `${quoteIdentifier(this.schema)}.${quoteIdentifier(name)}`
+  }
+}

--- a/src/main/storage/postgres/PostgresCasesQueryRepository.ts
+++ b/src/main/storage/postgres/PostgresCasesQueryRepository.ts
@@ -17,20 +17,33 @@ export class PostgresCasesQueryRepository {
     const sortBy = params.sort_by ?? 'created_at'
     const sortOrder = params.sort_order ?? 'desc'
 
+    const values: unknown[] = []
+    const whereClauses: string[] = []
+    const schemaName = quoteIdentifier(this.schema)
+
     if ((params.cohort_ids?.length ?? 0) > 0) {
-      throw new Error(
-        'cases:query cohort_ids filtering is not implemented for postgres sessions in Phase 4'
-      )
+      values.push(params.cohort_ids)
+      whereClauses.push(`
+        EXISTS (
+          SELECT 1
+          FROM ${schemaName}."case_cohort_links" ccl_filter
+          WHERE ccl_filter.case_id = c.id
+            AND ccl_filter.cohort_id = ANY($${values.length}::bigint[])
+        )
+      `)
     }
 
     if ((params.hpo_ids?.length ?? 0) > 0) {
-      throw new Error(
-        'cases:query hpo_ids filtering is not implemented for postgres sessions in Phase 4'
-      )
+      values.push(params.hpo_ids)
+      whereClauses.push(`
+        EXISTS (
+          SELECT 1
+          FROM ${schemaName}."case_hpo_terms" cht_filter
+          WHERE cht_filter.case_id = c.id
+            AND cht_filter.hpo_id = ANY($${values.length}::text[])
+        )
+      `)
     }
-
-    const values: unknown[] = []
-    const whereClauses: string[] = []
 
     if (searchTerm !== undefined && searchTerm !== '') {
       values.push(`%${searchTerm}%`)
@@ -41,7 +54,6 @@ export class PostgresCasesQueryRepository {
       sortBy === 'name' ? 'c.name' : sortBy === 'variant_count' ? 'c.variant_count' : 'c.created_at'
     const orderDirection = sortOrder === 'asc' ? 'ASC' : 'DESC'
     const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : ''
-    const schemaName = quoteIdentifier(this.schema)
 
     const rowsSql = `
       SELECT
@@ -55,7 +67,7 @@ export class PostgresCasesQueryRepository {
         cm.affected_status,
         cm.sex,
         COALESCE(array_agg(DISTINCT cg.name) FILTER (WHERE cg.name IS NOT NULL), '{}'::text[]) AS cohort_names,
-        COALESCE(array_agg(DISTINCT cg.id) FILTER (WHERE cg.id IS NOT NULL), '{}'::int[]) AS cohort_ids
+        COALESCE(array_agg(DISTINCT cg.id) FILTER (WHERE cg.id IS NOT NULL), '{}'::bigint[]) AS cohort_ids
       FROM ${schemaName}."cases" c
       LEFT JOIN ${schemaName}."case_metadata" cm ON cm.case_id = c.id
       LEFT JOIN ${schemaName}."case_cohort_links" ccl ON ccl.case_id = c.id

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -1,10 +1,25 @@
 import type { StorageReadExecutor, StorageReadTask } from '../read-executor'
 import type { PostgresAvailableBuildsRepository } from './PostgresAvailableBuildsRepository'
+import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
 import type { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 
 interface PostgresReadExecutorRepositories {
   casesQuery: Pick<PostgresCasesQueryRepository, 'queryCases'>
   availableBuilds: Pick<PostgresAvailableBuildsRepository, 'getAvailableGenomeBuilds'>
+  caseMetadata: Pick<
+    PostgresCaseMetadataRepository,
+    | 'getCaseMetadata'
+    | 'listCohortGroups'
+    | 'getCohortGroupByName'
+    | 'getCaseCohorts'
+    | 'getCaseHpoTerms'
+    | 'getCaseDataInfo'
+    | 'listCaseExternalIds'
+    | 'getDistinctHpoTerms'
+    | 'getDistinctPlatforms'
+    | 'getDistinctExternalIdTypes'
+    | 'getFullCaseMetadata'
+  >
 }
 
 export class PostgresReadExecutor implements StorageReadExecutor {
@@ -17,6 +32,39 @@ export class PostgresReadExecutor implements StorageReadExecutor {
 
       case 'cases:availableBuilds':
         return await this.repositories.availableBuilds.getAvailableGenomeBuilds()
+
+      case 'case-metadata:get':
+        return await this.repositories.caseMetadata.getCaseMetadata(task.params[0])
+
+      case 'case-metadata:listCohorts':
+        return await this.repositories.caseMetadata.listCohortGroups()
+
+      case 'case-metadata:getCohortByName':
+        return await this.repositories.caseMetadata.getCohortGroupByName(task.params[0])
+
+      case 'case-metadata:getCaseCohorts':
+        return await this.repositories.caseMetadata.getCaseCohorts(task.params[0])
+
+      case 'case-metadata:getHpoTerms':
+        return await this.repositories.caseMetadata.getCaseHpoTerms(task.params[0])
+
+      case 'case-metadata:getDataInfo':
+        return await this.repositories.caseMetadata.getCaseDataInfo(task.params[0])
+
+      case 'case-metadata:listExternalIds':
+        return await this.repositories.caseMetadata.listCaseExternalIds(task.params[0])
+
+      case 'case-metadata:distinctHpoTerms':
+        return await this.repositories.caseMetadata.getDistinctHpoTerms()
+
+      case 'case-metadata:distinctPlatforms':
+        return await this.repositories.caseMetadata.getDistinctPlatforms()
+
+      case 'case-metadata:distinctExternalIdTypes':
+        return await this.repositories.caseMetadata.getDistinctExternalIdTypes()
+
+      case 'case-metadata:getFullMetadata':
+        return await this.repositories.caseMetadata.getFullCaseMetadata(task.params[0])
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -6,9 +6,11 @@ import type { DbPool } from '../../database/DbPool'
 import type { Case } from '../../../shared/types/database'
 import { PostgresAvailableBuildsRepository } from './PostgresAvailableBuildsRepository'
 import { PostgresCaseListRepository } from './PostgresCaseListRepository'
+import { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
 import { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 import { PostgresReadExecutor } from './PostgresReadExecutor'
 import type { StorageReadExecutor } from '../read-executor'
+import { PostgresWriteExecutor } from './PostgresWriteExecutor'
 import {
   buildPostgresConnectionLabel,
   redactPostgresConnectionUrl,
@@ -16,6 +18,7 @@ import {
 } from '../config'
 import type { StorageSession } from '../session'
 import type { StorageCapabilities, StorageHealth, WorkspaceRef } from '../types'
+import type { StorageWriteExecutor } from '../write-executor'
 
 interface PostgresStorageSessionOptions {
   config: PostgresStorageConfig
@@ -47,14 +50,18 @@ export class PostgresStorageSession implements StorageSession {
   ) => PostgresCaseListRepository
   private readonly pool: Pool
   private readonly readExecutor: StorageReadExecutor
+  private readonly writeExecutor: StorageWriteExecutor
   private cases: PostgresCaseListRepository | null = null
 
   constructor(options: PostgresStorageSessionOptions) {
     this.pool = options.pool
+    const caseMetadata = new PostgresCaseMetadataRepository(options.pool, options.config.schema)
     this.readExecutor = new PostgresReadExecutor({
       casesQuery: new PostgresCasesQueryRepository(options.pool, options.config.schema),
-      availableBuilds: new PostgresAvailableBuildsRepository(options.pool, options.config.schema)
+      availableBuilds: new PostgresAvailableBuildsRepository(options.pool, options.config.schema),
+      caseMetadata
     })
+    this.writeExecutor = new PostgresWriteExecutor(caseMetadata)
     this.createCaseListRepository =
       options.createCaseListRepository ??
       ((pool: Pool, schema: string) => new PostgresCaseListRepository(pool, schema))
@@ -87,6 +94,10 @@ export class PostgresStorageSession implements StorageSession {
 
   getReadExecutor(): StorageReadExecutor {
     return this.readExecutor
+  }
+
+  getWriteExecutor(): StorageWriteExecutor {
+    return this.writeExecutor
   }
 
   getDatabaseService(): DatabaseService {

--- a/src/main/storage/postgres/PostgresWriteExecutor.ts
+++ b/src/main/storage/postgres/PostgresWriteExecutor.ts
@@ -1,8 +1,24 @@
 import type { StorageWriteExecutor, StorageWriteTask } from '../write-executor'
 import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
 
+type PostgresCaseMetadataWriter = Pick<
+  PostgresCaseMetadataRepository,
+  | 'upsertCaseMetadata'
+  | 'createCohortGroup'
+  | 'updateCohortGroup'
+  | 'deleteCohortGroup'
+  | 'assignCaseCohort'
+  | 'removeCaseCohort'
+  | 'setCaseCohorts'
+  | 'assignCaseHpoTerm'
+  | 'removeCaseHpoTerm'
+  | 'upsertCaseDataInfo'
+  | 'upsertCaseExternalId'
+  | 'deleteCaseExternalId'
+>
+
 export class PostgresWriteExecutor implements StorageWriteExecutor {
-  constructor(private readonly caseMetadata: PostgresCaseMetadataRepository) {}
+  constructor(private readonly caseMetadata: PostgresCaseMetadataWriter) {}
 
   async execute(task: StorageWriteTask): Promise<unknown> {
     switch (task.type) {

--- a/src/main/storage/postgres/PostgresWriteExecutor.ts
+++ b/src/main/storage/postgres/PostgresWriteExecutor.ts
@@ -1,0 +1,60 @@
+import type { StorageWriteExecutor, StorageWriteTask } from '../write-executor'
+import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
+
+export class PostgresWriteExecutor implements StorageWriteExecutor {
+  constructor(private readonly caseMetadata: PostgresCaseMetadataRepository) {}
+
+  async execute(task: StorageWriteTask): Promise<unknown> {
+    switch (task.type) {
+      case 'case-metadata:upsert':
+        return await this.caseMetadata.upsertCaseMetadata(task.params[0], task.params[1])
+
+      case 'case-metadata:createCohort':
+        return await this.caseMetadata.createCohortGroup(
+          task.params[0].name,
+          task.params[0].description
+        )
+
+      case 'case-metadata:updateCohort':
+        return await this.caseMetadata.updateCohortGroup(task.params[0], task.params[1])
+
+      case 'case-metadata:deleteCohort':
+        return await this.caseMetadata.deleteCohortGroup(task.params[0])
+
+      case 'case-metadata:assignCohort':
+        return await this.caseMetadata.assignCaseCohort(task.params[0], task.params[1])
+
+      case 'case-metadata:removeCohort':
+        return await this.caseMetadata.removeCaseCohort(task.params[0], task.params[1])
+
+      case 'case-metadata:setCohorts':
+        return await this.caseMetadata.setCaseCohorts(task.params[0], task.params[1])
+
+      case 'case-metadata:assignHpoTerm':
+        return await this.caseMetadata.assignCaseHpoTerm(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
+      case 'case-metadata:removeHpoTerm':
+        return await this.caseMetadata.removeCaseHpoTerm(task.params[0], task.params[1])
+
+      case 'case-metadata:upsertDataInfo':
+        return await this.caseMetadata.upsertCaseDataInfo(task.params[0], task.params[1])
+
+      case 'case-metadata:upsertExternalId':
+        return await this.caseMetadata.upsertCaseExternalId(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
+      case 'case-metadata:deleteExternalId':
+        return await this.caseMetadata.deleteCaseExternalId(task.params[0], task.params[1])
+    }
+
+    const exhaustive: never = task
+    throw new Error(`Unsupported storage write task: ${JSON.stringify(exhaustive)}`)
+  }
+}

--- a/src/main/storage/read-executor.ts
+++ b/src/main/storage/read-executor.ts
@@ -11,6 +11,17 @@ export type StorageReadTask =
       type: 'cases:availableBuilds'
       params: []
     }
+  | { type: 'case-metadata:get'; params: [caseId: number] }
+  | { type: 'case-metadata:listCohorts'; params: [] }
+  | { type: 'case-metadata:getCohortByName'; params: [name: string] }
+  | { type: 'case-metadata:getCaseCohorts'; params: [caseId: number] }
+  | { type: 'case-metadata:getHpoTerms'; params: [caseId: number] }
+  | { type: 'case-metadata:getDataInfo'; params: [caseId: number] }
+  | { type: 'case-metadata:listExternalIds'; params: [caseId: number] }
+  | { type: 'case-metadata:distinctHpoTerms'; params: [] }
+  | { type: 'case-metadata:distinctPlatforms'; params: [] }
+  | { type: 'case-metadata:distinctExternalIdTypes'; params: [] }
+  | { type: 'case-metadata:getFullMetadata'; params: [caseId: number] }
 
 export interface StorageReadExecutor {
   execute(task: StorageReadTask): Promise<unknown>

--- a/src/main/storage/session.ts
+++ b/src/main/storage/session.ts
@@ -3,6 +3,7 @@ import type { DbPool } from '../database/DbPool'
 import type { Case } from '../../shared/types/database'
 import type { StorageReadExecutor } from './read-executor'
 import type { StorageCapabilities, StorageHealth, WorkspaceRef } from './types'
+import type { StorageWriteExecutor } from './write-executor'
 
 export interface StorageSession {
   readonly workspace: WorkspaceRef
@@ -10,6 +11,7 @@ export interface StorageSession {
 
   listCases(): Promise<Case[]>
   getReadExecutor(): StorageReadExecutor
+  getWriteExecutor(): StorageWriteExecutor
   /**
    * Compatibility escape hatch for legacy SQLite-only paths.
    * New migrated slices must use getReadExecutor().

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -29,6 +29,104 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         }
 
         return this.databaseService.cases.getAvailableGenomeBuilds()
+
+      case 'case-metadata:get':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({ type: 'case-metadata:get', params: task.params })
+        }
+
+        return this.databaseService.metadata.getCaseMetadata(task.params[0])
+
+      case 'case-metadata:listCohorts':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({ type: 'case-metadata:listCohorts', params: task.params })
+        }
+
+        return this.databaseService.metadata.listCohortGroups()
+
+      case 'case-metadata:getCohortByName':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:getCohortByName',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.getCohortGroupByName(task.params[0])
+
+      case 'case-metadata:getCaseCohorts':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:getCaseCohorts',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.getCaseCohorts(task.params[0])
+
+      case 'case-metadata:getHpoTerms':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({ type: 'case-metadata:getHpoTerms', params: task.params })
+        }
+
+        return this.databaseService.metadata.getCaseHpoTerms(task.params[0])
+
+      case 'case-metadata:getDataInfo':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({ type: 'case-metadata:getDataInfo', params: task.params })
+        }
+
+        return this.databaseService.metadata.getCaseDataInfo(task.params[0])
+
+      case 'case-metadata:listExternalIds':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:listExternalIds',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.listCaseExternalIds(task.params[0])
+
+      case 'case-metadata:distinctHpoTerms':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:distinctHpoTerms',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.getDistinctHpoTerms()
+
+      case 'case-metadata:distinctPlatforms':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:distinctPlatforms',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.getDistinctPlatforms()
+
+      case 'case-metadata:distinctExternalIdTypes':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:distinctExternalIdTypes',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.getDistinctExternalIdTypes()
+
+      case 'case-metadata:getFullMetadata':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({
+            type: 'case-metadata:getFullMetadata',
+            params: task.params
+          })
+        }
+
+        return this.databaseService.metadata.getFullCaseMetadata(task.params[0])
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/sqlite/SqliteStorageSession.ts
+++ b/src/main/storage/sqlite/SqliteStorageSession.ts
@@ -4,7 +4,9 @@ import type { Case } from '../../../shared/types/database'
 import type { StorageReadExecutor } from '../read-executor'
 import type { StorageSession } from '../session'
 import type { StorageCapabilities, StorageHealth, WorkspaceRef } from '../types'
+import type { StorageWriteExecutor } from '../write-executor'
 import { SqliteReadExecutor } from './SqliteReadExecutor'
+import { SqliteWriteExecutor } from './SqliteWriteExecutor'
 
 interface SqliteStorageSessionOptions {
   databaseService: DatabaseService
@@ -28,11 +30,13 @@ export class SqliteStorageSession implements StorageSession {
   private readonly databaseService: DatabaseService
   private readonly dbPool: DbPool | null
   private readonly readExecutor: StorageReadExecutor
+  private readonly writeExecutor: StorageWriteExecutor
 
   constructor(options: SqliteStorageSessionOptions) {
     this.databaseService = options.databaseService
     this.dbPool = options.dbPool
     this.readExecutor = new SqliteReadExecutor(this.databaseService, this.dbPool)
+    this.writeExecutor = new SqliteWriteExecutor(this.databaseService)
 
     const dbPath = this.databaseService.getPath()
 
@@ -50,6 +54,10 @@ export class SqliteStorageSession implements StorageSession {
 
   getReadExecutor(): StorageReadExecutor {
     return this.readExecutor
+  }
+
+  getWriteExecutor(): StorageWriteExecutor {
+    return this.writeExecutor
   }
 
   async listCases(): Promise<Case[]> {

--- a/src/main/storage/sqlite/SqliteWriteExecutor.ts
+++ b/src/main/storage/sqlite/SqliteWriteExecutor.ts
@@ -1,0 +1,66 @@
+import type { DatabaseService } from '../../database/DatabaseService'
+import type { StorageWriteExecutor, StorageWriteTask } from '../write-executor'
+
+export class SqliteWriteExecutor implements StorageWriteExecutor {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async execute(task: StorageWriteTask): Promise<unknown> {
+    switch (task.type) {
+      case 'case-metadata:upsert':
+        return this.databaseService.metadata.upsertCaseMetadata(task.params[0], task.params[1])
+
+      case 'case-metadata:createCohort':
+        return this.databaseService.metadata.createCohortGroup(
+          task.params[0].name,
+          task.params[0].description
+        )
+
+      case 'case-metadata:updateCohort':
+        return this.databaseService.metadata.updateCohortGroup(task.params[0], task.params[1])
+
+      case 'case-metadata:deleteCohort':
+        this.databaseService.metadata.deleteCohortGroup(task.params[0])
+        return undefined
+
+      case 'case-metadata:assignCohort':
+        this.databaseService.metadata.assignCaseCohort(task.params[0], task.params[1])
+        return undefined
+
+      case 'case-metadata:removeCohort':
+        this.databaseService.metadata.removeCaseCohort(task.params[0], task.params[1])
+        return undefined
+
+      case 'case-metadata:setCohorts':
+        this.databaseService.metadata.setCaseCohorts(task.params[0], task.params[1])
+        return undefined
+
+      case 'case-metadata:assignHpoTerm':
+        return this.databaseService.metadata.assignCaseHpoTerm(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
+      case 'case-metadata:removeHpoTerm':
+        this.databaseService.metadata.removeCaseHpoTerm(task.params[0], task.params[1])
+        return undefined
+
+      case 'case-metadata:upsertDataInfo':
+        return this.databaseService.metadata.upsertCaseDataInfo(task.params[0], task.params[1])
+
+      case 'case-metadata:upsertExternalId':
+        return this.databaseService.metadata.upsertCaseExternalId(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
+      case 'case-metadata:deleteExternalId':
+        this.databaseService.metadata.deleteCaseExternalId(task.params[0], task.params[1])
+        return undefined
+    }
+
+    const exhaustive: never = task
+    throw new Error(`Unsupported storage write task: ${JSON.stringify(exhaustive)}`)
+  }
+}

--- a/src/main/storage/write-executor.ts
+++ b/src/main/storage/write-executor.ts
@@ -1,0 +1,27 @@
+import type {
+  CohortCreateParams,
+  CohortUpdateParams,
+  DataInfoUpdates,
+  MetadataUpdates
+} from './case-metadata-types'
+
+export type StorageWriteTask =
+  | { type: 'case-metadata:upsert'; params: [caseId: number, updates: MetadataUpdates] }
+  | { type: 'case-metadata:createCohort'; params: [params: CohortCreateParams] }
+  | {
+      type: 'case-metadata:updateCohort'
+      params: [cohortId: number, updates: CohortUpdateParams]
+    }
+  | { type: 'case-metadata:deleteCohort'; params: [cohortId: number] }
+  | { type: 'case-metadata:assignCohort'; params: [caseId: number, cohortId: number] }
+  | { type: 'case-metadata:removeCohort'; params: [caseId: number, cohortId: number] }
+  | { type: 'case-metadata:setCohorts'; params: [caseId: number, cohortIds: number[]] }
+  | { type: 'case-metadata:assignHpoTerm'; params: [caseId: number, hpoId: string, hpoLabel: string] }
+  | { type: 'case-metadata:removeHpoTerm'; params: [caseId: number, hpoId: string] }
+  | { type: 'case-metadata:upsertDataInfo'; params: [caseId: number, updates: DataInfoUpdates] }
+  | { type: 'case-metadata:upsertExternalId'; params: [caseId: number, idType: string, idValue: string] }
+  | { type: 'case-metadata:deleteExternalId'; params: [caseId: number, idType: string] }
+
+export interface StorageWriteExecutor {
+  execute(task: StorageWriteTask): Promise<unknown>
+}

--- a/src/main/storage/write-executor.ts
+++ b/src/main/storage/write-executor.ts
@@ -16,10 +16,16 @@ export type StorageWriteTask =
   | { type: 'case-metadata:assignCohort'; params: [caseId: number, cohortId: number] }
   | { type: 'case-metadata:removeCohort'; params: [caseId: number, cohortId: number] }
   | { type: 'case-metadata:setCohorts'; params: [caseId: number, cohortIds: number[]] }
-  | { type: 'case-metadata:assignHpoTerm'; params: [caseId: number, hpoId: string, hpoLabel: string] }
+  | {
+      type: 'case-metadata:assignHpoTerm'
+      params: [caseId: number, hpoId: string, hpoLabel: string]
+    }
   | { type: 'case-metadata:removeHpoTerm'; params: [caseId: number, hpoId: string] }
   | { type: 'case-metadata:upsertDataInfo'; params: [caseId: number, updates: DataInfoUpdates] }
-  | { type: 'case-metadata:upsertExternalId'; params: [caseId: number, idType: string, idValue: string] }
+  | {
+      type: 'case-metadata:upsertExternalId'
+      params: [caseId: number, idType: string, idValue: string]
+    }
   | { type: 'case-metadata:deleteExternalId'; params: [caseId: number, idType: string] }
 
 export interface StorageWriteExecutor {

--- a/tests/e2e/postgres-case-metadata-dev-mode.e2e.ts
+++ b/tests/e2e/postgres-case-metadata-dev-mode.e2e.ts
@@ -1,0 +1,154 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  dismissDisclaimerIfPresent,
+  launchElectronApp,
+  waitForAppShell
+} from './helpers/electron-app'
+
+function expectSuccessfulIpcResult<T>(result: T): T {
+  expect(result).not.toEqual(
+    expect.objectContaining({
+      code: expect.any(String),
+      message: expect.any(String),
+      userMessage: expect.any(String)
+    })
+  )
+
+  return result
+}
+
+test('postgres dev mode supports case metadata APIs and case filters', async () => {
+  test.skip(
+    process.env.VARLENS_RUN_POSTGRES_E2E !== '1',
+    'Set VARLENS_RUN_POSTGRES_E2E=1 after starting the local postgres container to run this test.'
+  )
+
+  let launched:
+    | Awaited<ReturnType<typeof launchElectronApp>>
+    | undefined
+
+  try {
+    launched = await launchElectronApp({
+      env: {
+        VARLENS_EXPERIMENTAL_STORAGE_BACKEND: 'postgres',
+        VARLENS_PG_URL:
+          process.env.VARLENS_PG_URL ??
+          'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SCHEMA: process.env.VARLENS_PG_SCHEMA ?? 'public'
+      }
+    })
+
+    await waitForAppShell(launched.window)
+    await dismissDisclaimerIfPresent(launched.window)
+
+    const results = await launched.window.evaluate(async () => {
+      const cohortCases = await window.api.cases.query({
+        limit: 25,
+        offset: 0,
+        cohort_ids: [1]
+      })
+      const hpoCases = await window.api.cases.query({
+        limit: 25,
+        offset: 0,
+        hpo_ids: ['HP:0001250']
+      })
+      const fullMetadata = await window.api.caseMetadata.getFullMetadata(1)
+      const assignedHpoTerm = await window.api.caseMetadata.assignHpoTerm(
+        2,
+        'HP:0000707',
+        'Abnormality of the nervous system'
+      )
+
+      return {
+        cohortCases,
+        hpoCases,
+        fullMetadata,
+        assignedHpoTerm
+      }
+    })
+
+    const cohortCases = expectSuccessfulIpcResult(results.cohortCases)
+    expect(cohortCases).toMatchObject({
+      total_count: 2,
+      data: [
+        expect.objectContaining({
+          id: 3,
+          name: 'Newest Case',
+          cohort_ids: expect.arrayContaining([1]),
+          cohort_names: expect.arrayContaining(['rare disease'])
+        }),
+        expect.objectContaining({
+          id: 1,
+          name: 'Oldest Case',
+          cohort_ids: expect.arrayContaining([1]),
+          cohort_names: expect.arrayContaining(['rare disease'])
+        })
+      ]
+    })
+
+    const hpoCases = expectSuccessfulIpcResult(results.hpoCases)
+    expect(hpoCases).toMatchObject({
+      total_count: 1,
+      data: [
+        expect.objectContaining({
+          id: 1,
+          name: 'Oldest Case',
+          affected_status: 'affected',
+          sex: 'female'
+        })
+      ]
+    })
+
+    const fullMetadata = expectSuccessfulIpcResult(results.fullMetadata)
+    expect(fullMetadata).toMatchObject({
+      metadata: expect.objectContaining({
+        case_id: 1,
+        affected_status: 'affected',
+        sex: 'female',
+        notes: 'index case'
+      }),
+      cohorts: [
+        expect.objectContaining({
+          id: 1,
+          name: 'rare disease'
+        })
+      ],
+      hpoTerms: [
+        expect.objectContaining({
+          case_id: 1,
+          hpo_id: 'HP:0001250',
+          hpo_label: 'Seizure'
+        })
+      ],
+      comments: [
+        expect.objectContaining({
+          case_id: 1,
+          category: 'clinical',
+          content: 'Reviewed for PostgreSQL parity smoke'
+        })
+      ],
+      metrics: [
+        expect.objectContaining({
+          case_id: 1,
+          numeric_value: 42
+        })
+      ],
+      dataInfo: null,
+      externalIds: []
+    })
+
+    const assignedHpoTerm = expectSuccessfulIpcResult(results.assignedHpoTerm)
+    expect(assignedHpoTerm).toMatchObject({
+      case_id: 2,
+      hpo_id: 'HP:0000707',
+      hpo_label: 'Abnormality of the nervous system'
+    })
+    expect(assignedHpoTerm).toHaveProperty('id')
+    expect(assignedHpoTerm).toHaveProperty('created_at')
+  } finally {
+    if (launched !== undefined) {
+      await launched.cleanup()
+    }
+  }
+})

--- a/tests/main/handlers/case-metadata-logic.test.ts
+++ b/tests/main/handlers/case-metadata-logic.test.ts
@@ -1,9 +1,17 @@
-/**
- * Case metadata logic smoke tests — verifies module exports are intact after extraction.
- */
-
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import * as logic from '../../../src/main/ipc/handlers/case-metadata-logic'
+import type { StorageSession } from '../../../src/main/storage/session'
+
+function createSession() {
+  const readExecute = vi.fn()
+  const writeExecute = vi.fn()
+  const session = {
+    getReadExecutor: () => ({ execute: readExecute }),
+    getWriteExecutor: () => ({ execute: writeExecute })
+  } as unknown as StorageSession
+
+  return { getSession: () => session, readExecute, writeExecute }
+}
 
 describe('case-metadata-logic exports', () => {
   it('exports expected functions', () => {
@@ -23,5 +31,83 @@ describe('case-metadata-logic exports', () => {
     expect(typeof logic.removeHpoTerm).toBe('function')
     expect(typeof logic.getDataInfo).toBe('function')
     expect(typeof logic.upsertDataInfo).toBe('function')
+  })
+})
+
+describe('case-metadata-logic storage executor routing', () => {
+  it('routes read helpers through the active read executor', async () => {
+    const { getSession, readExecute } = createSession()
+    readExecute.mockResolvedValue('read-result')
+
+    await expect(logic.getMetadata(1, getSession)).resolves.toBe('read-result')
+    await expect(logic.listCohorts(getSession)).resolves.toBe('read-result')
+    await expect(logic.getCohortByName('research', getSession)).resolves.toBe('read-result')
+    await expect(logic.getCaseCohorts(1, getSession)).resolves.toBe('read-result')
+    await expect(logic.getHpoTerms(1, getSession)).resolves.toBe('read-result')
+    await expect(logic.getDataInfo(1, getSession)).resolves.toBe('read-result')
+    await expect(logic.listExternalIds(1, getSession)).resolves.toBe('read-result')
+    await expect(logic.distinctHpoTerms(getSession)).resolves.toBe('read-result')
+    await expect(logic.distinctPlatforms(getSession)).resolves.toBe('read-result')
+    await expect(logic.distinctExternalIdTypes(getSession)).resolves.toBe('read-result')
+    await expect(logic.getFullMetadata(1, getSession)).resolves.toBe('read-result')
+
+    expect(readExecute.mock.calls.map(([task]) => task)).toEqual([
+      { type: 'case-metadata:get', params: [1] },
+      { type: 'case-metadata:listCohorts', params: [] },
+      { type: 'case-metadata:getCohortByName', params: ['research'] },
+      { type: 'case-metadata:getCaseCohorts', params: [1] },
+      { type: 'case-metadata:getHpoTerms', params: [1] },
+      { type: 'case-metadata:getDataInfo', params: [1] },
+      { type: 'case-metadata:listExternalIds', params: [1] },
+      { type: 'case-metadata:distinctHpoTerms', params: [] },
+      { type: 'case-metadata:distinctPlatforms', params: [] },
+      { type: 'case-metadata:distinctExternalIdTypes', params: [] },
+      { type: 'case-metadata:getFullMetadata', params: [1] }
+    ])
+  })
+
+  it('routes write helpers through the active write executor', async () => {
+    const { getSession, writeExecute } = createSession()
+    writeExecute.mockResolvedValue('write-result')
+
+    await expect(
+      logic.upsertMetadata(1, { affected_status: 'affected', age: 42 }, getSession)
+    ).resolves.toBe('write-result')
+    await expect(
+      logic.createCohort({ name: 'research', description: null }, getSession)
+    ).resolves.toBe('write-result')
+    await expect(logic.updateCohort(2, { name: 'updated' }, getSession)).resolves.toBe(
+      'write-result'
+    )
+    await expect(logic.deleteCohort(2, getSession)).resolves.toBe('write-result')
+    await expect(logic.assignCohort(1, 2, getSession)).resolves.toBe('write-result')
+    await expect(logic.removeCohort(1, 2, getSession)).resolves.toBe('write-result')
+    await expect(logic.setCohorts(1, [2, 3], getSession)).resolves.toBe('write-result')
+    await expect(logic.assignHpoTerm(1, 'HP:0001250', 'Seizure', getSession)).resolves.toBe(
+      'write-result'
+    )
+    await expect(logic.removeHpoTerm(1, 'HP:0001250', getSession)).resolves.toBe('write-result')
+    await expect(logic.upsertDataInfo(1, { platform: 'WGS' }, getSession)).resolves.toBe(
+      'write-result'
+    )
+    await expect(logic.upsertExternalId(1, 'MRN', '12345', getSession)).resolves.toBe(
+      'write-result'
+    )
+    await expect(logic.deleteExternalId(1, 'MRN', getSession)).resolves.toBe('write-result')
+
+    expect(writeExecute.mock.calls.map(([task]) => task)).toEqual([
+      { type: 'case-metadata:upsert', params: [1, { affected_status: 'affected', age: 42 }] },
+      { type: 'case-metadata:createCohort', params: [{ name: 'research', description: null }] },
+      { type: 'case-metadata:updateCohort', params: [2, { name: 'updated' }] },
+      { type: 'case-metadata:deleteCohort', params: [2] },
+      { type: 'case-metadata:assignCohort', params: [1, 2] },
+      { type: 'case-metadata:removeCohort', params: [1, 2] },
+      { type: 'case-metadata:setCohorts', params: [1, [2, 3]] },
+      { type: 'case-metadata:assignHpoTerm', params: [1, 'HP:0001250', 'Seizure'] },
+      { type: 'case-metadata:removeHpoTerm', params: [1, 'HP:0001250'] },
+      { type: 'case-metadata:upsertDataInfo', params: [1, { platform: 'WGS' }] },
+      { type: 'case-metadata:upsertExternalId', params: [1, 'MRN', '12345'] },
+      { type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] }
+    ])
   })
 })

--- a/tests/main/handlers/case-metadata-routing.test.ts
+++ b/tests/main/handlers/case-metadata-routing.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import { registerCaseMetadataHandlers } from '../../../src/main/ipc/handlers/case-metadata'
+
+type RegisteredHandler = (...args: unknown[]) => Promise<unknown>
+
+function setupHandlers() {
+  const readExecute = vi.fn()
+  const writeExecute = vi.fn()
+  const registered = new Map<string, RegisteredHandler>()
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: RegisteredHandler) => {
+      registered.set(channel, handler)
+    })
+  } as never
+
+  registerCaseMetadataHandlers({
+    ipcMain,
+    getDb: (() => {
+      throw new Error('getDb should not be called for postgres case metadata')
+    }) as never,
+    getDbManager: (() => ({
+      getCurrentSession: () => ({
+        getReadExecutor: () => ({ execute: readExecute }),
+        getWriteExecutor: () => ({ execute: writeExecute })
+      })
+    })) as never,
+    getDbPool: (() => {
+      throw new Error('getDbPool should not be called for postgres case metadata')
+    }) as never
+  })
+
+  return { readExecute, registered, writeExecute }
+}
+
+describe('case-metadata IPC storage session routing', () => {
+  it('routes case-metadata:get through the active read executor', async () => {
+    const expected = { case_id: 1, affected_status: 'affected' }
+    const { readExecute, registered } = setupHandlers()
+    readExecute.mockResolvedValue(expected)
+
+    const result = await registered.get('case-metadata:get')!(undefined, 1)
+
+    expect(result).toBe(expected)
+    expect(readExecute).toHaveBeenCalledWith({
+      type: 'case-metadata:get',
+      params: [1]
+    })
+  })
+
+  it('routes case-metadata:upsert through the active write executor without stripping age fields', async () => {
+    const expected = { case_id: 1, age: 42, date_of_birth: '1984-01-02' }
+    const { registered, writeExecute } = setupHandlers()
+    writeExecute.mockResolvedValue(expected)
+
+    const updates = {
+      affected_status: 'affected',
+      age: 42,
+      date_of_birth: '1984-01-02'
+    }
+    const result = await registered.get('case-metadata:upsert')!(undefined, 1, updates)
+
+    expect(result).toBe(expected)
+    expect(writeExecute).toHaveBeenCalledWith({
+      type: 'case-metadata:upsert',
+      params: [1, updates]
+    })
+  })
+
+  it('routes case-metadata:listCohorts through the active read executor', async () => {
+    const expected = [{ id: 2, name: 'research' }]
+    const { readExecute, registered } = setupHandlers()
+    readExecute.mockResolvedValue(expected)
+
+    const result = await registered.get('case-metadata:listCohorts')!(undefined)
+
+    expect(result).toBe(expected)
+    expect(readExecute).toHaveBeenCalledWith({
+      type: 'case-metadata:listCohorts',
+      params: []
+    })
+  })
+
+  it('routes case-metadata:assignHpoTerm through the active write executor', async () => {
+    const expected = { case_id: 1, hpo_id: 'HP:0001250', hpo_label: 'Seizure' }
+    const { registered, writeExecute } = setupHandlers()
+    writeExecute.mockResolvedValue(expected)
+
+    const result = await registered.get('case-metadata:assignHpoTerm')!(
+      undefined,
+      1,
+      'HP:0001250',
+      'Seizure'
+    )
+
+    expect(result).toBe(expected)
+    expect(writeExecute).toHaveBeenCalledWith({
+      type: 'case-metadata:assignHpoTerm',
+      params: [1, 'HP:0001250', 'Seizure']
+    })
+  })
+
+  it('routes case-metadata:getFullMetadata through the active read executor', async () => {
+    const expected = {
+      metadata: null,
+      cohorts: [],
+      hpoTerms: [],
+      comments: [],
+      metrics: [],
+      dataInfo: null,
+      externalIds: []
+    }
+    const { readExecute, registered } = setupHandlers()
+    readExecute.mockResolvedValue(expected)
+
+    const result = await registered.get('case-metadata:getFullMetadata')!(undefined, 1)
+
+    expect(result).toBe(expected)
+    expect(readExecute).toHaveBeenCalledWith({
+      type: 'case-metadata:getFullMetadata',
+      params: [1]
+    })
+  })
+})

--- a/tests/main/storage/postgres-case-metadata-repository.test.ts
+++ b/tests/main/storage/postgres-case-metadata-repository.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PostgresCaseMetadataRepository } from '../../../src/main/storage/postgres/PostgresCaseMetadataRepository'
+
+const makePool = () => {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn()
+  }
+
+  return {
+    pool: {
+      query: vi.fn(),
+      connect: vi.fn().mockResolvedValue(client)
+    },
+    client
+  }
+}
+
+describe('PostgresCaseMetadataRepository', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-24T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reads case metadata and normalizes numeric ids', async () => {
+    const { pool } = makePool()
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '7',
+          case_id: '1',
+          affected_status: 'affected',
+          sex: 'female',
+          notes: 'index case'
+        }
+      ]
+    })
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await expect(repository.getCaseMetadata(1)).resolves.toStrictEqual({
+      id: 7,
+      case_id: 1,
+      affected_status: 'affected',
+      sex: 'female',
+      notes: 'index case'
+    })
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('"public"."case_metadata"'),
+      [1]
+    )
+  })
+
+  it('upserts case metadata with conflict on case_id', async () => {
+    const { pool } = makePool()
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '8',
+          case_id: '1',
+          affected_status: 'affected',
+          sex: 'female',
+          notes: null,
+          age: 42,
+          date_of_birth: '1984-01-02'
+        }
+      ]
+    })
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await repository.upsertCaseMetadata(1, {
+      affected_status: 'affected',
+      sex: 'female',
+      age: 42,
+      date_of_birth: '1984-01-02'
+    })
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (case_id) DO UPDATE'),
+      expect.arrayContaining([1, 'affected', 'female', 42, '1984-01-02'])
+    )
+  })
+
+  it('sets case cohorts transactionally on one checked-out client', async () => {
+    const { pool, client } = makePool()
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await repository.setCaseCohorts(1, [2, 3])
+
+    expect(pool.connect).toHaveBeenCalledTimes(1)
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM "public"."case_cohort_links"'),
+      [1]
+    )
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO "public"."case_cohort_links"'),
+      [1, [2, 3]]
+    )
+    expect(client.query).toHaveBeenLastCalledWith('COMMIT')
+    expect(client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('rolls back setCaseCohorts when an insert fails', async () => {
+    const { pool, client } = makePool()
+    client.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('insert failed'))
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await expect(repository.setCaseCohorts(1, [2])).rejects.toThrow('insert failed')
+
+    expect(client.query).toHaveBeenCalledWith('ROLLBACK')
+    expect(client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns full case metadata with comments and metrics included', async () => {
+    const { pool } = makePool()
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ id: '1', case_id: '1', affected_status: 'affected' }] })
+      .mockResolvedValueOnce({ rows: [{ id: '2', name: 'rare disease' }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: '3', hpo_id: 'HP:0001250', hpo_label: 'Seizure' }]
+      })
+      .mockResolvedValueOnce({ rows: [{ id: '4', category: 'clinical', content: 'reviewed' }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: '5', metric_id: '6', name: 'Age', value_type: 'numeric', numeric_value: 42 }]
+      })
+      .mockResolvedValueOnce({ rows: [{ id: '7', platform: 'WGS' }] })
+      .mockResolvedValueOnce({ rows: [{ id: '8', id_type: 'MRN', id_value: '12345' }] })
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await expect(repository.getFullCaseMetadata(1)).resolves.toStrictEqual({
+      metadata: { id: 1, case_id: 1, affected_status: 'affected' },
+      cohorts: [{ id: 2, name: 'rare disease' }],
+      hpoTerms: [{ id: 3, hpo_id: 'HP:0001250', hpo_label: 'Seizure' }],
+      comments: [{ id: 4, category: 'clinical', content: 'reviewed' }],
+      metrics: [{ id: 5, metric_id: 6, name: 'Age', value_type: 'numeric', numeric_value: 42 }],
+      dataInfo: { id: 7, platform: 'WGS' },
+      externalIds: [{ id: 8, id_type: 'MRN', id_value: '12345' }]
+    })
+  })
+
+  it('returns stable distinct HPO terms by hpo_id and hpo_label', async () => {
+    const { pool } = makePool()
+    pool.query.mockResolvedValueOnce({
+      rows: [{ hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: '2' }]
+    })
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await expect(repository.getDistinctHpoTerms()).resolves.toStrictEqual([
+      { hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: 2 }
+    ])
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('GROUP BY hpo_id, hpo_label'),
+      []
+    )
+  })
+})

--- a/tests/main/storage/postgres-case-metadata-repository.test.ts
+++ b/tests/main/storage/postgres-case-metadata-repository.test.ts
@@ -146,7 +146,57 @@ describe('PostgresCaseMetadataRepository', () => {
     })
   })
 
-  it('returns stable distinct HPO terms by hpo_id and hpo_label', async () => {
+  it('normalizes bigint timestamps and nullable linked ids in returned rows', async () => {
+    const { pool } = makePool()
+    pool.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '1',
+            case_id: '1',
+            created_at: '1714060800000',
+            updated_at: '1714060801000'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '2',
+            case_id: '1',
+            gene_list_id: '3',
+            region_file_id: '4',
+            created_at: '1714060802000',
+            updated_at: '1714060803000'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await expect(repository.getFullCaseMetadata(1)).resolves.toMatchObject({
+      metadata: {
+        id: 1,
+        case_id: 1,
+        created_at: 1714060800000,
+        updated_at: 1714060801000
+      },
+      dataInfo: {
+        id: 2,
+        case_id: 1,
+        gene_list_id: 3,
+        region_file_id: 4,
+        created_at: 1714060802000,
+        updated_at: 1714060803000
+      }
+    })
+  })
+
+  it('returns stable distinct HPO terms grouped by hpo_id', async () => {
     const { pool } = makePool()
     pool.query.mockResolvedValueOnce({
       rows: [{ hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: '2' }]
@@ -156,9 +206,21 @@ describe('PostgresCaseMetadataRepository', () => {
     await expect(repository.getDistinctHpoTerms()).resolves.toStrictEqual([
       { hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: 2 }
     ])
-    expect(pool.query).toHaveBeenCalledWith(
-      expect.stringContaining('GROUP BY hpo_id, hpo_label'),
-      []
-    )
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('GROUP BY hpo_id'), [])
+  })
+
+  it('keeps distinct HPO terms to one row per HPO id with deterministic labels', async () => {
+    const { pool } = makePool()
+    pool.query.mockResolvedValueOnce({
+      rows: [{ hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: '2' }]
+    })
+    const repository = new PostgresCaseMetadataRepository(pool, 'public')
+
+    await repository.getDistinctHpoTerms()
+
+    const sql = pool.query.mock.calls[0][0] as string
+    expect(sql).toContain('MIN(hpo_label) AS hpo_label')
+    expect(sql).toContain('GROUP BY hpo_id')
+    expect(sql).not.toContain('GROUP BY hpo_id, hpo_label')
   })
 })

--- a/tests/main/storage/postgres-case-metadata-repository.test.ts
+++ b/tests/main/storage/postgres-case-metadata-repository.test.ts
@@ -199,12 +199,12 @@ describe('PostgresCaseMetadataRepository', () => {
   it('returns stable distinct HPO terms grouped by hpo_id', async () => {
     const { pool } = makePool()
     pool.query.mockResolvedValueOnce({
-      rows: [{ hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: '2' }]
+      rows: [{ hpo_id: 'HP:0001250', hpo_label: 'Seizure' }]
     })
     const repository = new PostgresCaseMetadataRepository(pool, 'public')
 
     await expect(repository.getDistinctHpoTerms()).resolves.toStrictEqual([
-      { hpo_id: 'HP:0001250', hpo_label: 'Seizure', case_count: 2 }
+      { hpo_id: 'HP:0001250', hpo_label: 'Seizure' }
     ])
     expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('GROUP BY hpo_id'), [])
   })
@@ -221,6 +221,7 @@ describe('PostgresCaseMetadataRepository', () => {
     const sql = pool.query.mock.calls[0][0] as string
     expect(sql).toContain('MIN(hpo_label) AS hpo_label')
     expect(sql).toContain('GROUP BY hpo_id')
+    expect(sql).not.toContain('case_count')
     expect(sql).not.toContain('GROUP BY hpo_id, hpo_label')
   })
 })

--- a/tests/main/storage/postgres-cases-query-repository.test.ts
+++ b/tests/main/storage/postgres-cases-query-repository.test.ts
@@ -68,27 +68,47 @@ describe('PostgresCasesQueryRepository', () => {
     )
   })
 
-  it('rejects unsupported cohort filtering explicitly', async () => {
-    const repository = new PostgresCasesQueryRepository({ query: vi.fn() } as never, 'public')
+  it('filters postgres cases by cohort ids', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ total_count: 0 }] })
+    }
+    const repository = new PostgresCasesQueryRepository(pool as never, 'public')
 
-    await expect(
-      repository.queryCases({
-        limit: 25,
-        offset: 0,
-        cohort_ids: [1]
-      })
-    ).rejects.toThrow('cohort_ids filtering is not implemented for postgres sessions in Phase 4')
+    await repository.queryCases({
+      limit: 25,
+      offset: 0,
+      cohort_ids: [1, 2]
+    })
+
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('ccl_filter.cohort_id = ANY'),
+      [[1, 2], 25, 0]
+    )
   })
 
-  it('rejects unsupported HPO filtering explicitly', async () => {
-    const repository = new PostgresCasesQueryRepository({ query: vi.fn() } as never, 'public')
+  it('filters postgres cases by hpo ids', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ total_count: 0 }] })
+    }
+    const repository = new PostgresCasesQueryRepository(pool as never, 'public')
 
-    await expect(
-      repository.queryCases({
-        limit: 25,
-        offset: 0,
-        hpo_ids: ['HP:0001250']
-      })
-    ).rejects.toThrow('hpo_ids filtering is not implemented for postgres sessions in Phase 4')
+    await repository.queryCases({
+      limit: 25,
+      offset: 0,
+      hpo_ids: ['HP:0001250']
+    })
+
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('cht_filter.hpo_id = ANY'),
+      [['HP:0001250'], 25, 0]
+    )
   })
 })

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -17,7 +17,11 @@ describe('PostgresReadExecutor', () => {
       sort_by: 'created_at' as const,
       sort_order: 'desc' as const
     }
-    const executor = new PostgresReadExecutor({ casesQuery, availableBuilds })
+    const executor = new PostgresReadExecutor({
+      casesQuery,
+      availableBuilds,
+      caseMetadata: {} as never
+    })
 
     await expect(executor.execute({ type: 'cases:query', params })).resolves.toBe(expected)
     expect(casesQuery.queryCases).toHaveBeenCalledWith(params)
@@ -32,12 +36,45 @@ describe('PostgresReadExecutor', () => {
     const availableBuilds = {
       getAvailableGenomeBuilds: vi.fn().mockResolvedValue(expected)
     }
-    const executor = new PostgresReadExecutor({ casesQuery, availableBuilds })
+    const executor = new PostgresReadExecutor({
+      casesQuery,
+      availableBuilds,
+      caseMetadata: {} as never
+    })
 
     await expect(executor.execute({ type: 'cases:availableBuilds', params: [] })).resolves.toBe(
       expected
     )
     expect(availableBuilds.getAvailableGenomeBuilds).toHaveBeenCalledWith()
     expect(casesQuery.queryCases).not.toHaveBeenCalled()
+  })
+
+  it('routes case metadata read tasks to the postgres repository', async () => {
+    const caseMetadata = {
+      getCaseMetadata: vi.fn().mockResolvedValue({ case_id: 1 }),
+      listCohortGroups: vi.fn().mockResolvedValue([]),
+      getFullCaseMetadata: vi.fn().mockResolvedValue({
+        metadata: null,
+        cohorts: [],
+        hpoTerms: [],
+        comments: [],
+        metrics: [],
+        dataInfo: null,
+        externalIds: []
+      })
+    }
+    const executor = new PostgresReadExecutor({
+      casesQuery: {} as never,
+      availableBuilds: {} as never,
+      caseMetadata: caseMetadata as never
+    })
+
+    await executor.execute({ type: 'case-metadata:get', params: [1] })
+    await executor.execute({ type: 'case-metadata:listCohorts', params: [] })
+    await executor.execute({ type: 'case-metadata:getFullMetadata', params: [1] })
+
+    expect(caseMetadata.getCaseMetadata).toHaveBeenCalledWith(1)
+    expect(caseMetadata.listCohortGroups).toHaveBeenCalledWith()
+    expect(caseMetadata.getFullCaseMetadata).toHaveBeenCalledWith(1)
   })
 })

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -38,6 +38,7 @@ describe('PostgresStorageSession', () => {
     expect(session.workspace.connectionUrlRedacted).toBe('postgres://127.0.0.1:55432/varlens_dev')
     expect(session.workspace.connectionLabel).toBe('127.0.0.1:55432/varlens_dev (public)')
     expect(session.getReadExecutor()).toBeDefined()
+    expect(session.getWriteExecutor()).toBeDefined()
     expect(session.capabilities).toEqual({
       backend: 'postgres',
       supportsEncryptionAtRest: false,
@@ -220,5 +221,32 @@ describe('PostgresStorageSession', () => {
 
     expect(pool.query).toHaveBeenCalledTimes(1)
     expect(pool.query.mock.calls[0][0]).toContain('"phase5_cases"."cases"')
+  })
+
+  it('routes case metadata writes through the session-owned postgres write executor', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ case_id: '1', sex: 'female' }]
+      }),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+    const session = new PostgresStorageSession({
+      config: makeConfig({ schema: 'phase6_metadata' }),
+      pool: pool as never
+    })
+
+    await expect(
+      session.getWriteExecutor().execute({
+        type: 'case-metadata:upsert',
+        params: [1, { sex: 'female' }]
+      })
+    ).resolves.toMatchObject({
+      case_id: 1,
+      sex: 'female'
+    })
+
+    expect(pool.query).toHaveBeenCalledTimes(1)
+    expect(pool.query.mock.calls[0][0]).toContain('"phase6_metadata"."case_metadata"')
   })
 })

--- a/tests/main/storage/postgres-write-executor.test.ts
+++ b/tests/main/storage/postgres-write-executor.test.ts
@@ -6,10 +6,19 @@ describe('PostgresWriteExecutor', () => {
   it('routes case metadata write tasks to the postgres repository', async () => {
     const repository = {
       upsertCaseMetadata: vi.fn().mockResolvedValue({ case_id: 1 }),
+      createCohortGroup: vi.fn(),
+      updateCohortGroup: vi.fn(),
+      deleteCohortGroup: vi.fn(),
+      assignCaseCohort: vi.fn(),
+      removeCaseCohort: vi.fn(),
       setCaseCohorts: vi.fn().mockResolvedValue(undefined),
+      assignCaseHpoTerm: vi.fn(),
+      removeCaseHpoTerm: vi.fn(),
+      upsertCaseDataInfo: vi.fn(),
+      upsertCaseExternalId: vi.fn(),
       deleteCaseExternalId: vi.fn().mockResolvedValue(undefined)
     }
-    const executor = new PostgresWriteExecutor(repository as never)
+    const executor = new PostgresWriteExecutor(repository)
 
     await executor.execute({ type: 'case-metadata:upsert', params: [1, { sex: 'female' }] })
     await executor.execute({ type: 'case-metadata:setCohorts', params: [1, [2, 3]] })

--- a/tests/main/storage/postgres-write-executor.test.ts
+++ b/tests/main/storage/postgres-write-executor.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PostgresWriteExecutor } from '../../../src/main/storage/postgres/PostgresWriteExecutor'
+
+describe('PostgresWriteExecutor', () => {
+  it('routes case metadata write tasks to the postgres repository', async () => {
+    const repository = {
+      upsertCaseMetadata: vi.fn().mockResolvedValue({ case_id: 1 }),
+      setCaseCohorts: vi.fn().mockResolvedValue(undefined),
+      deleteCaseExternalId: vi.fn().mockResolvedValue(undefined)
+    }
+    const executor = new PostgresWriteExecutor(repository as never)
+
+    await executor.execute({ type: 'case-metadata:upsert', params: [1, { sex: 'female' }] })
+    await executor.execute({ type: 'case-metadata:setCohorts', params: [1, [2, 3]] })
+    await executor.execute({ type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] })
+
+    expect(repository.upsertCaseMetadata).toHaveBeenCalledWith(1, { sex: 'female' })
+    expect(repository.setCaseCohorts).toHaveBeenCalledWith(1, [2, 3])
+    expect(repository.deleteCaseExternalId).toHaveBeenCalledWith(1, 'MRN')
+  })
+})

--- a/tests/main/storage/read-executor-contract.test.ts
+++ b/tests/main/storage/read-executor-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import type { AvailableBuild } from '../../../src/shared/types/database'
 import type { ValidatedCaseSearchParams } from '../../../src/shared/types/ipc-schemas'
@@ -9,6 +9,9 @@ describe('StorageReadExecutor contract', () => {
     const params: ValidatedCaseSearchParams = {
       limit: 25,
       offset: 0,
+      search_term: undefined,
+      cohort_ids: undefined,
+      hpo_ids: undefined,
       sort_by: 'created_at',
       sort_order: 'desc'
     }
@@ -31,5 +34,23 @@ describe('StorageReadExecutor contract', () => {
     expectTypeOf(task.params).toEqualTypeOf<[]>()
     expectTypeOf<AvailableBuild>().toEqualTypeOf<{ build: string; caseCount: number }>()
     expectTypeOf<StorageReadExecutor['execute']>().returns.toEqualTypeOf<Promise<unknown>>()
+  })
+
+  it('supports case metadata read tasks', () => {
+    const tasks = [
+      { type: 'case-metadata:get', params: [1] },
+      { type: 'case-metadata:listCohorts', params: [] },
+      { type: 'case-metadata:getCohortByName', params: ['research'] },
+      { type: 'case-metadata:getCaseCohorts', params: [1] },
+      { type: 'case-metadata:getHpoTerms', params: [1] },
+      { type: 'case-metadata:getDataInfo', params: [1] },
+      { type: 'case-metadata:listExternalIds', params: [1] },
+      { type: 'case-metadata:distinctHpoTerms', params: [] },
+      { type: 'case-metadata:distinctPlatforms', params: [] },
+      { type: 'case-metadata:distinctExternalIdTypes', params: [] },
+      { type: 'case-metadata:getFullMetadata', params: [1] }
+    ] satisfies StorageReadTask[]
+
+    expect(tasks).toHaveLength(11)
   })
 })

--- a/tests/main/storage/sqlite-read-executor.test.ts
+++ b/tests/main/storage/sqlite-read-executor.test.ts
@@ -11,6 +11,24 @@ describe('SqliteReadExecutor', () => {
     sort_order: 'desc'
   }
 
+  const caseMetadataReadTasks = [
+    {
+      task: { type: 'case-metadata:get' as const, params: [1] as [number] },
+      metadataMethod: 'getCaseMetadata',
+      expectedArgs: [1]
+    },
+    {
+      task: { type: 'case-metadata:listCohorts' as const, params: [] as [] },
+      metadataMethod: 'listCohortGroups',
+      expectedArgs: []
+    },
+    {
+      task: { type: 'case-metadata:getFullMetadata' as const, params: [1] as [number] },
+      metadataMethod: 'getFullCaseMetadata',
+      expectedArgs: [1]
+    }
+  ]
+
   it('uses the worker read pool for cases:query when a pool exists', async () => {
     const expected = { data: [], total_count: 0 }
     const dbPool = {
@@ -80,4 +98,37 @@ describe('SqliteReadExecutor', () => {
     )
     expect(databaseService.cases.getAvailableGenomeBuilds).toHaveBeenCalledWith()
   })
+
+  it.each(caseMetadataReadTasks)(
+    'uses the worker read pool for $task.type when a pool exists',
+    async ({ task }) => {
+      const expected = { ok: true }
+      const dbPool = {
+        run: vi.fn().mockResolvedValue(expected)
+      }
+      const databaseService = {
+        metadata: {}
+      }
+      const executor = new SqliteReadExecutor(databaseService as never, dbPool as never)
+
+      await expect(executor.execute(task)).resolves.toBe(expected)
+      expect(dbPool.run).toHaveBeenCalledWith(task)
+    }
+  )
+
+  it.each(caseMetadataReadTasks)(
+    'falls back to DatabaseService metadata for $task.type when no pool exists',
+    async ({ task, metadataMethod, expectedArgs }) => {
+      const expected = { ok: true }
+      const databaseService = {
+        metadata: {
+          [metadataMethod]: vi.fn().mockReturnValue(expected)
+        }
+      }
+      const executor = new SqliteReadExecutor(databaseService as never, null)
+
+      await expect(executor.execute(task)).resolves.toBe(expected)
+      expect(databaseService.metadata[metadataMethod]).toHaveBeenCalledWith(...expectedArgs)
+    }
+  )
 })

--- a/tests/main/storage/sqlite-storage-session.test.ts
+++ b/tests/main/storage/sqlite-storage-session.test.ts
@@ -31,6 +31,7 @@ describe('SqliteStorageSession', () => {
     expect(session.getDatabaseService()).toBe(db)
     expect(session.getDbPool()).toBeNull()
     expect(session.getReadExecutor()).toBeDefined()
+    expect(session.getWriteExecutor()).toBeDefined()
     expect(session.capabilities.backend).toBe('sqlite')
     expect(session.capabilities.supportsLocalFileLifecycle).toBe(true)
     expect(session.capabilities.supportsFileBackedWorkerWrites).toBe(true)

--- a/tests/main/storage/sqlite-write-executor.test.ts
+++ b/tests/main/storage/sqlite-write-executor.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SqliteWriteExecutor } from '../../../src/main/storage/sqlite/SqliteWriteExecutor'
+
+describe('SqliteWriteExecutor', () => {
+  it('delegates case-metadata:upsert and returns the repository result', async () => {
+    const expected = { case_id: 1, sex: 'female' }
+    const databaseService = {
+      metadata: {
+        upsertCaseMetadata: vi.fn().mockReturnValue(expected)
+      }
+    }
+    const executor = new SqliteWriteExecutor(databaseService as never)
+
+    await expect(
+      executor.execute({ type: 'case-metadata:upsert', params: [1, { sex: 'female' }] })
+    ).resolves.toBe(expected)
+    expect(databaseService.metadata.upsertCaseMetadata).toHaveBeenCalledWith(1, { sex: 'female' })
+  })
+
+  it('delegates case-metadata:setCohorts and resolves undefined', async () => {
+    const databaseService = {
+      metadata: {
+        setCaseCohorts: vi.fn()
+      }
+    }
+    const executor = new SqliteWriteExecutor(databaseService as never)
+
+    await expect(
+      executor.execute({ type: 'case-metadata:setCohorts', params: [1, [2, 3]] })
+    ).resolves.toBeUndefined()
+    expect(databaseService.metadata.setCaseCohorts).toHaveBeenCalledWith(1, [2, 3])
+  })
+
+  it('delegates case-metadata:deleteExternalId and resolves undefined', async () => {
+    const databaseService = {
+      metadata: {
+        deleteCaseExternalId: vi.fn()
+      }
+    }
+    const executor = new SqliteWriteExecutor(databaseService as never)
+
+    await expect(
+      executor.execute({ type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] })
+    ).resolves.toBeUndefined()
+    expect(databaseService.metadata.deleteCaseExternalId).toHaveBeenCalledWith(1, 'MRN')
+  })
+})

--- a/tests/main/storage/storage-manager-compat.test.ts
+++ b/tests/main/storage/storage-manager-compat.test.ts
@@ -75,6 +75,9 @@ describe('DatabaseManager storage-session compatibility', () => {
           throw new Error('not implemented')
         }
       }),
+      getWriteExecutor: () => ({
+        execute: vi.fn()
+      }),
       getDatabaseService: () => {
         throw new Error('DatabaseService is not available for postgres sessions')
       },

--- a/tests/main/storage/write-executor-contract.test.ts
+++ b/tests/main/storage/write-executor-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import type { StorageWriteExecutor, StorageWriteTask } from '../../../src/main/storage/write-executor'
+
+describe('StorageWriteExecutor contract', () => {
+  it('supports case metadata write tasks', () => {
+    const tasks = [
+      {
+        type: 'case-metadata:upsert',
+        params: [1, { affected_status: 'affected', age: 42, date_of_birth: '1984-01-02' }]
+      },
+      { type: 'case-metadata:createCohort', params: [{ name: 'research', description: null }] },
+      { type: 'case-metadata:updateCohort', params: [2, { name: 'updated' }] },
+      { type: 'case-metadata:deleteCohort', params: [2] },
+      { type: 'case-metadata:assignCohort', params: [1, 2] },
+      { type: 'case-metadata:removeCohort', params: [1, 2] },
+      { type: 'case-metadata:setCohorts', params: [1, [2, 3]] },
+      { type: 'case-metadata:assignHpoTerm', params: [1, 'HP:0001250', 'Seizure'] },
+      { type: 'case-metadata:removeHpoTerm', params: [1, 'HP:0001250'] },
+      { type: 'case-metadata:upsertDataInfo', params: [1, { platform: 'WGS' }] },
+      { type: 'case-metadata:upsertExternalId', params: [1, 'MRN', '12345'] },
+      { type: 'case-metadata:deleteExternalId', params: [1, 'MRN'] }
+    ] satisfies StorageWriteTask[]
+
+    expect(tasks).toHaveLength(12)
+    expectTypeOf<StorageWriteExecutor['execute']>().returns.toEqualTypeOf<Promise<unknown>>()
+  })
+})

--- a/tests/main/storage/write-executor-contract.test.ts
+++ b/tests/main/storage/write-executor-contract.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
-import type { StorageWriteExecutor, StorageWriteTask } from '../../../src/main/storage/write-executor'
+import type {
+  StorageWriteExecutor,
+  StorageWriteTask
+} from '../../../src/main/storage/write-executor'
 
 describe('StorageWriteExecutor contract', () => {
   it('supports case metadata write tasks', () => {


### PR DESCRIPTION
## Summary
- Adds Phase 6 PostgreSQL schema, repository, executor, and IPC routing for case metadata.
- Adds PostgreSQL cases-query support for cohort and HPO metadata filters.
- Adds gated Docker-backed PostgreSQL E2E coverage and WGS-readiness planning artifact.

## Test Plan
- [x] `make rebuild-node && npx vitest run tests/main/storage/read-executor-contract.test.ts tests/main/storage/write-executor-contract.test.ts tests/main/storage/sqlite-read-executor.test.ts tests/main/storage/sqlite-write-executor.test.ts tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-write-executor.test.ts tests/main/storage/postgres-case-metadata-repository.test.ts tests/main/storage/postgres-cases-query-repository.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/handlers/case-metadata-routing.test.ts tests/main/handlers/case-metadata-logic.test.ts`
- [x] `make typecheck`
- [x] `make ci`
- [x] `make rebuild && make build`
- [x] `make pg-reset && make pg-up && VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts tests/e2e/postgres-case-metadata-dev-mode.e2e.ts; make pg-down`

Refs: `.planning/specs/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md` and `.planning/plans/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md`.
