### PR TITLE
[codex] Add PostgreSQL variant read parity

### DIFF
--- a/.planning/archive/completed-plans/2026-04-24-postgresql-parity-phase-7-variants-read-parity.md
+++ b/.planning/archive/completed-plans/2026-04-24-postgresql-parity-phase-7-variants-read-parity.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Status:** Completed
+
 **Goal:** Add PostgreSQL-backed read parity for the first variant browsing slice: schema/read model, `variants:typeCounts`, `variants:typesPresent`, `variants:geneSymbols`, initial `variants:query`, PostgreSQL FTS, and optional basic filter metadata.
 
 **Architecture:** Extend the Phase 6 storage-session read executor rather than adding a new worker path. SQLite keeps its existing `DbPool`/`DatabaseService` behavior behind `SqliteReadExecutor`; PostgreSQL gets a focused `PostgresVariantReadRepository` with parameterized SQL, explicit unsupported-filter checks, and Docker-seeded variant fixtures. PostgreSQL FTS uses `tsvector` + GIN indexes and supports `search_query` inside `variants:query`; import/export/delete/rebuild/cohort/database-overview/renderer settings remain deferred.
@@ -12,7 +14,7 @@
 
 ## Reference Documents
 
-- Spec: `.planning/specs/2026-04-24-postgresql-parity-phase-7-variants-read-parity.md`
+- Spec: `.planning/archive/completed-specs/2026-04-24-postgresql-parity-phase-7-variants-read-parity.md`
 - Previous phase: `.planning/specs/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md`
 - Readiness input: `.planning/artifacts/postgres-parity-phase-6-wgs-readiness.md`
 - Existing SQLite query behavior: `src/main/database/VariantRepository.ts`

--- a/.planning/archive/completed-specs/2026-04-24-postgresql-parity-phase-7-variants-read-parity.md
+++ b/.planning/archive/completed-specs/2026-04-24-postgresql-parity-phase-7-variants-read-parity.md
@@ -1,9 +1,9 @@
 # PostgreSQL Parity Phase 7: Variants Read Parity
 
 **Date:** 2026-04-24
-**Status:** Proposed
-**Depends on:** [PostgreSQL Parity Phase 6: Case Metadata and Cases Filters](./2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md)
-**Planning input:** [PostgreSQL WGS-readiness Inventory](../artifacts/postgres-parity-phase-6-wgs-readiness.md)
+**Status:** Completed
+**Depends on:** [PostgreSQL Parity Phase 6: Case Metadata and Cases Filters](../../specs/2026-04-24-postgresql-parity-phase-6-case-metadata-and-cases-filters.md)
+**Planning input:** [PostgreSQL WGS-readiness Inventory](../../artifacts/postgres-parity-phase-6-wgs-readiness.md)
 **Goal:** Add PostgreSQL-backed variant read support for the first user-visible variant browsing slice without expanding into import, export, delete, rebuild, cohort, database overview, or renderer PostgreSQL settings work.
 
 ## Summary

--- a/.planning/artifacts/postgres-parity-phase-7-filter-metadata-deferral.md
+++ b/.planning/artifacts/postgres-parity-phase-7-filter-metadata-deferral.md
@@ -1,0 +1,15 @@
+# PostgreSQL Phase 7 Filter Metadata Deferral
+
+**Date:** 2026-04-24
+**Decision:** Defer `variants:filterOptions` and `variants:columnMeta` from Phase 7.
+
+## Reason
+
+The implementation requires more than a small read-only repository helper and would expand Phase 7 beyond variant read parity.
+
+## Required Follow-up
+
+- Add PostgreSQL base column metadata aggregation.
+- Add PostgreSQL extension column metadata aggregation.
+- Decide whether cohort-scoped `caseIds` metadata belongs with variant reads or cohort parity.
+- Add Docker E2E coverage after metadata is implemented.

