### PR TITLE
refactor: reduce panels agent health baseline

### DIFF
--- a/scripts/agent-health-baseline.json
+++ b/scripts/agent-health-baseline.json
@@ -23,13 +23,6 @@
       "reason": "existing large storage/import module; must not grow before responsibility split"
     },
     {
-      "path": "src/main/ipc/handlers/panels.ts",
-      "lines": 614,
-      "threshold": 600,
-      "category": "source",
-      "reason": "existing legacy IPC handler surface; must not grow before domain extraction"
-    },
-    {
       "path": "src/main/storage/postgres/PostgresCohortRepository.ts",
       "lines": 957,
       "threshold": 600,

--- a/src/main/ipc/handlers/panels-session.ts
+++ b/src/main/ipc/handlers/panels-session.ts
@@ -1,0 +1,206 @@
+import { mainLogger } from '../../services/MainLogger'
+import type { GeneReferenceDb } from '../../database/GeneReferenceDb'
+import type { PanelAppPanel } from '../../services/api/PanelAppClient'
+import type { PanelAppClient } from '../../services/api/PanelAppClient'
+import type { StringDbClient } from '../../services/api/StringDbClient'
+import type { StorageSession } from '../../storage/session'
+import type { CreatePanelInput, PanelGeneRow, PanelRow } from '../../../shared/types/panels'
+import type { PanelCacheCallbacks } from './panels-logic'
+
+const GREEN_LEVELS = new Set(['3', '4', 'green'])
+const GREEN_AMBER_LEVELS = new Set(['2', '3', '4', 'green', 'amber'])
+
+interface ResolvedGene {
+  hgncId: string
+  symbol: string
+}
+
+interface ValidationResult {
+  status: string
+  hgncId?: string
+  symbol?: string
+  currentSymbol?: string
+}
+
+function resolveValidatedGenes(validationResults: ValidationResult[]): ResolvedGene[] {
+  const resolved: ResolvedGene[] = []
+  const seenHgnc = new Set<string>()
+
+  for (const result of validationResults) {
+    const hgncId = result.hgncId
+    const symbol =
+      result.status === 'approved'
+        ? result.symbol
+        : result.status === 'alias'
+          ? result.currentSymbol
+          : undefined
+
+    if (hgncId !== undefined && symbol !== undefined && !seenHgnc.has(hgncId)) {
+      seenHgnc.add(hgncId)
+      resolved.push({ hgncId, symbol })
+    }
+  }
+
+  return resolved
+}
+
+async function createPanelWithGenes(
+  session: StorageSession,
+  input: CreatePanelInput,
+  genes: ResolvedGene[],
+  callbacks: PanelCacheCallbacks
+): Promise<PanelRow & { genes: PanelGeneRow[] }> {
+  const createdPanel = (await session
+    .getWriteExecutor()
+    .execute({ type: 'panels:create', params: [input] })) as PanelRow
+
+  if (genes.length > 0) {
+    await session
+      .getWriteExecutor()
+      .execute({ type: 'panels:setGenes', params: [createdPanel.id, genes] })
+  }
+
+  const panelGenes = (await session
+    .getReadExecutor()
+    .execute({ type: 'panels:getGenes', params: [createdPanel.id] })) as PanelGeneRow[]
+
+  callbacks.clearPanelIntervalCache()
+  return { ...createdPanel, genes: panelGenes }
+}
+
+export async function importPanelAppForSession(
+  session: StorageSession,
+  params: {
+    panelId: number
+    region: 'uk' | 'aus'
+    confidenceThreshold: string
+    name?: string
+  },
+  geneRef: GeneReferenceDb,
+  client: PanelAppClient,
+  callbacks: PanelCacheCallbacks
+): Promise<PanelRow & { genes: PanelGeneRow[] }> {
+  const panel: PanelAppPanel = await client.getPanel(params.panelId, params.region)
+  const confidenceSet =
+    params.confidenceThreshold === 'green'
+      ? GREEN_LEVELS
+      : params.confidenceThreshold === 'green_amber'
+        ? GREEN_AMBER_LEVELS
+        : null
+  const filteredGenes =
+    confidenceSet === null
+      ? panel.genes
+      : panel.genes.filter((gene) => confidenceSet.has(gene.confidence_level))
+  const symbols = filteredGenes.map((gene) => gene.gene_data.gene_symbol)
+  const resolvedGenes = resolveValidatedGenes(geneRef.validateSymbols(symbols))
+  const source = params.region === 'uk' ? 'panelapp_uk' : 'panelapp_aus'
+
+  return createPanelWithGenes(
+    session,
+    {
+      name: params.name ?? `${panel.name} (PanelApp ${params.region.toUpperCase()})`,
+      description: `Imported from PanelApp ${params.region.toUpperCase()} v${panel.version}`,
+      version: panel.version,
+      source,
+      sourceId: String(params.panelId),
+      sourceMetadata: {
+        confidence_threshold: params.confidenceThreshold,
+        total_genes: panel.genes.length,
+        filtered_genes: filteredGenes.length,
+        resolved_genes: resolvedGenes.length,
+        panel_version: panel.version
+      }
+    },
+    resolvedGenes,
+    callbacks
+  )
+}
+
+export async function generateStringDbForSession(
+  session: StorageSession,
+  params: {
+    seedGenes: string[]
+    requiredScore: number
+    networkType: 'physical' | 'functional'
+    name?: string
+  },
+  geneRef: GeneReferenceDb,
+  client: StringDbClient,
+  callbacks: PanelCacheCallbacks
+): Promise<PanelRow & { genes: PanelGeneRow[] }> {
+  const partners = await client.getInteractionPartners(params.seedGenes, {
+    requiredScore: params.requiredScore,
+    networkType: params.networkType
+  })
+  const allSymbols = [...params.seedGenes, ...partners.map((partner) => partner.symbol)]
+  const resolvedGenes = resolveValidatedGenes(geneRef.validateSymbols(allSymbols))
+
+  return createPanelWithGenes(
+    session,
+    {
+      name:
+        params.name ??
+        `StringDB Network (${params.seedGenes.slice(0, 3).join(', ')}${
+          params.seedGenes.length > 3 ? '...' : ''
+        })`,
+      description: `Generated from StringDB ${params.networkType} network (score >= ${params.requiredScore})`,
+      source: 'stringdb',
+      sourceMetadata: {
+        seed_genes: params.seedGenes,
+        score_threshold: params.requiredScore,
+        network_type: params.networkType,
+        partners_found: partners.length
+      }
+    },
+    resolvedGenes,
+    callbacks
+  )
+}
+
+export async function generateBedContentForSession(
+  session: StorageSession,
+  panelId: number,
+  assembly: string,
+  paddingBp: number,
+  geneRef: GeneReferenceDb
+): Promise<{ lines: string[]; panelName: string; geneCount: number }> {
+  const panel = (await session.getReadExecutor().execute({
+    type: 'panels:get',
+    params: [panelId]
+  })) as PanelRow | null
+  if (panel === null) throw new Error(`Panel ${panelId} not found`)
+
+  const genes = (await session.getReadExecutor().execute({
+    type: 'panels:getGenes',
+    params: [panelId]
+  })) as PanelGeneRow[]
+  if (genes.length === 0) {
+    throw new Error('Panel has no genes to export')
+  }
+
+  const coordsMap = geneRef.getCoordinatesForGenes(
+    genes.map((gene) => gene.hgnc_id),
+    assembly
+  )
+  if (coordsMap.size === 0) {
+    throw new Error(`No coordinates found for assembly ${assembly}`)
+  }
+
+  const lines = [`track name="${panel.name}" description="Gene panel: ${panel.name}"`]
+  for (const gene of genes) {
+    const coords = coordsMap.get(gene.hgnc_id)
+    if (coords === undefined) continue
+
+    const chr = coords.chromosome.startsWith('chr') ? coords.chromosome : `chr${coords.chromosome}`
+    const bedStart = Math.max(0, coords.start_pos - 1 - paddingBp)
+    const bedEnd = coords.end_pos + paddingBp
+    lines.push(`${chr}\t${bedStart}\t${bedEnd}\t${gene.symbol}`)
+  }
+
+  mainLogger.info(
+    `Generated BED content for panel "${panel.name}" (${coordsMap.size} genes)`,
+    'panels'
+  )
+
+  return { lines, panelName: panel.name, geneCount: coordsMap.size }
+}

--- a/src/main/ipc/handlers/panels.ts
+++ b/src/main/ipc/handlers/panels.ts
@@ -43,207 +43,15 @@ import {
   generateBedContent
 } from './panels-logic'
 import type { PanelCacheCallbacks } from './panels-logic'
-import type { StorageSession } from '../../storage/session'
-import type { GeneReferenceDb } from '../../database/GeneReferenceDb'
-import type { CreatePanelInput, PanelGeneRow, PanelRow } from '../../../shared/types/panels'
-import type { PanelAppPanel } from '../../services/api/PanelAppClient'
+import {
+  importPanelAppForSession,
+  generateStringDbForSession,
+  generateBedContentForSession
+} from './panels-session'
 
 /** Shared cache-clearing callback wired to the variant module's interval cache. */
 const cacheCallbacks: PanelCacheCallbacks = {
   clearPanelIntervalCache: () => clearPanelIntervalCache()
-}
-
-const GREEN_LEVELS = new Set(['3', '4', 'green'])
-const GREEN_AMBER_LEVELS = new Set(['2', '3', '4', 'green', 'amber'])
-
-interface ResolvedGene {
-  hgncId: string
-  symbol: string
-}
-
-interface ValidationResult {
-  status: string
-  hgncId?: string
-  symbol?: string
-  currentSymbol?: string
-}
-
-function resolveValidatedGenes(validationResults: ValidationResult[]): ResolvedGene[] {
-  const resolved: ResolvedGene[] = []
-  const seenHgnc = new Set<string>()
-
-  for (const result of validationResults) {
-    const hgncId = result.hgncId
-    const symbol =
-      result.status === 'approved'
-        ? result.symbol
-        : result.status === 'alias'
-          ? result.currentSymbol
-          : undefined
-
-    if (hgncId !== undefined && symbol !== undefined && !seenHgnc.has(hgncId)) {
-      seenHgnc.add(hgncId)
-      resolved.push({ hgncId, symbol })
-    }
-  }
-
-  return resolved
-}
-
-async function createPanelWithGenes(
-  session: StorageSession,
-  input: CreatePanelInput,
-  genes: ResolvedGene[]
-): Promise<PanelRow & { genes: PanelGeneRow[] }> {
-  const createdPanel = (await session
-    .getWriteExecutor()
-    .execute({ type: 'panels:create', params: [input] })) as PanelRow
-
-  if (genes.length > 0) {
-    await session
-      .getWriteExecutor()
-      .execute({ type: 'panels:setGenes', params: [createdPanel.id, genes] })
-  }
-
-  const panelGenes = (await session
-    .getReadExecutor()
-    .execute({ type: 'panels:getGenes', params: [createdPanel.id] })) as PanelGeneRow[]
-
-  cacheCallbacks.clearPanelIntervalCache()
-  return { ...createdPanel, genes: panelGenes }
-}
-
-async function importPanelAppForSession(
-  session: StorageSession,
-  params: {
-    panelId: number
-    region: 'uk' | 'aus'
-    confidenceThreshold: string
-    name?: string
-  },
-  geneRef: GeneReferenceDb,
-  client: PanelAppClient
-): Promise<PanelRow & { genes: PanelGeneRow[] }> {
-  const panel: PanelAppPanel = await client.getPanel(params.panelId, params.region)
-  const confidenceSet =
-    params.confidenceThreshold === 'green'
-      ? GREEN_LEVELS
-      : params.confidenceThreshold === 'green_amber'
-        ? GREEN_AMBER_LEVELS
-        : null
-  const filteredGenes =
-    confidenceSet === null
-      ? panel.genes
-      : panel.genes.filter((gene) => confidenceSet.has(gene.confidence_level))
-  const symbols = filteredGenes.map((gene) => gene.gene_data.gene_symbol)
-  const resolvedGenes = resolveValidatedGenes(geneRef.validateSymbols(symbols))
-  const source = params.region === 'uk' ? 'panelapp_uk' : 'panelapp_aus'
-
-  return createPanelWithGenes(
-    session,
-    {
-      name: params.name ?? `${panel.name} (PanelApp ${params.region.toUpperCase()})`,
-      description: `Imported from PanelApp ${params.region.toUpperCase()} v${panel.version}`,
-      version: panel.version,
-      source,
-      sourceId: String(params.panelId),
-      sourceMetadata: {
-        confidence_threshold: params.confidenceThreshold,
-        total_genes: panel.genes.length,
-        filtered_genes: filteredGenes.length,
-        resolved_genes: resolvedGenes.length,
-        panel_version: panel.version
-      }
-    },
-    resolvedGenes
-  )
-}
-
-async function generateStringDbForSession(
-  session: StorageSession,
-  params: {
-    seedGenes: string[]
-    requiredScore: number
-    networkType: 'physical' | 'functional'
-    name?: string
-  },
-  geneRef: GeneReferenceDb,
-  client: StringDbClient
-): Promise<PanelRow & { genes: PanelGeneRow[] }> {
-  const partners = await client.getInteractionPartners(params.seedGenes, {
-    requiredScore: params.requiredScore,
-    networkType: params.networkType
-  })
-  const allSymbols = [...params.seedGenes, ...partners.map((partner) => partner.symbol)]
-  const resolvedGenes = resolveValidatedGenes(geneRef.validateSymbols(allSymbols))
-
-  return createPanelWithGenes(
-    session,
-    {
-      name:
-        params.name ??
-        `StringDB Network (${params.seedGenes.slice(0, 3).join(', ')}${
-          params.seedGenes.length > 3 ? '...' : ''
-        })`,
-      description: `Generated from StringDB ${params.networkType} network (score >= ${params.requiredScore})`,
-      source: 'stringdb',
-      sourceMetadata: {
-        seed_genes: params.seedGenes,
-        score_threshold: params.requiredScore,
-        network_type: params.networkType,
-        partners_found: partners.length
-      }
-    },
-    resolvedGenes
-  )
-}
-
-async function generateBedContentForSession(
-  session: StorageSession,
-  panelId: number,
-  assembly: string,
-  paddingBp: number,
-  geneRef: GeneReferenceDb
-): Promise<{ lines: string[]; panelName: string; geneCount: number }> {
-  const panel = (await session.getReadExecutor().execute({
-    type: 'panels:get',
-    params: [panelId]
-  })) as PanelRow | null
-  if (panel === null) throw new Error(`Panel ${panelId} not found`)
-
-  const genes = (await session.getReadExecutor().execute({
-    type: 'panels:getGenes',
-    params: [panelId]
-  })) as PanelGeneRow[]
-  if (genes.length === 0) {
-    throw new Error('Panel has no genes to export')
-  }
-
-  const coordsMap = geneRef.getCoordinatesForGenes(
-    genes.map((gene) => gene.hgnc_id),
-    assembly
-  )
-  if (coordsMap.size === 0) {
-    throw new Error(`No coordinates found for assembly ${assembly}`)
-  }
-
-  const lines = [`track name="${panel.name}" description="Gene panel: ${panel.name}"`]
-  for (const gene of genes) {
-    const coords = coordsMap.get(gene.hgnc_id)
-    if (coords === undefined) continue
-
-    const chr = coords.chromosome.startsWith('chr') ? coords.chromosome : `chr${coords.chromosome}`
-    const bedStart = Math.max(0, coords.start_pos - 1 - paddingBp)
-    const bedEnd = coords.end_pos + paddingBp
-    lines.push(`${chr}\t${bedStart}\t${bedEnd}\t${gene.symbol}`)
-  }
-
-  mainLogger.info(
-    `Generated BED content for panel "${panel.name}" (${coordsMap.size} genes)`,
-    'panels'
-  )
-
-  return { lines, panelName: panel.name, geneCount: coordsMap.size }
 }
 
 /**
@@ -538,7 +346,7 @@ export function registerPanelHandlers({ ipcMain, getDb, getDbManager }: HandlerD
       const geneRef = getGeneReferenceDb()
       const session = getDbManager().getCurrentSession()
       if (session.capabilities.backend === 'postgres') {
-        return importPanelAppForSession(session, validated.data, geneRef, client)
+        return importPanelAppForSession(session, validated.data, geneRef, client, cacheCallbacks)
       }
       return importPanelApp(validated.data, getDb, geneRef, client, cacheCallbacks)
     })
@@ -558,7 +366,7 @@ export function registerPanelHandlers({ ipcMain, getDb, getDbManager }: HandlerD
       const geneRef = getGeneReferenceDb()
       const session = getDbManager().getCurrentSession()
       if (session.capabilities.backend === 'postgres') {
-        return generateStringDbForSession(session, validated.data, geneRef, client)
+        return generateStringDbForSession(session, validated.data, geneRef, client, cacheCallbacks)
       }
       return generateStringDb(validated.data, getDb, geneRef, client, cacheCallbacks)
     })

--- a/tests/main/handlers/panels-session.test.ts
+++ b/tests/main/handlers/panels-session.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  generateBedContentForSession,
+  generateStringDbForSession,
+  importPanelAppForSession
+} from '../../../src/main/ipc/handlers/panels-session'
+import type { GeneReferenceDb } from '../../../src/main/database/GeneReferenceDb'
+import type { StorageSession } from '../../../src/main/storage/session'
+import type { PanelAppClient } from '../../../src/main/services/api/PanelAppClient'
+import type { StringDbClient } from '../../../src/main/services/api/StringDbClient'
+
+function createSession(writeExecute = vi.fn(), readExecute = vi.fn()): StorageSession {
+  return {
+    getWriteExecutor: () => ({ execute: writeExecute }),
+    getReadExecutor: () => ({ execute: readExecute })
+  } as unknown as StorageSession
+}
+
+describe('panels session helpers', () => {
+  it('imports a PanelApp panel through storage session executors', async () => {
+    const writeExecute = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 7, name: 'Inherited cancer' })
+      .mockResolvedValueOnce(undefined)
+    const readExecute = vi.fn().mockResolvedValueOnce([{ hgnc_id: 'HGNC:1100', symbol: 'BRCA1' }])
+    const geneRef = {
+      validateSymbols: vi.fn().mockReturnValue([
+        {
+          status: 'approved',
+          hgncId: 'HGNC:1100',
+          symbol: 'BRCA1'
+        }
+      ])
+    } as unknown as GeneReferenceDb
+    const client = {
+      getPanel: vi.fn().mockResolvedValue({
+        name: 'Inherited cancer',
+        version: '1.2',
+        genes: [
+          { confidence_level: '3', gene_data: { gene_symbol: 'BRCA1' } },
+          { confidence_level: '1', gene_data: { gene_symbol: 'LOWCONF' } }
+        ]
+      })
+    } as unknown as PanelAppClient
+    const callbacks = { clearPanelIntervalCache: vi.fn() }
+
+    const result = await importPanelAppForSession(
+      createSession(writeExecute, readExecute),
+      { panelId: 42, region: 'uk', confidenceThreshold: 'green' },
+      geneRef,
+      client,
+      callbacks
+    )
+
+    expect(client.getPanel).toHaveBeenCalledWith(42, 'uk')
+    expect(geneRef.validateSymbols).toHaveBeenCalledWith(['BRCA1'])
+    expect(writeExecute).toHaveBeenNthCalledWith(1, {
+      type: 'panels:create',
+      params: [
+        expect.objectContaining({
+          name: 'Inherited cancer (PanelApp UK)',
+          version: '1.2',
+          source: 'panelapp_uk',
+          sourceId: '42',
+          sourceMetadata: expect.objectContaining({
+            total_genes: 2,
+            filtered_genes: 1,
+            resolved_genes: 1
+          })
+        })
+      ]
+    })
+    expect(writeExecute).toHaveBeenNthCalledWith(2, {
+      type: 'panels:setGenes',
+      params: [7, [{ hgncId: 'HGNC:1100', symbol: 'BRCA1' }]]
+    })
+    expect(readExecute).toHaveBeenCalledWith({ type: 'panels:getGenes', params: [7] })
+    expect(callbacks.clearPanelIntervalCache).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      id: 7,
+      name: 'Inherited cancer',
+      genes: [{ hgnc_id: 'HGNC:1100', symbol: 'BRCA1' }]
+    })
+  })
+
+  it('generates a StringDB panel through storage session executors', async () => {
+    const writeExecute = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 9, name: 'Custom network' })
+      .mockResolvedValueOnce(undefined)
+    const readExecute = vi.fn().mockResolvedValueOnce([
+      { hgnc_id: 'HGNC:1100', symbol: 'BRCA1' },
+      { hgnc_id: 'HGNC:1101', symbol: 'BRCA2' }
+    ])
+    const geneRef = {
+      validateSymbols: vi.fn().mockReturnValue([
+        { status: 'approved', hgncId: 'HGNC:1100', symbol: 'BRCA1' },
+        { status: 'alias', hgncId: 'HGNC:1101', currentSymbol: 'BRCA2' },
+        { status: 'approved', hgncId: 'HGNC:1100', symbol: 'BRCA1' }
+      ])
+    } as unknown as GeneReferenceDb
+    const client = {
+      getInteractionPartners: vi.fn().mockResolvedValue([{ symbol: 'BRCA2' }])
+    } as unknown as StringDbClient
+    const callbacks = { clearPanelIntervalCache: vi.fn() }
+
+    const result = await generateStringDbForSession(
+      createSession(writeExecute, readExecute),
+      {
+        seedGenes: ['BRCA1'],
+        requiredScore: 700,
+        networkType: 'physical',
+        name: 'Custom network'
+      },
+      geneRef,
+      client,
+      callbacks
+    )
+
+    expect(client.getInteractionPartners).toHaveBeenCalledWith(['BRCA1'], {
+      requiredScore: 700,
+      networkType: 'physical'
+    })
+    expect(geneRef.validateSymbols).toHaveBeenCalledWith(['BRCA1', 'BRCA2'])
+    expect(writeExecute).toHaveBeenNthCalledWith(1, {
+      type: 'panels:create',
+      params: [
+        expect.objectContaining({
+          name: 'Custom network',
+          source: 'stringdb',
+          sourceMetadata: expect.objectContaining({
+            seed_genes: ['BRCA1'],
+            score_threshold: 700,
+            network_type: 'physical',
+            partners_found: 1
+          })
+        })
+      ]
+    })
+    expect(writeExecute).toHaveBeenNthCalledWith(2, {
+      type: 'panels:setGenes',
+      params: [
+        9,
+        [
+          { hgncId: 'HGNC:1100', symbol: 'BRCA1' },
+          { hgncId: 'HGNC:1101', symbol: 'BRCA2' }
+        ]
+      ]
+    })
+    expect(readExecute).toHaveBeenCalledWith({ type: 'panels:getGenes', params: [9] })
+    expect(callbacks.clearPanelIntervalCache).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      id: 9,
+      name: 'Custom network',
+      genes: [
+        { hgnc_id: 'HGNC:1100', symbol: 'BRCA1' },
+        { hgnc_id: 'HGNC:1101', symbol: 'BRCA2' }
+      ]
+    })
+  })
+
+  it('generates BED content from storage session reads', async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 1, name: 'Cancer Panel' })
+      .mockResolvedValueOnce([{ hgnc_id: 'HGNC:1100', symbol: 'BRCA1' }])
+
+    const geneRef = {
+      getCoordinatesForGenes: vi.fn().mockReturnValue(
+        new Map([
+          [
+            'HGNC:1100',
+            {
+              chromosome: '17',
+              start_pos: 43044295,
+              end_pos: 43125483
+            }
+          ]
+        ])
+      )
+    } as unknown as GeneReferenceDb
+
+    const result = await generateBedContentForSession(
+      createSession(vi.fn(), execute),
+      1,
+      'GRCh38',
+      100,
+      geneRef
+    )
+
+    expect(execute).toHaveBeenNthCalledWith(1, { type: 'panels:get', params: [1] })
+    expect(execute).toHaveBeenNthCalledWith(2, { type: 'panels:getGenes', params: [1] })
+    expect(geneRef.getCoordinatesForGenes).toHaveBeenCalledWith(['HGNC:1100'], 'GRCh38')
+    expect(result).toEqual({
+      lines: [
+        'track name="Cancer Panel" description="Gene panel: Cancer Panel"',
+        'chr17\t43044194\t43125583\tBRCA1'
+      ],
+      panelName: 'Cancer Panel',
+      geneCount: 1
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Extract PostgreSQL/storage-session panel helper logic from `src/main/ipc/handlers/panels.ts` into `src/main/ipc/handlers/panels-session.ts`.
- Keep IPC registration, schema validation, Electron BED dialog/write behavior, and SQLite `panels-logic` path unchanged.
- Add focused mocked-session tests for PanelApp import, StringDB generation, and BED content generation.
- Remove `src/main/ipc/handlers/panels.ts` from `scripts/agent-health-baseline.json` after reducing it below 600 LOC.

## Agent-health baseline

- Before this batch: 23 baseline oversized source files, 6 report-only oversized test files.
- After this batch: 22 baseline oversized source files, 6 report-only oversized test files.
- `src/main/ipc/handlers/panels.ts`: 614 LOC -> 422 LOC.

## Verification

- Red test observed first: `npx vitest run tests/main/handlers/panels-session.test.ts` failed because `panels-session` did not exist.
- `npx vitest run tests/main/handlers/panels-session.test.ts tests/main/handlers/panels-logic.test.ts tests/shared/ipc/domains/panels.test.ts`
- `npx vitest run tests/main/storage/postgres-panels-repository.test.ts tests/main/storage/postgres-read-executor.test.ts tests/main/storage/postgres-write-executor.test.ts`
- `npm run typecheck:node`
- `make agent-check`
- `make ci` (324 test files passed, 4 skipped; 3572 tests passed, 29 skipped)

Stacked on #211 because #211 is open and not merged yet.
