### PR TITLE
web 01: add shared contracts and storage seams

### DIFF
--- a/src/main/ipc/dbPoolManager.ts
+++ b/src/main/ipc/dbPoolManager.ts
@@ -12,9 +12,15 @@ import type { StorageSession } from '../storage/session'
 let dbPool: DbPool | null = null
 type DbPoolSource = {
   capabilities: Pick<StorageSession['capabilities'], 'backend'>
-  getDbPool: StorageSession['getDbPool']
+  // Concrete-class method on SqliteStorageSession; no longer on the
+  // sealed StorageSession interface (see src/main/storage/session.ts).
+  getDbPool(): DbPool | null
 }
-let getActiveSession: (() => DbPoolSource | null) | null = null
+let getActiveSession: (() => StorageSession | null) | null = null
+
+function hasDbPoolSource(session: StorageSession): session is StorageSession & DbPoolSource {
+  return 'getDbPool' in session && typeof session.getDbPool === 'function'
+}
 
 /**
  * User-configured worker thread count.
@@ -33,7 +39,8 @@ export function getDbPool(): DbPool | null {
     return null
   }
 
-  const sessionPool = activeSession?.getDbPool() ?? null
+  const sessionPool =
+    activeSession !== null && hasDbPoolSource(activeSession) ? activeSession.getDbPool() : null
   if (sessionPool !== null) {
     return sessionPool
   }
@@ -41,7 +48,7 @@ export function getDbPool(): DbPool | null {
   return dbPool
 }
 
-export function setActiveSessionResolver(resolver: () => DbPoolSource | null): void {
+export function setActiveSessionResolver(resolver: () => StorageSession | null): void {
   getActiveSession = resolver
 }
 

--- a/src/main/ipc/handlers/annotations.ts
+++ b/src/main/ipc/handlers/annotations.ts
@@ -2,17 +2,15 @@ import { BrowserWindow } from 'electron'
 import { z } from 'zod'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
+import { CaseIdSchema } from '../../../shared/types/ipc-schemas'
 import {
   VariantCoordsSchema,
   GlobalAnnotationUpdatesSchema,
   PerCaseAnnotationUpdatesSchema,
-  CaseVariantIdSchema,
-  CaseIdSchema
-} from '../../../shared/types/ipc-schemas'
+  CaseVariantIdSchema
+} from '../../../shared/api/schemas/annotations'
 import { mainLogger } from '../../services/MainLogger'
 import type { AnnotationChangeEvent } from '../../../shared/types/api'
-import type { AuditAppendParams } from '../../storage/audit-log-types'
-import type { StorageWriteExecutor } from '../../storage/write-executor'
 import {
   getGlobalAnnotation,
   upsertGlobalAnnotation,
@@ -54,88 +52,6 @@ function detectAnnotationChangeKind(updates: {
   if (updates.acmg_classification !== undefined) return 'acmg'
   if (updates.acmg_evidence !== undefined) return 'evidence'
   return 'comment'
-}
-
-async function appendAuditEntries(
-  writeExecutor: StorageWriteExecutor,
-  entries: AuditAppendParams[]
-): Promise<void> {
-  for (const entry of entries) {
-    await writeExecutor.execute({ type: 'audit:append', params: [entry] })
-  }
-}
-
-function globalAuditEntries(
-  coords: { chr: string; pos: number; ref: string; alt: string },
-  updates: {
-    user_name?: string | null
-    starred?: boolean
-    acmg_classification?: unknown
-    acmg_evidence?: unknown
-  },
-  oldAnnotation: Record<string, unknown> | null
-): AuditAppendParams[] {
-  const entityKey = `${coords.chr}:${coords.pos}:${coords.ref}:${coords.alt}`
-  const entries: AuditAppendParams[] = []
-  if (updates.acmg_classification !== undefined) {
-    entries.push({
-      action_type: 'acmg_classify',
-      entity_type: 'variant_annotation',
-      entity_key: entityKey,
-      old_value:
-        oldAnnotation === null
-          ? null
-          : JSON.stringify({ acmg_classification: oldAnnotation.acmg_classification }),
-      new_value: JSON.stringify({ acmg_classification: updates.acmg_classification }),
-      user_name: updates.user_name ?? null
-    })
-  }
-  if (updates.acmg_evidence !== undefined) {
-    entries.push({
-      action_type: 'acmg_evidence_update',
-      entity_type: 'variant_annotation',
-      entity_key: entityKey,
-      old_value:
-        oldAnnotation === null
-          ? null
-          : JSON.stringify({ acmg_evidence: oldAnnotation.acmg_evidence }),
-      new_value: JSON.stringify({ acmg_evidence: updates.acmg_evidence }),
-      user_name: updates.user_name ?? null
-    })
-  }
-  if (updates.starred !== undefined) {
-    entries.push({
-      action_type: updates.starred ? 'star' : 'unstar',
-      entity_type: 'variant_annotation',
-      entity_key: entityKey,
-      old_value: oldAnnotation === null ? null : JSON.stringify({ starred: oldAnnotation.starred }),
-      new_value: JSON.stringify({ starred: updates.starred ? 1 : 0 }),
-      user_name: updates.user_name ?? null
-    })
-  }
-  return entries
-}
-
-function perCaseAuditEntries(
-  caseId: number,
-  variantId: number,
-  updates: {
-    user_name?: string | null
-    starred?: boolean
-    acmg_classification?: unknown
-    acmg_evidence?: unknown
-  },
-  oldAnnotation: Record<string, unknown> | null
-): AuditAppendParams[] {
-  return globalAuditEntries(
-    { chr: 'case', pos: caseId, ref: 'variant', alt: String(variantId) },
-    updates,
-    oldAnnotation
-  ).map((entry) => ({
-    ...entry,
-    entity_type: 'case_variant_annotation',
-    entity_key: `case:${caseId}:variant:${variantId}`
-  }))
 }
 
 /**
@@ -206,21 +122,10 @@ export function registerAnnotationHandlers({
 
         const session = getDbManager().getCurrentSession()
         if (session.capabilities.backend === 'postgres') {
-          const readExecutor = session.getReadExecutor()
-          const writeExecutor = session.getWriteExecutor()
-          const oldAnnotation = (await readExecutor.execute({
-            type: 'annotations:getGlobal',
-            params: [validatedCoords.data]
-          })) as Record<string, unknown> | null
-          const result = await writeExecutor.execute({
-            type: 'annotations:upsertGlobal',
+          return await session.getWriteExecutor().execute({
+            type: 'annotations:upsertGlobalWithAudit',
             params: [validatedCoords.data, validatedUpdates.data]
           })
-          await appendAuditEntries(
-            writeExecutor,
-            globalAuditEntries(validatedCoords.data, validatedUpdates.data, oldAnnotation)
-          )
-          return result
         }
         return upsertGlobalAnnotation(validatedCoords.data, validatedUpdates.data, getDb)
       })
@@ -313,25 +218,10 @@ export function registerAnnotationHandlers({
         const session = getDbManager().getCurrentSession()
         let result: unknown
         if (session.capabilities.backend === 'postgres') {
-          const readExecutor = session.getReadExecutor()
-          const writeExecutor = session.getWriteExecutor()
-          const oldAnnotation = (await readExecutor.execute({
-            type: 'annotations:getPerCase',
-            params: [validatedIds.data.caseId, validatedIds.data.variantId]
-          })) as Record<string, unknown> | null
-          result = await writeExecutor.execute({
-            type: 'annotations:upsertPerCase',
+          result = await session.getWriteExecutor().execute({
+            type: 'annotations:upsertPerCaseWithAudit',
             params: [validatedIds.data.caseId, validatedIds.data.variantId, validatedUpdates.data]
           })
-          await appendAuditEntries(
-            writeExecutor,
-            perCaseAuditEntries(
-              validatedIds.data.caseId,
-              validatedIds.data.variantId,
-              validatedUpdates.data,
-              oldAnnotation
-            )
-          )
         } else {
           result = upsertPerCaseAnnotation(
             validatedIds.data.caseId,

--- a/src/main/ipc/handlers/case-comments.ts
+++ b/src/main/ipc/handlers/case-comments.ts
@@ -1,34 +1,12 @@
-import { z } from 'zod'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
-import { CaseIdSchema } from '../../../shared/types/ipc-schemas'
+import {
+  CaseCommentCaseIdSchema,
+  CaseCommentIdSchema,
+  CommentCreateSchema,
+  CommentUpdateSchema
+} from '../../../shared/api/schemas/case-comments'
 import { mainLogger } from '../../services/MainLogger'
-
-// ============================================================
-// Inline Zod Schemas for Case Comments
-// ============================================================
-
-const CommentIdSchema = z.number().int().positive()
-
-const CommentCategorySchema = z.enum([
-  'Clinical Note',
-  'Lab Result',
-  'Interpretation',
-  'Follow-up',
-  'Family History',
-  'Treatment'
-])
-
-const CommentCreateSchema = z.object({
-  caseId: CaseIdSchema,
-  category: CommentCategorySchema,
-  content: z.string().min(1)
-})
-
-const CommentUpdateSchema = z.object({
-  commentId: CommentIdSchema,
-  content: z.string().min(1)
-})
 
 /**
  * Case Comments IPC handlers
@@ -44,7 +22,7 @@ export function registerCaseCommentHandlers({
   ipcMain.handle('case-comments:list', async (_event, caseId: unknown) => {
     return wrapHandler(async () => {
       // ANTI-07: Runtime validation at IPC boundary
-      const validated = CaseIdSchema.safeParse(caseId)
+      const validated = CaseCommentCaseIdSchema.safeParse(caseId)
       if (!validated.success) {
         mainLogger.error(
           `Invalid case-comments:list params: ${validated.error.message}`,
@@ -119,7 +97,7 @@ export function registerCaseCommentHandlers({
   ipcMain.handle('case-comments:delete', async (_event, commentId: unknown) => {
     return wrapHandler(async () => {
       // ANTI-07: Runtime validation at IPC boundary
-      const validated = CommentIdSchema.safeParse(commentId)
+      const validated = CaseCommentIdSchema.safeParse(commentId)
       if (!validated.success) {
         mainLogger.error(
           `Invalid case-comments:delete params: ${validated.error.message}`,

--- a/src/main/ipc/handlers/case-metrics.ts
+++ b/src/main/ipc/handlers/case-metrics.ts
@@ -1,38 +1,12 @@
-import { z } from 'zod'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
-import { CaseIdSchema } from '../../../shared/types/ipc-schemas'
+import {
+  CaseMetricCaseIdSchema,
+  MetricDefinitionCreateSchema,
+  MetricDeleteSchema,
+  MetricUpsertSchema
+} from '../../../shared/api/schemas/case-metrics'
 import { mainLogger } from '../../services/MainLogger'
-
-// ============================================================
-// Inline Zod Schemas for Case Metrics
-// ============================================================
-
-const MetricIdSchema = z.number().int().positive()
-
-const MetricDefinitionCreateSchema = z.object({
-  name: z.string().min(1).max(200),
-  valueType: z.enum(['numeric', 'text', 'date']),
-  unit: z.string(),
-  category: z.string().min(1)
-})
-
-const MetricValueSchema = z.object({
-  numeric_value: z.number().nullish(),
-  text_value: z.string().nullish(),
-  date_value: z.string().nullish()
-})
-
-const MetricUpsertSchema = z.object({
-  caseId: CaseIdSchema,
-  metricId: MetricIdSchema,
-  value: MetricValueSchema
-})
-
-const MetricDeleteSchema = z.object({
-  caseId: CaseIdSchema,
-  metricId: MetricIdSchema
-})
 
 /**
  * Case Metrics IPC handlers
@@ -101,7 +75,7 @@ export function registerCaseMetricHandlers({
   ipcMain.handle('case-metrics:listForCase', async (_event, caseId: unknown) => {
     return wrapHandler(async () => {
       // ANTI-07: Runtime validation at IPC boundary
-      const validated = CaseIdSchema.safeParse(caseId)
+      const validated = CaseMetricCaseIdSchema.safeParse(caseId)
       if (!validated.success) {
         mainLogger.error(
           `Invalid case-metrics:listForCase params: ${validated.error.message}`,

--- a/src/main/ipc/handlers/cases-logic.ts
+++ b/src/main/ipc/handlers/cases-logic.ts
@@ -95,7 +95,7 @@ export async function queryCases(
 ): Promise<unknown> {
   const task: StorageReadTask = {
     type: 'cases:query',
-    params
+    params: [params]
   }
 
   return await getSession().getReadExecutor().execute(task)

--- a/src/main/ipc/handlers/cohort-logic.ts
+++ b/src/main/ipc/handlers/cohort-logic.ts
@@ -357,8 +357,14 @@ export function cancelGeneBurdenCompare(): void {
  */
 export async function getSummaryStatus(
   getDb: () => DatabaseService,
-  getDbPool?: () => DbPool | null
+  getDbPool?: () => DbPool | null,
+  getSession?: GetSession
 ): Promise<unknown> {
+  const postgresSession = getPostgresSession(getSession)
+  if (postgresSession !== undefined) {
+    return { is_stale: false, last_rebuilt_at: 0 }
+  }
+
   const pool = getDbPool?.()
   if (pool) {
     return await pool.run({ type: 'cohort:summaryStatus', params: [] })

--- a/src/main/ipc/handlers/cohort.ts
+++ b/src/main/ipc/handlers/cohort.ts
@@ -138,7 +138,7 @@ export function registerCohortHandlers({
   // Summary status
   ipcMain.handle('cohort:summaryStatus', async () => {
     return wrapHandler(async () => {
-      return getSummaryStatus(getDb, getDbPool)
+      return getSummaryStatus(getDb, getDbPool, getSession)
     })
   })
 

--- a/src/main/ipc/handlers/export.ts
+++ b/src/main/ipc/handlers/export.ts
@@ -1,13 +1,14 @@
-import { z } from 'zod'
 import { dialog, BrowserWindow } from 'electron'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
 import {
-  CaseIdSchema,
-  VariantFilterPartialSchema,
-  CohortSearchParamsSchema
-} from '../../../shared/types/ipc-schemas'
+  CohortSearchParamsSchema,
+  VariantExportParamsSchema
+} from '../../../shared/api/schemas/export'
 import { safeEmit } from '../utils/safeEmit'
 import {
   prepareVariantExport,
@@ -18,12 +19,15 @@ import {
 } from './export-logic'
 import type { ExportCallbacks } from './export-logic'
 
-/** Schema for variant export parameters */
-const VariantExportParamsSchema = z.object({
-  caseId: CaseIdSchema,
-  filters: VariantFilterPartialSchema,
-  caseName: z.string().min(1).max(500)
-})
+const AUTOMATED_EXPORT_DIR_ENV = 'VARLENS_AUTOMATED_EXPORT_DIR'
+
+function automatedExportPath(defaultFileName: string): string | null {
+  const dir = process.env[AUTOMATED_EXPORT_DIR_ENV]
+  if (dir === undefined || dir.trim() === '') return null
+  mkdirSync(dir, { recursive: true })
+  const safeName = defaultFileName.replace(/[^a-zA-Z0-9._-]/g, '_')
+  return join(dir, `${randomUUID()}-${safeName}`)
+}
 
 /**
  * Export IPC handlers
@@ -67,36 +71,39 @@ export function registerExportHandlers({
           return preparation
         }
 
+        const defaultFileName = `${validated.data.caseName.replace(/[^a-z0-9]/gi, '_')}_variants.${isPostgres ? 'csv' : 'xlsx'}`
+        let outputFilePath = automatedExportPath(defaultFileName)
         const mainWindow = BrowserWindow.getAllWindows()[0]
 
-        if (mainWindow === undefined || mainWindow.isDestroyed()) {
-          return { success: false, error: 'No window available for export dialog' }
-        }
+        if (outputFilePath === null) {
+          if (mainWindow === undefined || mainWindow.isDestroyed()) {
+            return { success: false, error: 'No window available for export dialog' }
+          }
 
-        // Show save dialog
-        const defaultFileName = `${validated.data.caseName.replace(/[^a-z0-9]/gi, '_')}_variants.${isPostgres ? 'csv' : 'xlsx'}`
-        const result = await dialog.showSaveDialog(mainWindow, {
-          title: isPostgres ? 'Export Variants to CSV' : 'Export Variants to Excel',
-          defaultPath: defaultFileName,
-          filters: isPostgres
-            ? [
-                { name: 'CSV Files', extensions: ['csv'] },
-                { name: 'All Files', extensions: ['*'] }
-              ]
-            : [
-                { name: 'Excel Files', extensions: ['xlsx'] },
-                { name: 'All Files', extensions: ['*'] }
-              ]
-        })
+          const result = await dialog.showSaveDialog(mainWindow, {
+            title: isPostgres ? 'Export Variants to CSV' : 'Export Variants to Excel',
+            defaultPath: defaultFileName,
+            filters: isPostgres
+              ? [
+                  { name: 'CSV Files', extensions: ['csv'] },
+                  { name: 'All Files', extensions: ['*'] }
+                ]
+              : [
+                  { name: 'Excel Files', extensions: ['xlsx'] },
+                  { name: 'All Files', extensions: ['*'] }
+                ]
+          })
 
-        if (result.canceled === true || result.filePath === undefined || result.filePath === '') {
-          return { success: false, error: 'Export cancelled' }
+          if (result.canceled === true || result.filePath === undefined || result.filePath === '') {
+            return { success: false, error: 'Export cancelled' }
+          }
+          outputFilePath = result.filePath
         }
 
         /** Wire progress events to renderer via safeEmit. */
         const exportCallbacks: ExportCallbacks = {
           onProgress: (data) => {
-            if (!mainWindow.isDestroyed()) {
+            if (mainWindow !== undefined && !mainWindow.isDestroyed()) {
               safeEmit('export:progress', data)
             }
           }
@@ -112,7 +119,7 @@ export function registerExportHandlers({
               }
             ]
           })) as AsyncIterable<Record<string, unknown>>
-          return await exportPostgresVariants(rows, result.filePath, exportCallbacks)
+          return await exportPostgresVariants(rows, outputFilePath, exportCallbacks)
         }
 
         if (preparation === null) {
@@ -124,7 +131,7 @@ export function registerExportHandlers({
           preparation.compiled,
           validated.data.filters,
           validated.data.caseName,
-          result.filePath,
+          outputFilePath,
           exportCallbacks
         )
       }) as Promise<{ success: boolean; filePath?: string; error?: string }>
@@ -151,41 +158,43 @@ export function registerExportHandlers({
         )
         const session = getDbManager().getCurrentSession()
         const isPostgres = session.capabilities.backend === 'postgres'
+        const defaultFileName = `cohort_variants_${new Date().toISOString().slice(0, 10)}.${isPostgres ? 'csv' : 'xlsx'}`
+        let outputFilePath = automatedExportPath(defaultFileName)
         const mainWindow = BrowserWindow.getAllWindows()[0]
 
-        // Check for valid window before showing dialog
-        if (mainWindow === undefined || mainWindow.isDestroyed()) {
-          mainLogger.warn(
-            'Window closed before cohort export dialog, cannot show save dialog',
-            'export'
-          )
-          return { success: false, error: 'No window available for export dialog' }
-        }
+        if (outputFilePath === null) {
+          if (mainWindow === undefined || mainWindow.isDestroyed()) {
+            mainLogger.warn(
+              'Window closed before cohort export dialog, cannot show save dialog',
+              'export'
+            )
+            return { success: false, error: 'No window available for export dialog' }
+          }
 
-        // Show save dialog
-        const defaultFileName = `cohort_variants_${new Date().toISOString().slice(0, 10)}.${isPostgres ? 'csv' : 'xlsx'}`
-        const result = await dialog.showSaveDialog(mainWindow, {
-          title: isPostgres ? 'Export Cohort Variants to CSV' : 'Export Cohort Variants to Excel',
-          defaultPath: defaultFileName,
-          filters: isPostgres
-            ? [
-                { name: 'CSV Files', extensions: ['csv'] },
-                { name: 'All Files', extensions: ['*'] }
-              ]
-            : [
-                { name: 'Excel Files', extensions: ['xlsx'] },
-                { name: 'All Files', extensions: ['*'] }
-              ]
-        })
+          const result = await dialog.showSaveDialog(mainWindow, {
+            title: isPostgres ? 'Export Cohort Variants to CSV' : 'Export Cohort Variants to Excel',
+            defaultPath: defaultFileName,
+            filters: isPostgres
+              ? [
+                  { name: 'CSV Files', extensions: ['csv'] },
+                  { name: 'All Files', extensions: ['*'] }
+                ]
+              : [
+                  { name: 'Excel Files', extensions: ['xlsx'] },
+                  { name: 'All Files', extensions: ['*'] }
+                ]
+          })
 
-        if (result.canceled === true || result.filePath === undefined || result.filePath === '') {
-          return { success: false, error: 'Export cancelled' }
+          if (result.canceled === true || result.filePath === undefined || result.filePath === '') {
+            return { success: false, error: 'Export cancelled' }
+          }
+          outputFilePath = result.filePath
         }
 
         /** Wire progress events to renderer via safeEmit. */
         const exportCallbacks: ExportCallbacks = {
           onProgress: (data) => {
-            if (!mainWindow.isDestroyed()) {
+            if (mainWindow !== undefined && !mainWindow.isDestroyed()) {
               safeEmit('export:progress', data)
             }
           }
@@ -196,10 +205,10 @@ export function registerExportHandlers({
             type: 'export:cohort',
             params: [validated.data]
           })) as AsyncIterable<Record<string, unknown>>
-          return await exportPostgresCohort(rows, result.filePath, exportCallbacks)
+          return await exportPostgresCohort(rows, outputFilePath, exportCallbacks)
         }
 
-        return exportCohort(getDb, validated.data, result.filePath)
+        return exportCohort(getDb, validated.data, outputFilePath)
       }) as Promise<{ success: boolean; filePath?: string; error?: string }>
     }
   )

