### PR TITLE
chore: bump version to 0.59.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.59.2",
+      "version": "0.59.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "author": "Bernt Popp <bernt.popp@gmail.com>",


### PR DESCRIPTION
## Summary
- Bump VarLens patch version from 0.59.2 to 0.59.3 after merging agent health guardrails.
- Update package-lock metadata to match package.json.

## Test Plan
- [x] make ci