--- a/scripts/postgres/init-db/12-phase7-variants.sql
+++ b/scripts/postgres/init-db/12-phase7-variants.sql
@@ -1,0 +1,176 @@
+CREATE TABLE IF NOT EXISTS variants (
+  id BIGSERIAL PRIMARY KEY,
+  case_id BIGINT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  chr TEXT NOT NULL,
+  pos BIGINT NOT NULL,
+  ref TEXT NOT NULL,
+  alt TEXT NOT NULL,
+  gene_symbol TEXT,
+  omim_mim_number TEXT,
+  consequence TEXT,
+  gnomad_af DOUBLE PRECISION,
+  cadd DOUBLE PRECISION,
+  clinvar TEXT,
+  gt_num TEXT,
+  func TEXT,
+  qual DOUBLE PRECISION,
+  hpo_sim_score DOUBLE PRECISION,
+  transcript TEXT,
+  cdna TEXT,
+  aa_change TEXT,
+  hpo_match TEXT,
+  moi TEXT,
+  gq DOUBLE PRECISION,
+  dp BIGINT,
+  ad_ref BIGINT,
+  ad_alt BIGINT,
+  ab DOUBLE PRECISION,
+  filter TEXT,
+  info_json TEXT,
+  source_format TEXT,
+  variant_type TEXT NOT NULL DEFAULT 'snv',
+  end_pos BIGINT,
+  sv_type TEXT,
+  sv_length BIGINT,
+  caller TEXT,
+  search_document tsvector
+);
+
+CREATE TABLE IF NOT EXISTS variant_transcripts (
+  id BIGSERIAL PRIMARY KEY,
+  variant_id BIGINT NOT NULL REFERENCES variants(id) ON DELETE CASCADE,
+  transcript_id TEXT NOT NULL,
+  gene_symbol TEXT,
+  consequence TEXT,
+  cdna TEXT,
+  aa_change TEXT,
+  hpo_sim_score DOUBLE PRECISION,
+  moi TEXT,
+  is_selected INTEGER NOT NULL DEFAULT 0,
+  is_mane_select INTEGER,
+  is_canonical INTEGER,
+  UNIQUE(variant_id, transcript_id)
+);
+
+CREATE TABLE IF NOT EXISTS variant_frequency (
+  chr TEXT NOT NULL,
+  pos BIGINT NOT NULL,
+  ref TEXT NOT NULL,
+  alt TEXT NOT NULL,
+  case_count BIGINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (chr, pos, ref, alt)
+);
+
+CREATE TABLE IF NOT EXISTS variant_sv (
+  variant_id BIGINT PRIMARY KEY REFERENCES variants(id) ON DELETE CASCADE,
+  sv_is_precise INTEGER,
+  cipos_left BIGINT,
+  cipos_right BIGINT,
+  ciend_left BIGINT,
+  ciend_right BIGINT,
+  support BIGINT,
+  coverage TEXT,
+  strand TEXT,
+  stdev_len DOUBLE PRECISION,
+  stdev_pos DOUBLE PRECISION,
+  vaf DOUBLE PRECISION,
+  dr BIGINT,
+  dv BIGINT,
+  pe_support BIGINT,
+  sr_support BIGINT,
+  event_id TEXT,
+  mate_id TEXT,
+  search_document tsvector
+);
+
+CREATE TABLE IF NOT EXISTS variant_cnv (
+  variant_id BIGINT PRIMARY KEY REFERENCES variants(id) ON DELETE CASCADE,
+  copy_number BIGINT,
+  copy_number_quality BIGINT,
+  homozygosity_ref DOUBLE PRECISION,
+  homozygosity_alt DOUBLE PRECISION,
+  sm DOUBLE PRECISION,
+  bin_count BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS variant_str (
+  variant_id BIGINT PRIMARY KEY REFERENCES variants(id) ON DELETE CASCADE,
+  repeat_id TEXT,
+  variant_catalog_id TEXT,
+  repeat_unit TEXT,
+  display_repeat_unit TEXT,
+  ref_copies DOUBLE PRECISION,
+  alt_copies TEXT,
+  repeat_length BIGINT,
+  str_status TEXT,
+  normal_max BIGINT,
+  pathologic_min BIGINT,
+  disease TEXT,
+  inheritance_mode TEXT,
+  source_display TEXT,
+  rank_score TEXT,
+  locus_coverage DOUBLE PRECISION,
+  support_type TEXT,
+  confidence_interval TEXT,
+  search_document tsvector
+);
+
+CREATE OR REPLACE FUNCTION update_variants_search_document()
+RETURNS trigger AS $$
+BEGIN
+  NEW.search_document :=
+    to_tsvector('simple',
+      concat_ws(' ', NEW.gene_symbol, NEW.consequence, NEW.omim_mim_number, NEW.func, NEW.transcript, NEW.cdna, NEW.aa_change)
+    );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_variant_sv_search_document()
+RETURNS trigger AS $$
+BEGIN
+  NEW.search_document := to_tsvector('simple', concat_ws(' ', NEW.event_id, NEW.mate_id));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_variant_str_search_document()
+RETURNS trigger AS $$
+BEGIN
+  NEW.search_document :=
+    to_tsvector('simple',
+      concat_ws(' ', NEW.repeat_id, NEW.variant_catalog_id, NEW.repeat_unit, NEW.display_repeat_unit, NEW.str_status, NEW.disease)
+    );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS variants_search_document_tg ON variants;
+CREATE TRIGGER variants_search_document_tg
+BEFORE INSERT OR UPDATE ON variants
+FOR EACH ROW EXECUTE FUNCTION update_variants_search_document();
+
+DROP TRIGGER IF EXISTS variant_sv_search_document_tg ON variant_sv;
+CREATE TRIGGER variant_sv_search_document_tg
+BEFORE INSERT OR UPDATE ON variant_sv
+FOR EACH ROW EXECUTE FUNCTION update_variant_sv_search_document();
+
+DROP TRIGGER IF EXISTS variant_str_search_document_tg ON variant_str;
+CREATE TRIGGER variant_str_search_document_tg
+BEFORE INSERT OR UPDATE ON variant_str
+FOR EACH ROW EXECUTE FUNCTION update_variant_str_search_document();
+
+CREATE INDEX IF NOT EXISTS idx_variants_case_type ON variants(case_id, variant_type);
+CREATE INDEX IF NOT EXISTS idx_variants_case_gene ON variants(case_id, gene_symbol);
+CREATE INDEX IF NOT EXISTS idx_variants_case_pos ON variants(case_id, chr, pos);
+CREATE INDEX IF NOT EXISTS idx_variants_case_consequence ON variants(case_id, consequence);
+CREATE INDEX IF NOT EXISTS idx_variants_case_func ON variants(case_id, func);
+CREATE INDEX IF NOT EXISTS idx_variants_coord_case ON variants(chr, pos, ref, alt, case_id);
+CREATE INDEX IF NOT EXISTS idx_variants_search_document ON variants USING GIN(search_document);
+CREATE INDEX IF NOT EXISTS idx_variant_sv_search_document ON variant_sv USING GIN(search_document);
+CREATE INDEX IF NOT EXISTS idx_variant_str_search_document ON variant_str USING GIN(search_document);
+CREATE INDEX IF NOT EXISTS idx_vt_variant_id ON variant_transcripts(variant_id);
+CREATE INDEX IF NOT EXISTS idx_vt_selected ON variant_transcripts(variant_id, is_selected);
+CREATE INDEX IF NOT EXISTS idx_cnv_copy_number ON variant_cnv(copy_number);
+CREATE INDEX IF NOT EXISTS idx_str_repeat_id ON variant_str(repeat_id);
+CREATE INDEX IF NOT EXISTS idx_str_disease ON variant_str(disease);

--- a/scripts/postgres/init-db/21-phase7-seed-variants.sql
+++ b/scripts/postgres/init-db/21-phase7-seed-variants.sql
@@ -1,0 +1,45 @@
+INSERT INTO variants
+  (id, case_id, chr, pos, ref, alt, gene_symbol, omim_mim_number, consequence, gnomad_af, cadd, clinvar, gt_num, func, qual, hpo_sim_score, transcript, cdna, aa_change, moi, variant_type, end_pos, sv_type, sv_length, caller, source_format)
+VALUES
+  (1, 1, '1', 1000, 'A', 'G', 'BRCA1', '113705', 'HIGH', 0.001, 28.5, 'Pathogenic', '0/1', 'missense_variant', 99.0, 0.91, 'NM_007294.4', 'c.100A>G', 'p.Lys34Arg', 'AD', 'snv', NULL, NULL, NULL, 'vep', 'vcf'),
+  (2, 1, '1', 1050, 'AT', 'A', 'BRCA2', '600185', 'MODERATE', 0.02, 18.1, 'Likely benign', '0/1', 'frameshift_variant', 87.0, 0.72, 'NM_000059.4', 'c.200delT', 'p.Val67fs', 'AD', 'indel', NULL, NULL, NULL, 'vep', 'vcf'),
+  (3, 1, '2', 2000, 'N', '<DEL>', 'DMD', '310200', 'HIGH', NULL, 30.0, 'Pathogenic', '0/1', 'transcript_ablation', 80.0, 0.83, NULL, NULL, NULL, 'XR', 'sv', 2600, 'DEL', -600, 'manta', 'vcf'),
+  (4, 1, '3', 3000, 'N', '<DUP>', 'PMP22', '601097', 'MODERATE', NULL, 12.2, NULL, '1/1', 'copy_number_gain', 75.0, 0.55, NULL, NULL, NULL, 'AD', 'cnv', 9000, 'DUP', 6000, 'cnvnator', 'vcf'),
+  (5, 1, '4', 4000, 'CAG', '<STR>', 'HTT', '613004', 'MODERATE', NULL, 10.5, 'Pathogenic', '0/1', 'repeat_expansion', 60.0, 0.88, NULL, NULL, NULL, 'AD', 'str', 4045, NULL, NULL, 'expansionhunter', 'vcf'),
+  (6, 2, '1', 1000, 'A', 'G', 'BRCA1', '113705', 'HIGH', 0.001, 28.5, 'Pathogenic', '0/1', 'missense_variant', 99.0, 0.91, 'NM_007294.4', 'c.100A>G', 'p.Lys34Arg', 'AD', 'snv', NULL, NULL, NULL, 'vep', 'vcf')
+ON CONFLICT (id) DO UPDATE SET
+  case_id = EXCLUDED.case_id,
+  gene_symbol = EXCLUDED.gene_symbol,
+  consequence = EXCLUDED.consequence,
+  variant_type = EXCLUDED.variant_type;
+
+-- Phase 7 seed uses bare chromosome names (`1`, `2`, `3`, `4`) consistently
+-- so variant_frequency joins match the seeded variants literally.
+
+INSERT INTO variant_frequency (chr, pos, ref, alt, case_count)
+VALUES ('1', 1000, 'A', 'G', 2)
+ON CONFLICT (chr, pos, ref, alt) DO UPDATE SET case_count = EXCLUDED.case_count;
+
+INSERT INTO variant_sv (variant_id, support, event_id, mate_id)
+VALUES (3, 12, 'MANTA_EVENT_001', 'MATE_001')
+ON CONFLICT (variant_id) DO UPDATE SET support = EXCLUDED.support, event_id = EXCLUDED.event_id, mate_id = EXCLUDED.mate_id;
+
+INSERT INTO variant_cnv (variant_id, copy_number, copy_number_quality)
+VALUES (4, 4, 70)
+ON CONFLICT (variant_id) DO UPDATE SET copy_number = EXCLUDED.copy_number, copy_number_quality = EXCLUDED.copy_number_quality;
+
+INSERT INTO variant_str (variant_id, repeat_id, repeat_unit, disease, str_status)
+VALUES (5, 'HTT', 'CAG', 'Huntington disease', 'pathogenic')
+ON CONFLICT (variant_id) DO UPDATE SET repeat_id = EXCLUDED.repeat_id, repeat_unit = EXCLUDED.repeat_unit, disease = EXCLUDED.disease, str_status = EXCLUDED.str_status;
+
+UPDATE cases
+SET variant_count = seeded.count
+FROM (
+  SELECT case_id, COUNT(*)::BIGINT AS count
+  FROM variants
+  GROUP BY case_id
+) seeded
+WHERE cases.id = seeded.case_id;
+
+SELECT setval(pg_get_serial_sequence('public.variants', 'id'), COALESCE((SELECT MAX(id) FROM variants), 1), true);
+SELECT setval(pg_get_serial_sequence('public.variant_transcripts', 'id'), COALESCE((SELECT MAX(id) FROM variant_transcripts), 1), true);

--- a/scripts/postgres/init-db/README.md
+++ b/scripts/postgres/init-db/README.md
@@ -25,8 +25,12 @@ Current init files:
 - `10-phase3-cases.sql` creates the base `cases` table.
 - `11-phase6-case-metadata.sql` creates Phase 6 metadata/cohort/HPO/comment/metric
   tables that depend on `cases`.
+- `12-phase7-variants.sql` creates read-only PostgreSQL variant tables, indexes,
+  and FTS trigger-backed `tsvector` columns.
 - `20-phase3-seed-cases.sql` seeds deterministic development rows and resets
   sequences after explicit-ID seed inserts.
+- `21-phase7-seed-variants.sql` seeds deterministic variant rows for gated
+  Phase 7 E2E tests. It is not an import path.
 
 Future phases may add development-only helper objects here if they improve local
 iteration. Production migrations must not depend on this folder because these

--- a/src/main/ipc/handlers/variants-logic.ts
+++ b/src/main/ipc/handlers/variants-logic.ts
@@ -207,7 +207,7 @@ export async function searchVariants(
     throw new Error('PostgreSQL variants:search is deferred from Phase 7')
   }
 
-  const pool = deps.session !== undefined ? deps.getDbPool?.() : deps.getDbPool?.()
+  const pool = deps.getDbPool?.()
   if (pool) {
     return await pool.run({
       type: 'variants:search',

--- a/src/main/ipc/handlers/variants-logic.ts
+++ b/src/main/ipc/handlers/variants-logic.ts
@@ -8,8 +8,55 @@
 import type { VariantFilter, SortItem } from '../../database/types'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
+import type { StorageSession } from '../../storage/session'
 import type { ColumnFilterMeta } from '../../../shared/types/column-filters'
 import { computePanelIntervals } from './panelIntervalHelper'
+
+type GetSession = () => StorageSession
+type GetDb = () => DatabaseService
+type GetDbPool = () => DbPool | null
+
+function isStorageSession(value: unknown): value is StorageSession {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    ('getReadExecutor' in value || 'capabilities' in value)
+  )
+}
+
+function resolveReadDependencies(
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
+):
+  | { session: StorageSession; getDb?: GetDb; getDbPool?: GetDbPool }
+  | { session?: undefined; db: DatabaseService; getDb: GetDb; getDbPool?: GetDbPool } {
+  let value: StorageSession | DatabaseService
+  try {
+    value = getSessionOrDb()
+  } catch (error) {
+    if (getDbOrPool === undefined) throw error
+    const getDb = getDbOrPool as GetDb
+    return {
+      db: getDb(),
+      getDb,
+      getDbPool
+    }
+  }
+  if (isStorageSession(value)) {
+    return {
+      session: value,
+      getDb: getDbOrPool as GetDb | undefined,
+      getDbPool
+    }
+  }
+
+  return {
+    db: value,
+    getDb: getSessionOrDb as GetDb,
+    getDbPool: getDbOrPool as GetDbPool | undefined
+  }
+}
 
 /**
  * Build a full variant filter, resolving panel intervals if needed.
@@ -20,7 +67,8 @@ export function buildVariantFilter(
   caseId: number,
   filters: Partial<VariantFilter>,
   getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getDbPool?: () => DbPool | null,
+  getSession?: () => StorageSession
 ): VariantFilter {
   const fullFilter: VariantFilter = {
     case_id: caseId,
@@ -28,6 +76,16 @@ export function buildVariantFilter(
   }
 
   if (fullFilter.active_panel_ids && fullFilter.active_panel_ids.length > 0) {
+    if (getSession !== undefined) {
+      try {
+        if (getSession().capabilities.backend === 'postgres') {
+          return fullFilter
+        }
+      } catch {
+        // Legacy tests and compatibility callers may not provide a session yet.
+      }
+    }
+
     const pool = getDbPool?.()
     if (pool) {
       // Pool path: let the worker resolve intervals off the main thread.
@@ -78,10 +136,19 @@ export async function queryVariants(
   sortBy: SortItem[] | undefined,
   skipCount: boolean,
   includeUnfilteredCount: boolean,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<unknown> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session !== undefined) {
+    return await deps.session.getReadExecutor().execute({
+      type: 'variants:query',
+      params: [fullFilter, limit, offset, sortBy, skipCount, includeUnfilteredCount]
+    })
+  }
+
+  const pool = deps.getDbPool?.()
   if (pool) {
     return await pool.run({
       type: 'variants:query',
@@ -89,8 +156,7 @@ export async function queryVariants(
     })
   }
 
-  const db = getDb()
-  return db.variants.getVariants(
+  return deps.db.variants.getVariants(
     fullFilter,
     limit,
     offset,
@@ -105,16 +171,24 @@ export async function queryVariants(
  */
 export async function getFilterOptions(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<unknown> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session !== undefined) {
+    return await deps.session.getReadExecutor().execute({
+      type: 'variants:filterOptions',
+      params: [caseId]
+    })
+  }
+
+  const pool = deps.getDbPool?.()
   if (pool) {
     return await pool.run({ type: 'variants:filterOptions', params: [caseId] })
   }
 
-  const db = getDb()
-  return db.variants.getFilterOptions(caseId)
+  return deps.db.variants.getFilterOptions(caseId)
 }
 
 /**
@@ -124,10 +198,16 @@ export async function searchVariants(
   caseId: number,
   query: string,
   limit: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<unknown> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session?.capabilities.backend === 'postgres') {
+    throw new Error('PostgreSQL variants:search is deferred from Phase 7')
+  }
+
+  const pool = deps.session !== undefined ? deps.getDbPool?.() : deps.getDbPool?.()
   if (pool) {
     return await pool.run({
       type: 'variants:search',
@@ -135,7 +215,10 @@ export async function searchVariants(
     })
   }
 
-  const db = getDb()
+  const db = deps.session !== undefined ? deps.getDb?.() : deps.db
+  if (db === undefined) {
+    throw new Error('DatabaseService is required for variants:search')
+  }
   return db.variants.searchVariants(caseId, query, limit)
 }
 
@@ -146,10 +229,19 @@ export async function getGeneSymbols(
   caseId: number,
   query: string,
   limit: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<unknown> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session !== undefined) {
+    return await deps.session.getReadExecutor().execute({
+      type: 'variants:geneSymbols',
+      params: [caseId, query, limit]
+    })
+  }
+
+  const pool = deps.getDbPool?.()
   if (pool) {
     return await pool.run({
       type: 'variants:geneSymbols',
@@ -157,8 +249,7 @@ export async function getGeneSymbols(
     })
   }
 
-  const db = getDb()
-  return db.variants.getGeneSymbols(caseId, query, limit)
+  return deps.db.variants.getGeneSymbols(caseId, query, limit)
 }
 
 /**
@@ -166,10 +257,19 @@ export async function getGeneSymbols(
  */
 export async function getVariantTypeCounts(
   caseId: number,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<Record<string, number>> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session !== undefined) {
+    return (await deps.session.getReadExecutor().execute({
+      type: 'variants:typeCounts',
+      params: [caseId]
+    })) as Record<string, number>
+  }
+
+  const pool = deps.getDbPool?.()
   if (pool) {
     return (await pool.run({
       type: 'variants:typeCounts',
@@ -177,8 +277,7 @@ export async function getVariantTypeCounts(
     })) as Record<string, number>
   }
 
-  const db = getDb()
-  return db.variants.getVariantTypeCounts(caseId)
+  return deps.db.variants.getVariantTypeCounts(caseId)
 }
 
 /**
@@ -195,10 +294,19 @@ export async function getVariantTypeCounts(
 export async function getColumnMetaForKey(
   scope: { caseId: number } | { caseIds: number[] },
   columnKey: string,
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<ColumnFilterMeta> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session !== undefined) {
+    return (await deps.session.getReadExecutor().execute({
+      type: 'variants:columnMeta',
+      params: [scope, columnKey]
+    })) as ColumnFilterMeta
+  }
+
+  const pool = deps.getDbPool?.()
   if (pool) {
     return (await pool.run({
       type: 'variants:columnMeta',
@@ -206,8 +314,7 @@ export async function getColumnMetaForKey(
     })) as ColumnFilterMeta
   }
 
-  const db = getDb()
-  return db.variants.getColumnMeta(scope, columnKey)
+  return deps.db.variants.getColumnMeta(scope, columnKey)
 }
 
 /**
@@ -221,10 +328,19 @@ export async function getColumnMetaForKey(
  */
 export async function getVariantTypesPresent(
   scope: { caseId: number } | { caseIds: number[] },
-  getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getSessionOrDb: GetSession | GetDb,
+  getDbOrPool?: GetDb | GetDbPool,
+  getDbPool?: GetDbPool
 ): Promise<string[]> {
-  const pool = getDbPool?.()
+  const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
+  if (deps.session !== undefined) {
+    return (await deps.session.getReadExecutor().execute({
+      type: 'variants:typesPresent',
+      params: [scope]
+    })) as string[]
+  }
+
+  const pool = deps.getDbPool?.()
   if (pool) {
     // Worker already serializes Set → string[] (structured-clone drops Set
     // contents across thread boundaries); just forward the array.
@@ -234,6 +350,5 @@ export async function getVariantTypesPresent(
     })) as string[]
   }
 
-  const db = getDb()
-  return Array.from(db.variants.getVariantTypesPresent(scope))
+  return Array.from(deps.db.variants.getVariantTypesPresent(scope))
 }

