### PR TITLE
chore(deps): consolidate dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.58.1",
+  "version": "0.58.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.58.1",
+      "version": "0.58.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -35,7 +35,7 @@
         "vuedraggable": "^4.1.0",
         "vuetify": "^4.0.6",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-        "zod": "^4.4.0"
+        "zod": "^4.4.1"
       },
       "devDependencies": {
         "@electron-toolkit/preload": "^3.0.2",
@@ -56,7 +56,7 @@
         "@types/plotly.js": "^3.0.10",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-v8": "^4.1.5",
-        "@vue/test-utils": "^2.4.6",
+        "@vue/test-utils": "^2.4.9",
         "electron": "^40.9.2",
         "electron-builder": "^26.4.0",
         "electron-vite": "^5.0.0",
@@ -4731,14 +4731,24 @@
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
-      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.9.tgz",
+      "integrity": "sha512-YwgowiO1mPleZqpgAGfxvWu/A5A8nkLrbyH2SqiQRkyzCIaDzzo27/2uS/F1g7fRLvl8BUY0+Sr1eC+6+IHfrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-beautify": "^1.14.9",
-        "vue-component-type-helpers": "^2.0.0"
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vuetify/loader-shared": {
@@ -16392,9 +16402,9 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
-      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.7.tgz",
+      "integrity": "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -16869,9 +16879,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.0.tgz",
-      "integrity": "sha512-932TE3dEKhhYkEZFv6meaxLaCyg1m6LSI0ETKCIyUqIim+KgIsB/kha/4CKwDEbYgMzS5QxAe2mtDPpaHLHdsQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.58.1",
+  "version": "0.58.2",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "author": "Bernt Popp <bernt.popp@gmail.com>",
@@ -57,7 +57,7 @@
     "@types/plotly.js": "^3.0.10",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.5",
-    "@vue/test-utils": "^2.4.6",
+    "@vue/test-utils": "^2.4.9",
     "electron": "^40.9.2",
     "electron-builder": "^26.4.0",
     "electron-vite": "^5.0.0",
@@ -187,7 +187,7 @@
     "vuedraggable": "^4.1.0",
     "vuetify": "^4.0.6",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "zod": "^4.4.0"
+    "zod": "^4.4.1"
   },
   "overrides": {
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",


### PR DESCRIPTION
## Summary
- bump zod from 4.4.0 to 4.4.1
- bump @vue/test-utils from 2.4.6 to 2.4.9
- bump app patch version to 0.58.2

Supersedes #188 and #182.

#183 was closed separately because Vite 8 is incompatible with the current latest electron-vite peer range.

## Verification
- npm ci
- make ci
- make ci-package-linux