### PR TITLE
[codex] chore(release): bump version to 0.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.59.0",
+      "version": "0.59.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "author": "Bernt Popp <bernt.popp@gmail.com>",


### PR DESCRIPTION
## Summary
- bump package version from 0.59.0 to 0.59.1
- keep package-lock root metadata in sync

## Validation
- make ci