--- a/src/main/ipc/handlers/variants.ts
+++ b/src/main/ipc/handlers/variants.ts
@@ -35,7 +35,14 @@ export { clearPanelIntervalCache }
 // Schema for search query params
 const SearchQuerySchema = z.string().min(1).max(100)
 
-export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDependencies): void {
+export function registerVariantHandlers({
+  ipcMain,
+  getDb,
+  getDbManager,
+  getDbPool
+}: HandlerDependencies): void {
+  const getSession = () => getDbManager().getCurrentSession()
+
   ipcMain.handle(
     'variants:query',
     async (
@@ -115,7 +122,8 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
           validatedCaseId.data,
           validatedFilters.data,
           getDb,
-          getDbPool
+          getDbPool,
+          getSession
         )
 
         return queryVariants(
@@ -125,6 +133,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
           validatedSortBy,
           validatedSkipCount,
           validatedIncludeUnfilteredCount,
+          getSession,
           getDb,
           getDbPool
         )
@@ -144,7 +153,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
         throw new Error('Invalid case ID')
       }
 
-      return getFilterOptions(validatedCaseId.data, getDb, getDbPool)
+      return getFilterOptions(validatedCaseId.data, getSession, getDb, getDbPool)
     })
   })
 
@@ -192,6 +201,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
           validatedCaseId.data,
           validatedQuery.data,
           validatedLimit,
+          getSession,
           getDb,
           getDbPool
         )
@@ -238,6 +248,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
           validatedCaseId.data,
           validatedQuery.data,
           validatedLimit,
+          getSession,
           getDb,
           getDbPool
         )
@@ -261,7 +272,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
         throw new Error('Invalid case ID')
       }
 
-      return getVariantTypeCounts(validatedCaseId.data, getDb, getDbPool)
+      return getVariantTypeCounts(validatedCaseId.data, getSession, getDb, getDbPool)
     })
   })
 
@@ -290,7 +301,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
       const { caseId, caseIds, columnKey } = validated.data
       const scope: { caseId: number } | { caseIds: number[] } =
         caseIds !== undefined ? { caseIds } : { caseId: caseId as number }
-      return getColumnMetaForKey(scope, columnKey, getDb, getDbPool)
+      return getColumnMetaForKey(scope, columnKey, getSession, getDb, getDbPool)
     })
   })
 
@@ -318,7 +329,7 @@ export function registerVariantHandlers({ ipcMain, getDb, getDbPool }: HandlerDe
       const { caseId, caseIds } = validated.data
       const scope: { caseId: number } | { caseIds: number[] } =
         caseIds !== undefined ? { caseIds } : { caseId: caseId as number }
-      return getVariantTypesPresent(scope, getDb, getDbPool)
+      return getVariantTypesPresent(scope, getSession, getDb, getDbPool)
     })
   })
 }

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -27,7 +27,7 @@ interface PostgresReadExecutorRepositories {
   >
   variants: Pick<
     PostgresVariantReadRepository,
-    'getVariantTypeCounts' | 'getVariantTypesPresent' | 'getGeneSymbols'
+    'getVariantTypeCounts' | 'getVariantTypesPresent' | 'getGeneSymbols' | 'queryVariants'
   >
 }
 
@@ -89,6 +89,8 @@ export class PostgresReadExecutor implements StorageReadExecutor {
         )
 
       case 'variants:query':