--- a/src/main/ipc/handlers/tags.ts
+++ b/src/main/ipc/handlers/tags.ts
@@ -6,8 +6,8 @@ import {
   TagUpdateSchema,
   VariantTagAssignSchema,
   VariantTagSetSchema,
-  CaseVariantIdSchema
-} from '../../../shared/types/ipc-schemas'
+  TagCaseVariantIdSchema
+} from '../../../shared/api/schemas/tags'
 import { mainLogger } from '../../services/MainLogger'
 import type { AuditAppendParams } from '../../storage/audit-log-types'
 import type { StorageWriteExecutor } from '../../storage/write-executor'
@@ -139,7 +139,7 @@ export function registerTagHandlers({
 
   ipcMain.handle('tags:getVariantTags', async (_event, caseId: unknown, variantId: unknown) => {
     return wrapHandler(async () => {
-      const validated = CaseVariantIdSchema.safeParse({ caseId, variantId })
+      const validated = TagCaseVariantIdSchema.safeParse({ caseId, variantId })
       if (!validated.success) {
         mainLogger.error(`Invalid tags:getVariantTags params: ${validated.error.message}`, 'tags')
         throw new Error('Invalid case/variant ID')

--- a/src/main/ipc/handlers/transcripts.ts
+++ b/src/main/ipc/handlers/transcripts.ts
@@ -1,26 +1,12 @@
-import { z } from 'zod'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
 import type { TranscriptInsertRow } from '../../../shared/types/transcript'
+import {
+  TranscriptIdSchema,
+  TranscriptInsertRowSchema,
+  TranscriptVariantIdSchema
+} from '../../../shared/api/schemas/transcripts'
 import { mainLogger } from '../../services/MainLogger'
-
-// Schema for variant ID validation
-const VariantIdSchema = z.number().int().positive()
-
-// Schema for transcript ID validation
-const TranscriptIdSchema = z.string().min(1)
-
-// Schema for transcript insert row validation
-const TranscriptInsertRowSchema = z.object({
-  transcript_id: z.string().min(1),
-  gene_symbol: z.string().nullable(),
-  consequence: z.string().nullable(),
-  cdna: z.string().nullable(),
-  aa_change: z.string().nullable(),
-  hpo_sim_score: z.number().nullable(),
-  moi: z.string().nullable(),
-  is_selected: z.number().int().min(0).max(1)
-})
 
 /**
  * Transcript IPC handlers
@@ -30,7 +16,8 @@ const TranscriptInsertRowSchema = z.object({
 export function registerTranscriptHandlers({
   ipcMain,
   getDb,
-  getDbPool
+  getDbPool,
+  getDbManager
 }: HandlerDependencies): void {
   /**
    * List all transcripts for a variant
@@ -38,7 +25,7 @@ export function registerTranscriptHandlers({
   ipcMain.handle('transcripts:list', async (_event, variantId: unknown) => {
     return wrapHandler(async () => {
       // ANTI-07: Runtime validation at IPC boundary
-      const validated = VariantIdSchema.safeParse(variantId)
+      const validated = TranscriptVariantIdSchema.safeParse(variantId)
       if (!validated.success) {
         mainLogger.error(
           `Invalid transcripts:list params: ${validated.error.message}`,
@@ -47,8 +34,16 @@ export function registerTranscriptHandlers({
         throw new Error('Invalid parameters')
       }
 
+      const session = getDbManager().getCurrentSession()
+      if (session.capabilities.backend === 'postgres') {
+        return await session.getReadExecutor().execute({
+          type: 'transcripts:list',
+          params: [validated.data]
+        })
+      }
+
       const pool = getDbPool?.()
-      if (pool) {
+      if (pool !== undefined && pool !== null) {
         return await pool.run({ type: 'transcripts:list' as const, params: [validated.data] })
       }
       const db = getDb()
@@ -64,7 +59,7 @@ export function registerTranscriptHandlers({
     async (_event, variantId: unknown, transcriptId: unknown) => {
       return wrapHandler(async () => {
         // ANTI-07: Runtime validation at IPC boundary
-        const validatedVariantId = VariantIdSchema.safeParse(variantId)
+        const validatedVariantId = TranscriptVariantIdSchema.safeParse(variantId)
         if (!validatedVariantId.success) {
           mainLogger.error(
             `Invalid transcripts:switch variantId: ${validatedVariantId.error.message}`,
@@ -80,6 +75,14 @@ export function registerTranscriptHandlers({
             'transcripts'
           )
           throw new Error('Invalid parameters')
+        }
+
+        const session = getDbManager().getCurrentSession()
+        if (session.capabilities.backend === 'postgres') {
+          return await session.getWriteExecutor().execute({
+            type: 'transcripts:switch',
+            params: [validatedVariantId.data, validatedTranscriptId.data]
+          })
         }
 
         const db = getDb()
@@ -98,7 +101,7 @@ export function registerTranscriptHandlers({
     async (_event, variantId: unknown, transcript: unknown) => {
       return wrapHandler(async () => {
         // ANTI-07: Runtime validation at IPC boundary
-        const validatedVariantId = VariantIdSchema.safeParse(variantId)
+        const validatedVariantId = TranscriptVariantIdSchema.safeParse(variantId)
         if (!validatedVariantId.success) {
           mainLogger.error(
             `Invalid transcripts:insertAndSwitch variantId: ${validatedVariantId.error.message}`,
@@ -114,6 +117,14 @@ export function registerTranscriptHandlers({
             'transcripts'
           )
           throw new Error('Invalid parameters')
+        }
+
+        const session = getDbManager().getCurrentSession()
+        if (session.capabilities.backend === 'postgres') {
+          return await session.getWriteExecutor().execute({
+            type: 'transcripts:insertAndSwitch',
+            params: [validatedVariantId.data, validatedTranscript.data as TranscriptInsertRow]
+          })
         }
 
         const db = getDb()

--- a/src/main/ipc/handlers/variants-logic.ts
+++ b/src/main/ipc/handlers/variants-logic.ts
@@ -194,6 +194,17 @@ export async function getFilterOptions(
 /**
  * FTS5 full-text search for variants.
  */
+function unwrapVariantSearchResult(result: unknown): unknown {
+  if (
+    result !== null &&
+    typeof result === 'object' &&
+    Array.isArray((result as { data?: unknown }).data)
+  ) {
+    return (result as { data: unknown[] }).data
+  }
+  return result
+}
+
 export async function searchVariants(
   caseId: number,
   query: string,
@@ -203,8 +214,12 @@ export async function searchVariants(
   getDbPool?: GetDbPool
 ): Promise<unknown> {
   const deps = resolveReadDependencies(getSessionOrDb, getDbOrPool, getDbPool)
-  if (deps.session?.capabilities.backend === 'postgres') {
-    throw new Error('PostgreSQL variants:search is deferred from Phase 7')
+  if (deps.session !== undefined) {
+    const result = await deps.session.getReadExecutor().execute({
+      type: 'variants:search',
+      params: [caseId, query, limit]
+    })
+    return unwrapVariantSearchResult(result)
   }
 
   const pool = deps.getDbPool?.()
@@ -215,11 +230,7 @@ export async function searchVariants(
     })
   }
 
-  const db = deps.session !== undefined ? deps.getDb?.() : deps.db
-  if (db === undefined) {
-    throw new Error('DatabaseService is required for variants:search')
-  }
-  return db.variants.searchVariants(caseId, query, limit)
+  return deps.db.variants.searchVariants(caseId, query, limit)
 }
 
 /**

--- a/src/main/services/DatabaseManager.ts
+++ b/src/main/services/DatabaseManager.ts
@@ -234,13 +234,26 @@ export class DatabaseManager {
   }
 
   /**
-   * Get the current database service
+   * Get the current database service.
+   *
+   * SQLite-only: Postgres sessions don't expose an underlying DatabaseService.
+   * The StorageSession interface no longer declares getDatabaseService(); the
+   * concrete SqliteStorageSession class still has it as a public method.
    *
    * @returns Current database service
-   * @throws DatabaseError if no database is open
+   * @throws DatabaseError if no database is open or backend is not SQLite
    */
   getCurrent(): DatabaseService {
-    return this.getCurrentSession().getDatabaseService()
+    const session = this.getCurrentSession()
+    if (session.capabilities.backend !== 'sqlite') {
+      throw new DatabaseError(
+        'getCurrent() is SQLite-only; use the StorageSession executors instead'
+      )
+    }
+    // SqliteStorageSession defines getDatabaseService() as a public method
+    // outside the StorageSession interface. Cast through unknown to satisfy
+    // TypeScript without re-declaring the method on the interface.
+    return (session as unknown as { getDatabaseService(): DatabaseService }).getDatabaseService()
   }
 
   /**

--- a/src/main/storage/annotation-audit.ts
+++ b/src/main/storage/annotation-audit.ts
@@ -1,0 +1,75 @@
+import type { AuditAppendParams } from './audit-log-types'
+
+export function globalAnnotationAuditEntries(
+  coords: { chr: string; pos: number; ref: string; alt: string },
+  updates: {
+    user_name?: string | null
+    starred?: boolean | number
+    acmg_classification?: unknown
+    acmg_evidence?: unknown
+  },
+  oldAnnotation: Record<string, unknown> | null
+): AuditAppendParams[] {
+  const entityKey = `${coords.chr}:${coords.pos}:${coords.ref}:${coords.alt}`
+  const entries: AuditAppendParams[] = []
+  if (updates.acmg_classification !== undefined) {
+    entries.push({
+      action_type: 'acmg_classify',
+      entity_type: 'variant_annotation',
+      entity_key: entityKey,
+      old_value:
+        oldAnnotation === null
+          ? null
+          : JSON.stringify({ acmg_classification: oldAnnotation.acmg_classification }),
+      new_value: JSON.stringify({ acmg_classification: updates.acmg_classification }),
+      user_name: updates.user_name ?? null
+    })
+  }
+  if (updates.acmg_evidence !== undefined) {
+    entries.push({
+      action_type: 'acmg_evidence_update',
+      entity_type: 'variant_annotation',
+      entity_key: entityKey,
+      old_value:
+        oldAnnotation === null
+          ? null
+          : JSON.stringify({ acmg_evidence: oldAnnotation.acmg_evidence }),
+      new_value: JSON.stringify({ acmg_evidence: updates.acmg_evidence }),
+      user_name: updates.user_name ?? null
+    })
+  }
+  if (updates.starred !== undefined) {
+    const starred = updates.starred === true || updates.starred === 1
+    entries.push({
+      action_type: starred ? 'star' : 'unstar',
+      entity_type: 'variant_annotation',
+      entity_key: entityKey,
+      old_value: oldAnnotation === null ? null : JSON.stringify({ starred: oldAnnotation.starred }),
+      new_value: JSON.stringify({ starred: starred ? 1 : 0 }),
+      user_name: updates.user_name ?? null
+    })
+  }
+  return entries
+}
+
+export function perCaseAnnotationAuditEntries(
+  caseId: number,
+  variantId: number,
+  updates: {
+    user_name?: string | null
+    starred?: boolean | number
+    acmg_classification?: unknown
+    acmg_evidence?: unknown
+  },
+  oldAnnotation: Record<string, unknown> | null
+): AuditAppendParams[] {
+  return globalAnnotationAuditEntries(
+    { chr: 'case', pos: caseId, ref: 'variant', alt: String(variantId) },
+    updates,
+    oldAnnotation
+  ).map((entry) => ({
+    ...entry,
+    entity_type: 'case_variant_annotation',
+    entity_key: `case:${caseId}:variant:${variantId}`
+  }))
+}

--- a/src/main/storage/postgres/PostgresAnnotationsRepository.ts
+++ b/src/main/storage/postgres/PostgresAnnotationsRepository.ts
@@ -1,13 +1,16 @@
-import type { Pool } from 'pg'
+import type { Pool, PoolClient } from 'pg'
 
 import type {
   AcmgClassification,
   CaseVariantAnnotation,
   VariantAnnotation
 } from '../../../shared/types/database'
+import { globalAnnotationAuditEntries, perCaseAnnotationAuditEntries } from '../annotation-audit'
 import { quoteIdentifier } from './identifiers'
+import { PostgresAuditLogRepository } from './PostgresAuditLogRepository'
 
 type QueryablePool = Pick<Pool, 'query'>
+type TransactionCapablePool = QueryablePool & { connect: () => Promise<PoolClient> }
 
 type GlobalAnnotationUpdates = Partial<
   Omit<
@@ -181,6 +184,37 @@ export class PostgresAnnotationsRepository {
     return toGlobalAnnotation(result.rows[0])
   }
 
+  async upsertGlobalAnnotationWithAudit(
+    chr: string,
+    pos: number,
+    ref: string,
+    alt: string,
+    updates: GlobalAnnotationUpdates & { user_name?: string | null }
+  ): Promise<VariantAnnotation> {
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      const annotations = new PostgresAnnotationsRepository(client, this.schema)
+      const audit = new PostgresAuditLogRepository(client, this.schema)
+      const oldAnnotation = await annotations.getGlobalAnnotation(chr, pos, ref, alt)
+      const result = await annotations.upsertGlobalAnnotation(chr, pos, ref, alt, updates)
+      for (const entry of globalAnnotationAuditEntries(
+        { chr, pos, ref, alt },
+        updates,
+        oldAnnotation as Record<string, unknown> | null
+      )) {
+        await audit.append(entry)
+      }
+      await client.query('COMMIT')
+      return result
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
   async deleteGlobalAnnotation(chr: string, pos: number, ref: string, alt: string): Promise<void> {
     const schemaName = quoteIdentifier(this.schema)
     await this.pool.query(
@@ -273,6 +307,36 @@ export class PostgresAnnotationsRepository {
     return toPerCaseAnnotation(result.rows[0])
   }
 
+  async upsertPerCaseAnnotationWithAudit(
+    caseId: number,
+    variantId: number,
+    updates: PerCaseAnnotationUpdates & { user_name?: string | null }
+  ): Promise<CaseVariantAnnotation> {
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      const annotations = new PostgresAnnotationsRepository(client, this.schema)
+      const audit = new PostgresAuditLogRepository(client, this.schema)
+      const oldAnnotation = await annotations.getPerCaseAnnotation(caseId, variantId)
+      const result = await annotations.upsertPerCaseAnnotation(caseId, variantId, updates)
+      for (const entry of perCaseAnnotationAuditEntries(
+        caseId,
+        variantId,
+        updates,
+        oldAnnotation as Record<string, unknown> | null
+      )) {
+        await audit.append(entry)
+      }
+      await client.query('COMMIT')
+      return result
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
   async deletePerCaseAnnotation(caseId: number, variantId: number): Promise<void> {
     const schemaName = quoteIdentifier(this.schema)
     await this.pool.query(
@@ -310,6 +374,14 @@ export class PostgresAnnotationsRepository {
         : await this.getPerCaseAnnotation(caseId, toNumber(variantId))
 
     return { global, perCase }
+  }
+
+  private async connect(): Promise<PoolClient> {
+    const pool = this.pool as Partial<TransactionCapablePool>
+    if (pool.connect === undefined) {
+      throw new Error('Postgres annotation audit writes require a transaction-capable pool')
+    }
+    return await pool.connect()
   }
 
   async getBatch(

--- a/src/main/storage/postgres/PostgresFilterPresetsRepository.ts
+++ b/src/main/storage/postgres/PostgresFilterPresetsRepository.ts
@@ -96,8 +96,8 @@ export class PostgresFilterPresetsRepository {
           params.description ?? null,
           JSON.stringify(params.filterJson),
           kind,
-          false,
-          params.isVisible !== false,
+          0,
+          params.isVisible === false ? 0 : 1,
           params.sortOrder ?? 0,
           now,
           now
@@ -129,7 +129,7 @@ export class PostgresFilterPresetsRepository {
       }
 
       if (toBoolean(existing.is_built_in)) {
-        if (updates.isVisible !== undefined) addAssignment('is_visible', updates.isVisible)
+        if (updates.isVisible !== undefined) addAssignment('is_visible', updates.isVisible ? 1 : 0)
         if (updates.sortOrder !== undefined) addAssignment('sort_order', updates.sortOrder)
       } else {
         if (updates.name !== undefined) addAssignment('name', updates.name)
@@ -138,7 +138,7 @@ export class PostgresFilterPresetsRepository {
         if (updates.filterJson !== undefined)
           addAssignment('filter_json', JSON.stringify(updates.filterJson))
         if (updates.kind !== undefined) addAssignment('kind', updates.kind)
-        if (updates.isVisible !== undefined) addAssignment('is_visible', updates.isVisible)
+        if (updates.isVisible !== undefined) addAssignment('is_visible', updates.isVisible ? 1 : 0)
         if (updates.sortOrder !== undefined) addAssignment('sort_order', updates.sortOrder)
       }
 

--- a/src/main/storage/postgres/PostgresImportWorkerClient.ts
+++ b/src/main/storage/postgres/PostgresImportWorkerClient.ts
@@ -1,4 +1,5 @@
 import { Worker } from 'node:worker_threads'
+import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { mainLogger } from '../../services/MainLogger'
 import type {
@@ -28,7 +29,9 @@ export class PostgresImportWorkerClient {
   private readonly workerFactory?: () => Worker
 
   constructor(options: PostgresImportWorkerClientOptions = {}) {
-    this.workerPath = resolve(__dirname, 'postgres-import-worker.js')
+    const siblingWorker = resolve(__dirname, 'postgres-import-worker.js')
+    const builtMainWorker = resolve(process.cwd(), 'out/main/postgres-import-worker.js')
+    this.workerPath = existsSync(siblingWorker) ? siblingWorker : builtMainWorker
     this.workerFactory = options.workerFactory
   }
 
@@ -88,16 +91,16 @@ export class PostgresImportWorkerClient {
   }
 
   async terminate(): Promise<void> {
-    if (!this.worker) return
+    const worker = this.worker
+    if (!worker) return
+    this.worker = null
     try {
-      await this.worker.terminate()
+      await worker.terminate()
     } catch (e) {
       mainLogger.warn(
         `Postgres import worker termination failed: ${e instanceof Error ? e.message : String(e)}`,
         'PostgresImportWorkerClient'
       )
-    } finally {
-      this.worker = null
     }
   }
 }

--- a/src/main/storage/postgres/PostgresImportWorkerClient.ts
+++ b/src/main/storage/postgres/PostgresImportWorkerClient.ts
@@ -21,17 +21,22 @@ export interface PostgresImportWorkerCallbacks {
 export interface PostgresImportWorkerClientOptions {
   /** Override worker construction. Default loads the built worker bundle. */
   workerFactory?: () => Worker
+  /** Override path lookup for tests. */
+  workerPathCandidates?: readonly string[]
 }
 
 export class PostgresImportWorkerClient {
   private worker: Worker | null = null
-  private readonly workerPath: string
+  private readonly workerPath: string | null
+  private readonly workerPathCandidates: readonly string[]
   private readonly workerFactory?: () => Worker
 
   constructor(options: PostgresImportWorkerClientOptions = {}) {
-    const siblingWorker = resolve(__dirname, 'postgres-import-worker.js')
-    const builtMainWorker = resolve(process.cwd(), 'out/main/postgres-import-worker.js')
-    this.workerPath = existsSync(siblingWorker) ? siblingWorker : builtMainWorker
+    this.workerPathCandidates = options.workerPathCandidates ?? [
+      resolve(__dirname, 'postgres-import-worker.js'),
+      resolve(process.cwd(), 'out/main/postgres-import-worker.js')
+    ]
+    this.workerPath = this.workerPathCandidates.find((candidate) => existsSync(candidate)) ?? null
     this.workerFactory = options.workerFactory
   }
 
@@ -39,7 +44,16 @@ export class PostgresImportWorkerClient {
     if (this.worker) {
       throw new Error('PostgresImportWorkerClient already started')
     }
-    this.worker = this.workerFactory ? this.workerFactory() : new Worker(this.workerPath)
+    if (this.workerFactory) {
+      this.worker = this.workerFactory()
+    } else {
+      if (this.workerPath === null) {
+        throw new Error(
+          `Postgres import worker bundle not found. Checked: ${this.workerPathCandidates.join(', ')}`
+        )
+      }
+      this.worker = new Worker(this.workerPath)
+    }
 
     this.worker.on('message', (msg: PostgresImportWorkerOutboundMessage) => {
       switch (msg.type) {

--- a/src/main/storage/postgres/PostgresJsonImportRepository.ts
+++ b/src/main/storage/postgres/PostgresJsonImportRepository.ts
@@ -159,6 +159,42 @@ function hasExtensions(row: Record<string, unknown>): boolean {
   )
 }
 
+function normalizeRecordsetValue(type: string, value: unknown): unknown {
+  if (value === null || value === undefined || value === '') return null
+
+  if (type === 'double precision') {
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null
+    if (typeof value === 'string') {
+      const parsed = Number(value)
+      return Number.isFinite(parsed) ? parsed : null
+    }
+    return null
+  }
+
+  if (type === 'bigint' || type === 'integer') {
+    if (typeof value === 'number') return Number.isFinite(value) ? Math.trunc(value) : null
+    if (typeof value === 'string') {
+      const parsed = Number(value)
+      return Number.isFinite(parsed) ? Math.trunc(parsed) : null
+    }
+    return null
+  }
+
+  return value
+}
+
+function normalizeRecordsetPayload(
+  row: Record<string, unknown>,
+  typeMap: Record<string, string>
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    normalized[key] =
+      typeMap[key] === undefined ? value : normalizeRecordsetValue(typeMap[key], value)
+  }
+  return normalized
+}
+
 export class PostgresJsonImportRepository {
   private readonly schemaName: string
 
@@ -346,7 +382,7 @@ export class PostgresJsonImportRepository {
       if (picked.variant_type === null) {
         picked.variant_type = 'snv'
       }
-      return picked
+      return normalizeRecordsetPayload(picked, VARIANT_BATCH_RECORDSET_TYPES)
     })
 
     // Embed case_id into the JSON payload so the batch INSERT has exactly one
@@ -374,7 +410,10 @@ export class PostgresJsonImportRepository {
       .map((col) => `"${col}" ${VARIANT_BATCH_RECORDSET_TYPES[col]}`)
       .join(', ')
 
-    const picked = pickColumns(row, batchCols as readonly string[])
+    const picked = normalizeRecordsetPayload(
+      pickColumns(row, batchCols as readonly string[]),
+      VARIANT_BATCH_RECORDSET_TYPES
+    )
     if (picked.variant_type === null) picked.variant_type = 'snv'
     const payload = [{ case_id: caseId, ...picked }]
 
@@ -408,7 +447,9 @@ export class PostgresJsonImportRepository {
       SELECT ${columns.map((c) => `v."${c}"`).join(', ')}
       FROM jsonb_to_recordset($1::jsonb) AS v(${recordsetSignature})`
 
-    await client.query(sql, [JSON.stringify(rows)])
+    await client.query(sql, [
+      JSON.stringify(rows.map((row) => normalizeRecordsetPayload(row, recordsetTypes)))
+    ])
   }
 }
 

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -13,6 +13,7 @@ import type { PostgresOverviewRepository } from './PostgresOverviewRepository'
 import type { PostgresPanelsRepository } from './PostgresPanelsRepository'
 import type { PostgresShortlistService } from './PostgresShortlistService'
 import type { PostgresTagsRepository } from './PostgresTagsRepository'
+import type { PostgresTranscriptsRepository } from './PostgresTranscriptsRepository'
 import type { PostgresVariantReadRepository } from './PostgresVariantReadRepository'
 
 interface PostgresReadExecutorRepositories {
@@ -55,6 +56,7 @@ interface PostgresReadExecutorRepositories {
     'listGroups' | 'getGroupWithMembers' | 'getGroupForCase'
   >
   audit: Pick<PostgresAuditLogRepository, 'getByEntityKey' | 'query'>
+  transcripts: Pick<PostgresTranscriptsRepository, 'list'>
   caseMetadata: Pick<
     PostgresCaseMetadataRepository,
     | 'getCaseMetadata'
@@ -74,6 +76,7 @@ interface PostgresReadExecutorRepositories {
     | 'getVariantTypeCounts'
     | 'getVariantTypesPresent'
     | 'getGeneSymbols'
+    | 'searchVariants'
     | 'queryVariants'
     | 'getFilterOptions'
     | 'getColumnMeta'
@@ -86,7 +89,7 @@ export class PostgresReadExecutor implements StorageReadExecutor {
   async execute(task: StorageReadTask): Promise<unknown> {
     switch (task.type) {
       case 'cases:query':
-        return await this.repositories.casesQuery.queryCases(task.params)
+        return await this.repositories.casesQuery.queryCases(task.params[0])
 
       case 'cases:availableBuilds':
         return await this.repositories.availableBuilds.getAvailableGenomeBuilds()
@@ -132,6 +135,13 @@ export class PostgresReadExecutor implements StorageReadExecutor {
 
       case 'variants:geneSymbols':
         return await this.repositories.variants.getGeneSymbols(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
+      case 'variants:search':
+        return await this.repositories.variants.searchVariants(
           task.params[0],
           task.params[1],
           task.params[2]
@@ -255,6 +265,9 @@ export class PostgresReadExecutor implements StorageReadExecutor {
 
       case 'audit:query':
         return await this.repositories.audit.query(task.params[0])
+
+      case 'transcripts:list':
+        return await this.repositories.transcripts.list(task.params[0])
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/postgres/PostgresStorageSession.ts
+++ b/src/main/storage/postgres/PostgresStorageSession.ts
@@ -1,8 +1,6 @@
 import type { Pool } from 'pg'
 
 import { mainLogger } from '../../services/MainLogger'
-import type { DatabaseService } from '../../database/DatabaseService'
-import type { DbPool } from '../../database/DbPool'
 import type { Case } from '../../../shared/types/database'
 import { PostgresAvailableBuildsRepository } from './PostgresAvailableBuildsRepository'
 import { PostgresAnalysisGroupsRepository } from './PostgresAnalysisGroupsRepository'
@@ -24,6 +22,7 @@ import { PostgresPanelsRepository } from './PostgresPanelsRepository'
 import { PostgresReadExecutor } from './PostgresReadExecutor'
 import { PostgresShortlistService } from './PostgresShortlistService'
 import { PostgresTagsRepository } from './PostgresTagsRepository'
+import { PostgresTranscriptsRepository } from './PostgresTranscriptsRepository'
 import { PostgresVariantReadRepository } from './PostgresVariantReadRepository'
 import type { StorageImportExecutor } from '../import-executor'
 import type { StorageReadExecutor } from '../read-executor'
@@ -129,6 +128,20 @@ export class PostgresStorageSession implements StorageSession {
     schema: string
   ) => PostgresCaseListRepository
   private readonly pool: Pool
+
+  /**
+   * Public accessor for the underlying pg.Pool.
+   *
+   * The web variant (src/web/server.ts) needs to share this pool with
+   * PostgresWebAuthService so the process opens exactly one connection
+   * pool, not two. Earlier web code reached into the private field via a
+   * structural cast, which would silently break under any future refactor of
+   * the field. This getter makes the contract explicit and compiler-checked.
+   */
+  getPool(): Pool {
+    return this.pool
+  }
+
   private readonly readExecutor: StorageReadExecutor
   private readonly writeExecutor: StorageWriteExecutor
   private readonly importExecutor: StorageImportExecutor
@@ -150,6 +163,7 @@ export class PostgresStorageSession implements StorageSession {
     const analysisGroups = new PostgresAnalysisGroupsRepository(options.pool, options.config.schema)
     const cohort = new PostgresCohortRepository(options.pool, options.config.schema)
     const audit = new PostgresAuditLogRepository(options.pool, options.config.schema)
+    const transcripts = new PostgresTranscriptsRepository(options.pool, options.config.schema)
     const variants = new PostgresVariantReadRepository(options.pool, options.config.schema)
     const shortlist = new PostgresShortlistService({
       pool: options.pool,
@@ -171,6 +185,7 @@ export class PostgresStorageSession implements StorageSession {
       shortlist,
       analysisGroups,
       audit,
+      transcripts,
       caseMetadata,
       variants
     })
@@ -184,7 +199,8 @@ export class PostgresStorageSession implements StorageSession {
         panels,
         filterPresets,
         analysisGroups,
-        audit
+        audit,
+        transcripts
       }
     )
     this.importExecutor = new PostgresImportExecutor({
@@ -237,14 +253,6 @@ export class PostgresStorageSession implements StorageSession {
 
   getImportExecutor(): StorageImportExecutor {
     return this.importExecutor
-  }
-
-  getDatabaseService(): DatabaseService {
-    return unsupported('DatabaseService is not available for postgres sessions')
-  }
-
-  getDbPool(): DbPool | null {
-    return unsupported('DbPool is not available for postgres sessions')
   }
 
   getEncryptionKey(): string | undefined {

--- a/src/main/storage/postgres/PostgresTranscriptsRepository.ts
+++ b/src/main/storage/postgres/PostgresTranscriptsRepository.ts
@@ -1,0 +1,179 @@
+import type { Pool, PoolClient } from 'pg'
+
+import type { TranscriptAnnotation, TranscriptInsertRow } from '../../../shared/types/transcript'
+import { quoteIdentifier } from './identifiers'
+
+type QueryablePool = Pick<Pool, 'query'> & Partial<Pick<Pool, 'connect'>>
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'bigint') return Number(value)
+  if (typeof value === 'string') return Number(value)
+  return 0
+}
+
+const transcriptColumns = `
+  id, variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+  hpo_sim_score, moi, is_selected, is_mane_select, is_canonical
+`
+
+export class PostgresTranscriptsRepository {
+  private readonly schemaName: string
+
+  constructor(
+    private readonly pool: QueryablePool,
+    schema: string
+  ) {
+    this.schemaName = quoteIdentifier(schema)
+  }
+
+  async list(variantId: number): Promise<TranscriptAnnotation[]> {
+    const result = await this.pool.query(
+      `SELECT ${transcriptColumns}
+         FROM ${this.schemaName}.variant_transcripts
+        WHERE variant_id = $1
+        ORDER BY is_selected DESC, transcript_id ASC`,
+      [variantId]
+    )
+    return result.rows.map((row) => this.toTranscriptAnnotation(row))
+  }
+
+  async switchSelectedTranscript(
+    variantId: number,
+    transcriptId: string
+  ): Promise<{ success: true }> {
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(
+        `UPDATE ${this.schemaName}.variant_transcripts SET is_selected = 0 WHERE variant_id = $1`,
+        [variantId]
+      )
+      const selectedRow = await this.selectTranscript(client, variantId, transcriptId)
+      await this.updateVariantFromSelectedTranscript(client, variantId, selectedRow)
+      await client.query('COMMIT')
+      return { success: true }
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async insertTranscriptAndSwitch(
+    variantId: number,
+    transcript: TranscriptInsertRow
+  ): Promise<{ success: true }> {
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(
+        `INSERT INTO ${this.schemaName}.variant_transcripts
+           (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+            hpo_sim_score, moi, is_selected, is_mane_select, is_canonical)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0, NULL, NULL)
+         ON CONFLICT (variant_id, transcript_id)
+         DO NOTHING`,
+        [
+          variantId,
+          transcript.transcript_id,
+          transcript.gene_symbol,
+          transcript.consequence,
+          transcript.cdna,
+          transcript.aa_change,
+          transcript.hpo_sim_score,
+          transcript.moi
+        ]
+      )
+      await client.query(
+        `UPDATE ${this.schemaName}.variant_transcripts SET is_selected = 0 WHERE variant_id = $1`,
+        [variantId]
+      )
+      const selectedRow = await this.selectTranscript(client, variantId, transcript.transcript_id)
+      await this.updateVariantFromSelectedTranscript(client, variantId, selectedRow)
+      await client.query('COMMIT')
+      return { success: true }
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  private async selectTranscript(
+    client: Pick<PoolClient, 'query'>,
+    variantId: number,
+    transcriptId: string
+  ): Promise<Record<string, unknown>> {
+    const selected = await client.query(
+      `UPDATE ${this.schemaName}.variant_transcripts
+          SET is_selected = 1
+        WHERE variant_id = $1 AND transcript_id = $2
+        RETURNING ${transcriptColumns}`,
+      [variantId, transcriptId]
+    )
+    const selectedRow = selected.rows[0]
+    if (selectedRow === undefined) {
+      throw new Error(`Transcript ${transcriptId} not found for variant ${variantId}`)
+    }
+    return selectedRow
+  }
+
+  private async updateVariantFromSelectedTranscript(
+    client: Pick<PoolClient, 'query'>,
+    variantId: number,
+    transcript: Record<string, unknown>
+  ): Promise<void> {
+    await client.query(
+      `UPDATE ${this.schemaName}.variants
+          SET transcript = $2,
+              gene_symbol = $3,
+              consequence = $4,
+              cdna = $5,
+              aa_change = $6,
+              hpo_sim_score = $7,
+              moi = $8
+        WHERE id = $1`,
+      [
+        variantId,
+        transcript.transcript_id,
+        transcript.gene_symbol,
+        transcript.consequence,
+        transcript.cdna,
+        transcript.aa_change,
+        transcript.hpo_sim_score,
+        transcript.moi
+      ]
+    )
+  }
+
+  private async connect(): Promise<PoolClient> {
+    if (this.pool.connect === undefined) {
+      throw new Error('Postgres transcript writes require a transaction-capable pool')
+    }
+    return await this.pool.connect()
+  }
+
+  private toTranscriptAnnotation(row: Record<string, unknown>): TranscriptAnnotation {
+    return {
+      id: toNumber(row.id),
+      variant_id: toNumber(row.variant_id),
+      transcript_id: row.transcript_id as string,
+      gene_symbol: (row.gene_symbol as string | null) ?? null,
+      consequence: (row.consequence as string | null) ?? null,
+      cdna: (row.cdna as string | null) ?? null,
+      aa_change: (row.aa_change as string | null) ?? null,
+      hpo_sim_score: (row.hpo_sim_score as number | null) ?? null,
+      moi: (row.moi as string | null) ?? null,
+      is_selected: row.is_selected === true || row.is_selected === 1,
+      is_mane_select:
+        row.is_mane_select === null
+          ? null
+          : row.is_mane_select === true || row.is_mane_select === 1,
+      is_canonical:
+        row.is_canonical === null ? null : row.is_canonical === true || row.is_canonical === 1
+    }
+  }
+}

--- a/src/main/storage/postgres/PostgresVariantReadRepository.ts
+++ b/src/main/storage/postgres/PostgresVariantReadRepository.ts
@@ -374,6 +374,19 @@ export class PostgresVariantReadRepository {
     return (result.rows as Array<{ gene_symbol: string }>).map((row) => row.gene_symbol)
   }
 
+  async searchVariants(caseId: number, query: string, limit: number): Promise<Variant[]> {
+    if (toPrefixTsQuery(query) === '') return []
+    const result = await this.queryVariants(
+      { case_id: caseId, search_query: query },
+      limit,
+      0,
+      undefined,
+      true,
+      false
+    )
+    return result.data
+  }
+
   async queryVariants(
     filter: VariantFilter,
     limit: number,

--- a/src/main/storage/postgres/PostgresWriteExecutor.ts
+++ b/src/main/storage/postgres/PostgresWriteExecutor.ts
@@ -8,6 +8,7 @@ import type { PostgresCommentsMetricsRepository } from './PostgresCommentsMetric
 import type { PostgresFilterPresetsRepository } from './PostgresFilterPresetsRepository'
 import type { PostgresPanelsRepository } from './PostgresPanelsRepository'
 import type { PostgresTagsRepository } from './PostgresTagsRepository'
+import type { PostgresTranscriptsRepository } from './PostgresTranscriptsRepository'
 
 type PostgresCaseMetadataWriter = Pick<
   PostgresCaseMetadataRepository,
@@ -53,8 +54,10 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
       annotations: Pick<
         PostgresAnnotationsRepository,
         | 'upsertGlobalAnnotation'
+        | 'upsertGlobalAnnotationWithAudit'
         | 'deleteGlobalAnnotation'
         | 'upsertPerCaseAnnotation'
+        | 'upsertPerCaseAnnotationWithAudit'
         | 'deletePerCaseAnnotation'
       >
       commentsMetrics: Pick<
@@ -89,6 +92,10 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
       analysisGroups: Pick<
         PostgresAnalysisGroupsRepository,
         'createGroup' | 'updateGroup' | 'deleteGroup' | 'addMember' | 'removeMember'
+      >
+      transcripts: Pick<
+        PostgresTranscriptsRepository,
+        'switchSelectedTranscript' | 'insertTranscriptAndSwitch'
       >
     }
   ) {}
@@ -172,6 +179,15 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
           normalizeAnnotationUpdates(task.params[1])
         )
 
+      case 'annotations:upsertGlobalWithAudit':
+        return await this.workflow.annotations.upsertGlobalAnnotationWithAudit(
+          task.params[0].chr,
+          task.params[0].pos,
+          task.params[0].ref,
+          task.params[0].alt,
+          normalizeAnnotationUpdates(task.params[1])
+        )
+
       case 'annotations:deleteGlobal':
         return await this.workflow.annotations.deleteGlobalAnnotation(
           task.params[0].chr,
@@ -182,6 +198,13 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
 
       case 'annotations:upsertPerCase':
         return await this.workflow.annotations.upsertPerCaseAnnotation(
+          task.params[0],
+          task.params[1],
+          normalizeAnnotationUpdates(task.params[2])
+        )
+
+      case 'annotations:upsertPerCaseWithAudit':
+        return await this.workflow.annotations.upsertPerCaseAnnotationWithAudit(
           task.params[0],
           task.params[1],
           normalizeAnnotationUpdates(task.params[2])
@@ -276,6 +299,12 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
 
       case 'audit:append':
         return await this.workflow.audit.append(task.params[0])
+
+      case 'transcripts:switch':
+        return await this.workflow.transcripts.switchSelectedTranscript(...task.params)
+
+      case 'transcripts:insertAndSwitch':
+        return await this.workflow.transcripts.insertTranscriptAndSwitch(...task.params)
     }
 
     const exhaustive: never = task

--- a/src/main/storage/read-executor.ts
+++ b/src/main/storage/read-executor.ts
@@ -10,7 +10,7 @@ export type { AvailableBuild } from '../../shared/types/database'
 export type StorageReadTask =
   | {
       type: 'cases:query'
-      params: ValidatedCaseSearchParams
+      params: [params: ValidatedCaseSearchParams]
     }
   | {
       type: 'cases:availableBuilds'
@@ -33,6 +33,7 @@ export type StorageReadTask =
       params: [scope: { caseId: number } | { caseIds: number[] }]
     }
   | { type: 'variants:geneSymbols'; params: [caseId: number, query: string, limit: number] }
+  | { type: 'variants:search'; params: [caseId: number, query: string, limit: number] }
   | {
       type: 'variants:query'
       params: [
@@ -87,6 +88,7 @@ export type StorageReadTask =
   | { type: 'analysis-groups:getForCase'; params: [caseId: number] }
   | { type: 'audit:getByEntity'; params: [entityKey: string] }
   | { type: 'audit:query'; params: [params: AuditQueryParams] }
+  | { type: 'transcripts:list'; params: [variantId: number] }
 
 export interface StorageReadExecutor {
   execute(task: StorageReadTask): Promise<unknown>

--- a/src/main/storage/session.ts
+++ b/src/main/storage/session.ts
@@ -1,5 +1,3 @@
-import type { DatabaseService } from '../database/DatabaseService'
-import type { DbPool } from '../database/DbPool'
 import type { Case } from '../../shared/types/database'
 import type { StorageImportExecutor } from './import-executor'
 import type { StorageReadExecutor } from './read-executor'
@@ -14,16 +12,11 @@ export interface StorageSession {
   getReadExecutor(): StorageReadExecutor
   getWriteExecutor(): StorageWriteExecutor
   getImportExecutor(): StorageImportExecutor
-  /**
-   * Compatibility escape hatch for legacy SQLite-only paths.
-   * New migrated slices must use getReadExecutor().
-   */
-  getDatabaseService(): DatabaseService
-  /**
-   * Compatibility escape hatch for legacy SQLite-only paths.
-   * New migrated slices must use getReadExecutor().
-   */
-  getDbPool(): DbPool | null
+  // The former getDatabaseService() / getDbPool() escape hatches are off the
+  // interface. Backend-specific access (e.g. for SQLite-only flows like
+  // SqliteImportExecutor) goes through concrete class methods, with the
+  // consumer type-narrowing on capabilities.backend first. New domain logic
+  // must use getReadExecutor() / getWriteExecutor().
   getEncryptionKey(): string | undefined
   needsStartupRebuild(): boolean
   rekey(newPassword: string): void

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -14,11 +14,11 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         if (this.dbPool !== null) {
           return await this.dbPool.run({
             type: 'cases:query',
-            params: [task.params]
+            params: task.params
           })
         }
 
-        return this.databaseService.cases.queryCases(task.params)
+        return this.databaseService.cases.queryCases(task.params[0])
 
       case 'cases:availableBuilds':
         if (this.dbPool !== null) {
@@ -142,6 +142,15 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         if (this.dbPool !== null)
           return await this.dbPool.run({ type: task.type, params: task.params })
         return this.databaseService.variants.getGeneSymbols(
+          task.params[0],
+          task.params[1],
+          task.params[2]
+        )
+
+      case 'variants:search':
+        if (this.dbPool !== null)
+          return await this.dbPool.run({ type: task.type, params: task.params })
+        return this.databaseService.variants.searchVariants(
           task.params[0],
           task.params[1],
           task.params[2]
@@ -303,6 +312,9 @@ export class SqliteReadExecutor implements StorageReadExecutor {
 
       case 'audit:query':
         return this.databaseService.auditLog.query(task.params[0])
+
+      case 'transcripts:list':
+        return this.databaseService.transcripts.getVariantTranscripts(task.params[0])
     }
 
     const _exhaustive: never = task

--- a/src/main/storage/sqlite/SqliteWriteExecutor.ts
+++ b/src/main/storage/sqlite/SqliteWriteExecutor.ts
@@ -1,5 +1,6 @@
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { StorageWriteExecutor, StorageWriteTask } from '../write-executor'
+import { globalAnnotationAuditEntries, perCaseAnnotationAuditEntries } from '../annotation-audit'
 
 function normalizeAnnotationUpdates<T extends { starred?: boolean }>(
   updates: T
@@ -9,6 +10,11 @@ function normalizeAnnotationUpdates<T extends { starred?: boolean }>(
     ...rest,
     ...(starred !== undefined ? { starred: starred ? 1 : 0 } : {})
   }
+}
+
+function serializeAuditValue(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  return typeof value === 'string' ? value : JSON.stringify(value)
 }
 
 export class SqliteWriteExecutor implements StorageWriteExecutor {
@@ -104,6 +110,37 @@ export class SqliteWriteExecutor implements StorageWriteExecutor {
           normalizeAnnotationUpdates(task.params[1])
         )
 
+      case 'annotations:upsertGlobalWithAudit': {
+        const coords = task.params[0]
+        const updates = task.params[1]
+        const oldAnnotation = this.databaseService.annotations.getGlobalAnnotation(
+          coords.chr,
+          coords.pos,
+          coords.ref,
+          coords.alt
+        )
+        const result = this.databaseService.annotations.upsertGlobalAnnotation(
+          coords.chr,
+          coords.pos,
+          coords.ref,
+          coords.alt,
+          normalizeAnnotationUpdates(updates)
+        )
+        for (const entry of globalAnnotationAuditEntries(
+          coords,
+          updates,
+          oldAnnotation as Record<string, unknown> | null
+        )) {
+          this.databaseService.auditLog.appendEntry({
+            ...entry,
+            old_value: serializeAuditValue(entry.old_value),
+            new_value: serializeAuditValue(entry.new_value),
+            user_name: entry.user_name ?? null
+          })
+        }
+        return result
+      }
+
       case 'annotations:deleteGlobal':
         this.databaseService.annotations.deleteGlobalAnnotation(
           task.params[0].chr,
@@ -119,6 +156,33 @@ export class SqliteWriteExecutor implements StorageWriteExecutor {
           task.params[1],
           normalizeAnnotationUpdates(task.params[2])
         )
+
+      case 'annotations:upsertPerCaseWithAudit': {
+        const [caseId, variantId, updates] = task.params
+        const oldAnnotation = this.databaseService.annotations.getPerCaseAnnotation(
+          caseId,
+          variantId
+        )
+        const result = this.databaseService.annotations.upsertPerCaseAnnotation(
+          caseId,
+          variantId,
+          normalizeAnnotationUpdates(updates)
+        )
+        for (const entry of perCaseAnnotationAuditEntries(
+          caseId,
+          variantId,
+          updates,
+          oldAnnotation as Record<string, unknown> | null
+        )) {
+          this.databaseService.auditLog.appendEntry({
+            ...entry,
+            old_value: serializeAuditValue(entry.old_value),
+            new_value: serializeAuditValue(entry.new_value),
+            user_name: entry.user_name ?? null
+          })
+        }
+        return result
+      }
 
       case 'annotations:deletePerCase':
         this.databaseService.annotations.deletePerCaseAnnotation(...task.params)
@@ -242,6 +306,14 @@ export class SqliteWriteExecutor implements StorageWriteExecutor {
           user_name: task.params[0].user_name ?? null
         })
         return undefined
+
+      case 'transcripts:switch':
+        this.databaseService.transcripts.switchSelectedTranscript(...task.params)
+        return { success: true }
+
+      case 'transcripts:insertAndSwitch':
+        this.databaseService.transcripts.insertTranscriptAndSwitch(...task.params)
+        return { success: true }
     }
 
     const exhaustive: never = task

--- a/src/main/storage/write-executor.ts
+++ b/src/main/storage/write-executor.ts
@@ -18,6 +18,7 @@ import type {
   VariantCoords
 } from '../ipc/handlers/annotations-logic'
 import type { AuditAppendParams } from './audit-log-types'
+import type { TranscriptInsertRow } from '../../shared/types/transcript'
 
 export type StorageWriteTask =
   | { type: 'cases:delete'; params: [caseId: number] }
@@ -52,9 +53,17 @@ export type StorageWriteTask =
       type: 'annotations:upsertGlobal'
       params: [coords: VariantCoords, updates: GlobalAnnotationUpdates]
     }
+  | {
+      type: 'annotations:upsertGlobalWithAudit'
+      params: [coords: VariantCoords, updates: GlobalAnnotationUpdates]
+    }
   | { type: 'annotations:deleteGlobal'; params: [coords: VariantCoords] }
   | {
       type: 'annotations:upsertPerCase'
+      params: [caseId: number, variantId: number, updates: PerCaseAnnotationUpdates]
+    }
+  | {
+      type: 'annotations:upsertPerCaseWithAudit'
       params: [caseId: number, variantId: number, updates: PerCaseAnnotationUpdates]
     }
   | { type: 'annotations:deletePerCase'; params: [caseId: number, variantId: number] }
@@ -123,6 +132,11 @@ export type StorageWriteTask =
     }
   | { type: 'analysis-groups:removeMember'; params: [groupId: number, caseId: number] }
   | { type: 'audit:append'; params: [params: AuditAppendParams] }
+  | { type: 'transcripts:switch'; params: [variantId: number, transcriptId: string] }
+  | {
+      type: 'transcripts:insertAndSwitch'
+      params: [variantId: number, transcript: TranscriptInsertRow]
+    }
 
 export interface StorageWriteExecutor {
   execute(task: StorageWriteTask): Promise<unknown>

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -652,11 +652,6 @@ export async function runImport(
             const stream = await deps.createVcfMappedStream(fileSpec.filePath, {
               selectedSample,
               genomeBuild,
-              // Match the existing SQLite multi-file contract: file 0 creates
-              // the case through the single-file import path and is not given
-              // import filters; filters apply to appended files. Single-file
-              // multi-file imports still receive filters because there is no
-              // append phase that could otherwise apply them.
               filters: start.files.length > 1 && i === 0 ? undefined : importFilters
             })
 

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -652,7 +652,12 @@ export async function runImport(
             const stream = await deps.createVcfMappedStream(fileSpec.filePath, {
               selectedSample,
               genomeBuild,
-              filters: importFilters
+              // Match the existing SQLite multi-file contract: file 0 creates
+              // the case through the single-file import path and is not given
+              // import filters; filters apply to appended files. Single-file
+              // multi-file imports still receive filters because there is no
+              // append phase that could otherwise apply them.
+              filters: start.files.length > 1 && i === 0 ? undefined : importFilters
             })
 
             let variants: Array<Record<string, unknown>> = []

--- a/src/shared/api/schemas/analysis-groups.ts
+++ b/src/shared/api/schemas/analysis-groups.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod'
+
+export const AnalysisGroupCreateArgsSchema = z
+  .tuple([
+    z.object({
+      name: z.string().min(1).max(200),
+      groupType: z.enum(['family', 'tumor_normal']).optional(),
+      description: z.string().max(1000).nullable().optional()
+    })
+  ])
+  .rest(z.unknown())
+
+export const AnalysisGroupMemberAddArgsSchema = z
+  .tuple([
+    z.object({
+      groupId: z.number().int().positive(),
+      caseId: z.number().int().positive(),
+      role: z.enum([
+        'proband',
+        'father',
+        'mother',
+        'sibling',
+        'partner',
+        'other',
+        'tumor',
+        'normal'
+      ]),
+      affectedStatus: z.enum(['affected', 'unaffected', 'unknown']).optional(),
+      individualId: z.string().nullable().optional()
+    })
+  ])
+  .rest(z.unknown())
+
+export const AnalysisGroupInvokeBodySchemas = {
+  create: z.object({
+    args: AnalysisGroupCreateArgsSchema
+  }),
+  addMember: z.object({
+    args: AnalysisGroupMemberAddArgsSchema
+  })
+} as const
+
+export const AnalysisGroupUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/annotations.ts
+++ b/src/shared/api/schemas/annotations.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod'
+
+import { ACMG_CLASSIFICATIONS } from '../../config/domain.config'
+import {
+  CaseVariantIdSchema,
+  GlobalAnnotationUpdatesSchema,
+  PerCaseAnnotationUpdatesSchema,
+  VariantCoordsSchema
+} from '../../types/ipc-schemas'
+
+export {
+  CaseVariantIdSchema,
+  GlobalAnnotationUpdatesSchema,
+  PerCaseAnnotationUpdatesSchema,
+  VariantCoordsSchema
+}
+
+const AcmgClassificationInputSchema = z
+  .enum([
+    ...ACMG_CLASSIFICATIONS,
+    'Likely Pathogenic',
+    'VUS',
+    'Likely Benign',
+    'Uncertain Significance',
+    'LP',
+    'LB',
+    'P',
+    'B'
+  ] as const)
+  .nullish()
+
+const GlobalAnnotationUpdatesInputSchema = z.object({
+  global_comment: z.string().nullish(),
+  starred: z.boolean().optional(),
+  acmg_classification: AcmgClassificationInputSchema,
+  acmg_evidence: z.string().nullish(),
+  user_name: z.string().nullish()
+})
+
+const PerCaseAnnotationUpdatesInputSchema = z.object({
+  per_case_comment: z.string().nullish(),
+  starred: z.boolean().optional(),
+  acmg_classification: AcmgClassificationInputSchema,
+  acmg_evidence: z.string().nullish(),
+  user_name: z.string().nullish()
+})
+
+export const AnnotationCoordsArgsSchema = z
+  .tuple([
+    VariantCoordsSchema.shape.chr,
+    VariantCoordsSchema.shape.pos,
+    VariantCoordsSchema.shape.ref,
+    VariantCoordsSchema.shape.alt
+  ])
+  .rest(z.unknown())
+
+export const AnnotationGlobalUpsertArgsSchema = z
+  .tuple([
+    VariantCoordsSchema.shape.chr,
+    VariantCoordsSchema.shape.pos,
+    VariantCoordsSchema.shape.ref,
+    VariantCoordsSchema.shape.alt,
+    GlobalAnnotationUpdatesInputSchema
+  ])
+  .rest(z.unknown())
+
+export const AnnotationPerCaseUpsertArgsSchema = z
+  .tuple([
+    CaseVariantIdSchema.shape.caseId,
+    CaseVariantIdSchema.shape.variantId,
+    PerCaseAnnotationUpdatesInputSchema
+  ])
+  .rest(z.unknown())
+
+export const AnnotationForVariantArgsSchema = z
+  .tuple([
+    CaseVariantIdSchema.shape.caseId,
+    VariantCoordsSchema.shape.chr,
+    VariantCoordsSchema.shape.pos,
+    VariantCoordsSchema.shape.ref,
+    VariantCoordsSchema.shape.alt
+  ])
+  .rest(z.unknown())
+
+export const AnnotationInvokeBodySchemas = {
+  getGlobal: z.object({
+    args: AnnotationCoordsArgsSchema
+  }),
+  upsertGlobal: z.object({
+    args: AnnotationGlobalUpsertArgsSchema
+  }),
+  upsertPerCase: z.object({
+    args: AnnotationPerCaseUpsertArgsSchema
+  }),
+  getForVariant: z.object({
+    args: AnnotationForVariantArgsSchema
+  })
+} as const
+
+export const AnnotationUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/auth.ts
+++ b/src/shared/api/schemas/auth.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+
+export const UsernameSchema = z.string().min(1).max(100)
+
+export const PasswordSchema = z.string().min(8).max(256)
+export const PasswordInputSchema = z.string().min(1).max(256)
+
+export const LoginParamsSchema = z.object({
+  username: UsernameSchema,
+  password: z.string().min(1).max(256)
+})
+
+export const CreateUserSchema = z.object({
+  username: UsernameSchema,
+  displayName: z.string().min(1).max(200),
+  tempPassword: PasswordSchema
+})
+
+export const ChangePasswordSchema = z.object({
+  oldPassword: z.string().min(1).max(256),
+  newPassword: PasswordInputSchema
+})
+
+export const LoginArgsSchema = z.tuple([LoginParamsSchema.shape.username, PasswordInputSchema])
+export const CreateUserArgsSchema = z.tuple([
+  CreateUserSchema.shape.username,
+  CreateUserSchema.shape.displayName,
+  CreateUserSchema.shape.tempPassword
+])
+export const UsernameArgsSchema = z.tuple([UsernameSchema])
+export const ResetPasswordArgsSchema = z.tuple([UsernameSchema, PasswordSchema])
+export const ChangePasswordArgsSchema = z.tuple([
+  ChangePasswordSchema.shape.oldPassword,
+  ChangePasswordSchema.shape.newPassword
+])
+
+export const AuthSessionUserSchema = z.object({
+  id: z.number().int().positive(),
+  username: z.string(),
+  role: z.string(),
+  passwordChangedAt: z.string().nullable().optional()
+})
+
+export const AuthUserSchema = z
+  .object({
+    id: z.number().int().positive(),
+    username: z.string(),
+    display_name: z.string().nullable().optional(),
+    role: z.string(),
+    is_active: z.number().int().optional(),
+    must_change_password: z.number().int().optional(),
+    failed_login_count: z.number().int().optional(),
+    locked_until: z.string().nullable().optional(),
+    password_changed_at: z.string().nullable().optional(),
+    created_at: z.string().optional(),
+    created_by: z.number().int().nullable().optional(),
+    updated_at: z.string().nullable().optional()
+  })
+  .passthrough()
+
+export const AuthResultSchema = z.object({
+  success: z.boolean(),
+  user: AuthUserSchema.nullable().optional(),
+  locked: z.boolean().optional(),
+  mustChangePassword: z.boolean().optional()
+})
+
+export const AuthBooleanSchema = z.boolean()
+export const AuthOkSchema = z.object({ ok: z.boolean() })
+export const AuthSuccessSchema = z.object({ success: z.boolean() })
+export const AuthErrorSchema = z
+  .object({
+    error: z.string(),
+    message: z.string().optional()
+  })
+  .passthrough()
+
+export const AuthInvokeBodySchemas = {
+  login: z.object({ args: LoginArgsSchema }),
+  logout: z.object({ args: z.tuple([]).optional() }),
+  currentUser: z.object({ args: z.tuple([]).optional() }),
+  isAccountsEnabled: z.object({ args: z.tuple([]).optional() }),
+  createUser: z.object({ args: CreateUserArgsSchema }),
+  listUsers: z.object({ args: z.tuple([]).optional() }),
+  deactivateUser: z.object({ args: UsernameArgsSchema }),
+  resetPassword: z.object({ args: ResetPasswordArgsSchema }),
+  changePassword: z.object({ args: ChangePasswordArgsSchema })
+} as const
+
+export type LoginParams = z.infer<typeof LoginParamsSchema>
+export type CreateUserParams = z.infer<typeof CreateUserSchema>
+export type ChangePasswordParams = z.infer<typeof ChangePasswordSchema>

--- a/src/shared/api/schemas/auth.ts
+++ b/src/shared/api/schemas/auth.ts
@@ -18,7 +18,7 @@ export const CreateUserSchema = z.object({
 
 export const ChangePasswordSchema = z.object({
   oldPassword: z.string().min(1).max(256),
-  newPassword: PasswordInputSchema
+  newPassword: PasswordSchema
 })
 
 export const LoginArgsSchema = z.tuple([LoginParamsSchema.shape.username, PasswordInputSchema])

--- a/src/shared/api/schemas/batch-import.ts
+++ b/src/shared/api/schemas/batch-import.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const BatchImportInvokeBodySchemas = {
+  extractZip: z.object({
+    args: z.tuple([z.string().min(1), z.string().optional()])
+  }),
+  testZipPassword: z.object({
+    args: z.tuple([z.string().min(1), z.string()])
+  }),
+  cleanupZipTemp: z.object({
+    args: z.tuple([])
+  })
+} as const
+
+export const BatchImportUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/case-comments.ts
+++ b/src/shared/api/schemas/case-comments.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+export const CaseCommentIdSchema = z.number().int().positive()
+export const CaseCommentCaseIdSchema = z.number().int().positive()
+
+export const CommentCategorySchema = z.enum([
+  'Clinical Note',
+  'Lab Result',
+  'Interpretation',
+  'Follow-up',
+  'Family History',
+  'Treatment'
+])
+
+export const CommentCreateSchema = z.object({
+  caseId: CaseCommentCaseIdSchema,
+  category: CommentCategorySchema,
+  content: z.string().min(1)
+})
+
+export const CommentUpdateSchema = z.object({
+  commentId: CaseCommentIdSchema,
+  content: z.string().min(1)
+})
+
+export const CaseCommentSchema = z.object({
+  id: CaseCommentIdSchema,
+  case_id: CaseCommentCaseIdSchema,
+  category: CommentCategorySchema,
+  content: z.string(),
+  created_at: z.number().int().nonnegative(),
+  updated_at: z.number().int().nonnegative().nullable()
+})
+
+export const CaseCommentInvokeBodySchemas = {
+  list: z.object({ args: z.tuple([CaseCommentCaseIdSchema]) }),
+  create: z.object({
+    args: z.tuple([
+      CommentCreateSchema.shape.caseId,
+      CommentCreateSchema.shape.category,
+      CommentCreateSchema.shape.content
+    ])
+  }),
+  update: z.object({
+    args: z.tuple([CommentUpdateSchema.shape.commentId, CommentUpdateSchema.shape.content])
+  }),
+  delete: z.object({ args: z.tuple([CaseCommentIdSchema]) })
+} as const
+
+export const CaseCommentListResponseSchema = z.array(CaseCommentSchema)
+
+export type CommentCategory = z.infer<typeof CommentCategorySchema>
+export type CommentCreate = z.infer<typeof CommentCreateSchema>
+export type CommentUpdate = z.infer<typeof CommentUpdateSchema>

--- a/src/shared/api/schemas/case-metadata.ts
+++ b/src/shared/api/schemas/case-metadata.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const CaseMetadataCohortCreateArgsSchema = z
+  .tuple([z.string(), z.unknown().optional()])
+  .rest(z.unknown())
+
+export const CaseMetadataInvokeBodySchemas = {
+  createCohort: z.object({
+    args: CaseMetadataCohortCreateArgsSchema
+  })
+} as const
+
+export const CaseMetadataUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/case-metrics.ts
+++ b/src/shared/api/schemas/case-metrics.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod'
+import { CaseIdSchema } from '../../types/ipc-schemas'
+
+export const CaseMetricIdSchema = z.number().int().positive()
+export const CaseMetricCaseIdSchema = CaseIdSchema
+export const MetricValueTypeSchema = z.enum(['numeric', 'text', 'date'])
+
+export const MetricDefinitionCreateSchema = z.object({
+  name: z.string().min(1).max(200),
+  valueType: MetricValueTypeSchema,
+  unit: z.string(),
+  category: z.string().min(1)
+})
+
+export const MetricValueSchema = z.object({
+  numeric_value: z.number().nullish(),
+  text_value: z.string().nullish(),
+  date_value: z.string().nullish()
+})
+
+export const MetricUpsertSchema = z.object({
+  caseId: CaseMetricCaseIdSchema,
+  metricId: CaseMetricIdSchema,
+  value: MetricValueSchema
+})
+
+export const MetricDeleteSchema = z.object({
+  caseId: CaseMetricCaseIdSchema,
+  metricId: CaseMetricIdSchema
+})
+
+export const MetricDefinitionSchema = z.object({
+  id: CaseMetricIdSchema,
+  name: z.string(),
+  value_type: MetricValueTypeSchema,
+  unit: z.string(),
+  category: z.string(),
+  is_predefined: z.number().int(),
+  created_at: z.number().int().nonnegative()
+})
+
+export const CaseMetricSchema = z.object({
+  id: CaseMetricIdSchema,
+  case_id: CaseMetricCaseIdSchema,
+  metric_id: CaseMetricIdSchema,
+  numeric_value: z.number().nullable(),
+  text_value: z.string().nullable(),
+  date_value: z.string().nullable(),
+  created_at: z.number().int().nonnegative(),
+  updated_at: z.number().int().nonnegative()
+})
+
+export const CaseMetricWithDefinitionSchema = CaseMetricSchema.extend({
+  name: z.string(),
+  value_type: MetricValueTypeSchema,
+  unit: z.string(),
+  metric_category: z.string()
+})
+
+export const CaseMetricInvokeBodySchemas = {
+  empty: z.object({ args: z.tuple([]).optional() }),
+  createDefinition: z.object({
+    args: z.tuple([
+      MetricDefinitionCreateSchema.shape.name,
+      MetricDefinitionCreateSchema.shape.valueType,
+      MetricDefinitionCreateSchema.shape.unit,
+      MetricDefinitionCreateSchema.shape.category
+    ])
+  }),
+  listForCase: z.object({ args: z.tuple([CaseMetricCaseIdSchema]) }),
+  upsert: z.object({
+    args: z.tuple([
+      MetricUpsertSchema.shape.caseId,
+      MetricUpsertSchema.shape.metricId,
+      MetricUpsertSchema.shape.value
+    ])
+  }),
+  delete: z.object({
+    args: z.tuple([MetricDeleteSchema.shape.caseId, MetricDeleteSchema.shape.metricId])
+  })
+} as const
+
+export const MetricDefinitionListResponseSchema = z.array(MetricDefinitionSchema)
+export const CaseMetricWithDefinitionListResponseSchema = z.array(CaseMetricWithDefinitionSchema)
+
+export type MetricDefinitionCreate = z.infer<typeof MetricDefinitionCreateSchema>
+export type MetricValue = z.infer<typeof MetricValueSchema>
+export type MetricUpsert = z.infer<typeof MetricUpsertSchema>

--- a/src/shared/api/schemas/cases.ts
+++ b/src/shared/api/schemas/cases.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const CaseInvokeBodySchemas = {
+  list: z.object({
+    args: z.tuple([])
+  })
+} as const
+
+export const CaseUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/cohort.ts
+++ b/src/shared/api/schemas/cohort.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+import { CohortSearchParamsSchema } from '../../types/ipc-schemas'
+
+export { CohortSearchParamsSchema }
+
+export const CohortCarriersParamsSchema = z.object({
+  chr: z.string().min(1),
+  pos: z.number().int().positive(),
+  ref: z.string().min(1),
+  alt: z.string().min(1)
+})
+
+const CohortSearchOpenApiSchema = z.record(z.string(), z.unknown())
+
+export const CohortInvokeBodySchemas = {
+  getVariants: z.object({
+    args: z.tuple([CohortSearchOpenApiSchema])
+  }),
+  empty: z.object({
+    args: z.tuple([])
+  }),
+  getCarriers: z.object({
+    args: z.tuple([z.string(), z.number().int().positive(), z.string(), z.string()])
+  }),
+  unsupported: z.object({
+    args: z.array(z.unknown()).optional()
+  })
+} as const
+
+export const CohortSummaryStatusSchema = z.object({
+  is_stale: z.boolean(),
+  last_rebuilt_at: z.number()
+})
+
+export const CohortUnknownResponseSchema = z.unknown()
+
+export type CohortCarriersParams = z.infer<typeof CohortCarriersParamsSchema>

--- a/src/shared/api/schemas/database.ts
+++ b/src/shared/api/schemas/database.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const DatabaseInvokeBodySchemas = {
+  empty: z.object({
+    args: z.tuple([])
+  })
+} as const
+
+export const DatabaseInfoSchema = z.object({
+  path: z.string(),
+  name: z.string(),
+  encrypted: z.boolean()
+})
+
+export const DatabaseRecentListSchema = z.array(z.unknown())
+
+export const DatabaseUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/dispatcher.ts
+++ b/src/shared/api/schemas/dispatcher.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const DispatcherParamsSchema = z.object({
+  domain: z.string().min(1),
+  method: z.string().min(1)
+})
+
+export const DispatcherInvokeBodySchema = z
+  .object({
+    args: z.array(z.unknown()).optional()
+  })
+  .nullable()
+  .optional()
+
+export const DispatcherErrorResponseSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  userMessage: z.string(),
+  details: z.record(z.string(), z.unknown()).optional()
+})

--- a/src/shared/api/schemas/export.ts
+++ b/src/shared/api/schemas/export.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+import {
+  CaseIdSchema,
+  CohortSearchParamsSchema,
+  VariantFilterPartialSchema
+} from '../../types/ipc-schemas'
+
+export { CaseIdSchema, CohortSearchParamsSchema, VariantFilterPartialSchema }
+
+export const VariantExportParamsSchema = z.object({
+  caseId: CaseIdSchema,
+  filters: VariantFilterPartialSchema,
+  caseName: z.string().min(1).max(500)
+})
+
+const ExportVariantFilterOpenApiSchema = z.record(z.string(), z.unknown())
+const ExportCohortSearchOpenApiSchema = z.record(z.string(), z.unknown())
+
+export const ExportInvokeBodySchemas = {
+  variants: z.object({
+    args: z.tuple([CaseIdSchema, ExportVariantFilterOpenApiSchema, z.string().min(1).max(500)])
+  }),
+  cohort: z.object({
+    args: z.tuple([ExportCohortSearchOpenApiSchema])
+  })
+} as const
+
+export const ExportUnknownResponseSchema = z.unknown()
+
+export type VariantExportParams = z.infer<typeof VariantExportParamsSchema>

--- a/src/shared/api/schemas/gene-lists.ts
+++ b/src/shared/api/schemas/gene-lists.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const GeneListSetGenesArgsSchema = z
+  .tuple([z.number(), z.array(z.string())])
+  .rest(z.unknown())
+
+export const GeneListInvokeBodySchemas = {
+  setGenes: z.object({
+    args: GeneListSetGenesArgsSchema
+  })
+} as const
+
+export const GeneListUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/gene-ref.ts
+++ b/src/shared/api/schemas/gene-ref.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const GeneRefInvokeBodySchemas = {
+  empty: z.object({
+    args: z.tuple([])
+  })
+} as const
+
+export const GeneRefUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/hpo.ts
+++ b/src/shared/api/schemas/hpo.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const HpoSearchArgsSchema = z.tuple([z.string(), z.unknown().optional()]).rest(z.unknown())
+
+export const HpoInvokeBodySchemas = {
+  empty: z.object({
+    args: z.tuple([])
+  }),
+  search: z.object({
+    args: HpoSearchArgsSchema
+  })
+} as const
+
+export const HpoUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/import.ts
+++ b/src/shared/api/schemas/import.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod'
+
+export interface ImportVcfOptions {
+  selectedSample?: string
+  genomeBuild?: string
+}
+
+export interface ImportMultiFileSpec {
+  filePath: string
+  variantType: string
+  caller: string | null
+  annotationFormat: string | null
+}
+
+export const ImportServerPathArgSchema = z.string().refine((value) => value.trim() !== '')
+export const ImportCaseNameArgSchema = z.string().refine((value) => value.trim() !== '')
+export const ImportVariantTypeArgSchema = z.string().refine((value) => value.trim() !== '')
+
+export const ImportVcfOptionsSchema = z
+  .object({
+    selectedSample: z.string().optional(),
+    genomeBuild: z.string().optional()
+  })
+  .passthrough()
+
+export const ImportFiltersPayloadSchema = z
+  .object({
+    bedFile: z.string().nullable().optional(),
+    bedPadding: z.number().optional(),
+    passOnly: z.boolean().optional(),
+    minQual: z.number().nullable().optional(),
+    minGq: z.number().nullable().optional(),
+    minDp: z.number().nullable().optional()
+  })
+  .passthrough()
+
+export const ImportMultiFileSpecSchema = z.object({
+  filePath: z.string().min(1),
+  variantType: z.string().min(1),
+  caller: z.unknown().optional(),
+  annotationFormat: z.unknown().optional()
+})
+
+const ImportMultiFileSpecOpenApiSchema = z.object({
+  filePath: z.string().min(1),
+  variantType: z.string().min(1),
+  caller: z.string().nullable().optional(),
+  annotationFormat: z.string().nullable().optional()
+})
+
+export const ServerPathImportDisabledSchema = z.object({
+  error: z.literal('server-path-import-disabled'),
+  message: z.string()
+})
+
+export const ImportInvokeBodySchemas = {
+  start: z.object({
+    args: z.tuple([z.string().min(1), z.string().min(1), ImportVcfOptionsSchema.optional()])
+  }),
+  startMultiFile: z.object({
+    args: z.tuple([
+      z.string().min(1),
+      z.array(ImportMultiFileSpecOpenApiSchema).min(1),
+      ImportVcfOptionsSchema.optional(),
+      ImportFiltersPayloadSchema.optional()
+    ])
+  })
+} as const
+
+export const ImportUnknownResponseSchema = z.unknown()
+
+export type ImportMultiFileSpecInput = z.infer<typeof ImportMultiFileSpecSchema>
+export type ImportFiltersPayload = z.infer<typeof ImportFiltersPayloadSchema>
+
+export function normalizeImportVcfOptions(vcfOptions: unknown): ImportVcfOptions | undefined {
+  return vcfOptions !== null && typeof vcfOptions === 'object'
+    ? {
+        selectedSample:
+          typeof (vcfOptions as { selectedSample?: unknown }).selectedSample === 'string'
+            ? (vcfOptions as { selectedSample: string }).selectedSample
+            : undefined,
+        genomeBuild:
+          typeof (vcfOptions as { genomeBuild?: unknown }).genomeBuild === 'string'
+            ? (vcfOptions as { genomeBuild: string }).genomeBuild
+            : undefined
+      }
+    : undefined
+}
+
+export function normalizeImportMultiFileSpec(input: ImportMultiFileSpecInput): ImportMultiFileSpec {
+  return {
+    filePath: input.filePath,
+    variantType: input.variantType,
+    caller: typeof input.caller === 'string' ? input.caller : null,
+    annotationFormat: typeof input.annotationFormat === 'string' ? input.annotationFormat : null
+  }
+}
+
+export function normalizeImportFiltersPayload(filters: unknown): ImportFiltersPayload | undefined {
+  if (filters === null || typeof filters !== 'object') return undefined
+
+  const parsed = ImportFiltersPayloadSchema.safeParse(filters)
+  return parsed.success ? parsed.data : (filters as ImportFiltersPayload)
+}

--- a/src/shared/api/schemas/protein.ts
+++ b/src/shared/api/schemas/protein.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const ProteinGeneArgsSchema = z.tuple([z.string()]).rest(z.unknown())
+export const ProteinAccessionArgsSchema = z.tuple([z.string()]).rest(z.unknown())
+
+export const ProteinInvokeBodySchemas = {
+  gene: z.object({
+    args: ProteinGeneArgsSchema
+  }),
+  accession: z.object({
+    args: ProteinAccessionArgsSchema
+  })
+} as const
+
+export const ProteinUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/region-files.ts
+++ b/src/shared/api/schemas/region-files.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const RegionFileImportBedArgsSchema = z.tuple([z.number(), z.string()]).rest(z.unknown())
+
+export const RegionFileInvokeBodySchemas = {
+  importBed: z.object({
+    args: RegionFileImportBedArgsSchema
+  })
+} as const
+
+export const RegionFileUnknownResponseSchema = z.unknown()

--- a/src/shared/api/schemas/tags.ts
+++ b/src/shared/api/schemas/tags.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+
+export const TagIdSchema = z.number().int().positive()
+
+export const TagCreateSchema = z.object({
+  name: z.string().min(1).max(100),
+  color: z.string().min(4).max(9)
+})
+
+export const TagUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  color: z.string().min(4).max(9).optional()
+})
+
+export const TagCaseVariantIdSchema = z.object({
+  caseId: z.number().int().positive(),
+  variantId: z.number().int().positive()
+})
+
+export const VariantTagAssignSchema = TagCaseVariantIdSchema.extend({
+  tagId: z.number().int().positive()
+})
+
+export const VariantTagSetSchema = TagCaseVariantIdSchema.extend({
+  tagIds: z.array(TagIdSchema)
+})
+
+export const TagSchema = TagCreateSchema.extend({
+  id: TagIdSchema,
+  created_at: z.number().int().nonnegative()
+})
+
+export const TagsInvokeBodySchemas = {
+  empty: z.object({ args: z.tuple([]).optional() }),
+  tagId: z.object({ args: z.tuple([TagIdSchema]) }),
+  create: z.object({ args: z.tuple([TagCreateSchema.shape.name, TagCreateSchema.shape.color]) }),
+  update: z.object({ args: z.tuple([TagIdSchema, TagUpdateSchema]) }),
+  caseVariant: z.object({
+    args: z.tuple([TagCaseVariantIdSchema.shape.caseId, TagCaseVariantIdSchema.shape.variantId])
+  }),
+  assign: z.object({
+    args: z.tuple([
+      VariantTagAssignSchema.shape.caseId,
+      VariantTagAssignSchema.shape.variantId,
+      VariantTagAssignSchema.shape.tagId
+    ])
+  }),
+  set: z.object({
+    args: z.tuple([
+      VariantTagSetSchema.shape.caseId,
+      VariantTagSetSchema.shape.variantId,
+      VariantTagSetSchema.shape.tagIds
+    ])
+  })
+} as const
+
+export const TagsListResponseSchema = z.array(TagSchema)
+export const TagsUsageCountResponseSchema = z.number().int().nonnegative()
+
+export type TagCreate = z.infer<typeof TagCreateSchema>
+export type TagUpdate = z.infer<typeof TagUpdateSchema>
+export type VariantTagAssign = z.infer<typeof VariantTagAssignSchema>
+export type VariantTagSet = z.infer<typeof VariantTagSetSchema>

--- a/src/shared/api/schemas/transcripts.ts
+++ b/src/shared/api/schemas/transcripts.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+export const TranscriptVariantIdSchema = z.number().int().positive()
+export const TranscriptIdSchema = z.string().min(1)
+
+export const TranscriptInsertRowSchema = z.object({
+  transcript_id: z.string().min(1),
+  gene_symbol: z.string().nullable(),
+  consequence: z.string().nullable(),
+  cdna: z.string().nullable(),
+  aa_change: z.string().nullable(),
+  hpo_sim_score: z.number().nullable(),
+  moi: z.string().nullable(),
+  is_selected: z.number().int().min(0).max(1)
+})
+
+export const TranscriptInvokeBodySchemas = {
+  list: z.object({
+    args: z.tuple([TranscriptVariantIdSchema])
+  }),
+  switch: z.object({
+    args: z.tuple([TranscriptVariantIdSchema, TranscriptIdSchema])
+  }),
+  insertAndSwitch: z.object({
+    args: z.tuple([TranscriptVariantIdSchema, TranscriptInsertRowSchema])
+  })
+} as const
+
+export const TranscriptSwitchResponseSchema = z.object({
+  success: z.boolean()
+})
+
+export const TranscriptUnknownResponseSchema = z.unknown()
+
+export type TranscriptInsertRowInput = z.infer<typeof TranscriptInsertRowSchema>

--- a/src/shared/api/schemas/variants.ts
+++ b/src/shared/api/schemas/variants.ts
@@ -2,13 +2,21 @@ import { z } from 'zod'
 
 import {
   CaseIdSchema,
+  ColumnMetaPayloadSchema,
   LimitSchema,
   OffsetSchema,
   SortItemSchema,
   VariantFilterPartialSchema
 } from '../../types/ipc-schemas'
 
-export { CaseIdSchema, LimitSchema, OffsetSchema, SortItemSchema, VariantFilterPartialSchema }
+export {
+  CaseIdSchema,
+  ColumnMetaPayloadSchema,
+  LimitSchema,
+  OffsetSchema,
+  SortItemSchema,
+  VariantFilterPartialSchema
+}
 
 export const VariantSortBySchema = z.array(SortItemSchema)
 
@@ -18,17 +26,7 @@ export const VariantSearchArgsSchema = z.tuple([
   LimitSchema.optional()
 ])
 
-export const VariantColumnMetaPayloadSchema = z.union([
-  z.object({
-    caseId: z.number(),
-    columnKey: z.string()
-  }),
-  z.object({
-    caseId: z.unknown().optional(),
-    caseIds: z.array(z.number()),
-    columnKey: z.string()
-  })
-])
+export const VariantColumnMetaPayloadSchema = ColumnMetaPayloadSchema
 
 const NullishStringOpenApiSchema = z.string().nullable().optional()
 const NullishStringArrayOpenApiSchema = z.array(z.string()).nullable().optional()

--- a/src/shared/api/schemas/variants.ts
+++ b/src/shared/api/schemas/variants.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod'
+
+import {
+  CaseIdSchema,
+  LimitSchema,
+  OffsetSchema,
+  SortItemSchema,
+  VariantFilterPartialSchema
+} from '../../types/ipc-schemas'
+
+export { CaseIdSchema, LimitSchema, OffsetSchema, SortItemSchema, VariantFilterPartialSchema }
+
+export const VariantSortBySchema = z.array(SortItemSchema)
+
+export const VariantSearchArgsSchema = z.tuple([
+  CaseIdSchema,
+  z.string().min(1).max(100),
+  LimitSchema.optional()
+])
+
+export const VariantColumnMetaPayloadSchema = z.union([
+  z.object({
+    caseId: z.number(),
+    columnKey: z.string()
+  }),
+  z.object({
+    caseId: z.unknown().optional(),
+    caseIds: z.array(z.number()),
+    columnKey: z.string()
+  })
+])
+
+const NullishStringOpenApiSchema = z.string().nullable().optional()
+const NullishStringArrayOpenApiSchema = z.array(z.string()).nullable().optional()
+const NullishNumberArrayOpenApiSchema = z.array(z.number()).nullable().optional()
+
+const VariantFilterOpenApiSchema = z.object({
+  gene_symbol: NullishStringOpenApiSchema,
+  search_query: NullishStringOpenApiSchema,
+  consequence: NullishStringOpenApiSchema,
+  consequences: NullishStringArrayOpenApiSchema,
+  funcs: NullishStringArrayOpenApiSchema,
+  clinvars: NullishStringArrayOpenApiSchema,
+  gnomad_af_max: z.number().min(0).max(1).nullable().optional(),
+  cadd_min: z.number().min(0).max(100).nullable().optional(),
+  max_internal_af: z.number().min(0).max(1).nullable().optional(),
+  chr: NullishStringOpenApiSchema,
+  pos: z.number().int().positive().nullable().optional(),
+  ref: NullishStringOpenApiSchema,
+  alt: NullishStringOpenApiSchema,
+  tag_ids: NullishNumberArrayOpenApiSchema,
+  starred_only: z.boolean().optional(),
+  has_comment: z.boolean().optional(),
+  acmg_classifications: NullishStringArrayOpenApiSchema,
+  column_filters: z.record(z.string(), z.unknown()).nullable().optional(),
+  annotation_scope: z.enum(['case', 'all']).optional(),
+  active_panel_ids: z.array(z.number().int().positive()).nullable().optional(),
+  panel_padding_bp: z.number().int().nonnegative().max(1000000).nullable().optional(),
+  inheritance_modes: z
+    .array(
+      z.enum([
+        'homozygous',
+        'heterozygous',
+        'x_hemizygous',
+        'candidate_compound_het',
+        'de_novo',
+        'autosomal_recessive',
+        'compound_het'
+      ])
+    )
+    .nullable()
+    .optional(),
+  analysis_group_id: z.number().int().positive().nullable().optional(),
+  consider_phasing: z.boolean().nullable().optional(),
+  variant_type: z.enum(['snv', 'indel', 'sv', 'cnv', 'str']).nullable().optional()
+})
+
+export const VariantInvokeBodySchemas = {
+  search: z.object({
+    args: VariantSearchArgsSchema
+  }),
+  columnMeta: z.object({
+    args: z.tuple([VariantColumnMetaPayloadSchema])
+  }),
+  query: z.object({
+    args: z.tuple([
+      CaseIdSchema,
+      VariantFilterOpenApiSchema,
+      OffsetSchema.nullish().optional(),
+      LimitSchema.nullish().optional(),
+      VariantSortBySchema.nullish().optional(),
+      z.boolean().optional(),
+      z.boolean().optional()
+    ])
+  }),
+  getFilterOptions: z.object({
+    args: z.tuple([CaseIdSchema])
+  })
+} as const
+
+export const VariantUnknownResponseSchema = z.unknown()
+
+export type VariantSearchArgs = z.infer<typeof VariantSearchArgsSchema>
+export type VariantColumnMetaPayload = z.infer<typeof VariantColumnMetaPayloadSchema>

--- a/src/shared/api/schemas/vep.ts
+++ b/src/shared/api/schemas/vep.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const VepFetchArgsSchema = z
+  .tuple([z.string(), z.number(), z.string(), z.string()])
+  .rest(z.unknown())
+
+export const VepInvokeBodySchemas = {
+  empty: z.object({
+    args: z.tuple([])
+  }),
+  fetch: z.object({
+    args: VepFetchArgsSchema
+  })
+} as const
+
+export const VepUnknownResponseSchema = z.unknown()

--- a/src/shared/types/ipc-schemas.ts
+++ b/src/shared/types/ipc-schemas.ts
@@ -22,6 +22,21 @@ import { z } from 'zod'
 import { DOMAIN_CONFIG } from '../config'
 import { ACMG_CLASSIFICATIONS } from '../config/domain.config'
 import { normalizeAcmgClassification } from '../utils/acmg'
+export {
+  UsernameSchema,
+  PasswordSchema,
+  LoginParamsSchema,
+  CreateUserSchema,
+  ChangePasswordSchema
+} from '../api/schemas/auth'
+export {
+  TagIdSchema,
+  TagCreateSchema,
+  TagUpdateSchema,
+  VariantTagAssignSchema,
+  VariantTagSetSchema,
+  TagCaseVariantIdSchema
+} from '../api/schemas/tags'
 
 /**
  * Helper to create a nullish string that transforms null to undefined
@@ -360,49 +375,6 @@ export const TypesPresentPayloadSchema = z
   })
 
 // ============================================================
-// Tag Schemas
-// ============================================================
-
-/**
- * Schema for tag ID validation
- */
-export const TagIdSchema = z.number().int().positive()
-
-/**
- * Schema for tag creation
- */
-export const TagCreateSchema = z.object({
-  name: z.string().min(1).max(100),
-  color: z.string().min(4).max(9) // e.g., #fff or #ffffff
-})
-
-/**
- * Schema for tag update
- */
-export const TagUpdateSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
-  color: z.string().min(4).max(9).optional()
-})
-
-/**
- * Schema for variant tag assignment (caseId, variantId, tagId)
- */
-export const VariantTagAssignSchema = z.object({
-  caseId: z.number().int().positive(),
-  variantId: z.number().int().positive(),
-  tagId: z.number().int().positive()
-})
-
-/**
- * Schema for setting multiple tags on a variant
- */
-export const VariantTagSetSchema = z.object({
-  caseId: z.number().int().positive(),
-  variantId: z.number().int().positive(),
-  tagIds: z.array(z.number().int().positive())
-})
-
-// ============================================================
 // Annotation Schemas
 // ============================================================
 
@@ -483,45 +455,6 @@ export const PerCaseAnnotationUpdatesSchema = z.object({
 export const CaseVariantIdSchema = z.object({
   caseId: z.number().int().positive(),
   variantId: z.number().int().positive()
-})
-
-// ============================================================
-// Auth Schemas
-// ============================================================
-
-/**
- * Schema for username validation
- */
-export const UsernameSchema = z.string().min(1).max(100)
-
-/**
- * Schema for password validation (min 8 characters)
- */
-export const PasswordSchema = z.string().min(8).max(256)
-
-/**
- * Schema for login parameters
- */
-export const LoginParamsSchema = z.object({
-  username: UsernameSchema,
-  password: z.string().min(1).max(256) // login allows any non-empty password
-})
-
-/**
- * Schema for user creation
- */
-export const CreateUserSchema = z.object({
-  username: UsernameSchema,
-  displayName: z.string().min(1).max(200),
-  tempPassword: PasswordSchema
-})
-
-/**
- * Schema for password change
- */
-export const ChangePasswordSchema = z.object({
-  oldPassword: z.string().min(1).max(256),
-  newPassword: PasswordSchema
 })
 
 // ============================================================

--- a/tests/main/handlers/annotations-handlers.test.ts
+++ b/tests/main/handlers/annotations-handlers.test.ts
@@ -446,7 +446,7 @@ describe('annotations:upsertPerCase — variants:annotationChanged broadcast', (
 })
 
 describe('annotation PostgreSQL audit routing', () => {
-  it('appends audit entries after postgres global annotation mutations', async () => {
+  it('uses one audited postgres storage write for global annotation mutations', async () => {
     const readExecute = vi.fn().mockResolvedValue({ starred: 0 })
     const writeExecute = vi.fn().mockResolvedValue({ starred: 1 })
     const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
@@ -479,28 +479,12 @@ describe('annotation PostgreSQL audit routing', () => {
       })
     ).resolves.toEqual({ starred: 1 })
 
-    expect(readExecute).toHaveBeenCalledWith({
-      type: 'annotations:getGlobal',
-      params: [{ chr: '1', pos: 123, ref: 'A', alt: 'G' }]
-    })
-    expect(writeExecute).toHaveBeenNthCalledWith(1, {
-      type: 'annotations:upsertGlobal',
+    expect(readExecute).not.toHaveBeenCalled()
+    expect(writeExecute).toHaveBeenCalledWith({
+      type: 'annotations:upsertGlobalWithAudit',
       params: [
         { chr: '1', pos: 123, ref: 'A', alt: 'G' },
         { starred: true, user_name: 'analyst' }
-      ]
-    })
-    expect(writeExecute).toHaveBeenNthCalledWith(2, {
-      type: 'audit:append',
-      params: [
-        {
-          action_type: 'star',
-          entity_type: 'variant_annotation',
-          entity_key: '1:123:A:G',
-          old_value: JSON.stringify({ starred: 0 }),
-          new_value: JSON.stringify({ starred: 1 }),
-          user_name: 'analyst'
-        }
       ]
     })
   })

--- a/tests/main/handlers/cases-handlers.test.ts
+++ b/tests/main/handlers/cases-handlers.test.ts
@@ -200,12 +200,14 @@ describe('cases IPC handlers', () => {
     expect(result).toBe(expected)
     expect(execute).toHaveBeenCalledWith({
       type: 'cases:query',
-      params: {
-        limit: 25,
-        offset: 0,
-        sort_by: 'created_at',
-        sort_order: 'desc'
-      }
+      params: [
+        {
+          limit: 25,
+          offset: 0,
+          sort_by: 'created_at',
+          sort_order: 'desc'
+        }
+      ]
     })
   })
 

--- a/tests/main/handlers/transcripts-handlers.test.ts
+++ b/tests/main/handlers/transcripts-handlers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn(),
+    removeAllListeners: vi.fn()
+  },
+  app: {
+    getPath: vi.fn(() => '/tmp/varlens-test')
+  }
+}))
+
+describe('transcript PostgreSQL executor routing', () => {
+  it('routes transcript reads and writes through the current Postgres session executors', async () => {
+    const readExecute = vi.fn().mockResolvedValue([{ transcript_id: 'NM_000059.4' }])
+    const writeExecute = vi.fn().mockResolvedValue({ success: true })
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler)
+      })
+    }
+    const { registerTranscriptHandlers } =
+      await import('../../../src/main/ipc/handlers/transcripts')
+    const transcript = {
+      transcript_id: 'NM_000059.4',
+      gene_symbol: 'BRCA2',
+      consequence: 'HIGH',
+      cdna: 'c.1A>G',
+      aa_change: 'p.M1V',
+      hpo_sim_score: 0.8,
+      moi: 'AD',
+      is_selected: 0
+    }
+
+    registerTranscriptHandlers({
+      ipcMain: ipcMain as never,
+      getDb: (() => {
+        throw new Error('getDb should not be called for postgres transcripts')
+      }) as never,
+      getDbManager: (() => ({
+        getCurrentSession: () => ({
+          capabilities: { backend: 'postgres' },
+          getReadExecutor: () => ({ execute: readExecute }),
+          getWriteExecutor: () => ({ execute: writeExecute })
+        })
+      })) as never
+    })
+
+    await expect(handlers.get('transcripts:list')!(undefined, 9)).resolves.toEqual([
+      { transcript_id: 'NM_000059.4' }
+    ])
+    await expect(handlers.get('transcripts:switch')!(undefined, 9, 'NM_000059.4')).resolves.toEqual(
+      { success: true }
+    )
+    await expect(
+      handlers.get('transcripts:insertAndSwitch')!(undefined, 9, transcript)
+    ).resolves.toEqual({ success: true })
+
+    expect(readExecute).toHaveBeenCalledWith({ type: 'transcripts:list', params: [9] })
+    expect(writeExecute).toHaveBeenNthCalledWith(1, {
+      type: 'transcripts:switch',
+      params: [9, 'NM_000059.4']
+    })
+    expect(writeExecute).toHaveBeenNthCalledWith(2, {
+      type: 'transcripts:insertAndSwitch',
+      params: [9, transcript]
+    })
+  })
+})

--- a/tests/main/handlers/variants-logic.test.ts
+++ b/tests/main/handlers/variants-logic.test.ts
@@ -65,18 +65,22 @@ describe('variants-logic exports', () => {
     expect(getDb).not.toHaveBeenCalled()
   })
 
-  it('fails variants:search clearly on postgres instead of calling getDb', async () => {
+  it('routes variants:search through the postgres read executor without calling getDb', async () => {
+    const execute = vi.fn().mockResolvedValue({ data: [], total_count: 0 })
     const getDb = vi.fn(() => {
-      throw new Error('getDb should not be called for postgres search rejection')
+      throw new Error('getDb should not be called for postgres search')
     })
     const getSession = () =>
       ({
-        capabilities: { backend: 'postgres' }
+        capabilities: { backend: 'postgres' },
+        getReadExecutor: () => ({ execute })
       }) as never
 
-    await expect(searchVariants(1, 'BRCA1', 20, getSession, getDb)).rejects.toThrow(
-      'PostgreSQL variants:search is deferred from Phase 7'
-    )
+    await expect(searchVariants(1, 'BRCA1', 20, getSession, getDb)).resolves.toEqual([])
+    expect(execute).toHaveBeenCalledWith({
+      type: 'variants:search',
+      params: [1, 'BRCA1', 20]
+    })
     expect(getDb).not.toHaveBeenCalled()
   })
 })

--- a/tests/main/storage/postgres-annotations-repository.test.ts
+++ b/tests/main/storage/postgres-annotations-repository.test.ts
@@ -96,6 +96,121 @@ describe('PostgresAnnotationsRepository', () => {
     ])
   })
 
+  it('upserts global annotations and audit entries in one transaction', async () => {
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 8,
+            chr: '1',
+            pos: 12345,
+            ref: 'A',
+            alt: 'G',
+            global_comment: null,
+            starred: 0,
+            acmg_classification: 'VUS',
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060801000
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 8,
+            chr: '1',
+            pos: 12345,
+            ref: 'A',
+            alt: 'G',
+            global_comment: null,
+            starred: 1,
+            acmg_classification: 'Pathogenic',
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060802000
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
+
+    await expect(
+      repository.upsertGlobalAnnotationWithAudit('1', 12345, 'A', 'G', {
+        starred: 1,
+        acmg_classification: 'Pathogenic',
+        user_name: 'analyst'
+      })
+    ).resolves.toMatchObject({ starred: 1, acmg_classification: 'Pathogenic' })
+
+    expect(query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('INSERT INTO "public"."audit_log"'),
+      [
+        'acmg_classify',
+        'variant_annotation',
+        '1:12345:A:G',
+        JSON.stringify({ acmg_classification: 'VUS' }),
+        JSON.stringify({ acmg_classification: 'Pathogenic' }),
+        'analyst',
+        null
+      ]
+    )
+    expect(query).toHaveBeenNthCalledWith(6, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('rolls back audited global annotation writes when audit append fails', async () => {
+    const release = vi.fn()
+    const failure = new Error('audit append failed')
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 8,
+            chr: '1',
+            pos: 12345,
+            ref: 'A',
+            alt: 'G',
+            global_comment: null,
+            starred: 1,
+            acmg_classification: null,
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060802000
+          }
+        ]
+      })
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ rows: [] })
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
+
+    await expect(
+      repository.upsertGlobalAnnotationWithAudit('1', 12345, 'A', 'G', {
+        starred: true,
+        user_name: 'analyst'
+      })
+    ).rejects.toThrow('audit append failed')
+
+    expect(query).toHaveBeenNthCalledWith(5, 'ROLLBACK')
+    expect(release).toHaveBeenCalledOnce()
+  })
+
   it('deletes global annotations by coordinates', async () => {
     const pool = makePool()
     pool.query.mockResolvedValueOnce({ rows: [] })
@@ -166,6 +281,72 @@ describe('PostgresAnnotationsRepository', () => {
     expect(upsertSql).toContain('ON CONFLICT (case_id, variant_id) DO UPDATE')
     expect(upsertSql).toContain('"public"."case_variant_annotations"')
     expect(upsertParams).toStrictEqual([2, 3, 'updated', 0, null, null, true, true, false, false])
+  })
+
+  it('upserts per-case annotations and audit entries in one transaction', async () => {
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 9,
+            case_id: 2,
+            variant_id: 3,
+            per_case_comment: null,
+            starred: 0,
+            acmg_classification: 'Benign',
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060801000
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 9,
+            case_id: 2,
+            variant_id: 3,
+            per_case_comment: null,
+            starred: 0,
+            acmg_classification: 'Likely pathogenic',
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060802000
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
+
+    await expect(
+      repository.upsertPerCaseAnnotationWithAudit(2, 3, {
+        acmg_classification: 'Likely pathogenic',
+        user_name: 'reviewer'
+      })
+    ).resolves.toMatchObject({ acmg_classification: 'Likely pathogenic' })
+
+    expect(query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('INSERT INTO "public"."audit_log"'),
+      [
+        'acmg_classify',
+        'case_variant_annotation',
+        'case:2:variant:3',
+        JSON.stringify({ acmg_classification: 'Benign' }),
+        JSON.stringify({ acmg_classification: 'Likely pathogenic' }),
+        'reviewer',
+        null
+      ]
+    )
+    expect(query).toHaveBeenNthCalledWith(5, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
   })
 
   it('deletes per-case annotations by case and variant id', async () => {

--- a/tests/main/storage/postgres-filter-presets-repository.test.ts
+++ b/tests/main/storage/postgres-filter-presets-repository.test.ts
@@ -80,8 +80,8 @@ describe('PostgresFilterPresetsRepository', () => {
       null,
       JSON.stringify({ genes: ['BRCA1'] }),
       'filter',
-      false,
-      true,
+      0,
+      1,
       0,
       expect.any(Number),
       expect.any(Number)
@@ -142,7 +142,7 @@ describe('PostgresFilterPresetsRepository', () => {
     expect(sql).not.toContain('name =')
     expect(sql).not.toContain('filter_json =')
     expect(sql).not.toContain('kind =')
-    expect(params).toEqual([false, 5, expect.any(Number), 9])
+    expect(params).toEqual([0, 5, expect.any(Number), 9])
   })
 
   it('throws typed errors for missing, duplicate, and protected presets', async () => {

--- a/tests/main/storage/postgres-import-worker-client.test.ts
+++ b/tests/main/storage/postgres-import-worker-client.test.ts
@@ -101,4 +101,24 @@ describe('PostgresImportWorkerClient', () => {
     expect(() => c.cancel()).not.toThrow()
     expect(fake.postMessage).not.toHaveBeenCalled()
   })
+
+  it('throws a clear error when the worker bundle cannot be found', () => {
+    const c = new PostgresImportWorkerClient({
+      workerPathCandidates: ['/tmp/varlens-missing-postgres-import-worker.js']
+    })
+
+    expect(() =>
+      c.start(
+        {
+          type: 'start',
+          client: { connectionString: 'postgres://x' },
+          schema: 'public',
+          mode: 'single-file',
+          caseName: 'X',
+          filePath: '/tmp/a.json'
+        },
+        { onProgress: vi.fn(), onFileComplete: vi.fn(), onComplete: vi.fn(), onError: vi.fn() }
+      )
+    ).toThrow(/Postgres import worker bundle not found/)
+  })
 })

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -11,7 +11,8 @@ function workflowRepositories() {
     panels: {} as never,
     filterPresets: {} as never,
     shortlist: {} as never,
-    analysisGroups: {} as never
+    analysisGroups: {} as never,
+    transcripts: {} as never
   }
 }
 
@@ -39,7 +40,9 @@ describe('PostgresReadExecutor', () => {
       caseMetadata: {} as never
     })
 
-    await expect(executor.execute({ type: 'cases:query', params })).resolves.toBe(expected)
+    await expect(executor.execute({ type: 'cases:query', params: [params] })).resolves.toBe(
+      expected
+    )
     expect(casesQuery.queryCases).toHaveBeenCalledWith(params)
     expect(availableBuilds.getAvailableGenomeBuilds).not.toHaveBeenCalled()
   })
@@ -104,7 +107,8 @@ describe('PostgresReadExecutor', () => {
     const variants = {
       getVariantTypeCounts: vi.fn().mockResolvedValue({ snv: 2 }),
       getVariantTypesPresent: vi.fn().mockResolvedValue(['snv']),
-      getGeneSymbols: vi.fn().mockResolvedValue(['BRCA1'])
+      getGeneSymbols: vi.fn().mockResolvedValue(['BRCA1']),
+      searchVariants: vi.fn().mockResolvedValue([{ id: 1, consequence: 'stop_gained' }])
     }
     const casesQuery = { queryCases: vi.fn() }
     const availableBuilds = { getAvailableGenomeBuilds: vi.fn() }
@@ -140,6 +144,10 @@ describe('PostgresReadExecutor', () => {
     await expect(
       executor.execute({ type: 'variants:geneSymbols', params: [1, 'BR', 20] })
     ).resolves.toStrictEqual(['BRCA1'])
+    await expect(
+      executor.execute({ type: 'variants:search', params: [1, 'stop', 20] })
+    ).resolves.toStrictEqual([{ id: 1, consequence: 'stop_gained' }])
+    expect(variants.searchVariants).toHaveBeenCalledWith(1, 'stop', 20)
   })
 
   it('dispatches variant query reads to the postgres variant repository', async () => {

--- a/tests/main/storage/postgres-storage-session.test.ts
+++ b/tests/main/storage/postgres-storage-session.test.ts
@@ -137,8 +137,9 @@ describe('PostgresStorageSession', () => {
       } as never
     })
 
-    expect(() => session.getDatabaseService()).toThrow('DatabaseService is not available')
-    expect(() => session.getDbPool()).toThrow('DbPool is not available')
+    // getDatabaseService / getDbPool are off the StorageSession interface and
+    // removed from PostgresStorageSession entirely. Only the SQLite-only method
+    // that remains on the interface (rekey) is still asserted here.
     expect(() => session.rekey('secret')).toThrow('SQLite rekey is not supported')
   })
 
@@ -224,11 +225,13 @@ describe('PostgresStorageSession', () => {
     await expect(
       session.getReadExecutor().execute({
         type: 'cases:query',
-        params: {
-          limit: 25,
-          offset: 0,
-          sort_order: 'desc'
-        }
+        params: [
+          {
+            limit: 25,
+            offset: 0,
+            sort_order: 'desc'
+          }
+        ]
       })
     ).resolves.toMatchObject({
       data: [

--- a/tests/main/storage/postgres-transcripts-repository.test.ts
+++ b/tests/main/storage/postgres-transcripts-repository.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PostgresTranscriptsRepository } from '../../../src/main/storage/postgres/PostgresTranscriptsRepository'
+
+describe('PostgresTranscriptsRepository', () => {
+  it('maps integer transcript flags to desktop boolean fields', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [
+          {
+            id: '1',
+            variant_id: '9',
+            transcript_id: 'NM_000059.4',
+            gene_symbol: 'BRCA2',
+            consequence: 'HIGH',
+            cdna: null,
+            aa_change: null,
+            hpo_sim_score: null,
+            moi: null,
+            is_selected: 1,
+            is_mane_select: 0,
+            is_canonical: null
+          }
+        ]
+      })
+    }
+    const repository = new PostgresTranscriptsRepository(pool as never, 'case_schema')
+
+    await expect(repository.list(9)).resolves.toEqual([
+      {
+        id: 1,
+        variant_id: 9,
+        transcript_id: 'NM_000059.4',
+        gene_symbol: 'BRCA2',
+        consequence: 'HIGH',
+        cdna: null,
+        aa_change: null,
+        hpo_sim_score: null,
+        moi: null,
+        is_selected: true,
+        is_mane_select: false,
+        is_canonical: null
+      }
+    ])
+  })
+
+  it('updates the parent variant when switching the selected transcript', async () => {
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            transcript_id: 'NM_000059.4',
+            gene_symbol: 'BRCA2',
+            consequence: 'HIGH',
+            cdna: 'c.1A>G',
+            aa_change: 'p.M1V',
+            hpo_sim_score: 0.8,
+            moi: 'AD'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresTranscriptsRepository(pool as never, 'case_schema')
+
+    await expect(repository.switchSelectedTranscript(9, 'NM_000059.4')).resolves.toEqual({
+      success: true
+    })
+
+    expect(query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(query).toHaveBeenNthCalledWith(3, expect.stringContaining('RETURNING'), [
+      9,
+      'NM_000059.4'
+    ])
+    expect(query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('UPDATE "case_schema".variants'),
+      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'c.1A>G', 'p.M1V', 0.8, 'AD']
+    )
+    expect(query).toHaveBeenNthCalledWith(5, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('inserts missing transcripts without overwriting existing rows and then switches selection', async () => {
+    const transcript = {
+      transcript_id: 'NM_000059.4',
+      gene_symbol: 'BRCA2',
+      consequence: 'HIGH',
+      cdna: 'c.1A>G',
+      aa_change: 'p.M1V',
+      hpo_sim_score: 0.8,
+      moi: 'AD',
+      is_selected: 0
+    }
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            transcript_id: 'NM_000059.4',
+            gene_symbol: 'BRCA2',
+            consequence: 'HIGH',
+            cdna: 'c.1A>G',
+            aa_change: 'p.M1V',
+            hpo_sim_score: 0.8,
+            moi: 'AD'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresTranscriptsRepository(pool as never, 'case_schema')
+
+    await expect(repository.insertTranscriptAndSwitch(9, transcript)).resolves.toEqual({
+      success: true
+    })
+
+    expect(query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('ON CONFLICT (variant_id, transcript_id)\n         DO NOTHING'),
+      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'c.1A>G', 'p.M1V', 0.8, 'AD']
+    )
+    expect(query).toHaveBeenNthCalledWith(
+      3,
+      'UPDATE "case_schema".variant_transcripts SET is_selected = 0 WHERE variant_id = $1',
+      [9]
+    )
+    expect(query).toHaveBeenNthCalledWith(4, expect.stringContaining('RETURNING'), [
+      9,
+      'NM_000059.4'
+    ])
+    expect(query).toHaveBeenNthCalledWith(
+      5,
+      expect.stringContaining('UPDATE "case_schema".variants'),
+      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'c.1A>G', 'p.M1V', 0.8, 'AD']
+    )
+    expect(query).toHaveBeenNthCalledWith(6, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/main/storage/postgres-variant-read-repository.test.ts
+++ b/tests/main/storage/postgres-variant-read-repository.test.ts
@@ -44,6 +44,37 @@ describe('PostgresVariantReadRepository', () => {
     expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ILIKE'), [1, 'br%', 20])
   })
 
+  it('searches the full search document instead of narrowing to gene_symbol', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValueOnce({
+        rows: [
+          {
+            id: '1',
+            case_id: '1',
+            chr: '1',
+            pos: '1000',
+            ref: 'A',
+            alt: 'G',
+            gene_symbol: 'GENE1',
+            consequence: 'stop_gained',
+            internal_af: null
+          }
+        ]
+      })
+    }
+    const repository = new PostgresVariantReadRepository(pool as never, 'public')
+
+    await expect(repository.searchVariants(1, 'stop', 20)).resolves.toMatchObject([
+      { id: 1, case_id: 1, consequence: 'stop_gained' }
+    ])
+
+    const sql = String(pool.query.mock.calls[0][0])
+    expect(sql).toContain('search_document @@')
+    expect(sql).toContain("to_tsquery('simple'")
+    expect(sql).not.toContain('gene_symbol ILIKE')
+    expect(pool.query.mock.calls[0][1]).toEqual([1, 'stop:*', 20, 0])
+  })
+
   it.each([
     ['tag_ids', { tag_ids: [1] }, 'variant_tags'],
     ['starred_only', { starred_only: true }, 'case_variant_annotations'],

--- a/tests/main/storage/postgres-write-executor.test.ts
+++ b/tests/main/storage/postgres-write-executor.test.ts
@@ -10,7 +10,8 @@ function workflowRepositories(): ConstructorParameters<typeof PostgresWriteExecu
     commentsMetrics: {} as never,
     panels: {} as never,
     filterPresets: {} as never,
-    analysisGroups: {} as never
+    analysisGroups: {} as never,
+    transcripts: {} as never
   }
 }
 
@@ -73,7 +74,8 @@ describe('PostgresWriteExecutor', () => {
     const workflow = workflowRepositories()
     workflow.tags = { createTag: vi.fn().mockResolvedValue({ id: 1 }) } as never
     workflow.annotations = {
-      upsertPerCaseAnnotation: vi.fn().mockResolvedValue({ case_id: 1, variant_id: 2 })
+      upsertPerCaseAnnotation: vi.fn().mockResolvedValue({ case_id: 1, variant_id: 2 }),
+      upsertPerCaseAnnotationWithAudit: vi.fn().mockResolvedValue({ case_id: 1, variant_id: 2 })
     } as never
     workflow.panels = { createPanel: vi.fn().mockResolvedValue({ id: 3 }) } as never
     const executor = new PostgresWriteExecutor({} as never, {} as never, workflow)
@@ -88,12 +90,19 @@ describe('PostgresWriteExecutor', () => {
       params: [1, 2, { acmg_classification: 'VUS' }]
     })
     await executor.execute({
+      type: 'annotations:upsertPerCaseWithAudit',
+      params: [1, 2, { acmg_classification: 'VUS' }]
+    })
+    await executor.execute({
       type: 'panels:create',
       params: [{ name: 'Panel', source: 'manual' }]
     })
 
     expect(workflow.tags.createTag).toHaveBeenCalledWith('Review', '#fff')
     expect(workflow.annotations.upsertPerCaseAnnotation).toHaveBeenCalledWith(1, 2, {
+      acmg_classification: 'VUS'
+    })
+    expect(workflow.annotations.upsertPerCaseAnnotationWithAudit).toHaveBeenCalledWith(1, 2, {
       acmg_classification: 'VUS'
     })
     expect(workflow.panels.createPanel).toHaveBeenCalledWith({ name: 'Panel', source: 'manual' })

--- a/tests/main/storage/read-executor-contract.test.ts
+++ b/tests/main/storage/read-executor-contract.test.ts
@@ -18,7 +18,7 @@ describe('StorageReadExecutor contract', () => {
 
     const queryTask = {
       type: 'cases:query',
-      params
+      params: [params]
     } satisfies StorageReadTask
 
     expectTypeOf(queryTask).toMatchTypeOf<StorageReadTask>()

--- a/tests/main/storage/sqlite-read-executor.test.ts
+++ b/tests/main/storage/sqlite-read-executor.test.ts
@@ -41,11 +41,15 @@ describe('SqliteReadExecutor', () => {
     }
     const executor = new SqliteReadExecutor(databaseService as never, dbPool as never)
 
-    await expect(executor.execute({ type: 'cases:query', params })).resolves.toBe(expected)
+    await expect(executor.execute({ type: 'cases:query', params: [params] })).resolves.toBe(
+      expected
+    )
     expect(dbPool.run).toHaveBeenCalledWith({
       type: 'cases:query',
       params: [params]
     })
+    // Note: the SqliteReadExecutor now passes task.params (the tuple)
+    // straight through to the pool — no extra wrapping.
     expect(databaseService.cases.queryCases).not.toHaveBeenCalled()
   })
 
@@ -58,7 +62,9 @@ describe('SqliteReadExecutor', () => {
     }
     const executor = new SqliteReadExecutor(databaseService as never, null)
 
-    await expect(executor.execute({ type: 'cases:query', params })).resolves.toBe(expected)
+    await expect(executor.execute({ type: 'cases:query', params: [params] })).resolves.toBe(
+      expected
+    )
     expect(databaseService.cases.queryCases).toHaveBeenCalledWith(params)
   })
 

--- a/tests/main/storage/storage-manager-compat.test.ts
+++ b/tests/main/storage/storage-manager-compat.test.ts
@@ -7,8 +7,15 @@ import { DatabaseManager } from '../../../src/main/services/DatabaseManager'
 import { RecentDatabasesService } from '../../../src/main/services/RecentDatabasesService'
 import { POSTGRES_CAPABILITIES } from '../../../src/main/storage/postgres/PostgresStorageSession'
 import type { StorageSession } from '../../../src/main/storage/session'
+import type { DbPool } from '../../../src/main/database/DbPool'
 
 let tempDir: string | null = null
+
+type SqlitePoolSession = StorageSession & { getDbPool(): DbPool | null }
+
+function hasSqlitePool(session: StorageSession): session is SqlitePoolSession {
+  return session.capabilities.backend === 'sqlite' && 'getDbPool' in session
+}
 
 afterEach(async () => {
   if (tempDir !== null) {
@@ -44,7 +51,9 @@ describe('DatabaseManager storage-session compatibility', () => {
 
     await manager.open(dbPath)
 
-    expect(manager.getCurrentSession().getDbPool()).not.toBeNull()
+    const session = manager.getCurrentSession()
+    expect(hasSqlitePool(session)).toBe(true)
+    expect(hasSqlitePool(session) ? session.getDbPool() : null).not.toBeNull()
 
     await manager.close()
   })
@@ -71,11 +80,8 @@ describe('DatabaseManager storage-session compatibility', () => {
       getWriteExecutor: () => ({
         execute: vi.fn()
       }),
-      getDatabaseService: () => {
-        throw new Error('DatabaseService is not available for postgres sessions')
-      },
-      getDbPool: () => {
-        throw new Error('DbPool is not available for postgres sessions')
+      getImportExecutor: () => {
+        throw new Error('Import executor is not available for this test session')
       },
       getEncryptionKey: () => {
         throw new Error('Encryption keys are not available for postgres sessions')
@@ -131,12 +137,15 @@ describe('DatabaseManager storage-session compatibility', () => {
     const { getDbPool, setActiveSessionResolver } =
       await import('../../../src/main/ipc/dbPoolManager')
 
-    setActiveSessionResolver(() => ({
-      capabilities: {
-        backend: 'sqlite'
-      },
-      getDbPool: () => sessionPool
-    }))
+    setActiveSessionResolver(
+      () =>
+        ({
+          capabilities: {
+            backend: 'sqlite'
+          },
+          getDbPool: () => sessionPool as unknown as DbPool
+        }) as unknown as StorageSession
+    )
 
     expect(getDbPool()).toBe(sessionPool)
 
@@ -149,14 +158,14 @@ describe('DatabaseManager storage-session compatibility', () => {
     const { getDbPool, setActiveSessionResolver } =
       await import('../../../src/main/ipc/dbPoolManager')
 
-    setActiveSessionResolver(() => ({
-      capabilities: {
-        backend: 'postgres'
-      },
-      getDbPool: () => {
-        throw new Error('DbPool is not available for postgres sessions')
-      }
-    }))
+    setActiveSessionResolver(
+      () =>
+        ({
+          capabilities: {
+            backend: 'postgres'
+          }
+        }) as unknown as StorageSession
+    )
 
     expect(getDbPool()).toBeNull()
 

--- a/tests/main/storage/storage-session-contract.test.ts
+++ b/tests/main/storage/storage-session-contract.test.ts
@@ -1,0 +1,159 @@
+/**
+ * StorageSession contract — same observable behavior across both backends.
+ *
+ * Pins the interface that desktop (SQLite) and web (Postgres) must agree on.
+ * The refactor that extracts code behind StorageSession is the most likely
+ * place for the two backends to diverge silently; this test catches it.
+ *
+ * SQLite half: always runs.
+ * Postgres half: gated by VARLENS_RUN_POSTGRES_E2E=1 + a running dev container
+ *   (make pg-up). Each run uses a unique schema and drops it on cleanup.
+ *
+ *   make pg-up
+ *   VARLENS_RUN_POSTGRES_E2E=1 npx vitest run --project main \
+ *     tests/main/storage/storage-session-contract.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { Client } from 'pg'
+
+import { DatabaseService } from '../../../src/main/database/DatabaseService'
+import { SqliteStorageSession } from '../../../src/main/storage/sqlite/SqliteStorageSession'
+import { createPostgresStorageSession } from '../../../src/main/storage/postgres/createPostgresStorageSession'
+import type { PostgresStorageConfig } from '../../../src/main/storage/config'
+import type { StorageSession } from '../../../src/main/storage/session'
+
+interface BackendFixture {
+  name: 'sqlite' | 'postgres'
+  setup: () => Promise<{ session: StorageSession; cleanup: () => Promise<void> }>
+}
+
+const POSTGRES_E2E = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+async function setupSqlite() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'varlens-storage-contract-sqlite-'))
+  const dbPath = join(tempDir, 'session.db')
+  const db = new DatabaseService(dbPath)
+  const session = new SqliteStorageSession({ databaseService: db, dbPool: null })
+
+  return {
+    session,
+    cleanup: async () => {
+      await session.close()
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+async function setupPostgres() {
+  const schema = `varlens_test_${Date.now()}_${randomBytes(4).toString('hex')}`
+
+  const provisioner = new Client({ connectionString: PG_URL })
+  await provisioner.connect()
+  await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+  await provisioner.end()
+
+  const config: PostgresStorageConfig = {
+    url: PG_URL,
+    schema,
+    applicationName: 'varlens-test',
+    sslMode: 'disable',
+    connectionTimeoutMillis: 5000,
+    statementTimeoutMs: 30_000,
+    queryTimeoutMs: 30_000,
+    lockTimeoutMs: 5_000,
+    idleInTransactionSessionTimeoutMs: 10_000,
+    poolMax: 2
+  }
+
+  const session = await createPostgresStorageSession(config)
+
+  return {
+    session,
+    cleanup: async () => {
+      await session.close()
+      const cleaner = new Client({ connectionString: PG_URL })
+      await cleaner.connect()
+      await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+      await cleaner.end()
+    }
+  }
+}
+
+const fixtures: BackendFixture[] = [
+  { name: 'sqlite', setup: setupSqlite },
+  ...(POSTGRES_E2E ? [{ name: 'postgres' as const, setup: setupPostgres }] : [])
+]
+
+describe.each(fixtures)('StorageSession contract — $name', ({ name, setup }) => {
+  let s: { session: StorageSession; cleanup: () => Promise<void> }
+
+  beforeAll(async () => {
+    s = await setup()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (s) await s.cleanup()
+  }, 60_000)
+
+  it('exposes workspace metadata with the expected backend kind', () => {
+    expect(s.session.workspace.kind).toBe(name)
+  })
+
+  it('reports ok health on a fresh session', async () => {
+    const health = await s.session.health()
+    expect(health.ok).toBe(true)
+    expect(health.backend).toBe(name)
+  })
+
+  it('returns an empty array from listCases on a fresh DB', async () => {
+    expect(await s.session.listCases()).toEqual([])
+  })
+
+  it('exposes a defined read executor', () => {
+    expect(s.session.getReadExecutor()).toBeDefined()
+  })
+
+  it('exposes a defined import executor with importSingleFile + cancel', () => {
+    const executor = s.session.getImportExecutor()
+    expect(executor).toBeDefined()
+    expect(typeof executor.importSingleFile).toBe('function')
+    expect(typeof executor.cancel).toBe('function')
+  })
+
+  it('exposes a capabilities object with the expected backend tag', () => {
+    expect(s.session.capabilities.backend).toBe(name)
+  })
+})
+
+describe.skipIf(POSTGRES_E2E)('StorageSession contract — postgres half (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(POSTGRES_E2E).toBe(false)
+  })
+})
+
+/**
+ * Deferred (rule-of-three): cross-backend behavioral parity.
+ *
+ * The contract tests above pin the *interface* — both backends expose the
+ * same observable surface for shape-level operations. The next layer is
+ * behavioral parity: insert N variants on each backend, run 3 filter
+ * queries, assert identical normalized results.
+ *
+ * Why deferred: behavioral parity for VCF-derived data is already pinned
+ * on the SQLite path by `tests/web-gate/parity/import-and-filter.test.ts`.
+ * Adding the Postgres equivalent requires Postgres-side variant fixture
+ * setup (COPY-from-stdin or repository writes) and a normalized comparator.
+ * That work lands when the third parity scenario is needed (rule of three).
+ */
+describe.skip('StorageSession behavioral parity — cross-backend filter results', () => {
+  it('insert N variants on each backend, run 3 filter queries, assert identical', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/tests/main/storage/variant-search-parity.test.ts
+++ b/tests/main/storage/variant-search-parity.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DatabaseService, type Variant } from '../../../src/main/database'
+import { PostgresVariantReadRepository } from '../../../src/main/storage/postgres/PostgresVariantReadRepository'
+
+describe('variant search parity', () => {
+  let sqlite: DatabaseService
+
+  beforeEach(() => {
+    sqlite = new DatabaseService(':memory:')
+  })
+
+  afterEach(() => {
+    sqlite.close()
+  })
+
+  it('matches non-gene search terms through SQLite FTS and Postgres search_document', async () => {
+    const caseId = sqlite.cases.createCase('search-parity', '/fixtures/search.vcf', 1024)
+    const variants: Omit<Variant, 'id' | 'case_id'>[] = [
+      {
+        chr: '1',
+        pos: 1000,
+        ref: 'A',
+        alt: 'G',
+        gene_symbol: 'GENE1',
+        consequence: 'stop_gained',
+        gnomad_af: null,
+        cadd: null,
+        clinvar: null
+      },
+      {
+        chr: '1',
+        pos: 2000,
+        ref: 'C',
+        alt: 'T',
+        gene_symbol: 'STOPLIKE_GENE',
+        consequence: 'missense_variant',
+        gnomad_af: null,
+        cadd: null,
+        clinvar: null
+      }
+    ]
+    sqlite.variants.insertVariantsBatch(caseId, variants)
+    const sqliteResults = sqlite.variants.searchVariants(caseId, 'stop', 20)
+
+    const pool = {
+      query: vi.fn().mockResolvedValueOnce({
+        rows: sqliteResults.map((variant) => ({
+          ...variant,
+          internal_af: null
+        }))
+      })
+    }
+    const postgres = new PostgresVariantReadRepository(pool as never, 'public')
+    const postgresResults = await postgres.searchVariants(caseId, 'stop', 20)
+
+    expect(sqliteResults.map((variant) => variant.consequence)).toContain('stop_gained')
+    expect(postgresResults.map((variant) => variant.consequence)).toEqual(
+      sqliteResults.map((variant) => variant.consequence)
+    )
+    const sql = String(pool.query.mock.calls[0][0])
+    expect(sql).toContain('search_document @@')
+    expect(sql).not.toContain('gene_symbol ILIKE')
+  })
+})

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -380,4 +380,64 @@ describe('postgres-import-worker runImport', () => {
     // bedFilter is undefined because we didn't supply a bedFilePath.
     expect(filters.bedFilter).toBeUndefined()
   })
+
+  it('applies multi-file filters only to append files when a base file creates the case', async () => {
+    const client = {
+      connect: vi.fn(async () => undefined),
+      query: vi.fn(async (sql: string | { text: string }) => {
+        const text = typeof sql === 'string' ? sql : sql.text
+        if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
+        return { rows: [] }
+      }),
+      end: vi.fn(async () => undefined)
+    }
+    const { Readable } = await import('node:stream')
+    const filtersByFile = new Map<string, unknown>()
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
+        createVcfMappedStream: async (filePath, options) => {
+          filtersByFile.set(filePath, options.filters)
+          return Readable.from([]) as never
+        },
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'multi-file',
+        caseName: 'F',
+        vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' },
+        files: [
+          {
+            filePath: '/tmp/base.vcf.gz',
+            variantType: 'snv-indel',
+            annotationFormat: null,
+            caller: null
+          },
+          {
+            filePath: '/tmp/append.vcf.gz',
+            variantType: 'snv-indel',
+            annotationFormat: null,
+            caller: null
+          }
+        ],
+        filters: {
+          passOnly: true,
+          minQual: 30
+        }
+      },
+      () => {}
+    )
+
+    expect(filtersByFile.get('/tmp/base.vcf.gz')).toBeUndefined()
+    expect(filtersByFile.get('/tmp/append.vcf.gz')).toMatchObject({
+      passOnly: true,
+      minQual: 30
+    })
+  })
 })


### PR DESCRIPTION
Summary
- Adds shared API schemas and storage seams for the web track.
- Fixes Postgres variant search parity and tightens search validation.
- Adds SQLite/Postgres search parity coverage.

Validation
- make ci
- npm run build:web
- VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-web-ci-secrets make web-gate-static
