### PR TITLE
web 04: add container and web gate contract

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,63 @@
+# Excluded from the docker build context. Mirrors .gitignore plus the
+# desktop-only artifact dirs we never want shipped in the web image.
+
+# Host node_modules MUST be excluded — `COPY . .` would otherwise overwrite
+# the freshly rebuilt system-Node-ABI binaries with the developer's local
+# Electron-ABI binaries from `make dev`, producing a broken image.
+node_modules/
+**/node_modules/
+
+# VCS / agent state
+.git/
+.github/
+.husky/
+.claude/
+.vscode/
+.idea/
+.codex
+
+# Build/test outputs (the builder stage rebuilds what it needs)
+out/
+dist/
+release/
+coverage/
+.nyc_output/
+.eslintcache
+.prettiercache
+.cache/
+.playwright-mcp/
+playwright-report/
+playwright-output/
+test-results/
+tests/.cache/
+
+# Desktop-only assets
+build/
+resources/
+scripts/perf/
+scripts/postgres/
+
+# Docs / planning never shipped in the runtime image
+docs/
+.planning/
+
+# Local secrets / env
+.env
+.env.local
+.env.*.local
+.env.web
+
+# Test fixtures (large)
+tests/test-data/
+
+# OS / editor cruft
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*.log
+npm-debug.log*
+
+# Local databases
+*.db
+*.db-journal

--- a/.env.web.example
+++ b/.env.web.example
@@ -1,0 +1,71 @@
+# VarLens — web mode environment
+#
+# Only used when running the Fastify web build (`out/web/server.cjs` or the
+# container image). Desktop builds ignore this file entirely.
+#
+# Local web development usually reads `.env.postgres.local` via:
+#
+#   make web-dev
+#   VARLENS_WEB=1 make dev
+#
+# That target builds the browser bundle with `VARLENS_WEB_BASE=/` and runs
+# the server with `APP_PATH_PREFIX=/`, so local requests go straight to
+# Fastify without a production reverse-proxy path prefix.
+#
+# Copy this file only if you want a separate hand-run web server env.
+# In production the deployment operator sets these via the deploy repo.
+
+# --- Server ---------------------------------------------------------------
+
+# Bind port. Local default is 8787 via `make web-dev`; the container default
+# is 8080 and should be remapped externally by the runtime platform.
+VARLENS_WEB_PORT=8787
+
+# Local direct runs should bind localhost. Containers should leave this unset
+# or set it to 0.0.0.0 so the runtime platform can reach the app.
+VARLENS_WEB_HOST=127.0.0.1
+
+# Optional development-only delay for `/api/*` calls. Ignored unless
+# NODE_ENV=development. `make web-dev` defaults to 75ms to expose UI
+# loading/race assumptions that localhost otherwise hides.
+VARLENS_WEB_API_LATENCY_MS=75
+
+# Pino log level: trace | debug | info | warn | error | fatal
+VARLENS_LOG_LEVEL=info
+
+# --- Storage --------------------------------------------------------------
+
+# REQUIRED. Web mode is Postgres-only. For local development, `make pg-up`
+# starts the dev container described by `.env.postgres.local`.
+VARLENS_PG_URL=postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev
+VARLENS_PG_SCHEMA=web_dev
+
+# Required for persisted cookie/session signing when you run the server
+# outside tests. Must be absolute. `make web-dev` sets this automatically.
+VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-web-dev
+
+# Runtime URL prefix. This MUST match the build-time VARLENS_WEB_BASE used
+# for the browser bundle, except that APP_PATH_PREFIX has no trailing slash
+# and VARLENS_WEB_BASE does. Example: APP_PATH_PREFIX=/varlens pairs with
+# VARLENS_WEB_BASE=/varlens/. `/` means root mount for direct Fastify runs.
+APP_PATH_PREFIX=/
+
+# --- Admin bootstrap (optional, one-shot) --------------------------------
+#
+# If username plus VARLENS_ADMIN_PASSWORD_HASH are set on FIRST boot, the
+# server creates a Postgres-backed admin account. Generate the hash with
+# `npm run varlens:hash-password` so plaintext never sits in env or shell
+# history. Plaintext bootstrap is refused.
+#
+# After the first successful boot, remove these values from your
+# environment so bootstrap material does not linger in /proc/<pid>/environ
+# or `docker inspect` output.
+#
+# If left empty, no admin is created — the operator handles bootstrap
+# manually via the UI on first visit.
+# `make web-dev` does not supply a password. Set VARLENS_ADMIN_PASSWORD_HASH
+# explicitly for a local first run.
+
+VARLENS_ADMIN_USERNAME=
+VARLENS_ADMIN_PASSWORD_HASH=
+VARLENS_ADMIN_DISPLAY_NAME=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,10 +327,11 @@ jobs:
 
   # ── 5. Required-status-check aggregator ────────────────────────────
   # Branch protection should require THIS job (and secrets-scan) only.
-  # It succeeds when all upstream jobs succeeded, except docs-only PRs
-  # where code-gated jobs were intentionally skipped. This avoids the
-  # `paths-ignore` pending-forever trap while still failing on cancelled
-  # or unexpectedly skipped upstream jobs.
+  # It succeeds when all required upstream jobs for the changed surface
+  # succeeded, except docs-only / planning-only PRs where desktop and web
+  # gated jobs were intentionally skipped. This avoids the `paths-ignore`
+  # pending-forever trap while still failing on cancelled or unexpectedly
+  # skipped upstream jobs.
   ci:
     name: CI
     needs: [changes, secrets-scan, checks, package, web-ci]