+        return await this.repositories.variants.queryVariants(...task.params)
+
       case 'variants:filterOptions':
       case 'variants:columnMeta':
         return deferredVariantReadTask(task.type)

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -3,6 +3,10 @@ import type { PostgresAvailableBuildsRepository } from './PostgresAvailableBuild
 import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
 import type { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 
+function deferredVariantReadTask(taskType: string): never {
+  throw new Error(`${taskType} is not implemented by this storage executor yet`)
+}
+
 interface PostgresReadExecutorRepositories {
   casesQuery: Pick<PostgresCasesQueryRepository, 'queryCases'>
   availableBuilds: Pick<PostgresAvailableBuildsRepository, 'getAvailableGenomeBuilds'>
@@ -65,6 +69,14 @@ export class PostgresReadExecutor implements StorageReadExecutor {
 
       case 'case-metadata:getFullMetadata':
         return await this.repositories.caseMetadata.getFullCaseMetadata(task.params[0])
+
+      case 'variants:typeCounts':
+      case 'variants:typesPresent':
+      case 'variants:geneSymbols':
+      case 'variants:query':
+      case 'variants:filterOptions':
+      case 'variants:columnMeta':
+        return deferredVariantReadTask(task.type)
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -2,6 +2,7 @@ import type { StorageReadExecutor, StorageReadTask } from '../read-executor'
 import type { PostgresAvailableBuildsRepository } from './PostgresAvailableBuildsRepository'
 import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
 import type { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
+import type { PostgresVariantReadRepository } from './PostgresVariantReadRepository'
 
 function deferredVariantReadTask(taskType: string): never {
   throw new Error(`${taskType} is not implemented by this storage executor yet`)
@@ -23,6 +24,10 @@ interface PostgresReadExecutorRepositories {
     | 'getDistinctPlatforms'
     | 'getDistinctExternalIdTypes'
     | 'getFullCaseMetadata'
+  >
+  variants: Pick<
+    PostgresVariantReadRepository,
+    'getVariantTypeCounts' | 'getVariantTypesPresent' | 'getGeneSymbols'
   >
 }
 
@@ -71,8 +76,18 @@ export class PostgresReadExecutor implements StorageReadExecutor {
         return await this.repositories.caseMetadata.getFullCaseMetadata(task.params[0])
 
       case 'variants:typeCounts':
+        return await this.repositories.variants.getVariantTypeCounts(task.params[0])
+
       case 'variants:typesPresent':
+        return await this.repositories.variants.getVariantTypesPresent(task.params[0])
+
       case 'variants:geneSymbols':
+        return await this.repositories.variants.getGeneSymbols(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
       case 'variants:query':
       case 'variants:filterOptions':
       case 'variants:columnMeta':

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -4,10 +4,6 @@ import type { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepos
 import type { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 import type { PostgresVariantReadRepository } from './PostgresVariantReadRepository'
 
-function deferredVariantReadTask(taskType: string): never {
-  throw new Error(`${taskType} is not implemented by this storage executor yet`)
-}
-
 interface PostgresReadExecutorRepositories {
   casesQuery: Pick<PostgresCasesQueryRepository, 'queryCases'>
   availableBuilds: Pick<PostgresAvailableBuildsRepository, 'getAvailableGenomeBuilds'>
@@ -27,7 +23,12 @@ interface PostgresReadExecutorRepositories {
   >
   variants: Pick<
     PostgresVariantReadRepository,
-    'getVariantTypeCounts' | 'getVariantTypesPresent' | 'getGeneSymbols' | 'queryVariants'
+    | 'getVariantTypeCounts'
+    | 'getVariantTypesPresent'
+    | 'getGeneSymbols'
+    | 'queryVariants'
+    | 'getFilterOptions'
+    | 'getColumnMeta'
   >
 }
 
@@ -92,8 +93,10 @@ export class PostgresReadExecutor implements StorageReadExecutor {
         return await this.repositories.variants.queryVariants(...task.params)
 
       case 'variants:filterOptions':
+        return await this.repositories.variants.getFilterOptions(task.params[0])
+
       case 'variants:columnMeta':
-        return deferredVariantReadTask(task.type)
+        return await this.repositories.variants.getColumnMeta(task.params[0], task.params[1])
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -9,6 +9,7 @@ import { PostgresCaseListRepository } from './PostgresCaseListRepository'
 import { PostgresCaseMetadataRepository } from './PostgresCaseMetadataRepository'
 import { PostgresCasesQueryRepository } from './PostgresCasesQueryRepository'
 import { PostgresReadExecutor } from './PostgresReadExecutor'
+import { PostgresVariantReadRepository } from './PostgresVariantReadRepository'
 import type { StorageReadExecutor } from '../read-executor'
 import { PostgresWriteExecutor } from './PostgresWriteExecutor'
 import {
@@ -59,7 +60,8 @@ export class PostgresStorageSession implements StorageSession {
     this.readExecutor = new PostgresReadExecutor({
       casesQuery: new PostgresCasesQueryRepository(options.pool, options.config.schema),
       availableBuilds: new PostgresAvailableBuildsRepository(options.pool, options.config.schema),
-      caseMetadata
+      caseMetadata,
+      variants: new PostgresVariantReadRepository(options.pool, options.config.schema)
     })
     this.writeExecutor = new PostgresWriteExecutor(caseMetadata)
     this.createCaseListRepository =

--- a/src/main/storage/postgres/PostgresVariantReadRepository.ts
+++ b/src/main/storage/postgres/PostgresVariantReadRepository.ts
@@ -22,7 +22,21 @@ const NUMERIC_VARIANT_FIELDS = new Set([
   'dp',
   'ad_ref',
   'ad_alt',
-  'internal_af'
+  'internal_af',
+  '_sv_support',
+  '_sv_dr',
+  '_sv_dv',
+  '_sv_vaf',
+  '_sv_is_precise',
+  '_sv_stdev_len',
+  '_sv_stdev_pos',
+  '_cnv_copy_number',
+  '_cnv_gq',
+  '_cnv_ho_ref',
+  '_cnv_ho_alt',
+  '_str_ref_copies',
+  '_str_normal_max',
+  '_str_pathologic_min'
 ])
 
 function toNumber(value: unknown): number {
@@ -334,9 +348,15 @@ export class PostgresVariantReadRepository {
   ): void {
     if (filter.column_filters === undefined) return
 
+    const unsupportedColumns = Object.keys(filter.column_filters).filter(
+      (column) => POSTGRES_BASE_SORT_COLUMNS[column] === undefined
+    )
+    if (unsupportedColumns.length > 0) {
+      throw new Error(`Unsupported PostgreSQL column filter(s): ${unsupportedColumns.join(', ')}`)
+    }
+
     for (const [column, filterDef] of Object.entries(filter.column_filters)) {
       const sqlColumn = POSTGRES_BASE_SORT_COLUMNS[column]
-      if (sqlColumn === undefined) continue
       const { operator, value } = filterDef
 
       if (operator === 'in' && Array.isArray(value)) {

--- a/src/main/storage/postgres/PostgresVariantReadRepository.ts
+++ b/src/main/storage/postgres/PostgresVariantReadRepository.ts
@@ -1,6 +1,29 @@
 import type { Pool } from 'pg'
 
+import { BASE_SORTABLE_COLUMNS } from '../../database/VariantFilterBuilder'
+import type {
+  PaginatedResult,
+  SortItem,
+  Variant,
+  VariantFilter
+} from '../../../shared/types/database'
 import { quoteIdentifier } from './identifiers'
+
+const POSTGRES_BASE_SORT_COLUMNS = Object.fromEntries(
+  Object.entries(BASE_SORTABLE_COLUMNS).map(([key, column]) => [key, `v.${column}`])
+)
+
+const NUMERIC_VARIANT_FIELDS = new Set([
+  'id',
+  'case_id',
+  'pos',
+  'end_pos',
+  'sv_length',
+  'dp',
+  'ad_ref',
+  'ad_alt',
+  'internal_af'
+])
 
 function toNumber(value: unknown): number {
   if (typeof value === 'number') return value
@@ -19,6 +42,19 @@ function toPrefixTsQuery(query: string): string {
 }
 
 export const toPrefixTsQueryForTest = toPrefixTsQuery
+
+function normalizeVariantRow(row: Record<string, unknown>): Variant {
+  const normalized: Record<string, unknown> = { ...row }
+  for (const field of NUMERIC_VARIANT_FIELDS) {
+    const value = normalized[field]
+    if (typeof value === 'string') normalized[field] = Number(value)
+  }
+  return normalized as unknown as Variant
+}
+
+function isNonEmptyArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.length > 0
+}
 
 export class PostgresVariantReadRepository {
   private readonly schemaName: string
@@ -76,5 +112,264 @@ export class PostgresVariantReadRepository {
       [caseId, `${query}%`, limit]
     )
     return (result.rows as Array<{ gene_symbol: string }>).map((row) => row.gene_symbol)
+  }
+
+  async queryVariants(
+    filter: VariantFilter,
+    limit: number,
+    offset: number = 0,
+    sortBy?: SortItem[],
+    skipCount?: boolean,
+    includeUnfilteredCount?: boolean
+  ): Promise<PaginatedResult<Variant> & { unfiltered_count?: number }> {
+    this.assertSupportedQueryFilter(filter)
+
+    const whereParts: string[] = []
+    const params: unknown[] = []
+    const addParam = (value: unknown): string => {
+      params.push(value)
+      return `$${params.length}`
+    }
+    const addWhere = (sql: string): void => {
+      whereParts.push(sql)
+    }
+
+    addWhere(`v.case_id = ${addParam(filter.case_id)}`)
+
+    if (filter.variant_type !== undefined && filter.variant_type !== '') {
+      if (filter.variant_type === 'snv') {
+        addWhere("v.variant_type IN ('snv', 'indel')")
+      } else {
+        addWhere(`v.variant_type = ${addParam(filter.variant_type)}`)
+      }
+    }
+
+    if (filter.gene_symbol !== undefined && filter.gene_symbol !== '') {
+      addWhere(`v.gene_symbol ILIKE ${addParam(`%${filter.gene_symbol}%`)}`)
+    }
+
+    if (isNonEmptyArray(filter.consequences)) {
+      addWhere(
+        `v.consequence IN (${filter.consequences.map((value) => addParam(value)).join(', ')})`
+      )
+    } else if (filter.consequence !== undefined && filter.consequence !== '') {
+      addWhere(`v.consequence = ${addParam(filter.consequence)}`)
+    }
+
+    if (isNonEmptyArray(filter.funcs)) {
+      addWhere(`v.func IN (${filter.funcs.map((value) => addParam(value)).join(', ')})`)
+    }
+
+    if (isNonEmptyArray(filter.clinvars)) {
+      addWhere(`v.clinvar IN (${filter.clinvars.map((value) => addParam(value)).join(', ')})`)
+    }
+
+    if (filter.gnomad_af_max !== undefined) {
+      addWhere(`(v.gnomad_af IS NULL OR v.gnomad_af <= ${addParam(filter.gnomad_af_max)})`)
+    }
+
+    if (filter.cadd_min !== undefined) {
+      addWhere(`(v.cadd IS NULL OR v.cadd >= ${addParam(filter.cadd_min)})`)
+    }
+
+    const internalAfExpression = `vf.case_count::double precision / NULLIF((SELECT COUNT(*) FROM ${this.schemaName}."cases"), 0)`
+
+    if (filter.max_internal_af !== undefined && filter.max_internal_af > 0) {
+      addWhere(
+        `(vf.case_count IS NULL OR ${internalAfExpression} <= ${addParam(filter.max_internal_af)})`
+      )
+    }
+
+    const tsQuery = filter.search_query !== undefined ? toPrefixTsQuery(filter.search_query) : ''
+    if (tsQuery !== '') {
+      const tsParam = addParam(tsQuery)
+      addWhere(`(
+        v.search_document @@ to_tsquery('simple', ${tsParam})
+        OR EXISTS (
+          SELECT 1 FROM ${this.schemaName}."variant_sv" sv_search
+          WHERE sv_search.variant_id = v.id
+            AND sv_search.search_document @@ to_tsquery('simple', ${tsParam})
+        )
+        OR EXISTS (
+          SELECT 1 FROM ${this.schemaName}."variant_str" str_search
+          WHERE str_search.variant_id = v.id
+            AND str_search.search_document @@ to_tsquery('simple', ${tsParam})
+        )
+      )`)
+    }
+
+    if (filter.chr !== undefined && filter.chr !== '') {
+      addWhere(`v.chr = ${addParam(filter.chr)}`)
+    }
+    if (filter.pos !== undefined) {
+      addWhere(`v.pos = ${addParam(filter.pos)}`)
+    }
+    if (filter.ref !== undefined && filter.ref !== '') {
+      addWhere(`v.ref = ${addParam(filter.ref)}`)
+    }
+    if (filter.alt !== undefined && filter.alt !== '') {
+      addWhere(`v.alt = ${addParam(filter.alt)}`)
+    }
+
+    this.addColumnFilters(filter, addParam, addWhere)
+
+    const joins = [
+      `LEFT JOIN ${this.schemaName}."variant_frequency" vf ON vf.chr = v.chr AND vf.pos = v.pos AND vf.ref = v.ref AND vf.alt = v.alt`
+    ]
+    const projections = [`v.*`, `${internalAfExpression} AS internal_af`]
+
+    if (filter.variant_type === 'sv') {
+      joins.push(`LEFT JOIN ${this.schemaName}."variant_sv" sv ON sv.variant_id = v.id`)
+      projections.push(
+        'sv.support AS _sv_support',
+        'sv.dr AS _sv_dr',
+        'sv.dv AS _sv_dv',
+        'sv.vaf AS _sv_vaf',
+        'sv.sv_is_precise AS _sv_is_precise',
+        'sv.strand AS _sv_strand',
+        'sv.coverage AS _sv_coverage',
+        'sv.stdev_len AS _sv_stdev_len',
+        'sv.stdev_pos AS _sv_stdev_pos'
+      )
+    } else if (filter.variant_type === 'cnv') {
+      joins.push(`LEFT JOIN ${this.schemaName}."variant_cnv" cnv ON cnv.variant_id = v.id`)
+      projections.push(
+        'cnv.copy_number AS _cnv_copy_number',
+        'cnv.copy_number_quality AS _cnv_gq',
+        'cnv.homozygosity_ref AS _cnv_ho_ref',
+        'cnv.homozygosity_alt AS _cnv_ho_alt'
+      )
+    } else if (filter.variant_type === 'str') {
+      joins.push(`LEFT JOIN ${this.schemaName}."variant_str" str_ext ON str_ext.variant_id = v.id`)
+      projections.push(
+        'str_ext.repeat_id AS _str_repeat_id',
+        'str_ext.repeat_unit AS _str_repeat_unit',
+        'str_ext.display_repeat_unit AS _str_display_ru',
+        'str_ext.ref_copies AS _str_ref_copies',
+        'str_ext.alt_copies AS _str_alt_copies',
+        'str_ext.str_status AS _str_status',
+        'str_ext.normal_max AS _str_normal_max',
+        'str_ext.pathologic_min AS _str_pathologic_min',
+        'str_ext.disease AS _str_disease',
+        'str_ext.inheritance_mode AS _str_inheritance_mode',
+        'str_ext.rank_score AS _str_rank_score'
+      )
+    }
+
+    const fromAndWhereSql = `FROM ${this.schemaName}."variants" v
+      ${joins.join('\n')}
+      WHERE ${whereParts.join('\n        AND ')}`
+
+    let totalCount = 0
+    if (skipCount !== true) {
+      const countResult = await this.pool.query(
+        `SELECT COUNT(*)::int AS count
+         ${fromAndWhereSql}`,
+        params
+      )
+      totalCount = toNumber((countResult.rows[0] as { count?: unknown } | undefined)?.count)
+    }
+
+    const dataParams = [...params, limit, offset]
+    const dataResult = await this.pool.query(
+      `SELECT ${projections.join(', ')}
+       ${fromAndWhereSql}
+       ${this.buildOrderBy(sortBy)}
+       LIMIT $${dataParams.length - 1}
+       OFFSET $${dataParams.length}`,
+      dataParams
+    )
+
+    let unfilteredCount: number | undefined
+    if (includeUnfilteredCount === true) {
+      const result = await this.pool.query(
+        `SELECT COUNT(*)::int AS count FROM ${this.schemaName}."variants" WHERE case_id = $1`,
+        [filter.case_id]
+      )
+      unfilteredCount = toNumber((result.rows[0] as { count?: unknown } | undefined)?.count)
+    }
+
+    return {
+      data: (dataResult.rows as Array<Record<string, unknown>>).map((row) =>
+        normalizeVariantRow(row)
+      ),
+      total_count: totalCount,
+      ...(unfilteredCount !== undefined ? { unfiltered_count: unfilteredCount } : {})
+    }
+  }
+
+  private assertSupportedQueryFilter(filter: VariantFilter): void {
+    const unsupported: string[] = []
+    if ((filter.tag_ids?.length ?? 0) > 0) unsupported.push('tag_ids')
+    if (filter.starred_only === true) unsupported.push('starred_only')
+    if (filter.has_comment === true) unsupported.push('has_comment')
+    if ((filter.acmg_classifications?.length ?? 0) > 0) unsupported.push('acmg_classifications')
+    if (filter.annotation_scope !== undefined) unsupported.push('annotation_scope')
+    if ((filter.active_panel_ids?.length ?? 0) > 0) unsupported.push('active_panel_ids')
+    if ((filter.panel_intervals?.length ?? 0) > 0) unsupported.push('panel_intervals')
+    if ((filter.inheritance_modes?.length ?? 0) > 0) unsupported.push('inheritance_modes')
+    if (filter.analysis_group_id !== undefined) unsupported.push('analysis_group_id')
+    if (filter.consider_phasing !== undefined) unsupported.push('consider_phasing')
+
+    if (unsupported.length > 0) {
+      throw new Error(`Unsupported PostgreSQL variant filter(s): ${unsupported.join(', ')}`)
+    }
+  }
+
+  private addColumnFilters(
+    filter: VariantFilter,
+    addParam: (value: unknown) => string,
+    addWhere: (sql: string) => void
+  ): void {
+    if (filter.column_filters === undefined) return
+
+    for (const [column, filterDef] of Object.entries(filter.column_filters)) {
+      const sqlColumn = POSTGRES_BASE_SORT_COLUMNS[column]
+      if (sqlColumn === undefined) continue
+      const { operator, value } = filterDef
+
+      if (operator === 'in' && Array.isArray(value)) {
+        if (value.length === 0) continue
+        addWhere(`${sqlColumn} IN (${value.map((item) => addParam(String(item))).join(', ')})`)
+      } else if (operator === 'like' && typeof value === 'string') {
+        if (value.trim() === '') continue
+        addWhere(`${sqlColumn} ILIKE ${addParam(`%${value}%`)}`)
+      } else if (
+        (operator === '=' || operator === '!=') &&
+        (typeof value === 'string' || typeof value === 'number')
+      ) {
+        addWhere(`${sqlColumn} ${operator} ${addParam(this.normalizeColumnFilterValue(value))}`)
+      } else if (
+        (operator === '<' || operator === '>' || operator === '<=' || operator === '>=') &&
+        (typeof value === 'string' || typeof value === 'number')
+      ) {
+        const comparison = `${sqlColumn} ${operator} ${addParam(this.normalizeColumnFilterValue(value))}`
+        addWhere(
+          filterDef.includeEmpty === false ? comparison : `(${sqlColumn} IS NULL OR ${comparison})`
+        )
+      }
+    }
+  }
+
+  private normalizeColumnFilterValue(value: string | number): string | number {
+    if (typeof value === 'number') return value
+    const numericValue = Number(value)
+    return Number.isFinite(numericValue) ? numericValue : value
+  }
+
+  private buildOrderBy(sortBy?: SortItem[]): string {
+    const orderParts: string[] = []
+    for (const sort of sortBy ?? []) {
+      const sqlColumn = POSTGRES_BASE_SORT_COLUMNS[sort.key]
+      if (sqlColumn !== undefined) {
+        orderParts.push(`${sqlColumn} ${sort.order.toUpperCase()} NULLS LAST`)
+      }
+    }
+
+    if (orderParts.length === 0) {
+      orderParts.push('v.pos ASC NULLS LAST')
+    }
+    orderParts.push('v.id ASC')
+    return `ORDER BY ${orderParts.join(', ')}`
   }
 }

--- a/src/main/storage/postgres/PostgresVariantReadRepository.ts
+++ b/src/main/storage/postgres/PostgresVariantReadRepository.ts
@@ -298,6 +298,17 @@ export class PostgresVariantReadRepository {
     }
   }
 
+  async getFilterOptions(_caseId: number): Promise<never> {
+    throw new Error('PostgreSQL variants:filterOptions is deferred from Phase 7')
+  }
+
+  async getColumnMeta(
+    _scope: { caseId: number } | { caseIds: number[] },
+    _columnKey: string
+  ): Promise<never> {
+    throw new Error('PostgreSQL variants:columnMeta is deferred from Phase 7')
+  }
+
   private assertSupportedQueryFilter(filter: VariantFilter): void {
     const unsupported: string[] = []
     if ((filter.tag_ids?.length ?? 0) > 0) unsupported.push('tag_ids')

--- a/src/main/storage/postgres/PostgresVariantReadRepository.ts
+++ b/src/main/storage/postgres/PostgresVariantReadRepository.ts
@@ -1,0 +1,80 @@
+import type { Pool } from 'pg'
+
+import { quoteIdentifier } from './identifiers'
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') return Number(value)
+  return 0
+}
+
+function toPrefixTsQuery(query: string): string {
+  return query
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/[^A-Za-z0-9_]/g, ''))
+    .filter((token) => token.length > 0)
+    .map((token) => `${token}:*`)
+    .join(' & ')
+}
+
+export const toPrefixTsQueryForTest = toPrefixTsQuery
+
+export class PostgresVariantReadRepository {
+  private readonly schemaName: string
+
+  constructor(
+    private readonly pool: Pick<Pool, 'query'>,
+    schema: string
+  ) {
+    this.schemaName = quoteIdentifier(schema)
+  }
+
+  async getVariantTypeCounts(caseId: number): Promise<Record<string, number>> {
+    const result = await this.pool.query(
+      `SELECT variant_type, COUNT(*)::int AS count
+       FROM ${this.schemaName}."variants"
+       WHERE case_id = $1
+       GROUP BY variant_type
+       ORDER BY variant_type`,
+      [caseId]
+    )
+    const counts: Record<string, number> = {}
+    for (const row of result.rows as Array<{ variant_type: string; count: unknown }>) {
+      counts[row.variant_type] = toNumber(row.count)
+    }
+    return counts
+  }
+
+  async getVariantTypesPresent(
+    scope: { caseId: number } | { caseIds: number[] }
+  ): Promise<string[]> {
+    const caseIds = 'caseId' in scope ? [scope.caseId] : scope.caseIds
+    if (caseIds.length === 0) return []
+    const result =
+      caseIds.length === 1
+        ? await this.pool.query(
+            `SELECT DISTINCT variant_type FROM ${this.schemaName}."variants" WHERE case_id = $1 AND variant_type IS NOT NULL ORDER BY variant_type`,
+            [caseIds[0]]
+          )
+        : await this.pool.query(
+            `SELECT DISTINCT variant_type FROM ${this.schemaName}."variants" WHERE case_id = ANY($1::bigint[]) AND variant_type IS NOT NULL ORDER BY variant_type`,
+            [caseIds]
+          )
+    return (result.rows as Array<{ variant_type: string }>).map((row) => row.variant_type)
+  }
+
+  async getGeneSymbols(caseId: number, query: string, limit: number): Promise<string[]> {
+    const result = await this.pool.query(
+      `SELECT DISTINCT gene_symbol
+       FROM ${this.schemaName}."variants"
+       WHERE case_id = $1
+         AND gene_symbol IS NOT NULL
+         AND gene_symbol ILIKE $2
+       ORDER BY gene_symbol
+       LIMIT $3`,
+      [caseId, `${query}%`, limit]
+    )
+    return (result.rows as Array<{ gene_symbol: string }>).map((row) => row.gene_symbol)
+  }
+}

--- a/src/main/storage/read-executor.ts
+++ b/src/main/storage/read-executor.ts
@@ -1,3 +1,4 @@
+import type { SortItem, VariantFilter } from '../../shared/types/database'
 import type { ValidatedCaseSearchParams } from '../../shared/types/ipc-schemas'
 
 export type { AvailableBuild } from '../../shared/types/database'
@@ -22,6 +23,28 @@ export type StorageReadTask =
   | { type: 'case-metadata:distinctPlatforms'; params: [] }
   | { type: 'case-metadata:distinctExternalIdTypes'; params: [] }
   | { type: 'case-metadata:getFullMetadata'; params: [caseId: number] }
+  | { type: 'variants:typeCounts'; params: [caseId: number] }
+  | {
+      type: 'variants:typesPresent'
+      params: [scope: { caseId: number } | { caseIds: number[] }]
+    }
+  | { type: 'variants:geneSymbols'; params: [caseId: number, query: string, limit: number] }
+  | {
+      type: 'variants:query'
+      params: [
+        filter: VariantFilter,
+        limit: number,
+        offset: number,
+        sortBy: SortItem[] | undefined,
+        skipCount: boolean,
+        includeUnfilteredCount: boolean
+      ]
+    }
+  | { type: 'variants:filterOptions'; params: [caseId: number] }
+  | {
+      type: 'variants:columnMeta'
+      params: [scope: { caseId: number } | { caseIds: number[] }, columnKey: string]
+    }
 
 export interface StorageReadExecutor {
   execute(task: StorageReadTask): Promise<unknown>

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -2,10 +2,6 @@ import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
 import type { StorageReadExecutor, StorageReadTask } from '../read-executor'
 
-function deferredVariantReadTask(taskType: string): never {
-  throw new Error(`${taskType} is not implemented by this storage executor yet`)
-}
-
 export class SqliteReadExecutor implements StorageReadExecutor {
   constructor(
     private readonly databaseService: DatabaseService,
@@ -133,12 +129,38 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         return this.databaseService.metadata.getFullCaseMetadata(task.params[0])
 
       case 'variants:typeCounts':
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return this.databaseService.variants.getVariantTypeCounts(task.params[0])
+
       case 'variants:typesPresent':
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return Array.from(this.databaseService.variants.getVariantTypesPresent(task.params[0]))
+
       case 'variants:geneSymbols':
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return this.databaseService.variants.getGeneSymbols(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
       case 'variants:query':
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return this.databaseService.variants.getVariants(...task.params)
+
       case 'variants:filterOptions':
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return this.databaseService.variants.getFilterOptions(task.params[0])
+
       case 'variants:columnMeta':
-        return deferredVariantReadTask(task.type)
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return this.databaseService.variants.getColumnMeta(task.params[0], task.params[1])
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -2,6 +2,10 @@ import type { DatabaseService } from '../../database/DatabaseService'
 import type { DbPool } from '../../database/DbPool'
 import type { StorageReadExecutor, StorageReadTask } from '../read-executor'
 
+function deferredVariantReadTask(taskType: string): never {
+  throw new Error(`${taskType} is not implemented by this storage executor yet`)
+}
+
 export class SqliteReadExecutor implements StorageReadExecutor {
   constructor(
     private readonly databaseService: DatabaseService,
@@ -127,6 +131,14 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         }
 
         return this.databaseService.metadata.getFullCaseMetadata(task.params[0])
+
+      case 'variants:typeCounts':
+      case 'variants:typesPresent':
+      case 'variants:geneSymbols':
+      case 'variants:query':
+      case 'variants:filterOptions':
+      case 'variants:columnMeta':
+        return deferredVariantReadTask(task.type)
     }
 
     const _exhaustive: never = task

--- a/tests/e2e/postgres-variants-read-dev-mode.e2e.ts
+++ b/tests/e2e/postgres-variants-read-dev-mode.e2e.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  dismissDisclaimerIfPresent,
+  launchElectronApp,
+  waitForAppShell
+} from './helpers/electron-app'
+
+function expectSuccessfulIpcResult<T>(result: T): T {
+  expect(result).not.toEqual(
+    expect.objectContaining({
+      code: expect.any(String),
+      message: expect.any(String),
+      userMessage: expect.any(String)
+    })
+  )
+  return result
+}
+
+test('postgres dev mode supports phase 7 variant reads', async () => {
+  test.skip(
+    process.env.VARLENS_RUN_POSTGRES_E2E !== '1',
+    'Set VARLENS_RUN_POSTGRES_E2E=1 after starting the local postgres container to run this test.'
+  )
+
+  let launched: Awaited<ReturnType<typeof launchElectronApp>> | undefined
+
+  try {
+    launched = await launchElectronApp({
+      env: {
+        VARLENS_EXPERIMENTAL_STORAGE_BACKEND: 'postgres',
+        VARLENS_PG_URL:
+          process.env.VARLENS_PG_URL ??
+          'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev',
+        VARLENS_PG_SCHEMA: process.env.VARLENS_PG_SCHEMA ?? 'public'
+      }
+    })
+
+    await waitForAppShell(launched.window)
+    await dismissDisclaimerIfPresent(launched.window)
+
+    const results = await launched.window.evaluate(async () => {
+      return {
+        typeCounts: await window.api.variants.typeCounts(1),
+        typesPresent: await window.api.variants.typesPresent({ caseId: 1 }),
+        geneSymbols: await window.api.variants.geneSymbols(1, 'BR', 20),
+        snvQuery: await window.api.variants.query(1, { variant_type: 'snv' }, 0, 25, [{ key: 'pos', order: 'asc' }], false, true),
+        baseFilterQuery: await window.api.variants.query(1, { funcs: ['missense_variant'] }, 0, 25),
+        numericFilterQuery: await window.api.variants.query(1, { cadd_min: 25 }, 0, 25),
+        columnFilterQuery: await window.api.variants.query(1, { column_filters: { consequence: { operator: 'in', value: ['HIGH'] } } }, 0, 25),
+        internalAfQuery: await window.api.variants.query(1, { max_internal_af: 0.6 }, 0, 25),
+        ftsQuery: await window.api.variants.query(1, { search_query: 'Huntington' }, 0, 25),
+        coordinateQuery: await window.api.variants.query(1, { chr: '1', pos: 1000, ref: 'A', alt: 'G' }, 0, 25)
+      }
+    })
+
+    expect(expectSuccessfulIpcResult(results.typeCounts)).toMatchObject({
+      snv: 1,
+      indel: 1,
+      sv: 1,
+      cnv: 1,
+      str: 1
+    })
+    expect(expectSuccessfulIpcResult(results.typesPresent)).toEqual(['cnv', 'indel', 'snv', 'str', 'sv'])
+    expect(expectSuccessfulIpcResult(results.geneSymbols)).toEqual(['BRCA1', 'BRCA2'])
+
+    const snvQuery = expectSuccessfulIpcResult(results.snvQuery)
+    expect(snvQuery).toMatchObject({
+      total_count: 2,
+      unfiltered_count: 5,
+      data: [
+        expect.objectContaining({ gene_symbol: 'BRCA1', variant_type: 'snv' }),
+        expect.objectContaining({ gene_symbol: 'BRCA2', variant_type: 'indel' })
+      ]
+    })
+    expect(snvQuery.data[0].internal_af).toBeCloseTo(2 / 3)
+
+    expect(expectSuccessfulIpcResult(results.baseFilterQuery)).toMatchObject({
+      total_count: 1,
+      data: [expect.objectContaining({ gene_symbol: 'BRCA1', func: 'missense_variant' })]
+    })
+
+    expect(expectSuccessfulIpcResult(results.numericFilterQuery)).toMatchObject({
+      total_count: 2,
+      data: expect.arrayContaining([
+        expect.objectContaining({ gene_symbol: 'BRCA1' }),
+        expect.objectContaining({ gene_symbol: 'DMD' })
+      ])
+    })
+
+    expect(expectSuccessfulIpcResult(results.columnFilterQuery)).toMatchObject({
+      total_count: 2,
+      data: expect.arrayContaining([
+        expect.objectContaining({ gene_symbol: 'BRCA1' }),
+        expect.objectContaining({ gene_symbol: 'DMD' })
+      ])
+    })
+
+    expect(expectSuccessfulIpcResult(results.internalAfQuery)).toMatchObject({
+      total_count: 4,
+      data: expect.not.arrayContaining([expect.objectContaining({ gene_symbol: 'BRCA1' })])
+    })
+
+    expect(expectSuccessfulIpcResult(results.ftsQuery)).toMatchObject({
+      total_count: 1,
+      data: [expect.objectContaining({ gene_symbol: 'HTT', variant_type: 'str' })]
+    })
+
+    expect(expectSuccessfulIpcResult(results.coordinateQuery)).toMatchObject({
+      total_count: 1,
+      data: [expect.objectContaining({ gene_symbol: 'BRCA1', pos: 1000 })]
+    })
+  } finally {
+    if (launched !== undefined) {
+      await launched.cleanup()
+    }
+  }
+})

--- a/tests/e2e/postgres-variants-schema-dev-mode.e2e.ts
+++ b/tests/e2e/postgres-variants-schema-dev-mode.e2e.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test'
+import { setTimeout as delay } from 'node:timers/promises'
+import { Pool, type QueryResult } from 'pg'
+
+async function queryWithStartupRetry<T>(
+  pool: Pool,
+  sql: string,
+  params: unknown[] = []
+): Promise<QueryResult<T>> {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      return await pool.query<T>(sql, params)
+    } catch (error) {
+      lastError = error
+      await delay(500)
+    }
+  }
+
+  throw lastError
+}
+
+test('postgres dev schema exposes phase 7 variant read tables and seed data', async () => {
+  test.skip(
+    process.env.VARLENS_RUN_POSTGRES_E2E !== '1',
+    'Set VARLENS_RUN_POSTGRES_E2E=1 after starting the local postgres container to run this test.'
+  )
+
+  const pool = new Pool({
+    connectionString:
+      process.env.VARLENS_PG_URL ??
+      'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+  })
+
+  try {
+    const tables = await queryWithStartupRetry<{ table_name: string }>(
+      pool,
+      `SELECT table_name
+       FROM information_schema.tables
+       WHERE table_schema = $1
+         AND table_name = ANY($2::text[])
+       ORDER BY table_name`,
+      [
+        process.env.VARLENS_PG_SCHEMA ?? 'public',
+        ['variants', 'variant_frequency', 'variant_sv', 'variant_cnv', 'variant_str']
+      ]
+    )
+    expect(tables.rows.map((row) => row.table_name)).toEqual([
+      'variant_cnv',
+      'variant_frequency',
+      'variant_str',
+      'variant_sv',
+      'variants'
+    ])
+
+    const seeded = await pool.query<{ count: number }>(
+      'SELECT COUNT(*)::int AS count FROM variants WHERE case_id = $1',
+      [1]
+    )
+    expect(seeded.rows[0]?.count).toBe(5)
+
+    const baseSearch = await pool.query<{ id: number }>(
+      "SELECT id::int AS id FROM variants WHERE search_document @@ to_tsquery('simple', 'brca1:*') ORDER BY id"
+    )
+    expect(baseSearch.rows.map((row) => row.id)).toContain(1)
+
+    const strSearch = await pool.query<{ variant_id: number }>(
+      "SELECT variant_id::int AS variant_id FROM variant_str WHERE search_document @@ to_tsquery('simple', 'huntington:*')"
+    )
+    expect(strSearch.rows.map((row) => row.variant_id)).toContain(5)
+
+    const simpleConfig = await pool.query<{ simple: string; english: string }>(
+      "SELECT to_tsvector('simple', 'RUNS')::text AS simple, to_tsvector('english', 'RUNS')::text AS english"
+    )
+    expect(simpleConfig.rows[0]?.simple).not.toBe(simpleConfig.rows[0]?.english)
+  } finally {
+    await pool.end()
+  }
+})

--- a/tests/main/handlers/variants-logic.test.ts
+++ b/tests/main/handlers/variants-logic.test.ts
@@ -2,8 +2,14 @@
  * Variants logic smoke tests — verifies module exports are intact after extraction.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import * as logic from '../../../src/main/ipc/handlers/variants-logic'
+import {
+  buildVariantFilter,
+  getVariantTypeCounts,
+  queryVariants,
+  searchVariants
+} from '../../../src/main/ipc/handlers/variants-logic'
 
 describe('variants-logic exports', () => {
   it('exports expected functions', () => {
@@ -12,5 +18,65 @@ describe('variants-logic exports', () => {
     expect(typeof logic.getFilterOptions).toBe('function')
     expect(typeof logic.searchVariants).toBe('function')
     expect(typeof logic.getGeneSymbols).toBe('function')
+  })
+
+  it('routes typeCounts through the active storage session read executor', async () => {
+    const execute = vi.fn().mockResolvedValue({ snv: 2 })
+    const getSession = () => ({ getReadExecutor: () => ({ execute }) }) as never
+
+    await expect(getVariantTypeCounts(1, getSession)).resolves.toStrictEqual({ snv: 2 })
+    expect(execute).toHaveBeenCalledWith({ type: 'variants:typeCounts', params: [1] })
+  })
+
+  it('routes query through the active storage session read executor', async () => {
+    const execute = vi.fn().mockResolvedValue({ data: [], total_count: 0 })
+    const getSession = () => ({ getReadExecutor: () => ({ execute }) }) as never
+
+    await queryVariants({ case_id: 1 }, 25, 0, undefined, false, false, getSession)
+
+    expect(execute).toHaveBeenCalledWith({
+      type: 'variants:query',
+      params: [{ case_id: 1 }, 25, 0, undefined, false, false]
+    })
+  })
+
+  it('does not call getDb while preparing postgres active panel filters', () => {
+    const getDb = vi.fn(() => {
+      throw new Error('getDb should not be called for postgres panel rejection')
+    })
+    const getSession = () =>
+      ({
+        capabilities: { backend: 'postgres' }
+      }) as never
+
+    expect(
+      buildVariantFilter(
+        1,
+        { active_panel_ids: [1], panel_padding_bp: 50 },
+        getDb,
+        undefined,
+        getSession
+      )
+    ).toMatchObject({
+      case_id: 1,
+      active_panel_ids: [1],
+      panel_padding_bp: 50
+    })
+    expect(getDb).not.toHaveBeenCalled()
+  })
+
+  it('fails variants:search clearly on postgres instead of calling getDb', async () => {
+    const getDb = vi.fn(() => {
+      throw new Error('getDb should not be called for postgres search rejection')
+    })
+    const getSession = () =>
+      ({
+        capabilities: { backend: 'postgres' }
+      }) as never
+
+    await expect(searchVariants(1, 'BRCA1', 20, getSession, getDb)).rejects.toThrow(
+      'PostgreSQL variants:search is deferred from Phase 7'
+    )
+    expect(getDb).not.toHaveBeenCalled()
   })
 })

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -77,4 +77,43 @@ describe('PostgresReadExecutor', () => {
     expect(caseMetadata.listCohortGroups).toHaveBeenCalledWith()
     expect(caseMetadata.getFullCaseMetadata).toHaveBeenCalledWith(1)
   })
+
+  it('dispatches variant small reads to the postgres variant repository', async () => {
+    const variants = {
+      getVariantTypeCounts: vi.fn().mockResolvedValue({ snv: 2 }),
+      getVariantTypesPresent: vi.fn().mockResolvedValue(['snv']),
+      getGeneSymbols: vi.fn().mockResolvedValue(['BRCA1'])
+    }
+    const casesQuery = { queryCases: vi.fn() }
+    const availableBuilds = { getAvailableGenomeBuilds: vi.fn() }
+    const caseMetadata = {
+      getCaseMetadata: vi.fn(),
+      listCohortGroups: vi.fn(),
+      getCohortGroupByName: vi.fn(),
+      getCaseCohorts: vi.fn(),
+      getCaseHpoTerms: vi.fn(),
+      getCaseDataInfo: vi.fn(),
+      listCaseExternalIds: vi.fn(),
+      getDistinctHpoTerms: vi.fn(),
+      getDistinctPlatforms: vi.fn(),
+      getDistinctExternalIdTypes: vi.fn(),
+      getFullCaseMetadata: vi.fn()
+    }
+    const executor = new PostgresReadExecutor({
+      casesQuery,
+      availableBuilds,
+      caseMetadata,
+      variants
+    } as never)
+
+    await expect(
+      executor.execute({ type: 'variants:typeCounts', params: [1] })
+    ).resolves.toStrictEqual({ snv: 2 })
+    await expect(
+      executor.execute({ type: 'variants:typesPresent', params: [{ caseId: 1 }] })
+    ).resolves.toStrictEqual(['snv'])
+    await expect(
+      executor.execute({ type: 'variants:geneSymbols', params: [1, 'BR', 20] })
+    ).resolves.toStrictEqual(['BRCA1'])
+  })
 })

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -146,4 +146,34 @@ describe('PostgresReadExecutor', () => {
       true
     )
   })
+
+  it('dispatches variant metadata reads to explicit postgres deferral methods', async () => {
+    const variants = {
+      getVariantTypeCounts: vi.fn(),
+      getVariantTypesPresent: vi.fn(),
+      getGeneSymbols: vi.fn(),
+      queryVariants: vi.fn(),
+      getFilterOptions: vi
+        .fn()
+        .mockRejectedValue(new Error('PostgreSQL variants:filterOptions is deferred from Phase 7')),
+      getColumnMeta: vi
+        .fn()
+        .mockRejectedValue(new Error('PostgreSQL variants:columnMeta is deferred from Phase 7'))
+    }
+    const executor = new PostgresReadExecutor({
+      casesQuery: {} as never,
+      availableBuilds: {} as never,
+      caseMetadata: {} as never,
+      variants
+    } as never)
+
+    await expect(executor.execute({ type: 'variants:filterOptions', params: [1] })).rejects.toThrow(
+      'PostgreSQL variants:filterOptions is deferred from Phase 7'
+    )
+    await expect(
+      executor.execute({ type: 'variants:columnMeta', params: [{ caseId: 1 }, 'cadd'] })
+    ).rejects.toThrow('PostgreSQL variants:columnMeta is deferred from Phase 7')
+    expect(variants.getFilterOptions).toHaveBeenCalledWith(1)
+    expect(variants.getColumnMeta).toHaveBeenCalledWith({ caseId: 1 }, 'cadd')
+  })
 })

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -116,4 +116,34 @@ describe('PostgresReadExecutor', () => {
       executor.execute({ type: 'variants:geneSymbols', params: [1, 'BR', 20] })
     ).resolves.toStrictEqual(['BRCA1'])
   })
+
+  it('dispatches variant query reads to the postgres variant repository', async () => {
+    const variants = {
+      getVariantTypeCounts: vi.fn(),
+      getVariantTypesPresent: vi.fn(),
+      getGeneSymbols: vi.fn(),
+      queryVariants: vi.fn().mockResolvedValue({ data: [], total_count: 0 })
+    }
+    const executor = new PostgresReadExecutor({
+      casesQuery: {} as never,
+      availableBuilds: {} as never,
+      caseMetadata: {} as never,
+      variants
+    } as never)
+
+    await expect(
+      executor.execute({
+        type: 'variants:query',
+        params: [{ case_id: 1 }, 25, 0, undefined, false, true]
+      })
+    ).resolves.toStrictEqual({ data: [], total_count: 0 })
+    expect(variants.queryVariants).toHaveBeenCalledWith(
+      { case_id: 1 },
+      25,
+      0,
+      undefined,
+      false,
+      true
+    )
+  })
 })

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -249,4 +249,28 @@ describe('PostgresStorageSession', () => {
     expect(pool.query).toHaveBeenCalledTimes(1)
     expect(pool.query.mock.calls[0][0]).toContain('"phase6_metadata"."case_metadata"')
   })
+
+  it('routes variant small reads through the session-owned postgres read executor', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ variant_type: 'snv', count: '2' }]
+      }),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn()
+    }
+    const session = new PostgresStorageSession({
+      config: makeConfig({ schema: 'phase7_variants' }),
+      pool: pool as never
+    })
+
+    await expect(
+      session.getReadExecutor().execute({
+        type: 'variants:typeCounts',
+        params: [1]
+      })
+    ).resolves.toEqual({ snv: 2 })
+
+    expect(pool.query).toHaveBeenCalledTimes(1)
+    expect(pool.query.mock.calls[0][0]).toContain('"phase7_variants"."variants"')
+  })
 })

--- a/tests/main/storage/postgres-variant-read-repository.test.ts
+++ b/tests/main/storage/postgres-variant-read-repository.test.ts
@@ -44,7 +44,139 @@ describe('PostgresVariantReadRepository', () => {
     expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ILIKE'), [1, 'br%', 20])
   })
 
-  it('keeps the postgres tsquery test helper private to repository tests for now', () => {
-    expect(toPrefixTsQueryForTest('')).toBe('')
+  it.each([
+    ['tag_ids', { tag_ids: [1] }],
+    ['starred_only', { starred_only: true }],
+    ['has_comment', { has_comment: true }],
+    ['acmg_classifications', { acmg_classifications: ['Pathogenic'] }],
+    ['annotation_scope', { annotation_scope: 'all' }],
+    ['active_panel_ids', { active_panel_ids: [1] }],
+    ['panel_intervals', { panel_intervals: [{ chr: '1', start: 1, end: 2 }] }],
+    ['inheritance_modes', { inheritance_modes: ['de_novo'] }]
+  ])('rejects unsupported postgres variant filter %s', async (_name, filter) => {
+    const repository = new PostgresVariantReadRepository({ query: vi.fn() } as never, 'public')
+
+    await expect(
+      repository.queryVariants({ case_id: 1, ...filter }, 25, 0, undefined, false, false)
+    ).rejects.toThrow('Unsupported PostgreSQL variant filter')
+  })
+
+  it('queries variants with supported filters, sorting, counts, and unfiltered count', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ count: '2' }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: '1',
+              case_id: '1',
+              chr: '1',
+              pos: '1000',
+              ref: 'A',
+              alt: 'G',
+              gene_symbol: 'BRCA1',
+              variant_type: 'snv',
+              internal_af: 0.5
+            }
+          ]
+        })
+        .mockResolvedValueOnce({ rows: [{ count: '5' }] })
+    }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(
+      repository.queryVariants(
+        {
+          case_id: 1,
+          variant_type: 'snv',
+          gene_symbol: 'BRC',
+          consequences: ['HIGH'],
+          funcs: ['missense_variant'],
+          clinvars: ['Pathogenic'],
+          gnomad_af_max: 0.01,
+          cadd_min: 20,
+          max_internal_af: 0.6,
+          search_query: 'BRCA1',
+          column_filters: {
+            consequence: { operator: 'in', value: ['HIGH'] },
+            gene_symbol: { operator: 'like', value: 'BRC' }
+          }
+        },
+        25,
+        0,
+        [{ key: 'pos', order: 'asc' }],
+        false,
+        true
+      )
+    ).resolves.toStrictEqual({
+      data: [
+        expect.objectContaining({
+          id: 1,
+          case_id: 1,
+          pos: 1000,
+          gene_symbol: 'BRCA1',
+          variant_type: 'snv',
+          internal_af: 0.5
+        })
+      ],
+      total_count: 2,
+      unfiltered_count: 5
+    })
+
+    const countSql = pool.query.mock.calls[0][0] as string
+    const dataSql = pool.query.mock.calls[1][0] as string
+    expect(countSql).toContain('COUNT(*)::int AS count')
+    expect(dataSql).toContain('to_tsquery')
+    expect(dataSql).toContain('LEFT JOIN "public"."variant_frequency"')
+    expect(dataSql).toContain('COUNT(*) FROM "public"."cases"')
+    expect(dataSql).toContain('EXISTS')
+    expect(dataSql).toContain('"public"."variant_sv"')
+    expect(dataSql).toContain('"public"."variant_str"')
+    expect(dataSql).toContain('search_document @@')
+    expect(dataSql).toContain('v.consequence IN')
+    expect(dataSql).toContain('v.gene_symbol ILIKE')
+    expect(dataSql).toContain("variant_type IN ('snv', 'indel')")
+  })
+
+  it('sanitizes postgres tsquery search tokens before appending prefix operators', async () => {
+    expect(toPrefixTsQueryForTest('BRCA1')).toBe('BRCA1:*')
+    expect(toPrefixTsQueryForTest('chr1:1000 A>G')).toBe('chr11000:* & AG:*')
+    expect(toPrefixTsQueryForTest('***')).toBe('')
+  })
+
+  it('adds STR extension projections for str variant queries', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ count: '1' }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: '5',
+              case_id: '1',
+              chr: '4',
+              pos: '4000',
+              ref: 'CAG',
+              alt: '<STR>',
+              variant_type: 'str',
+              _str_repeat_id: 'HTT'
+            }
+          ]
+        })
+    }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await repository.queryVariants(
+      { case_id: 1, variant_type: 'str' },
+      25,
+      0,
+      undefined,
+      false,
+      false
+    )
+
+    expect(pool.query.mock.calls[1][0]).toContain('variant_str')
+    expect(pool.query.mock.calls[1][0]).toContain('_str_repeat_id')
   })
 })

--- a/tests/main/storage/postgres-variant-read-repository.test.ts
+++ b/tests/main/storage/postgres-variant-read-repository.test.ts
@@ -179,4 +179,15 @@ describe('PostgresVariantReadRepository', () => {
     expect(pool.query.mock.calls[1][0]).toContain('variant_str')
     expect(pool.query.mock.calls[1][0]).toContain('_str_repeat_id')
   })
+
+  it('fails filter metadata reads with explicit Phase 7 deferral errors', async () => {
+    const repository = new PostgresVariantReadRepository({ query: vi.fn() } as never, 'public')
+
+    await expect(repository.getFilterOptions(1)).rejects.toThrow(
+      'PostgreSQL variants:filterOptions is deferred from Phase 7'
+    )
+    await expect(repository.getColumnMeta({ caseId: 1 }, 'cadd')).rejects.toThrow(
+      'PostgreSQL variants:columnMeta is deferred from Phase 7'
+    )
+  })
 })

--- a/tests/main/storage/postgres-variant-read-repository.test.ts
+++ b/tests/main/storage/postgres-variant-read-repository.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  PostgresVariantReadRepository,
+  toPrefixTsQueryForTest
+} from '../../../src/main/storage/postgres/PostgresVariantReadRepository'
+
+describe('PostgresVariantReadRepository', () => {
+  it('returns variant type counts with bigint strings normalized', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValueOnce({
+        rows: [
+          { variant_type: 'snv', count: '2' },
+          { variant_type: 'sv', count: '1' }
+        ]
+      })
+    }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(repository.getVariantTypeCounts(1)).resolves.toStrictEqual({ snv: 2, sv: 1 })
+    expect(pool.query).toHaveBeenCalledWith(expect.stringMatching(/\bvariants\b/), [1])
+  })
+
+  it('returns distinct variant types for a case scope', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ variant_type: 'snv' }, { variant_type: 'str' }] })
+    }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(repository.getVariantTypesPresent({ caseId: 1 })).resolves.toStrictEqual([
+      'snv',
+      'str'
+    ])
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('case_id = $1'), [1])
+  })
+
+  it('returns gene symbols by prefix case-insensitively', async () => {
+    const pool = { query: vi.fn().mockResolvedValueOnce({ rows: [{ gene_symbol: 'BRCA1' }] }) }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(repository.getGeneSymbols(1, 'br', 20)).resolves.toStrictEqual(['BRCA1'])
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ILIKE'), [1, 'br%', 20])
+  })
+
+  it('keeps the postgres tsquery test helper private to repository tests for now', () => {
+    expect(toPrefixTsQueryForTest('')).toBe('')
+  })
+})