@@ -347,17 +348,24 @@ jobs:
               exit 1
             fi
           done
-          if [ "${{ needs.changes.outputs.code }}" = "false" ]; then
-            echo "No code changed; build jobs were intentionally skipped. PASS."
+          if [ "${{ needs.changes.outputs.code }}" = "false" ] && [ "${{ needs.changes.outputs.web }}" = "false" ]; then
+            echo "No code or web surface changed; build jobs were intentionally skipped. PASS."
             exit 0
           fi
-          for r in \
-            "${{ needs.checks.result }}" \
-            "${{ needs.package.result }}" \
-            "${{ needs.web-ci.result }}"; do
-            if [ "$r" != "success" ]; then
-              echo "::error::Required job result was '$r' (expected 'success'). Failing."
+          if [ "${{ needs.changes.outputs.code }}" = "true" ]; then
+            for r in \
+              "${{ needs.checks.result }}" \
+              "${{ needs.package.result }}"; do
+              if [ "$r" != "success" ]; then
+                echo "::error::Required desktop job result was '$r' (expected 'success'). Failing."
+                exit 1
+              fi
+            done
+          fi
+          if [ "${{ needs.changes.outputs.web }}" = "true" ]; then
+            if [ "${{ needs.web-ci.result }}" != "success" ]; then
+              echo "::error::Required web-ci job result was '${{ needs.web-ci.result }}' (expected 'success'). Failing."
               exit 1
             fi
-          done
+          fi
           echo "All required jobs succeeded."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Cancel stale in-flight runs on the same PR branch when a new push arrives.
 # Gated on pull_request so a push-to-main or release run is never cancelled