--- a/tests/main/storage/postgres-variant-read-repository.test.ts
+++ b/tests/main/storage/postgres-variant-read-repository.test.ts
@@ -180,6 +180,62 @@ describe('PostgresVariantReadRepository', () => {
     expect(pool.query.mock.calls[1][0]).toContain('_str_repeat_id')
   })
 
+  it('normalizes numeric extension projection aliases returned as strings', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ count: '1' }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: '3',
+              case_id: '1',
+              chr: '2',
+              pos: '2000',
+              ref: 'N',
+              alt: '<DEL>',
+              variant_type: 'sv',
+              _sv_support: '12',
+              _sv_dr: '8',
+              _sv_dv: '4',
+              _sv_is_precise: '1'
+            }
+          ]
+        })
+    }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(
+      repository.queryVariants({ case_id: 1, variant_type: 'sv' }, 25, 0, undefined, false, false)
+    ).resolves.toMatchObject({
+      data: [
+        expect.objectContaining({
+          _sv_support: 12,
+          _sv_dr: 8,
+          _sv_dv: 4,
+          _sv_is_precise: 1
+        })
+      ]
+    })
+  })
+
+  it('rejects unsupported postgres column filter keys instead of ignoring them', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [] }) }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(
+      repository.queryVariants(
+        { case_id: 1, column_filters: { 'sv.support': { operator: '>', value: 1 } } },
+        25,
+        0,
+        undefined,
+        false,
+        false
+      )
+    ).rejects.toThrow('Unsupported PostgreSQL column filter(s): sv.support')
+    expect(pool.query).not.toHaveBeenCalled()
+  })
+
   it('fails filter metadata reads with explicit Phase 7 deferral errors', async () => {
     const repository = new PostgresVariantReadRepository({ query: vi.fn() } as never, 'public')
 

--- a/tests/main/storage/read-executor-contract.test.ts
+++ b/tests/main/storage/read-executor-contract.test.ts
@@ -53,4 +53,28 @@ describe('StorageReadExecutor contract', () => {
 
     expect(tasks).toHaveLength(11)
   })
+
+  it('supports phase 7 variant read tasks', () => {
+    const tasks = [
+      { type: 'variants:typeCounts', params: [1] },
+      { type: 'variants:typesPresent', params: [{ caseId: 1 }] },
+      { type: 'variants:typesPresent', params: [{ caseIds: [1, 2] }] },
+      { type: 'variants:geneSymbols', params: [1, 'BR', 20] },
+      {
+        type: 'variants:query',
+        params: [
+          { case_id: 1, variant_type: 'snv' },
+          25,
+          0,
+          [{ key: 'pos', order: 'asc' }],
+          false,
+          true
+        ]
+      },
+      { type: 'variants:filterOptions', params: [1] },
+      { type: 'variants:columnMeta', params: [{ caseId: 1 }, 'cadd'] }
+    ] satisfies StorageReadTask[]
+
+    expect(tasks).toHaveLength(7)
+  })
 })

--- a/tests/main/storage/sqlite-read-executor.test.ts
+++ b/tests/main/storage/sqlite-read-executor.test.ts
@@ -131,4 +131,36 @@ describe('SqliteReadExecutor', () => {
       expect(databaseService.metadata[metadataMethod]).toHaveBeenCalledWith(...expectedArgs)
     }
   )
+
+  it('dispatches variant reads through the sqlite worker pool when present', async () => {
+    const dbPool = { run: vi.fn().mockResolvedValue({ snv: 1 }) }
+    const executor = new SqliteReadExecutor({} as never, dbPool as never)
+
+    await expect(
+      executor.execute({ type: 'variants:typeCounts', params: [1] })
+    ).resolves.toStrictEqual({ snv: 1 })
+
+    expect(dbPool.run).toHaveBeenCalledWith({ type: 'variants:typeCounts', params: [1] })
+  })
+
+  it('dispatches variant reads to DatabaseService when no pool is present', async () => {
+    const databaseService = {
+      variants: {
+        getVariantTypeCounts: vi.fn().mockReturnValue({ snv: 1 }),
+        getVariantTypesPresent: vi.fn().mockReturnValue(new Set(['snv'])),
+        getGeneSymbols: vi.fn().mockReturnValue(['BRCA1'])
+      }
+    }
+    const executor = new SqliteReadExecutor(databaseService as never, null)
+
+    await expect(
+      executor.execute({ type: 'variants:typeCounts', params: [1] })
+    ).resolves.toStrictEqual({ snv: 1 })
+    await expect(
+      executor.execute({ type: 'variants:typesPresent', params: [{ caseId: 1 }] })
+    ).resolves.toStrictEqual(['snv'])
+    await expect(
+      executor.execute({ type: 'variants:geneSymbols', params: [1, 'BR', 20] })
+    ).resolves.toStrictEqual(['BRCA1'])
+  })
 })