@@ -28,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      web: ${{ steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # dorny/paths-filter@v4.0.1
@@ -47,6 +49,21 @@ jobs:
               - '.github/workflows/**'
               - 'vitest.config.ts'
               - 'Makefile'
+            web:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.env.web.example'
+              - 'Makefile'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'src/main/storage/**'
+              - 'src/web/**'
+              - 'src/renderer/src/**'
+              - 'src/shared/**'
+              - 'tests/web-gate/**'
+              - 'vite.web*.config.ts'
+              - '.github/workflows/build.yml'
+              - '.github/workflows/*web*.yml'
 
   secrets-scan:
     name: Secrets Scan
@@ -258,7 +275,57 @@ jobs:
             test-results/
             .planning/artifacts/perf/phase1/baseline/packaged-smoke/
 
-  # ── 4. Required-status-check aggregator ────────────────────────────
+  # ── 4. Web-mode required check for web app surfaces ────────────────
+  # The standalone `Web CI` workflow stays for readability, but this
+  # job folds the same web readiness gate into the required Build / CI
+  # aggregator. A web-only app change therefore cannot merge on the
+  # desktop checks alone.
+  web-ci:
+    name: Web CI
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: varlens_web_ci
+          POSTGRES_USER: varlens
+          POSTGRES_PASSWORD: varlens
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U varlens -d varlens_web_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      VARLENS_PG_URL: postgres://varlens:varlens@127.0.0.1:5432/varlens_web_ci
+      VARLENS_RECOVERY_KEY_DIR: /tmp/varlens-web-ci-secrets
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev build-essential
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run opt-in web gate
+        run: make web-ci
+
+      - name: Docker runtime image smoke
+        if: github.event_name == 'pull_request'
+        run: docker build --target runtime -t varlens-web-pr-smoke .
+
+  # ── 5. Required-status-check aggregator ────────────────────────────
   # Branch protection should require THIS job (and secrets-scan) only.
   # It succeeds when all upstream jobs succeeded, except docs-only PRs
   # where code-gated jobs were intentionally skipped. This avoids the
@@ -266,7 +333,7 @@ jobs:
   # or unexpectedly skipped upstream jobs.
   ci:
     name: CI
-    needs: [changes, secrets-scan, checks, package]
+    needs: [changes, secrets-scan, checks, package, web-ci]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -286,7 +353,8 @@ jobs:
           fi
           for r in \
             "${{ needs.checks.result }}" \
-            "${{ needs.package.result }}"; do
+            "${{ needs.package.result }}" \
+            "${{ needs.web-ci.result }}"; do
             if [ "$r" != "success" ]; then
               echo "::error::Required job result was '$r' (expected 'success'). Failing."
               exit 1

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -60,7 +60,7 @@ jobs:
       VARLENS_RECOVERY_KEY_DIR: /tmp/varlens-web-ci-secrets
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # actions/checkout@v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
@@ -96,7 +96,7 @@ jobs:
       SCAN_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-scan-${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # actions/checkout@v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # docker/setup-buildx-action@v3.3.0

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -1,0 +1,218 @@
+# Build, Trivy-scan, and publish the VarLens web image to GHCR.
+#
+# Triggers:
+#   - manual workflow_dispatch
+#   - published GitHub release
+#
+# Versioned deploy orchestration lives outside this application repo.
+# This workflow only builds, tests, scans, and optionally publishes the
+# web application image.
+#
+# Trivy posture:
+#   - Gating step: CRITICAL only — fails the workflow if any non-ignored
+#     CRITICAL CVE is present. A bad CRITICAL must not be silently shipped.
+#   - Advisory step: HIGH (and below) — uploaded to the Security tab as
+#     SARIF for review, never blocks. SARIF is uploaded with an explicit
+#     `category` so future scanners can coexist.
+#
+# The published digest goes into the workflow summary so an external
+# operator/deploy repository can pin the image by sha256.
+#
+# Fork note: `GITHUB_TOKEN` can only push to an existing GHCR package when
+# that package grants this repository write access. Forks should still run the
+# web gate, but they should not fail only because publish access is absent. Set
+# repository variable `VARLENS_WEB_PUBLISH_GHCR=1` after granting package access
+# if a fork intentionally needs to publish an edge image.
+
+name: publish-web
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/varlens-web
+
+jobs:
+  web-ci:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: varlens_web_ci
+          POSTGRES_USER: varlens
+          POSTGRES_PASSWORD: varlens
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U varlens -d varlens_web_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      VARLENS_PG_URL: postgres://varlens:varlens@127.0.0.1:5432/varlens_web_ci
+      VARLENS_RECOVERY_KEY_DIR: /tmp/varlens-web-ci-secrets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # actions/checkout@v4.1.7
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev build-essential
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run opt-in web gate
+        run: make web-ci
+
+  build-and-push:
+    needs: web-ci
+    if: |
+      github.repository == 'berntpopp/VarLens'
+      || vars.VARLENS_WEB_PUBLISH_GHCR == '1'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    env:
+      SCAN_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-scan-${{ github.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # actions/checkout@v4.1.7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # docker/setup-buildx-action@v3.3.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build image for security gate
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # docker/build-push-action@v6.6.1
+        with:
+          context: .
+          push: false
+          load: true
+          tags: |
+            ${{ env.SCAN_TAG }}
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy gate — CRITICAL only (fails before push)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.SCAN_TAG }}
+          format: table
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Trivy advisory scan (HIGH+) — SARIF for Security tab
+        id: trivy-advisory
+        if: always()
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.SCAN_TAG }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Upload SARIF
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@b7cec7526559c32f1616476ff32d17ba4c59b2d6 # github/codeql-action/upload-sarif@v3.25.15
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-web-image
+
+      - name: Push scanned image
+        id: push
+        shell: bash
+        run: |
+          first_tag=''
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            if [ -z "$first_tag" ]; then first_tag="$tag"; fi
+            docker push "$tag"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+          if [ -z "$first_tag" ]; then
+            echo "No image tags were produced." >&2
+            exit 1
+          fi
+
+          digest="$(docker buildx imagetools inspect "$first_tag" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Summarise digest
+        run: |
+          {
+            echo "## Published image"
+            echo ""
+            echo "**Digest:** \`${{ steps.push.outputs.digest }}\`"
+            echo ""
+            echo "**Tags:**"
+            echo "${{ steps.meta.outputs.tags }}" | sed 's/^/- `/' | sed 's/$/`/'
+            echo ""
+            echo "Pin in the deploy repo \`compose/docker-compose.yml\`:"
+            echo ""
+            echo "\`\`\`yaml"
+            echo "image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-skipped:
+    needs: web-ci
+    if: |
+      github.repository != 'berntpopp/VarLens'
+      && vars.VARLENS_WEB_PUBLISH_GHCR != '1'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped GHCR publish
+        run: |
+          {
+            echo "## GHCR publish skipped"
+            echo ""
+            echo "The web gate passed, but this repository is not configured to publish"
+            echo "\`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge\`."
+            echo ""
+            echo "This avoids fork-only 403 failures when the existing GHCR package"
+            echo "is owned by another repository. To publish from this repository,"
+            echo "grant it write access to the GHCR package and set repository"
+            echo "variable \`VARLENS_WEB_PUBLISH_GHCR=1\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,72 @@
+name: Web CI
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.env.web.example'
+      - 'Makefile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/main/storage/**'
+      - 'src/web/**'
+      - 'src/renderer/src/**'
+      - 'src/shared/**'
+      - 'tests/web-gate/**'
+      - 'vite.web*.config.ts'
+      - '.github/workflows/build.yml'
+      - '.github/workflows/*web*.yml'
+  push:
+    branches:
+      - VarLens-Web
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  web-ci:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: varlens_web_ci
+          POSTGRES_USER: varlens
+          POSTGRES_PASSWORD: varlens
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U varlens -d varlens_web_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      VARLENS_PG_URL: postgres://varlens:varlens@127.0.0.1:5432/varlens_web_ci
+      VARLENS_RECOVERY_KEY_DIR: /tmp/varlens-web-ci-secrets
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev build-essential
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run opt-in web gate
+        run: make web-ci
+
+      - name: Docker runtime image smoke
+        if: github.event_name == 'pull_request'
+        run: docker build --target runtime -t varlens-web-pr-smoke .

--- a/.planning/web/context/runtime-contract.md
+++ b/.planning/web/context/runtime-contract.md
@@ -1,0 +1,69 @@
+# Web Runtime Contract
+
+Status: Current for the web app branch
+
+This app repository owns the web server, browser bundle, container image, and
+database migrations. Infrastructure and operator automation live outside this
+repository and consume the image as an immutable artifact.
+
+## Image Contract
+
+| Contract | Value |
+| --- | --- |
+| Image | `ghcr.io/<owner>/varlens-web:<tag>` or a pinned digest |
+| Process | `node out/web/server.cjs` via `tini` |
+| User | uid/gid `1001` (`varlens`) |
+| Internal port | `8080` |
+| Health endpoint | `GET /healthz` |
+| Writable runtime path | `/data` by default |
+
+Operators may remap the external port and route traffic through any reverse
+proxy. The container's internal port and healthcheck remain fixed at `8080`.
+
+## Required Runtime Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `VARLENS_PG_URL` | yes | PostgreSQL connection URL. Web mode refuses to boot without it. |
+| `VARLENS_PG_SCHEMA` | no | PostgreSQL schema. Defaults to `public`. |
+| `VARLENS_RECOVERY_KEY_DIR` | recommended | Absolute directory for session-secret material. Defaults to `/data`. |
+| `VARLENS_SESSION_SECRET_HEX` | no | Optional 32-byte hex session secret. If absent, the server seals one in the recovery directory. |
+| `VARLENS_ADMIN_USERNAME` | first boot only | Optional one-shot admin bootstrap username. |
+| `VARLENS_ADMIN_PASSWORD_HASH` | first boot only | Optional one-shot Argon2id admin bootstrap hash. Plaintext bootstrap is refused. |
+| `VARLENS_ADMIN_DISPLAY_NAME` | first boot only | Optional display name for the bootstrap admin. |
+| `VARLENS_LOG_LEVEL` | no | Pino log level. Defaults to `info`. |
+
+Bootstrap variables are intentionally one-shot. After an admin exists, the
+server logs that env-based rotation is ignored; password changes happen through
+the authenticated app flow.
+
+## URL Prefix Contract
+
+The browser bundle and server redirects must agree on the public path prefix:
+
+| Layer | Variable | Example |
+| --- | --- | --- |
+| Browser build | `VARLENS_WEB_BASE` | `/varlens/` |
+| Server runtime | `APP_PATH_PREFIX` | `/varlens` |
+
+`VARLENS_WEB_BASE` is build-time because Vite embeds asset and API paths into
+the browser bundle. `APP_PATH_PREFIX` is runtime because the login wall and
+redirects are rendered by the server. If the operator serves the app at `/`,
+build with `VARLENS_WEB_BASE=/` and run with `APP_PATH_PREFIX=/`.
+
+Reverse proxies that strip a prefix before forwarding to Fastify are supported,
+provided browser-visible URLs still use the same prefix configured above.
+
+## Deployment Boundary
+
+The app repository does not own:
+
+- cloud resources
+- DNS/TLS automation
+- production Compose files
+- Caddy, uptime, log-viewer, or backup configuration
+- OpenTofu/Terraform state
+- operator credentials or recovery runbooks
+
+The deploy repository should pin an image digest produced by the app repository
+and provide the runtime environment described here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,23 +75,42 @@ Do **not** use `electron-builder install-app-deps` — it has been broken for El
 
 The **Makefile is the source of truth**. GitHub Actions workflows mirror it target-for-target. When in doubt, run the `make` target, not the underlying npm script.
 
-| Command                                                             | Purpose                                                                    |
-| ------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `make dev`                                                          | Rebuild for Electron, start hot-reload dev server                          |
-| `make lint` / `make lint-check`                                     | ESLint with / without auto-fix                                             |
-| `make format` / `make format-check`                                 | Prettier with / without write                                              |
-| `make typecheck`                                                    | `vue-tsc` (renderer) + `tsc` (node) in parallel                            |
-| `make test`                                                         | Vitest once (run `make rebuild-node` first)                                |
-| `make test-watch` / `make test-coverage`                            | Vitest watch / with coverage                                               |
-| `make agent-check`                                                  | Check LLM-sustainable source size and context guardrails                   |
-| `make build`                                                        | `electron-vite build` into `out/`                                          |
-| `make dist` / `make dist-linux` / `make dist-mac` / `make dist-win` | Build + package                                                            |
-| `make ci`                                                           | Local minimum: lint-check + format-check + typecheck + rebuild-node + test |
-| `make ci-full` / `make ci-actions`                                  | Full local mirror of GitHub Actions pipeline                               |
-| `make ci-startup-smoke`                                             | Playwright Electron startup smoke under xvfb (Linux)                       |
-| `make docs-dev` / `make docs`                                       | VitePress user docs                                                        |
+| Command                                                             | Purpose                                                                                       |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `make dev`                                                          | Rebuild for Electron, start hot-reload dev server                                             |
+| `make lint` / `make lint-check`                                     | ESLint with / without auto-fix                                                                |
+| `make format` / `make format-check`                                 | Prettier with / without write                                                                 |
+| `make typecheck`                                                    | `vue-tsc` (renderer) + `tsc` (node) in parallel                                               |
+| `make test`                                                         | Vitest once (run `make rebuild-node` first)                                                   |
+| `make test-watch` / `make test-coverage`                            | Vitest watch / with coverage                                                                  |
+| `make agent-check`                                                  | Check LLM-sustainable source size and context guardrails                                      |
+| `make build`                                                        | `electron-vite build` into `out/`                                                             |
+| `make dist` / `make dist-linux` / `make dist-mac` / `make dist-win` | Build + package                                                                               |
+| `make ci`                                                           | Local minimum: lint-check + format-check + typecheck + rebuild-node + test                    |
+| `make ci-full` / `make ci-actions`                                  | Full local mirror of GitHub Actions pipeline                                                  |
+| `make ci-startup-smoke`                                             | Playwright Electron startup smoke under xvfb (Linux)                                          |
+| `make docs-dev` / `make docs`                                       | VitePress user docs                                                                           |
+| `VARLENS_WEB=1 make ...`                                            | Mode toggle: extends `dev` / `test` / `ci` to include the web layer (see "Mode toggle" below) |
 
 **Before claiming work is done, run `make ci` at minimum.** If you have run local packaging first, clean `release/` before `make ci` because ESLint still traverses generated release artifacts. For anything touching Electron lifecycle, IPC, workers, or packaging, run `make ci-full`.
+
+### Mode toggle: desktop (default) / web (opt-in)
+
+`VARLENS_WEB=1` extends `make dev`, `make test`, and `make ci` to include the web layer. Default is desktop. Direct targets (`make web-gate-static`, etc.) still work for web-only invocations.
+
+```
+make test                    # desktop suite (main + renderer + refactor-checkpoint)
+VARLENS_WEB=1 make test      # adds web-gate static + integration
+
+make ci                      # desktop CI gate
+VARLENS_WEB=1 make ci        # desktop + web
+
+make dev                     # Electron dev server
+VARLENS_WEB=1 make dev       # local Postgres-backed web server at http://localhost:8787/
+make web-dev                 # same web server target without setting VARLENS_WEB
+```
+
+This matches the desktop-default, web-opt-in model. A desktop-only contributor never needs to set the var; a web-track contributor sets it once per shell.
 
 ## Testing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # are pinned to 8080 here.
 
 # ---- Stage 1: builder -----------------------------------------------------
-FROM node:24.14.1-bookworm-slim AS builder
+FROM node:24.15.0-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -49,6 +49,8 @@ RUN npm prune --omit=dev --ignore-scripts
 # theoretically misresolve.
 RUN node -e "(async () => { \
     require('./out/web/server.cjs'); \
+    require('node:fs').accessSync('./out/web/postgres-import-worker.cjs'); \
+    require('./out/web/postgres-import-worker.cjs'); \
     const Database = require('better-sqlite3-multiple-ciphers'); \
     new Database(':memory:').prepare('SELECT 1').get(); \
     const argon2 = require('@node-rs/argon2'); \
@@ -57,7 +59,7 @@ RUN node -e "(async () => { \
   })().catch((e) => { console.error(e); process.exit(1); })"
 
 # ---- Stage 2: runtime -----------------------------------------------------
-FROM node:24.14.1-bookworm-slim AS runtime
+FROM node:24.15.0-bookworm-slim AS runtime
 
 ENV NODE_ENV=production \
     VARLENS_WEB_PORT=8080 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,110 @@
+# VarLens — web build container.
+#
+# Multi-stage:
+#   1. builder — installs deps, runs `npm run build:web` to produce
+#      out/web/server.cjs, then trims node_modules to production-only.
+#   2. runtime — minimal image carrying the bundle plus the production
+#      modules that the bundle keeps external (fastify, pg,
+#      better-sqlite3-multiple-ciphers, @node-rs/argon2, nanoid).
+#
+# Node version matches .nvmrc; Debian (bookworm-slim) is chosen over Alpine
+# because better-sqlite3-multiple-ciphers ships glibc prebuilds. Switching
+# to Alpine would require an in-image rebuild step.
+#
+# Internal port is fixed at 8080. Operators that need a different external
+# port should remap it in the runtime platform or reverse proxy rather than
+# overriding VARLENS_WEB_PORT inside the container. EXPOSE and HEALTHCHECK
+# are pinned to 8080 here.
+
+# ---- Stage 1: builder -----------------------------------------------------
+FROM node:24.14.1-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Native deps for any optional rebuilds.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 make g++ ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json ./
+# Skip the repo's own postinstall (it runs `@electron/rebuild` for the
+# desktop ABI, which is wrong for the web container) but explicitly rebuild
+# the native modules we actually need so prebuild-install fetches their
+# .node binaries for system Node 24's ABI.
+RUN npm ci --ignore-scripts \
+ && npm rebuild better-sqlite3-multiple-ciphers @node-rs/argon2
+
+COPY . .
+RUN npm run build:web
+
+# Reduce to production deps only.
+RUN npm prune --omit=dev --ignore-scripts
+
+# Verify what actually ships: bundle resolves AND the native bindings
+# load AND actually invoke their hot path against the post-prune
+# node_modules tree. This is the same set the runtime stage will copy,
+# so a passing smoke here is binding. @node-rs/argon2 dispatches to
+# platform-specific .node files via optional dependencies — only an
+# actual `hash()` call exercises the dlopen path that prune could
+# theoretically misresolve.
+RUN node -e "(async () => { \
+    require('./out/web/server.cjs'); \
+    const Database = require('better-sqlite3-multiple-ciphers'); \
+    new Database(':memory:').prepare('SELECT 1').get(); \
+    const argon2 = require('@node-rs/argon2'); \
+    await argon2.hash('smoke'); \
+    console.log('post-prune bundle + native bindings ok'); \
+  })().catch((e) => { console.error(e); process.exit(1); })"
+
+# ---- Stage 2: runtime -----------------------------------------------------
+FROM node:24.14.1-bookworm-slim AS runtime
+
+ENV NODE_ENV=production \
+    VARLENS_WEB_PORT=8080 \
+    VARLENS_LOG_LEVEL=info
+
+# Web mode is Postgres-only. The runtime must provide VARLENS_PG_URL.
+# /data remains the default writable runtime directory for session-secret
+# material and any future operator-mounted app state.
+
+WORKDIR /app
+
+# tini: PID 1 init that forwards signals and reaps zombies. Cheap insurance
+# for any future subprocess (workers, native helpers) and the standard
+# Docker-best-practice posture.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tini wget ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop to a non-root user. /data is the persistent volume mount.
+RUN groupadd --system --gid 1001 varlens \
+ && useradd --system --uid 1001 --gid varlens --home /app --shell /usr/sbin/nologin varlens \
+ && mkdir -p /data \
+ && chown varlens:varlens /data
+
+COPY --from=builder /app/out/web ./out/web
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+# Postgres migration SQL files are read at runtime by
+# src/main/storage/postgres/migrations/definitions.ts. Vite bundles only
+# JS, so the .sql files have to ride along separately. The migration
+# resolver walks three candidate dirs; PACKAGED_SQL_DIR is
+# `<resourcesPath>/postgres-migrations` and `resourcesPath` falls back
+# to `process.cwd()` (= /app) outside Electron, so this lands at the
+# expected `/app/postgres-migrations/` path.
+COPY --from=builder \
+    /app/src/main/storage/postgres/migrations/sql \
+    ./postgres-migrations
+
+USER varlens
+
+EXPOSE 8080
+VOLUME ["/data"]
+
+# Self-describing liveness — operators do not have to re-encode the probe.
+# Tied to the pinned internal port (see header).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget --quiet --spider http://127.0.0.1:8080/healthz || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "out/web/server.cjs"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-.PHONY: help rebuild dev dev-postgres build build-web build-web-server build-web-renderer preview lint lint-check agent-check test test-watch test-coverage web-gate web-gate-static web-gate-integration web-gate-parity typecheck dist dist-linux dist-mac dist-win package package-linux package-mac package-win clean clean-all install reinstall all ci ci-full ci-build ci-checks ci-startup-smoke ci-package-linux ci-packaged-smoke-linux ci-actions docs docs-dev docs-preview docs-screenshots pg-up pg-down pg-logs pg-psql pg-query-perf pg-seed-dev pg-hosted-smoke pg-reset
+.PHONY: help rebuild dev dev-postgres web-dev build build-web build-web-server build-web-renderer preview lint lint-check agent-check test test-watch test-coverage web-ci web-gate web-gate-static web-gate-integration web-gate-postgres web-gate-parity typecheck dist dist-linux dist-mac dist-win package package-linux package-mac package-win clean clean-all install reinstall all ci ci-full ci-build ci-checks ci-startup-smoke ci-package-linux ci-packaged-smoke-linux ci-actions docs docs-dev docs-preview docs-screenshots pg-up pg-down pg-logs pg-psql pg-query-perf pg-seed-dev pg-hosted-smoke pg-reset
 
 # Default target - show help
 .DEFAULT_GOAL := help
 
 CI_NODE_VERSION ?= $(shell tr -d '\n' < .nvmrc)
 XVFB_RUN ?= $(shell if command -v xvfb-run >/dev/null 2>&1; then printf 'xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" '; fi)
+WEB_DEV_PORT ?= 8787
+WEB_DEV_SCHEMA ?= web_dev
+WEB_DEV_RECOVERY_KEY_DIR ?= /tmp/varlens-web-dev
+WEB_DEV_API_LATENCY_MS ?= 75
+WEB_DEV_ADMIN_USERNAME ?= admin
 
 define ensure_ci_node
 	@current_node="$$(node -v | sed 's/^v//')"; \
@@ -14,6 +19,28 @@ define ensure_ci_node
 		exit 1; \
 	fi
 endef
+
+#---------------------------------------------------------------------------
+# Mode toggle: desktop (default) / web (opt-in via VARLENS_WEB=1)
+#
+# Sets which projects vitest runs and whether `make dev` starts the web
+# server. Direct targets (web-gate-static, etc.) still work standalone for
+# web-only invocations.
+#---------------------------------------------------------------------------
+
+# Web mode is opt-in only. Set VARLENS_WEB=1 explicitly when a target
+# should extend itself with web checks.
+VARLENS_WEB ?= 0
+
+# Export so it propagates to sub-makes and child processes; make does
+# not export variables by default.
+export VARLENS_WEB
+
+ifeq ($(VARLENS_WEB),1)
+    VITEST_EXTRA_ARGS := -- --project web-gate
+else
+    VITEST_EXTRA_ARGS :=
+endif
 
 #---------------------------------------------------------------------------
 # Help
@@ -36,8 +63,38 @@ rebuild: ## Rebuild native modules for Electron (fixes native module version mis
 rebuild-node: ## Rebuild native modules for Node.js (needed before running tests)
 	npm run rebuild:node
 
-dev: rebuild ## Start development server with hot reload
+ifeq ($(VARLENS_WEB),1)
+dev: web-dev ## Start development server (set VARLENS_WEB=1 for web mode)
+else
+dev: rebuild ## Start development server (set VARLENS_WEB=1 for web mode)
 	npm run dev
+endif
+
+web-dev: ## Start local Postgres-backed web mode at http://localhost:$(WEB_DEV_PORT)/
+	@if [ ! -f .env.postgres.local ]; then echo "Missing .env.postgres.local. Copy .env.postgres.example first."; exit 1; fi
+	$(MAKE) pg-up
+	VARLENS_WEB_BASE=/ npm run build:web
+	@echo ""
+	@echo "Starting VarLens web mode:"
+	@echo "  URL:      http://localhost:$(WEB_DEV_PORT)/"
+	@echo "  Health:   http://localhost:$(WEB_DEV_PORT)/healthz"
+	@echo "  Postgres: .env.postgres.local"
+	@echo "  Schema:   $(WEB_DEV_SCHEMA)"
+	@echo "  Secrets:  $${VARLENS_RECOVERY_KEY_DIR:-$(WEB_DEV_RECOVERY_KEY_DIR)}"
+	@echo "  API delay: $${VARLENS_WEB_API_LATENCY_MS:-$(WEB_DEV_API_LATENCY_MS)}ms"
+	@echo "  Dev admin bootstrap: set VARLENS_ADMIN_PASSWORD_HASH for first run"
+	@echo ""
+	@set -a; . ./.env.postgres.local; set +a; \
+		NODE_ENV=development \
+		APP_PATH_PREFIX=/ \
+		VARLENS_WEB_HOST="$${VARLENS_WEB_HOST:-127.0.0.1}" \
+		VARLENS_WEB_PORT="$${VARLENS_WEB_PORT:-$(WEB_DEV_PORT)}" \
+		VARLENS_WEB_API_LATENCY_MS="$${VARLENS_WEB_API_LATENCY_MS:-$(WEB_DEV_API_LATENCY_MS)}" \
+		VARLENS_PG_SCHEMA="$(WEB_DEV_SCHEMA)" \
+		VARLENS_RECOVERY_KEY_DIR="$${VARLENS_RECOVERY_KEY_DIR:-$(WEB_DEV_RECOVERY_KEY_DIR)}" \
+		VARLENS_ADMIN_USERNAME="$${VARLENS_ADMIN_USERNAME:-$(WEB_DEV_ADMIN_USERNAME)}" \
+		VARLENS_ADMIN_PASSWORD_HASH="$${VARLENS_ADMIN_PASSWORD_HASH:-}" \
+		node out/web/server.cjs
 
 dev-postgres: ## Start development server with PostgreSQL backend enabled
 	@if [ ! -f .env.postgres.local ]; then echo "Missing .env.postgres.local. Copy .env.postgres.example first."; exit 1; fi
@@ -112,8 +169,8 @@ typecheck: ## Run TypeScript type checking
 # Testing
 #---------------------------------------------------------------------------
 
-test: ## Run tests once
-	npm run test
+test: ## Run tests once (set VARLENS_WEB=1 to include web-gate project)
+	npm run test $(VITEST_EXTRA_ARGS)
 
 test-watch: ## Run tests in watch mode
 	npm run test:watch
@@ -130,14 +187,20 @@ web-gate-static: ## Run opt-in web migration static gate tests
 web-gate-integration: ## Run opt-in web migration integration gate tests
 	npx vitest run --project web-gate tests/web-gate/integration/*.test.ts
 
+web-gate-postgres: build-web ## Run fail-loud Postgres-backed web integration tests (requires VARLENS_PG_URL)
+	@if [ -z "$$VARLENS_PG_URL" ]; then echo "VARLENS_PG_URL is required for web-gate-postgres. This is intentionally opt-in and never part of default desktop CI."; exit 2; fi
+	npx vitest run --project web-gate tests/web-gate/integration
+
 web-gate-parity: ## Run opt-in desktop/web parity gate tests
 	VARLENS_RUN_WEB_GATE_PARITY=1 npx vitest run --project web-gate-parity --passWithNoTests
+
+web-ci: rebuild-node build-web web-gate-static web-gate-postgres ## Opt-in web readiness gate; requires VARLENS_PG_URL
 
 #---------------------------------------------------------------------------
 # CI / Full Checks
 #---------------------------------------------------------------------------
 
-ci: lint-check format-check typecheck rebuild-node test ## Run all CI checks (lint, format, typecheck, rebuild, test)
+ci: lint-check format-check typecheck rebuild-node test ## Run all CI checks (lint, format, typecheck, rebuild, test). Set VARLENS_WEB=1 to include web-gate.
 
 ci-checks: ## Run the GitHub Actions "Checks (Ubuntu)" job under Node $(CI_NODE_VERSION)
 	@echo "=== Checks (Ubuntu) using Node $(CI_NODE_VERSION) ==="

--- a/src/main/storage/postgres/PostgresImportWorkerClient.ts
+++ b/src/main/storage/postgres/PostgresImportWorkerClient.ts
@@ -33,7 +33,9 @@ export class PostgresImportWorkerClient {
 
   constructor(options: PostgresImportWorkerClientOptions = {}) {
     this.workerPathCandidates = options.workerPathCandidates ?? [
+      resolve(__dirname, 'postgres-import-worker.cjs'),
       resolve(__dirname, 'postgres-import-worker.js'),
+      resolve(process.cwd(), 'out/web/postgres-import-worker.cjs'),
       resolve(process.cwd(), 'out/main/postgres-import-worker.js')
     ]
     this.workerPath = this.workerPathCandidates.find((candidate) => existsSync(candidate)) ?? null

--- a/src/shared/api/schemas/auth.ts
+++ b/src/shared/api/schemas/auth.ts
@@ -31,7 +31,7 @@ export const UsernameArgsSchema = z.tuple([UsernameSchema])
 export const ResetPasswordArgsSchema = z.tuple([UsernameSchema, PasswordSchema])
 export const ChangePasswordArgsSchema = z.tuple([
   ChangePasswordSchema.shape.oldPassword,
-  ChangePasswordSchema.shape.newPassword
+  PasswordInputSchema
 ])
 
 export const AuthSessionUserSchema = z.object({

--- a/src/shared/api/schemas/import.ts
+++ b/src/shared/api/schemas/import.ts
@@ -100,5 +100,5 @@ export function normalizeImportFiltersPayload(filters: unknown): ImportFiltersPa
   if (filters === null || typeof filters !== 'object') return undefined
 
   const parsed = ImportFiltersPayloadSchema.safeParse(filters)
-  return parsed.success ? parsed.data : (filters as ImportFiltersPayload)
+  return parsed.success ? parsed.data : undefined
 }

--- a/src/web/server/routes/import.ts
+++ b/src/web/server/routes/import.ts
@@ -93,6 +93,13 @@ export function buildImportOverrides(): Record<string, OverrideHandler> {
         }
 
         const normalizedFilters = normalizeImportFiltersPayload(filters)
+        if (filters !== undefined && filters !== null && normalizedFilters === undefined) {
+          reply.code(400)
+          return {
+            error: 'invalid-filters',
+            message: 'filters must match the import filter schema'
+          }
+        }
 
         return await startMultiFileImport(
           validatedCaseName.data,

--- a/tests/main/storage/postgres-import-worker-client.test.ts
+++ b/tests/main/storage/postgres-import-worker-client.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { PostgresImportWorkerClient } from '../../../src/main/storage/postgres/PostgresImportWorkerClient'
 import type { PostgresImportWorkerStartMessage } from '../../../src/shared/types/postgres-import-worker'
 
@@ -120,5 +123,36 @@ describe('PostgresImportWorkerClient', () => {
         { onProgress: vi.fn(), onFileComplete: vi.fn(), onComplete: vi.fn(), onError: vi.fn() }
       )
     ).toThrow(/Postgres import worker bundle not found/)
+  })
+
+  it('loads the web-built worker bundle when only out/web is shipped', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'varlens-web-worker-'))
+    const previousCwd = process.cwd()
+    try {
+      const webOut = join(tmp, 'out', 'web')
+      mkdirSync(webOut, { recursive: true })
+      writeFileSync(
+        join(webOut, 'postgres-import-worker.cjs'),
+        "const { parentPort } = require('node:worker_threads'); parentPort.on('message', () => {});\n"
+      )
+      process.chdir(tmp)
+
+      const c = new PostgresImportWorkerClient()
+      c.start(
+        {
+          type: 'start',
+          client: { connectionString: 'postgres://x' },
+          schema: 'public',
+          mode: 'single-file',
+          caseName: 'X',
+          filePath: '/tmp/a.json'
+        },
+        { onProgress: vi.fn(), onFileComplete: vi.fn(), onComplete: vi.fn(), onError: vi.fn() }
+      )
+      await c.terminate()
+    } finally {
+      process.chdir(previousCwd)
+      rmSync(tmp, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/web-gate/dispatcher-adapters-auth-import.test.ts
+++ b/tests/web-gate/dispatcher-adapters-auth-import.test.ts
@@ -137,7 +137,7 @@ describe('web dispatcher adapters: auth and import', () => {
     }
   })
 
-  test('import.startMultiFile preserves object filter payloads for import logic', async () => {
+  test('import.startMultiFile normalizes valid object filter payloads for import logic', async () => {
     const prevNodeEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'test'
     try {
@@ -157,7 +157,7 @@ describe('web dispatcher adapters: auth and import', () => {
             }
           ],
           { genomeBuild: 'hg38' },
-          { bedPadding: 'legacy-string' }
+          { bedPadding: 10, passOnly: true, minQual: 30, minGq: null }
         ],
         request as never,
         reply as never,
@@ -177,7 +177,90 @@ describe('web dispatcher adapters: auth and import', () => {
             }
           ],
           vcfOptions: { genomeBuild: 'hg38', selectedSample: undefined },
-          filters: expect.objectContaining({ bedPadding: 'legacy-string' })
+          filters: expect.objectContaining({
+            bedPadding: 10,
+            passOnly: true,
+            minQual: 30,
+            minGq: null
+          })
+        })
+      )
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+    }
+  })
+
+  test('import.startMultiFile rejects malformed filter payloads before import logic', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'test'
+    try {
+      const { deps, importMultiFile, reply } = makeDeps()
+      const { overrides } = buildDispatcher(deps)
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      const result = await overrides['import:startMultiFile'].handle(
+        [
+          'Case A',
+          [
+            {
+              filePath: '/tmp/input.vcf',
+              variantType: 'snv',
+              caller: 'caller',
+              annotationFormat: null
+            }
+          ],
+          { genomeBuild: 'hg38' },
+          { minQual: '30', passOnly: 'true' }
+        ],
+        request as never,
+        reply as never,
+        deps
+      )
+
+      expect(reply.code).toHaveBeenCalledWith(400)
+      expect(result).toEqual({
+        error: 'invalid-filters',
+        message: 'filters must match the import filter schema'
+      })
+      expect(importMultiFile).not.toHaveBeenCalled()
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+    }
+  })
+
+  test('import.startMultiFile treats null filter payloads as absent', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'test'
+    try {
+      const { deps, importMultiFile, reply } = makeDeps()
+      const { overrides } = buildDispatcher(deps)
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      await overrides['import:startMultiFile'].handle(
+        [
+          'Case A',
+          [
+            {
+              filePath: '/tmp/input.vcf',
+              variantType: 'snv',
+              caller: 'caller',
+              annotationFormat: null
+            }
+          ],
+          { genomeBuild: 'hg38' },
+          null
+        ],
+        request as never,
+        reply as never,
+        deps
+      )
+
+      expect(reply.code).not.toHaveBeenCalled()
+      expect(importMultiFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: undefined
         })
       )
     } finally {

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -82,9 +82,12 @@ export default defineConfig({
     emptyOutDir: true,
     ssr: true,
     rollupOptions: {
-      input: resolve(__dirname, 'src/web/server.ts'),
+      input: {
+        server: resolve(__dirname, 'src/web/server.ts'),
+        'postgres-import-worker': resolve(__dirname, 'src/main/workers/postgres-import-worker.ts')
+      },
       output: {
-        entryFileNames: 'server.cjs',
+        entryFileNames: (chunkInfo) => (chunkInfo.name === 'server' ? 'server.cjs' : '[name].cjs'),
         format: 'cjs'
       },
       external: [


### PR DESCRIPTION
Summary
- Adds web container build contract and web CI gates.
- Publishes only by manual/release trigger and gates image push behind a local Trivy CRITICAL scan.
- Keeps runtime app files root-owned with only /data writable.

Stack
- Follows #214, #217, and #218.

Validation
- make ci
- npm run build:web
- VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-web-ci-secrets make web-gate-static
- docker build --target runtime -t varlens-web-pr4-smoke .