### PR DESCRIPTION
## Summary
- Add PostgreSQL Phase 7 variant read schema, deterministic Docker seed data, and FTS-backed search documents.
- Route Phase 7 `variants:*` reads through storage sessions while preserving SQLite executor behavior.
- Implement PostgreSQL `variants:typeCounts`, `variants:typesPresent`, `variants:geneSymbols`, and initial `variants:query` with supported filters, pagination, sorting, extension projections, and explicit unsupported-filter errors.
- Defer `variants:filterOptions` and `variants:columnMeta` with a planning artifact and explicit PostgreSQL errors to keep Phase 7 scope bounded.
- Add Docker-backed PostgreSQL schema and variant read E2E coverage.

## Validation
- `make rebuild-node && npx vitest run tests/main/storage/read-executor-contract.test.ts tests/main/storage/sqlite-read-executor.test.ts tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-storage-session.test.ts tests/main/storage/postgres-variant-read-repository.test.ts tests/main/handlers/variants-logic.test.ts tests/main/handlers/variants-handlers.test.ts tests/shared/types/preload-contract.test.ts`
- `make typecheck`
- `make rebuild`
- `make pg-reset && make pg-up && VARLENS_RUN_POSTGRES_E2E=1 npx playwright test tests/e2e/postgres-cases-list-dev-mode.e2e.ts tests/e2e/postgres-case-metadata-dev-mode.e2e.ts tests/e2e/postgres-variants-schema-dev-mode.e2e.ts tests/e2e/postgres-variants-read-dev-mode.e2e.ts; make pg-down`
- `make ci`

## Notes
- PostgreSQL import/export/delete/rebuild, cohort parity, database overview, and renderer PostgreSQL settings remain out of scope for Phase 7.
- Basic variant filter metadata is documented as deferred in `.planning/artifacts/postgres-parity-phase-7-filter-metadata-deferral.md`.
