### PR TITLE
web 02: add Postgres web auth service

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "docs:screenshots": "npx playwright test tests/e2e/screenshots.e2e.ts",
-    "build:gene-ref": "npx tsx scripts/build-gene-reference-db.ts"
+    "build:gene-ref": "npx tsx scripts/build-gene-reference-db.ts",
+    "varlens:hash-password": "npx tsx scripts/varlens-hash-password.ts"
   },
   "devDependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/scripts/varlens-hash-password.ts
+++ b/scripts/varlens-hash-password.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env tsx
+/**
+ * Hash a password into the Argon2id PHC string the web bootstrap
+ * expects.
+ *
+ * Usage:
+ *
+ *   $ npm run varlens:hash-password
+ *   Enter password: ********
+ *   Confirm:        ********
+ *   $argon2id$v=19$m=65536,t=3,p=4$<salt>$<hash>
+ *
+ *   # Then in the operator environment:
+ *   VARLENS_ADMIN_PASSWORD_HASH=$argon2id$v=19$...
+ *   # VARLENS_ADMIN_PASSWORD is not supported.
+ *
+ * Why this CLI exists: the web track refuses plaintext credentials
+ * for production. The operator generates the Argon2id hash locally
+ * with the same `defaultPasswordProvider` the server uses, so the
+ * encoded parameters (memoryCost / timeCost / parallelism) are
+ * guaranteed to match what `verifyPassword` expects at boot. Pasting
+ * a hash from a third-party tool with different params would either
+ * silently lock the operator out or accept a weaker hash than policy.
+ *
+ * No password ever lands on disk: stdin is read with echo disabled
+ * (raw mode), the plaintext lives only in this process's memory for
+ * the few milliseconds between input and hash, and the result goes
+ * straight to stdout for the operator to copy.
+ */
+import { defaultPasswordProvider } from '../src/main/auth/providers/argon2-provider'
+
+const MIN_PASSWORD_LENGTH = 12
+
+/**
+ * Read all of stdin into a line iterator. Used in non-TTY mode so a
+ * single-shot pipe like `printf 'pw\npw\n' | varlens:hash-password`
+ * works — the previous "read one line at a time, throw away the
+ * rest of the buffer" approach lost the second line.
+ */
+async function bufferStdinLines(): Promise<() => string | undefined> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer))
+  }
+  const lines = Buffer.concat(chunks).toString('utf8').split(/\r?\n/)
+  let i = 0
+  return () => (i < lines.length ? lines[i++] : undefined)
+}
+
+/**
+ * TTY-mode interactive read with echo suppressed. Honours backspace
+ * and Ctrl-C; ignores other control characters.
+ */
+async function readSecretTty(prompt: string): Promise<string> {
+  process.stdout.write(prompt)
+  const stdin = process.stdin
+  return await new Promise<string>((resolve, reject) => {
+    let buf = ''
+    stdin.setRawMode(true)
+    stdin.resume()
+    stdin.setEncoding('utf8')
+
+    const cleanup = (): void => {
+      stdin.setRawMode(false)
+      stdin.pause()
+      stdin.off('data', onData)
+    }
+    const onData = (chunk: string): void => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n') {
+          process.stdout.write('\n')
+          cleanup()
+          resolve(buf)
+          return
+        }
+        if (ch === '\x03') {
+          cleanup()
+          process.stdout.write('\n')
+          reject(new Error('cancelled'))
+          return
+        }
+        if (ch === '' || ch === '\b') {
+          buf = buf.slice(0, -1)
+          continue
+        }
+        if (ch.charCodeAt(0) < 0x20) continue
+        buf += ch
+      }
+    }
+    stdin.on('data', onData)
+  })
+}
+
+async function main(): Promise<void> {
+  process.stderr.write('VarLens admin password — Argon2id hash generator\n')
+  process.stderr.write('--------------------------------------------------\n')
+
+  let pw: string
+  let confirm: string
+  if (process.stdin.isTTY === true) {
+    pw = await readSecretTty('Enter password: ')
+    confirm = await readSecretTty('Confirm:        ')
+  } else {
+    const next = await bufferStdinLines()
+    pw = next() ?? ''
+    confirm = next() ?? ''
+  }
+
+  if (pw.length < MIN_PASSWORD_LENGTH) {
+    process.stderr.write(
+      `Password too short (${pw.length} chars; minimum ${MIN_PASSWORD_LENGTH}).\n`
+    )
+    process.exit(2)
+  }
+  if (pw !== confirm) {
+    process.stderr.write('Passwords did not match.\n')
+    process.exit(2)
+  }
+
+  process.stderr.write('Hashing (Argon2id, m=64MB, t=3, p=4)...\n')
+  const hash = await defaultPasswordProvider.hashPassword(pw)
+
+  // Hash to stdout, instructions to stderr — so a pipe-into-file
+  // captures only the hash.
+  process.stdout.write(hash + '\n')
+  process.stderr.write('\nDone. Add to your .env:\n')
+  process.stderr.write('  VARLENS_ADMIN_PASSWORD_HASH=' + hash + '\n')
+  process.stderr.write('Plaintext VARLENS_ADMIN_PASSWORD is not supported.\n')
+}
+
+main().catch((err) => {
+  process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/scripts/varlens-hash-password.ts
+++ b/scripts/varlens-hash-password.ts
@@ -10,8 +10,11 @@
  *   Confirm:        ********
  *   $argon2id$v=19$m=65536,t=3,p=4$<salt>$<hash>
  *
+ *   # Capture only the hash:
+ *   $ printf 'password\npassword\n' | npm run --silent varlens:hash-password > admin.hash
+ *
  *   # Then in the operator environment:
- *   VARLENS_ADMIN_PASSWORD_HASH=$argon2id$v=19$...
+ *   VARLENS_ADMIN_PASSWORD_HASH='$argon2id$v=19$...'
  *   # VARLENS_ADMIN_PASSWORD is not supported.
  *
  * Why this CLI exists: the web track refuses plaintext credentials
@@ -28,8 +31,7 @@
  * straight to stdout for the operator to copy.
  */
 import { defaultPasswordProvider } from '../src/main/auth/providers/argon2-provider'
-
-const MIN_PASSWORD_LENGTH = 12
+import { WEB_MIN_PASSWORD_LENGTH } from '../src/shared/auth/auth-constants'
 
 /**
  * Read all of stdin into a line iterator. Used in non-TTY mode so a
@@ -79,7 +81,7 @@ async function readSecretTty(prompt: string): Promise<string> {
           reject(new Error('cancelled'))
           return
         }
-        if (ch === '' || ch === '\b') {
+        if (ch === '\x7f' || ch === '\b') {
           buf = buf.slice(0, -1)
           continue
         }
@@ -106,9 +108,9 @@ async function main(): Promise<void> {
     confirm = next() ?? ''
   }
 
-  if (pw.length < MIN_PASSWORD_LENGTH) {
+  if (pw.length < WEB_MIN_PASSWORD_LENGTH) {
     process.stderr.write(
-      `Password too short (${pw.length} chars; minimum ${MIN_PASSWORD_LENGTH}).\n`
+      `Password too short (${pw.length} chars; minimum ${WEB_MIN_PASSWORD_LENGTH}).\n`
     )
     process.exit(2)
   }
@@ -120,11 +122,11 @@ async function main(): Promise<void> {
   process.stderr.write('Hashing (Argon2id, m=64MB, t=3, p=4)...\n')
   const hash = await defaultPasswordProvider.hashPassword(pw)
 
-  // Hash to stdout, instructions to stderr — so a pipe-into-file
-  // captures only the hash.
+  // Hash to stdout, instructions to stderr. Use `npm run --silent`
+  // when redirecting so npm's banner does not enter the output file.
   process.stdout.write(hash + '\n')
   process.stderr.write('\nDone. Add to your .env:\n')
-  process.stderr.write('  VARLENS_ADMIN_PASSWORD_HASH=' + hash + '\n')
+  process.stderr.write(`  VARLENS_ADMIN_PASSWORD_HASH='${hash}'\n`)
   process.stderr.write('Plaintext VARLENS_ADMIN_PASSWORD is not supported.\n')
 }
 

--- a/src/main/auth/providers/argon2-provider.ts
+++ b/src/main/auth/providers/argon2-provider.ts
@@ -1,0 +1,32 @@
+/**
+ * Argon2id password provider — the only place in the codebase allowed to
+ * import `@node-rs/argon2`. Everywhere else gets the abstract
+ * `PasswordProvider` interface.
+ *
+ * Enforced by `tests/web-gate/auth-isolation.test.ts`.
+ */
+import { hash, verify } from '@node-rs/argon2'
+
+export const ARGON2_POLICY = {
+  memoryCost: 65536, // 64 MB
+  timeCost: 3,
+  parallelism: 4
+} as const
+
+export interface PasswordProvider {
+  hashPassword(plain: string): Promise<string>
+  verifyPassword(hashed: string, plain: string): Promise<boolean>
+}
+
+export class Argon2PasswordProvider implements PasswordProvider {
+  async hashPassword(plain: string): Promise<string> {
+    return await hash(plain, ARGON2_POLICY)
+  }
+
+  async verifyPassword(hashed: string, plain: string): Promise<boolean> {
+    return await verify(hashed, plain)
+  }
+}
+
+/** Module-level default. AuthService picks this up unless DI'd otherwise. */
+export const defaultPasswordProvider: PasswordProvider = new Argon2PasswordProvider()

--- a/src/main/auth/types.ts
+++ b/src/main/auth/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Auth type definitions.
+ *
+ * `Credential` is a discriminated union prepared for token-based auth. The
+ * current auth path only implements the `password` arm; the `token` arm exists
+ * so future auth providers can plug in without touching call sites.
+ *
+ * Enforced by `tests/web-gate/auth-isolation.test.ts` ("Credential
+ * discriminated union is shaped for OIDC retrofit").
+ */
+export type Credential =
+  | { kind: 'password'; username: string; password: string }
+  | { kind: 'token'; jwt: string }

--- a/src/main/services/auth/AuthService.ts
+++ b/src/main/services/auth/AuthService.ts
@@ -5,63 +5,47 @@
  * databases that have accounts enabled.
  */
 
-import { hash, verify } from '@node-rs/argon2'
 import { nanoid } from 'nanoid'
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
 
-const ARGON2_OPTIONS = {
-  memoryCost: 65536, // 64 MB
-  timeCost: 3,
-  parallelism: 4
-}
-
-/** Max failed login attempts before lockout */
-const MAX_FAILED_ATTEMPTS = 5
-
-/** Lockout duration in minutes */
-const LOCKOUT_DURATION_MINUTES = 15
-
-interface User {
-  id: number
-  username: string
-  display_name: string | null
-  password_hash: string
-  role: string
-  is_active: number
-  must_change_password: number
-  failed_login_count: number
-  locked_until: string | null
-  password_changed_at: string | null
-  created_at: string
-  created_by: number | null
-  updated_at: string | null
-}
-
-interface AuthResult {
-  success: boolean
-  user: Omit<User, 'password_hash'> | null
-  locked?: boolean
-  mustChangePassword?: boolean
-}
+import {
+  defaultPasswordProvider,
+  type PasswordProvider
+} from '../../auth/providers/argon2-provider'
+import {
+  LOCKOUT_DURATION_MINUTES,
+  MAX_FAILED_ATTEMPTS,
+  ROLE_ADMIN,
+  ROLE_USER,
+  type UserRole
+} from '../../../shared/auth/auth-constants'
+import type { AuthResult, User } from '../../../shared/auth/types'
 
 export class AuthService {
-  constructor(private db: DatabaseType) {}
+  private readonly passwordProvider: PasswordProvider
+
+  constructor(
+    private db: DatabaseType,
+    passwordProvider: PasswordProvider = defaultPasswordProvider
+  ) {
+    this.passwordProvider = passwordProvider
+  }
 
   async createFirstUser(
     username: string,
     displayName: string,
     password: string
-  ): Promise<{ id: number; username: string; role: string; recoveryKey: string }> {
+  ): Promise<{ id: number; username: string; role: UserRole; recoveryKey: string }> {
     // Check no admin exists
-    const existing = this.db.prepare("SELECT id FROM users WHERE role = 'admin' LIMIT 1").get() as
-      | { id: number }
-      | undefined
+    const existing = this.db
+      .prepare('SELECT id FROM users WHERE role = ? LIMIT 1')
+      .get(ROLE_ADMIN) as { id: number } | undefined
 
     if (existing) throw new Error('Admin user already exists')
 
-    const passwordHash = await hash(password, ARGON2_OPTIONS)
+    const passwordHash = await this.passwordProvider.hashPassword(password)
     const recoveryKey = nanoid(32)
-    const recoveryKeyHash = await hash(recoveryKey, ARGON2_OPTIONS)
+    const recoveryKeyHash = await this.passwordProvider.hashPassword(recoveryKey)
 
     const createUser = this.db.transaction(() => {
       // Store recovery key hash
@@ -79,9 +63,9 @@ export class AuthService {
       return this.db
         .prepare(
           `INSERT INTO users (username, display_name, password_hash, role, password_changed_at)
-           VALUES (?, ?, ?, 'admin', datetime('now'))`
+           VALUES (?, ?, ?, ?, datetime('now'))`
         )
-        .run(username, displayName, passwordHash)
+        .run(username, displayName, passwordHash, ROLE_ADMIN)
     })
 
     const result = createUser()
@@ -89,7 +73,7 @@ export class AuthService {
     return {
       id: Number(result.lastInsertRowid),
       username,
-      role: 'admin',
+      role: ROLE_ADMIN,
       recoveryKey
     }
   }
@@ -110,7 +94,7 @@ export class AuthService {
       return { success: false, user: null, locked: true }
     }
 
-    const valid = await verify(user.password_hash, password)
+    const valid = await this.passwordProvider.verifyPassword(user.password_hash, password)
 
     if (!valid) {
       const newCount = user.failed_login_count + 1
@@ -146,21 +130,21 @@ export class AuthService {
     displayName: string,
     tempPassword: string,
     createdByUsername: string
-  ): Promise<{ id: number; username: string; role: string; must_change_password: number }> {
+  ): Promise<{ id: number; username: string; role: UserRole; must_change_password: number }> {
     const creator = this.getUser(createdByUsername)
-    const passwordHash = await hash(tempPassword, ARGON2_OPTIONS)
+    const passwordHash = await this.passwordProvider.hashPassword(tempPassword)
 
     const result = this.db
       .prepare(
         `INSERT INTO users (username, display_name, password_hash, role, must_change_password, created_by, password_changed_at)
-         VALUES (?, ?, ?, 'user', 1, ?, datetime('now'))`
+         VALUES (?, ?, ?, ?, 1, ?, datetime('now'))`
       )
-      .run(username, displayName, passwordHash, creator?.id ?? null)
+      .run(username, displayName, passwordHash, ROLE_USER, creator?.id ?? null)
 
     return {
       id: Number(result.lastInsertRowid),
       username,
-      role: 'user',
+      role: ROLE_USER,
       must_change_password: 1
     }
   }
@@ -187,7 +171,7 @@ export class AuthService {
   }
 
   async resetPassword(username: string, newPassword: string): Promise<void> {
-    const passwordHash = await hash(newPassword, ARGON2_OPTIONS)
+    const passwordHash = await this.passwordProvider.hashPassword(newPassword)
     this.db
       .prepare(
         `UPDATE users SET password_hash = ?, must_change_password = 1,
@@ -209,10 +193,10 @@ export class AuthService {
 
     if (!user) return false
 
-    const valid = await verify(user.password_hash, oldPassword)
+    const valid = await this.passwordProvider.verifyPassword(user.password_hash, oldPassword)
     if (!valid) return false
 
-    const passwordHash = await hash(newPassword, ARGON2_OPTIONS)
+    const passwordHash = await this.passwordProvider.hashPassword(newPassword)
     this.db
       .prepare(
         `UPDATE users SET password_hash = ?, must_change_password = 0,

--- a/src/main/storage/postgres/PostgresAnnotationsRepository.ts
+++ b/src/main/storage/postgres/PostgresAnnotationsRepository.ts
@@ -89,6 +89,14 @@ function valuesListForVariantKeys(keys: VariantKey[], params: unknown[]): string
     .join(', ')
 }
 
+async function rollbackTransaction(client: Pick<PoolClient, 'query'>): Promise<void> {
+  try {
+    await client.query('ROLLBACK')
+  } catch {
+    // Preserve the original transaction failure; rollback errors add noise here.
+  }
+}
+
 export class PostgresAnnotationsRepository {
   constructor(
     private readonly pool: QueryablePool,
@@ -208,7 +216,7 @@ export class PostgresAnnotationsRepository {
       await client.query('COMMIT')
       return result
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackTransaction(client)
       throw error
     } finally {
       client.release()
@@ -330,7 +338,7 @@ export class PostgresAnnotationsRepository {
       await client.query('COMMIT')
       return result
     } catch (error) {
-      await client.query('ROLLBACK')
+      await rollbackTransaction(client)
       throw error
     } finally {
       client.release()

--- a/src/main/storage/postgres/PostgresTranscriptsRepository.ts
+++ b/src/main/storage/postgres/PostgresTranscriptsRepository.ts
@@ -12,6 +12,22 @@ function toNumber(value: unknown): number {
   return 0
 }
 
+function toBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value === 1
+  if (typeof value === 'bigint') return value === 1n
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized === 't' || normalized === 'true' || normalized === '1'
+  }
+  return false
+}
+
+function toNullableBoolean(value: unknown): boolean | null {
+  if (value === null || value === undefined) return null
+  return toBoolean(value)
+}
+
 const transcriptColumns = `
   id, variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
   hpo_sim_score, moi, is_selected, is_mane_select, is_canonical
@@ -167,13 +183,9 @@ export class PostgresTranscriptsRepository {
       aa_change: (row.aa_change as string | null) ?? null,
       hpo_sim_score: (row.hpo_sim_score as number | null) ?? null,
       moi: (row.moi as string | null) ?? null,
-      is_selected: row.is_selected === true || row.is_selected === 1,
-      is_mane_select:
-        row.is_mane_select === null
-          ? null
-          : row.is_mane_select === true || row.is_mane_select === 1,
-      is_canonical:
-        row.is_canonical === null ? null : row.is_canonical === true || row.is_canonical === 1
+      is_selected: toBoolean(row.is_selected),
+      is_mane_select: toNullableBoolean(row.is_mane_select),
+      is_canonical: toNullableBoolean(row.is_canonical)
     }
   }
 }

--- a/src/main/storage/postgres/migrations/PostgresMigrationRunner.ts
+++ b/src/main/storage/postgres/migrations/PostgresMigrationRunner.ts
@@ -29,7 +29,7 @@ export class PostgresMigrationRunner {
     try {
       await client.query('BEGIN')
       transactionStarted = true
-      await client.query('SELECT pg_advisory_xact_lock(928714, hashtext($1))', [this.schema])
+      await this.acquireMigrationLocks(client)
       await client.query(`CREATE SCHEMA IF NOT EXISTS ${this.schemaName}`)
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.schemaName}."schema_migrations" (
@@ -83,6 +83,21 @@ export class PostgresMigrationRunner {
     } finally {
       client.release()
     }
+  }
+
+  private async acquireMigrationLocks(client: MigrationClient): Promise<void> {
+    const lockTimeoutResult = await client.query<{ lock_timeout: string }>(
+      "SELECT current_setting('lock_timeout') AS lock_timeout"
+    )
+    const lockTimeout = lockTimeoutResult.rows[0]?.lock_timeout ?? '0'
+
+    await client.query("SELECT set_config('lock_timeout', '0', true)")
+    // Some migrations touch database-global objects such as extensions.
+    // PostgreSQL can race on concurrent CREATE EXTENSION IF NOT EXISTS calls,
+    // so keep cross-schema migration runners serialized before schema DDL.
+    await client.query('SELECT pg_advisory_xact_lock(928714, 0)')
+    await client.query('SELECT pg_advisory_xact_lock(928714, hashtext($1))', [this.schema])
+    await client.query("SELECT set_config('lock_timeout', $1, true)", [lockTimeout])
   }
 
   private validateAppliedMigrations(applied: Map<string, string>): void {

--- a/src/main/storage/postgres/migrations/definitions.ts
+++ b/src/main/storage/postgres/migrations/definitions.ts
@@ -38,6 +38,11 @@ const MIGRATION_FILES: readonly MigrationFile[] = [
     version: '0007',
     name: 'perf_indexes',
     fileName: '0007_perf_indexes.sql'
+  },
+  {
+    version: '0008',
+    name: 'create_users_and_settings',
+    fileName: '0008_create_users_and_settings.sql'
   }
 ]
 

--- a/src/main/storage/postgres/migrations/sql/0008_create_users_and_settings.sql
+++ b/src/main/storage/postgres/migrations/sql/0008_create_users_and_settings.sql
@@ -1,0 +1,45 @@
+-- Postgres-side auth tables, mirroring SQLite migrations.ts v12.
+--
+-- Schema kept lockstep with the desktop schema so the two backends share
+-- column names, role enum, lockout shape, and audit fields. The constants
+-- module (src/shared/auth/auth-constants.ts) is the single source of truth for
+-- these names and values.
+--
+-- Differences from SQLite by necessity (not policy):
+--   - INTEGER PRIMARY KEY AUTOINCREMENT     -> BIGSERIAL PRIMARY KEY
+--   - INTEGER 0/1 boolean                   -> BOOLEAN
+--   - TEXT timestamp via datetime('now')    -> TIMESTAMPTZ DEFAULT now()
+--   - INTEGER counters                      -> INTEGER (kept; row counts fit fine)
+-- Argon2 hashes are TEXT in both. CHECK constraints on role mirror exactly.
+
+CREATE TABLE IF NOT EXISTS "__schema__"."users" (
+  id BIGSERIAL PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  display_name TEXT,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'user' CHECK(role IN ('admin', 'user')),
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  must_change_password BOOLEAN NOT NULL DEFAULT FALSE,
+  failed_login_count INTEGER NOT NULL DEFAULT 0,
+  locked_until TIMESTAMPTZ,
+  password_changed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT REFERENCES "__schema__"."users"(id),
+  updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_username
+  ON "__schema__"."users"(username);
+
+-- Concurrency guard for createFirstUser: at most one active admin row may
+-- exist in this schema. Inactive admin rows must not permanently block
+-- bootstrap after manual recovery, while concurrent active bootstrap attempts
+-- still collapse to one successful INSERT.
+CREATE UNIQUE INDEX IF NOT EXISTS users_only_one_active_admin
+  ON "__schema__"."users"(role)
+  WHERE role = 'admin' AND is_active = TRUE;
+
+CREATE TABLE IF NOT EXISTS "__schema__"."database_settings" (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/src/shared/auth/auth-constants.ts
+++ b/src/shared/auth/auth-constants.ts
@@ -1,0 +1,49 @@
+/**
+ * Cross-backend auth policy constants.
+ *
+ * Both the desktop SQLite AuthService and PostgresWebAuthService import from
+ * here. Without a single source of truth the two backends
+ * drift on policy — different lockout thresholds, mismatched role
+ * enums, divergent CHECK constraints between SQLite migrations.ts v12
+ * and Postgres migrations/sql/0007_*.sql.
+ *
+ * Anything that is *policy* belongs here. SQL fragments, query
+ * shape, and row-mapping stay in the per-backend implementation.
+ *
+ * SECURITY POLICY: changes to the lockout threshold or duration are
+ * security-policy changes, not refactors. They affect every operator's
+ * exposure to credential-stuffing and brute-force attacks. The pinned-
+ * value tests in tests/main/services/auth/auth-constants.test.ts force
+ * these edits to be deliberate, but reviewers should treat any PR that
+ * touches these constants as a security review, not a routine cleanup.
+ */
+
+/** Allowed values for the users.role column. */
+export const USER_ROLES = ['admin', 'user'] as const
+export type UserRole = (typeof USER_ROLES)[number]
+
+/**
+ * Named role constants — use these in code paths instead of string
+ * literals so a rename of the role enum is a TypeScript-caught change
+ * rather than a silent runtime divergence between schema and inserts.
+ */
+export const ROLE_ADMIN: UserRole = 'admin'
+export const ROLE_USER: UserRole = 'user'
+
+/**
+ * Default value for the users.role column. Both backends declare
+ * `DEFAULT 'user'`; the migration-parity tests pin both to this value.
+ */
+export const DEFAULT_USER_ROLE: UserRole = ROLE_USER
+
+/**
+ * After this many consecutive failed login attempts the account is
+ * temporarily locked. Matches the desktop AuthService constant.
+ */
+export const MAX_FAILED_ATTEMPTS = 5
+
+/**
+ * How long an account stays locked after exceeding MAX_FAILED_ATTEMPTS.
+ * Both backends compute `locked_until = now() + this duration`.
+ */
+export const LOCKOUT_DURATION_MINUTES = 15

--- a/src/shared/auth/auth-constants.ts
+++ b/src/shared/auth/auth-constants.ts
@@ -5,7 +5,7 @@
  * here. Without a single source of truth the two backends
  * drift on policy — different lockout thresholds, mismatched role
  * enums, divergent CHECK constraints between SQLite migrations.ts v12
- * and Postgres migrations/sql/0007_*.sql.
+ * and Postgres migrations/sql/0008_*.sql.
  *
  * Anything that is *policy* belongs here. SQL fragments, query
  * shape, and row-mapping stay in the per-backend implementation.
@@ -35,6 +35,13 @@ export const ROLE_USER: UserRole = 'user'
  * `DEFAULT 'user'`; the migration-parity tests pin both to this value.
  */
 export const DEFAULT_USER_ROLE: UserRole = ROLE_USER
+
+/**
+ * Minimum length for passwords accepted by the web track. Desktop auth keeps
+ * its existing looser behavior; web bootstrap and password rotation share this
+ * value so the hash CLI cannot drift from the Postgres auth service.
+ */
+export const WEB_MIN_PASSWORD_LENGTH = 12
 
 /**
  * After this many consecutive failed login attempts the account is

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Cross-backend auth types — single source of truth so the desktop
+ * SQLite AuthService and the web Postgres PostgresWebAuthService can't
+ * drift on return shapes.
+ *
+ * Both implementations import from this module; any field added, removed, or
+ * renamed lands in both runtimes simultaneously.
+ *
+ * Storage representation differs between backends:
+ *   - SQLite stores integer 0/1 for booleans, TEXT ISO strings for
+ *     timestamps, INTEGER PK for ids.
+ *   - Postgres stores native BOOLEAN, TIMESTAMPTZ, BIGINT.
+ * Each backend's row mapper normalises to this shared `User` shape so
+ * handlers (and the AuthResult contract) never have to branch.
+ */
+import type { UserRole } from './auth-constants'
+
+export interface User {
+  id: number
+  username: string
+  display_name: string | null
+  password_hash: string
+  role: UserRole
+  is_active: number
+  must_change_password: number
+  failed_login_count: number
+  locked_until: string | null
+  password_changed_at: string | null
+  created_at: string
+  created_by: number | null
+  updated_at: string | null
+}
+
+export interface AuthResult {
+  success: boolean
+  user: Omit<User, 'password_hash'> | null
+  locked?: boolean
+  mustChangePassword?: boolean
+}

--- a/src/web/auth/PostgresWebAuthService.ts
+++ b/src/web/auth/PostgresWebAuthService.ts
@@ -1,0 +1,545 @@
+/**
+ * PostgresWebAuthService — Postgres-backed user authentication for the
+ * web variant.
+ *
+ * Mirrors the desktop SQLite AuthService surface one method for one method:
+ * Argon2id hashing via PasswordProvider, lockout after MAX_FAILED_ATTEMPTS,
+ * the accounts_enabled flag in database_settings, and password rotation.
+ *
+ * Web-only — never imported by main process. Lives under src/web/ so
+ * the desktop AuthService stays a pure SQLite surface and can't be
+ * regressed by web-specific concerns.
+ *
+ * Cross-backend policy values (USER_ROLES, MAX_FAILED_ATTEMPTS,
+ * LOCKOUT_DURATION_MINUTES) come from src/shared/auth/auth-constants —
+ * the constants module is process-agnostic and the only thing the two
+ * implementations share.
+ */
+import type { Pool } from 'pg'
+
+import {
+  ARGON2_POLICY,
+  defaultPasswordProvider,
+  type PasswordProvider
+} from '../../main/auth/providers/argon2-provider'
+import {
+  LOCKOUT_DURATION_MINUTES,
+  MAX_FAILED_ATTEMPTS,
+  ROLE_ADMIN,
+  ROLE_USER,
+  type UserRole
+} from '../../shared/auth/auth-constants'
+
+/**
+ * Minimum length for any new password set on the web track. Picked at
+ * 12 to align with NIST SP 800-63B guidance for memorised secrets in
+ * an admin/single-user context. The desktop AuthService keeps its
+ * own (laxer) rule because that surface predates this policy.
+ */
+export const MIN_PASSWORD_LENGTH = 12
+
+/**
+ * Server-side validation errors that callers need to discriminate
+ * (the standalone login page surfaces them as inline messages, the
+ * dispatcher maps them to specific 4xx codes). Distinct from
+ * "invalid old password" which is signalled by a `false` return.
+ */
+export class PasswordPolicyError extends Error {
+  readonly name = 'PasswordPolicyError'
+  readonly code: 'too-short' | 'same-as-old'
+  constructor(code: 'too-short' | 'same-as-old', message: string) {
+    super(message)
+    this.code = code
+  }
+}
+
+function assertPasswordMinLength(password: string, label = 'Password'): void {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new PasswordPolicyError(
+      'too-short',
+      `${label} must be at least ${MIN_PASSWORD_LENGTH} characters.`
+    )
+  }
+}
+
+/**
+ * Shape-check an Argon2id PHC string without invoking the verifier. This
+ * rejects plaintext, other hash families, malformed salt/hash segments, and
+ * parameter values that do not match the provider policy so bootstrap fails
+ * loudly before any database write.
+ */
+const ARGON2ID_PHC_PATTERN =
+  /^\$argon2id\$v=(\d+)\$m=(\d+),t=(\d+),p=(\d+)\$([A-Za-z0-9+/]+={0,2})\$([A-Za-z0-9+/]+={0,2})$/
+
+function isValidPhcBase64(value: string): boolean {
+  return value.length > 0 && value.length % 4 !== 1
+}
+
+function isLikelyArgon2idHash(value: string): boolean {
+  const match = value.match(ARGON2ID_PHC_PATTERN)
+  return match !== null && isValidPhcBase64(match[5]) && isValidPhcBase64(match[6])
+}
+
+function assertArgon2idHashMatchesProviderPolicy(value: string): void {
+  const match = value.match(ARGON2ID_PHC_PATTERN)
+  if (match === null || !isValidPhcBase64(match[5]) || !isValidPhcBase64(match[6])) {
+    throw new Error(
+      'createFirstUserFromHash: passwordHash does not look like an Argon2id hash. ' +
+        'Generate one with `npm run varlens:hash-password`.'
+    )
+  }
+
+  const [, version, memoryCost, timeCost, parallelism] = match
+  const mismatches: string[] = []
+  if (version !== '19') mismatches.push(`v=${version}`)
+  if (Number(memoryCost) !== ARGON2_POLICY.memoryCost) mismatches.push(`m=${memoryCost}`)
+  if (Number(timeCost) !== ARGON2_POLICY.timeCost) mismatches.push(`t=${timeCost}`)
+  if (Number(parallelism) !== ARGON2_POLICY.parallelism) mismatches.push(`p=${parallelism}`)
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      'createFirstUserFromHash: passwordHash Argon2id parameters do not match the ' +
+        `VarLens provider policy (m=${ARGON2_POLICY.memoryCost},t=${ARGON2_POLICY.timeCost},` +
+        `p=${ARGON2_POLICY.parallelism}). Mismatched parameter(s): ${mismatches.join(', ')}.`
+    )
+  }
+}
+
+export { isLikelyArgon2idHash, assertArgon2idHashMatchesProviderPolicy }
+// Cross-backend User + AuthResult shape: both implementations import the same
+// types so shape parity is enforced at compile time.
+import type { AuthResult, User } from '../../shared/auth/types'
+
+export type { AuthResult, User }
+
+export interface PostgresWebAuthServiceOptions {
+  pool: Pool
+  schema: string
+  passwordProvider?: PasswordProvider
+}
+
+/**
+ * Typed sentinel for the admin-already-exists case. Callers (notably
+ * src/web/server.ts maybeBootstrapAdmin) want to distinguish this
+ * specific failure from any other createFirstUser error so they can
+ * take the env-rotation-ignored warn-and-skip path instead of crashing
+ * the boot. The previous regex-on-message detection was brittle to
+ * wording changes; this class makes the contract explicit and
+ * instanceof-checkable.
+ */
+export class AdminAlreadyExistsError extends Error {
+  readonly name = 'AdminAlreadyExistsError'
+  constructor(cause?: unknown) {
+    super('Admin user already exists', cause === undefined ? undefined : { cause })
+  }
+}
+
+export function isAdminAlreadyExists(err: unknown): err is AdminAlreadyExistsError {
+  return err instanceof AdminAlreadyExistsError
+}
+
+/**
+ * Convert a Postgres row (BOOLEAN / TIMESTAMPTZ / BIGINT-as-string) to
+ * the cross-backend User shape (number / ISO string / number).
+ *
+ * Why number for booleans: the desktop AuthService returns 0/1 because
+ * SQLite stores them that way. Renderer code already handles 0/1; the
+ * web path keeps the same shape so the handler-seam guarantee holds.
+ */
+function mapPgRowToUser(raw: Record<string, unknown>): User {
+  const toIso = (v: unknown): string | null => {
+    if (v === null || v === undefined) return null
+    if (v instanceof Date) return v.toISOString()
+    // The migration declares TIMESTAMPTZ; node-postgres returns Date by
+    // default. If we get a non-Date, non-null value here, a custom type
+    // parser was installed and it's emitting raw PG strings — the User
+    // contract advertises ISO 8601, so refuse rather than silently
+    // pass through a non-ISO format.
+    if (typeof v === 'string') {
+      const parsed = new Date(v)
+      if (isNaN(parsed.getTime())) {
+        throw new Error(`mapPgRowToUser: cannot parse timestamp value: ${v}`)
+      }
+      return parsed.toISOString()
+    }
+    throw new Error(
+      `mapPgRowToUser: unexpected timestamp type ${typeof v} (${String(v).slice(0, 40)})`
+    )
+  }
+  const toBoolNumber = (v: unknown): number => {
+    if (typeof v === 'boolean') return v ? 1 : 0
+    if (typeof v === 'number') return v === 0 ? 0 : 1
+    // Postgres BOOLEAN under custom type parsers can arrive as 't'/'f'
+    // or 'true'/'false'. Whitelist the known truthy strings; treat
+    // anything else as false (parity with SQLite which stores 0/1 INT).
+    if (v === 't' || v === 'true' || v === '1') return 1
+    return 0
+  }
+  const toNumberOrNull = (v: unknown): number | null => {
+    if (v === null || v === undefined) return null
+    return Number(v)
+  }
+  return {
+    id: Number(raw.id),
+    username: String(raw.username),
+    display_name: raw.display_name === null ? null : String(raw.display_name),
+    password_hash: String(raw.password_hash),
+    role: String(raw.role) as UserRole,
+    is_active: toBoolNumber(raw.is_active),
+    must_change_password: toBoolNumber(raw.must_change_password),
+    failed_login_count: Number(raw.failed_login_count ?? 0),
+    locked_until: toIso(raw.locked_until),
+    password_changed_at: toIso(raw.password_changed_at),
+    created_at: toIso(raw.created_at) ?? '',
+    created_by: toNumberOrNull(raw.created_by),
+    updated_at: toIso(raw.updated_at)
+  }
+}
+
+function quoteSchema(schema: string): string {
+  // Defence against unsanitised schema names. Postgres identifiers
+  // can be arbitrary unicode; the only safe quoting is doubling
+  // embedded `"`. A schema with `"` in its name is pathological but
+  // valid SQL — we handle it instead of refusing.
+  return `"${schema.replace(/"/g, '""')}"`
+}
+
+export class PostgresWebAuthService {
+  private readonly pool: Pool
+  private readonly schemaQuoted: string
+  private readonly passwordProvider: PasswordProvider
+
+  constructor(options: PostgresWebAuthServiceOptions) {
+    this.pool = options.pool
+    this.schemaQuoted = quoteSchema(options.schema)
+    this.passwordProvider = options.passwordProvider ?? defaultPasswordProvider
+  }
+
+  // ---------- bootstrap ----------
+
+  /**
+   * Cheap pre-check used by server.ts maybeBootstrapAdmin to avoid
+   * paying Argon2's ~600ms hashing cost (and reserving an FS path)
+   * on every reboot of an already-bootstrapped instance. The
+   * createFirstUser race-safety still holds — the partial unique
+   * index on `role='admin'` is the source of truth — but skipping
+   * the heavy work for the steady-state case keeps restart latency
+   * low and avoids the wx-EEXIST trap when the operator hasn't
+   * captured/deleted the recovery-key file yet.
+   */
+  async hasAdmin(): Promise<boolean> {
+    const sch = this.schemaQuoted
+    const sel = await this.pool.query(
+      `SELECT 1 FROM ${sch}."users" WHERE role = $1 AND is_active = TRUE LIMIT 1`,
+      [ROLE_ADMIN]
+    )
+    return (sel.rowCount ?? 0) > 0
+  }
+
+  /**
+   * Hash-bootstrap path. Accepts a pre-computed Argon2id hash and
+   * does **not** ever see the plaintext. This is the preferred
+   * path for production: `VARLENS_ADMIN_PASSWORD_HASH` lives in the
+   * operator's `.env` and on the server's `.env`; the plaintext
+   * exists only in the operator's memory between typing it and
+   * `npm run varlens:hash-password` printing the hash.
+   *
+   * The recovery-key write (DB + plaintext file) used to live here.
+   * It was carried over from the desktop track but no consumer code
+   * reads it back, and the on-disk plaintext file was a real
+   * footgun (mode 0600 yes, but still a plaintext credential lying
+   * around until manually captured + deleted). Removed entirely; if
+   * a recovery flow ships later it can issue a key at that point.
+   */
+  async createFirstUserFromHash(
+    username: string,
+    displayName: string,
+    passwordHash: string
+  ): Promise<{ id: number; username: string; role: UserRole }> {
+    if (!isLikelyArgon2idHash(passwordHash)) {
+      throw new Error(
+        'createFirstUserFromHash: passwordHash does not look like an Argon2id hash. ' +
+          'Generate one with `npm run varlens:hash-password`.'
+      )
+    }
+    assertArgon2idHashMatchesProviderPolicy(passwordHash)
+    return await this.insertFirstUser(username, displayName, passwordHash)
+  }
+
+  /**
+   * Internal test/helper path. Production web bootstrap refuses
+   * plaintext env credentials and calls createFirstUserFromHash().
+   */
+  async createFirstUser(
+    username: string,
+    displayName: string,
+    password: string
+  ): Promise<{ id: number; username: string; role: UserRole }> {
+    assertPasswordMinLength(password)
+    const passwordHash = await this.passwordProvider.hashPassword(password)
+    return await this.insertFirstUser(username, displayName, passwordHash)
+  }
+
+  private async insertFirstUser(
+    username: string,
+    displayName: string,
+    passwordHash: string
+  ): Promise<{ id: number; username: string; role: UserRole }> {
+    const sch = this.schemaQuoted
+    // Race-safety: the SELECT-outside-transaction pattern in earlier
+    // revisions of this method allowed two concurrent first-user calls
+    // to both observe "no admin" and both proceed. The partial unique
+    // index `users_only_one_active_admin` guarantees at most one active admin
+    // row per schema; the second concurrent INSERT trips unique_violation
+    // (SQLSTATE 23505) and we translate it into the same friendly error a
+    // serial caller would see.
+    //
+    // The bootstrapped admin is created with must_change_password=TRUE
+    // so the first login forces a rotation before any session-bearing
+    // request can reach the application surface. The dispatcher's
+    // pre-rotation gate enforces this server-side; the operator never
+    // sees an exposure window where the bootstrap credential could
+    // call /api/* freely.
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(
+        `INSERT INTO ${sch}."database_settings" (key, value) VALUES ('accounts_enabled', 'true')
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`
+      )
+      const inserted = await client.query<{ id: string }>(
+        `INSERT INTO ${sch}."users"
+          (username, display_name, password_hash, role, must_change_password, password_changed_at)
+         VALUES ($1, $2, $3, $4, TRUE, now())
+         RETURNING id`,
+        [username, displayName, passwordHash, ROLE_ADMIN]
+      )
+      await client.query('COMMIT')
+      return {
+        id: Number(inserted.rows[0].id),
+        username,
+        role: ROLE_ADMIN
+      }
+    } catch (err) {
+      try {
+        await client.query('ROLLBACK')
+      } catch {
+        // ignore rollback failures; original error wins
+      }
+      // Translate unique-violation on the partial admin index into a
+      // typed sentinel callers (server.ts maybeBootstrapAdmin) can
+      // discriminate from generic create failures.
+      if (typeof err === 'object' && err !== null && 'code' in err && err.code === '23505') {
+        throw new AdminAlreadyExistsError(err)
+      }
+      throw err
+    } finally {
+      client.release()
+    }
+  }
+
+  // ---------- authenticate ----------
+
+  async authenticate(username: string, password: string): Promise<AuthResult> {
+    const sch = this.schemaQuoted
+    const sel = await this.pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${sch}."users" WHERE username = $1 AND is_active = TRUE`,
+      [username]
+    )
+    if ((sel.rowCount ?? 0) === 0) {
+      return { success: false, user: null }
+    }
+    const user = mapPgRowToUser(sel.rows[0])
+
+    if (user.locked_until !== null && user.locked_until !== '') {
+      if (new Date(user.locked_until).getTime() > Date.now()) {
+        return { success: false, user: null, locked: true }
+      }
+    }
+
+    const valid = await this.passwordProvider.verifyPassword(user.password_hash, password)
+
+    if (!valid) {
+      // Atomic increment + conditional lockout, single round trip. The
+      // previous SELECT-then-UPDATE pattern was racy under pg's
+      // concurrency model: two concurrent failed logins could both read
+      // failed_login_count = N-1 and both write N, defeating the
+      // MAX_FAILED_ATTEMPTS gate. SQLite's single-writer model hid the
+      // race on desktop; the web path needs DB-level atomicity.
+      const lockUntil = new Date(Date.now() + LOCKOUT_DURATION_MINUTES * 60 * 1000)
+      await this.pool.query(
+        `UPDATE ${sch}."users"
+            SET failed_login_count = failed_login_count + 1,
+                locked_until = CASE
+                  WHEN failed_login_count + 1 >= $1 THEN $2
+                  ELSE locked_until
+                END
+          WHERE id = $3`,
+        [MAX_FAILED_ATTEMPTS, lockUntil, user.id]
+      )
+      return { success: false, user: null }
+    }
+
+    await this.pool.query(
+      `UPDATE ${sch}."users" SET failed_login_count = 0, locked_until = NULL WHERE id = $1`,
+      [user.id]
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password_hash: _hash, ...safeUser } = user
+    return {
+      success: true,
+      user: safeUser,
+      mustChangePassword: user.must_change_password === 1
+    }
+  }
+
+  // ---------- user management ----------
+
+  async createUser(
+    username: string,
+    displayName: string,
+    tempPassword: string,
+    createdByUsername: string
+  ): Promise<{ id: number; username: string; role: UserRole; must_change_password: number }> {
+    const sch = this.schemaQuoted
+    assertPasswordMinLength(tempPassword, 'Temporary password')
+    const creator = await this.getUser(createdByUsername)
+    const passwordHash = await this.passwordProvider.hashPassword(tempPassword)
+
+    const inserted = await this.pool.query<{ id: string }>(
+      `INSERT INTO ${sch}."users"
+        (username, display_name, password_hash, role, must_change_password, created_by, password_changed_at)
+       VALUES ($1, $2, $3, $4, TRUE, $5, now())
+       RETURNING id`,
+      [username, displayName, passwordHash, ROLE_USER, creator?.id ?? null]
+    )
+
+    return {
+      id: Number(inserted.rows[0].id),
+      username,
+      role: ROLE_USER,
+      must_change_password: 1
+    }
+  }
+
+  async getUser(username: string): Promise<User | undefined> {
+    const sch = this.schemaQuoted
+    const sel = await this.pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${sch}."users" WHERE username = $1`,
+      [username]
+    )
+    if ((sel.rowCount ?? 0) === 0) return undefined
+    return mapPgRowToUser(sel.rows[0])
+  }
+
+  async listUsers(): Promise<Omit<User, 'password_hash'>[]> {
+    const sch = this.schemaQuoted
+    const sel = await this.pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${sch}."users" ORDER BY created_at`
+    )
+    return sel.rows.map((row) => {
+      const u = mapPgRowToUser(row)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { password_hash: _hash, ...rest } = u
+      return rest
+    })
+  }
+
+  async deactivateUser(username: string): Promise<void> {
+    const sch = this.schemaQuoted
+    const existing = await this.pool.query<{ role: UserRole }>(
+      `SELECT role FROM ${sch}."users" WHERE username = $1`,
+      [username]
+    )
+    if ((existing.rowCount ?? 0) === 0) {
+      throw new Error(`User not found: ${username}`)
+    }
+    if (existing.rows[0].role === ROLE_ADMIN) {
+      throw new Error('Cannot deactivate an admin user')
+    }
+
+    const result = await this.pool.query(
+      `UPDATE ${sch}."users" SET is_active = FALSE, updated_at = now() WHERE username = $1`,
+      [username]
+    )
+    if ((result.rowCount ?? 0) === 0) {
+      throw new Error(`User not found: ${username}`)
+    }
+  }
+
+  async resetPassword(username: string, newPassword: string): Promise<void> {
+    const sch = this.schemaQuoted
+    assertPasswordMinLength(newPassword, 'New password')
+    const passwordHash = await this.passwordProvider.hashPassword(newPassword)
+    await this.pool.query(
+      `UPDATE ${sch}."users"
+         SET password_hash = $1, must_change_password = TRUE,
+             failed_login_count = 0, locked_until = NULL,
+             password_changed_at = now(), updated_at = now()
+       WHERE username = $2`,
+      [passwordHash, username]
+    )
+  }
+
+  /**
+   * Rotate a user's password.
+   *
+   * Returns `false` when `oldPassword` doesn't verify (caller maps to
+   * 401). Throws `PasswordPolicyError` for policy violations the
+   * caller can surface as targeted 4xx codes (too short / reused).
+   * Other errors propagate as 500.
+   *
+   * Server-side enforcement of:
+   *   - newPassword length >= MIN_PASSWORD_LENGTH (12)
+   *   - newPassword !== oldPassword (defence-in-depth even if the
+   *     UI also checks; the server is authoritative)
+   *
+   * On success, must_change_password is cleared and the dispatcher's
+   * pre-rotation gate stops blocking other endpoints for this
+   * session.
+   */
+  async changePassword(
+    username: string,
+    oldPassword: string,
+    newPassword: string
+  ): Promise<boolean> {
+    assertPasswordMinLength(newPassword, 'New password')
+    if (newPassword === oldPassword) {
+      throw new PasswordPolicyError(
+        'same-as-old',
+        'New password must differ from the current password.'
+      )
+    }
+    const sch = this.schemaQuoted
+    const sel = await this.pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${sch}."users" WHERE username = $1`,
+      [username]
+    )
+    if ((sel.rowCount ?? 0) === 0) return false
+    const user = mapPgRowToUser(sel.rows[0])
+
+    const valid = await this.passwordProvider.verifyPassword(user.password_hash, oldPassword)
+    if (!valid) return false
+
+    const passwordHash = await this.passwordProvider.hashPassword(newPassword)
+    await this.pool.query(
+      `UPDATE ${sch}."users"
+         SET password_hash = $1, must_change_password = FALSE,
+             password_changed_at = now(), updated_at = now()
+       WHERE username = $2`,
+      [passwordHash, username]
+    )
+    return true
+  }
+
+  // ---------- settings ----------
+
+  async isAccountsEnabled(): Promise<boolean> {
+    const sch = this.schemaQuoted
+    const sel = await this.pool.query<{ value: string }>(
+      `SELECT value FROM ${sch}."database_settings" WHERE key = 'accounts_enabled'`
+    )
+    return sel.rows[0]?.value === 'true'
+  }
+}

--- a/src/web/auth/PostgresWebAuthService.ts
+++ b/src/web/auth/PostgresWebAuthService.ts
@@ -11,9 +11,9 @@
  * regressed by web-specific concerns.
  *
  * Cross-backend policy values (USER_ROLES, MAX_FAILED_ATTEMPTS,
- * LOCKOUT_DURATION_MINUTES) come from src/shared/auth/auth-constants —
- * the constants module is process-agnostic and the only thing the two
- * implementations share.
+ * LOCKOUT_DURATION_MINUTES) and web password policy come from
+ * src/shared/auth/auth-constants — the constants module is process-agnostic
+ * and the only thing the two implementations share.
  */
 import type { Pool } from 'pg'
 
@@ -27,6 +27,7 @@ import {
   MAX_FAILED_ATTEMPTS,
   ROLE_ADMIN,
   ROLE_USER,
+  WEB_MIN_PASSWORD_LENGTH,
   type UserRole
 } from '../../shared/auth/auth-constants'
 
@@ -36,7 +37,7 @@ import {
  * an admin/single-user context. The desktop AuthService keeps its
  * own (laxer) rule because that surface predates this policy.
  */
-export const MIN_PASSWORD_LENGTH = 12
+export const MIN_PASSWORD_LENGTH = WEB_MIN_PASSWORD_LENGTH
 
 /**
  * Server-side validation errors that callers need to discriminate

--- a/tests/main/services/auth/auth-constants.test.ts
+++ b/tests/main/services/auth/auth-constants.test.ts
@@ -1,0 +1,191 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_USER_ROLE,
+  LOCKOUT_DURATION_MINUTES,
+  MAX_FAILED_ATTEMPTS,
+  ROLE_ADMIN,
+  ROLE_USER,
+  USER_ROLES,
+  type UserRole
+} from '../../../../src/shared/auth/auth-constants'
+
+/**
+ * Cross-backend auth policy lives in one module.
+ *
+ * Both backends (the existing SQLite AuthService and the upcoming
+ * PostgresWebAuthService under src/web/auth/) consume the same role
+ * enum, lockout threshold, lockout duration, and DEFAULT role value.
+ * Without a shared source of truth they drift on policy.
+ *
+ * Test goes RED before auth-constants.ts exists; goes GREEN once the
+ * module is added, AuthService imports from it, and both migrations
+ * (SQLite v12 + Postgres 0008) match the constants in CHECK enum,
+ * DEFAULT clause, and named role usage.
+ *
+ * The migration regexes here are whitespace-tolerant by design — a
+ * future SQL reformat (extra spaces, line breaks, alternate quote
+ * style) must NOT cause a false-positive drift signal. Real drift
+ * (different role names, missing/extra entries, different default)
+ * still fires.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..')
+
+const SQLITE_MIGRATION_PATH = resolve(REPO_ROOT, 'src/main/database/migrations.ts')
+const PG_USERS_MIGRATION_PATH = resolve(
+  REPO_ROOT,
+  'src/main/storage/postgres/migrations/sql/0008_create_users_and_settings.sql'
+)
+
+function readOrFail(path: string, hint: string): string {
+  if (!existsSync(path)) {
+    throw new Error(
+      `${hint} not found at ${path}. ` +
+        'If the migration file was renamed or moved, update auth-constants.test.ts ' +
+        'to point at the new location.'
+    )
+  }
+  return readFileSync(path, 'utf8')
+}
+
+function extractEnumFromCheckClause(sql: string, tableHint: string): string[] {
+  // Tolerant of whitespace and line breaks. Capture the enum body of
+  // a `role IN (...)` clause; require the surrounding context to
+  // mention the table by name so we don't accidentally match an
+  // unrelated `role` CHECK from a different table in the same file.
+  const re = new RegExp(
+    String.raw`${tableHint}[\s\S]+?role\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'([^']+)'\s+CHECK\s*\(\s*role\s+IN\s*\(([^)]+)\)\s*\)`,
+    'i'
+  )
+  const m = sql.match(re)
+  if (!m) {
+    throw new Error(
+      `Could not locate the users.role CHECK clause anchored on '${tableHint}'. ` +
+        'Either the migration was restructured or the regex needs an update.'
+    )
+  }
+  const defaultValue = m[1]
+  const enumeratedRoles = m[2]
+    .split(',')
+    .map((s) => s.trim().replace(/^'(.*)'$/s, '$1'))
+    .filter(Boolean)
+  return [defaultValue, ...enumeratedRoles]
+}
+
+describe('auth-constants module', () => {
+  it('exposes USER_ROLES with admin and user (no others)', () => {
+    expect(new Set(USER_ROLES)).toEqual(new Set(['admin', 'user']))
+  })
+
+  it('exposes named role constants (ROLE_ADMIN, ROLE_USER) matching USER_ROLES', () => {
+    expect(ROLE_ADMIN).toBe('admin')
+    expect(ROLE_USER).toBe('user')
+    expect(USER_ROLES).toContain(ROLE_ADMIN)
+    expect(USER_ROLES).toContain(ROLE_USER)
+  })
+
+  it('DEFAULT_USER_ROLE is a member of USER_ROLES', () => {
+    // Drift detector: a future change to USER_ROLES that drops the
+    // current default value would fail this assertion before it ships.
+    expect(USER_ROLES).toContain(DEFAULT_USER_ROLE)
+  })
+
+  it('exposes lockout threshold + duration matching pre-refactor values', () => {
+    // Pinned values — see SECURITY POLICY note in auth-constants.ts.
+    // Changing these is a security-policy edit, not a refactor: the
+    // PR that touches these numbers must include a security review.
+    expect(MAX_FAILED_ATTEMPTS).toBe(5)
+    expect(LOCKOUT_DURATION_MINUTES).toBe(15)
+  })
+
+  it('UserRole type is a typed alias of USER_ROLES values (compile-time)', () => {
+    // Compile-time witnesses: the `satisfies` pattern locks UserRole to
+    // a subset of the array's values — TS will refuse to compile if
+    // someone widens UserRole to `string` or adds a value missing from
+    // USER_ROLES.
+    const _admin = ROLE_ADMIN satisfies UserRole
+    const _user = ROLE_USER satisfies UserRole
+    expect([_admin, _user]).toEqual(['admin', 'user'])
+  })
+})
+
+describe('AuthService.ts uses the constants module (no role literals)', () => {
+  it('imports ROLE_ADMIN, ROLE_USER, and UserRole from auth-constants', () => {
+    const src = readOrFail(
+      resolve(REPO_ROOT, 'src/main/services/auth/AuthService.ts'),
+      'AuthService.ts'
+    )
+    expect(src, 'AuthService must import named role constants from the shared module').toMatch(
+      /import\s*\{[\s\S]*?ROLE_ADMIN[\s\S]*?\}\s*from\s*['"][^'"]*shared\/auth\/auth-constants['"]/
+    )
+    expect(src, 'AuthService must import ROLE_USER').toMatch(/ROLE_USER/)
+    expect(src, 'AuthService must import the UserRole type').toMatch(/type UserRole/)
+  })
+
+  it('does not redeclare the policy constants locally', () => {
+    const src = readOrFail(
+      resolve(REPO_ROOT, 'src/main/services/auth/AuthService.ts'),
+      'AuthService.ts'
+    )
+    expect(src, 'no shadowed MAX_FAILED_ATTEMPTS').not.toMatch(/^const\s+MAX_FAILED_ATTEMPTS\s*=/m)
+    expect(src, 'no shadowed LOCKOUT_DURATION_MINUTES').not.toMatch(
+      /^const\s+LOCKOUT_DURATION_MINUTES\s*=/m
+    )
+  })
+
+  it('uses ROLE_ADMIN/ROLE_USER as parameter values (no inline role string literals in SQL or returns)', () => {
+    const src = readOrFail(
+      resolve(REPO_ROOT, 'src/main/services/auth/AuthService.ts'),
+      'AuthService.ts'
+    )
+    // Allow the strings inside import statements + comments only. Strip
+    // those, then check no bare `'admin'` / `'user'` survives in code.
+    const stripped = src
+      .replace(/import[\s\S]*?from\s*['"][^'"]+['"]/g, '') // imports
+      .replace(/\/\/[^\n]*/g, '') // line comments
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    expect(stripped, `AuthService must use ROLE_ADMIN, not the string literal 'admin'`).not.toMatch(
+      /'admin'/
+    )
+    expect(stripped, `AuthService must use ROLE_USER, not the string literal 'user'`).not.toMatch(
+      /'user'/
+    )
+  })
+})
+
+describe('migration parity — SQLite v12', () => {
+  it('users.role CHECK enumerates exactly USER_ROLES', () => {
+    const sql = readOrFail(SQLITE_MIGRATION_PATH, 'SQLite migrations.ts')
+    const [defaultValue, ...enumerated] = extractEnumFromCheckClause(
+      sql,
+      'CREATE TABLE IF NOT EXISTS users'
+    )
+    expect(new Set(enumerated)).toEqual(new Set(USER_ROLES))
+    expect(defaultValue).toBe(DEFAULT_USER_ROLE)
+  })
+})
+
+describe('migration parity — Postgres 0008', () => {
+  it('users.role CHECK enumerates exactly USER_ROLES', () => {
+    const sql = readOrFail(PG_USERS_MIGRATION_PATH, 'Postgres 0008 migration')
+    const [defaultValue, ...enumerated] = extractEnumFromCheckClause(sql, '"users"')
+    expect(new Set(enumerated)).toEqual(new Set(USER_ROLES))
+    expect(defaultValue).toBe(DEFAULT_USER_ROLE)
+  })
+})
+
+describe('cross-backend defaults agree', () => {
+  it('SQLite and Postgres both DEFAULT to DEFAULT_USER_ROLE', () => {
+    const sqlite = readOrFail(SQLITE_MIGRATION_PATH, 'SQLite migrations.ts')
+    const pg = readOrFail(PG_USERS_MIGRATION_PATH, 'Postgres 0008 migration')
+    const [sqliteDefault] = extractEnumFromCheckClause(sqlite, 'CREATE TABLE IF NOT EXISTS users')
+    const [pgDefault] = extractEnumFromCheckClause(pg, '"users"')
+    expect(sqliteDefault).toBe(pgDefault)
+    expect(sqliteDefault).toBe(DEFAULT_USER_ROLE)
+  })
+})

--- a/tests/main/services/auth/auth-constants.test.ts
+++ b/tests/main/services/auth/auth-constants.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_FAILED_ATTEMPTS,
   ROLE_ADMIN,
   ROLE_USER,
+  WEB_MIN_PASSWORD_LENGTH,
   USER_ROLES,
   type UserRole
 } from '../../../../src/shared/auth/auth-constants'
@@ -103,6 +104,10 @@ describe('auth-constants module', () => {
     expect(LOCKOUT_DURATION_MINUTES).toBe(15)
   })
 
+  it('exposes the web password minimum used by the hash CLI and Postgres service', () => {
+    expect(WEB_MIN_PASSWORD_LENGTH).toBe(12)
+  })
+
   it('UserRole type is a typed alias of USER_ROLES values (compile-time)', () => {
     // Compile-time witnesses: the `satisfies` pattern locks UserRole to
     // a subset of the array's values — TS will refuse to compile if
@@ -155,6 +160,26 @@ describe('AuthService.ts uses the constants module (no role literals)', () => {
     expect(stripped, `AuthService must use ROLE_USER, not the string literal 'user'`).not.toMatch(
       /'user'/
     )
+  })
+})
+
+describe('web password policy uses the shared constant', () => {
+  it('PostgresWebAuthService imports WEB_MIN_PASSWORD_LENGTH from auth-constants', () => {
+    const src = readOrFail(
+      resolve(REPO_ROOT, 'src/web/auth/PostgresWebAuthService.ts'),
+      'PostgresWebAuthService.ts'
+    )
+    expect(src).toMatch(/WEB_MIN_PASSWORD_LENGTH/)
+    expect(src).not.toMatch(/^export const MIN_PASSWORD_LENGTH\s*=\s*12/m)
+  })
+
+  it('the hash-password CLI imports WEB_MIN_PASSWORD_LENGTH from auth-constants', () => {
+    const src = readOrFail(
+      resolve(REPO_ROOT, 'scripts/varlens-hash-password.ts'),
+      'scripts/varlens-hash-password.ts'
+    )
+    expect(src).toMatch(/WEB_MIN_PASSWORD_LENGTH/)
+    expect(src).not.toMatch(/^const MIN_PASSWORD_LENGTH\s*=\s*12/m)
   })
 })
 

--- a/tests/main/storage/postgres-annotations-repository.test.ts
+++ b/tests/main/storage/postgres-annotations-repository.test.ts
@@ -211,6 +211,49 @@ describe('PostgresAnnotationsRepository', () => {
     expect(release).toHaveBeenCalledOnce()
   })
 
+  it('preserves the original audited global annotation failure when rollback fails', async () => {
+    const release = vi.fn()
+    const failure = new Error('audit append failed')
+    const rollbackFailure = new Error('rollback failed')
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 8,
+            chr: '1',
+            pos: 12345,
+            ref: 'A',
+            alt: 'G',
+            global_comment: null,
+            starred: 1,
+            acmg_classification: null,
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060802000
+          }
+        ]
+      })
+      .mockRejectedValueOnce(failure)
+      .mockRejectedValueOnce(rollbackFailure)
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
+
+    await expect(
+      repository.upsertGlobalAnnotationWithAudit('1', 12345, 'A', 'G', {
+        starred: true,
+        user_name: 'analyst'
+      })
+    ).rejects.toThrow('audit append failed')
+
+    expect(query).toHaveBeenNthCalledWith(5, 'ROLLBACK')
+    expect(release).toHaveBeenCalledOnce()
+  })
+
   it('deletes global annotations by coordinates', async () => {
     const pool = makePool()
     pool.query.mockResolvedValueOnce({ rows: [] })
@@ -346,6 +389,47 @@ describe('PostgresAnnotationsRepository', () => {
       ]
     )
     expect(query).toHaveBeenNthCalledWith(5, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the original audited per-case annotation failure when rollback fails', async () => {
+    const release = vi.fn()
+    const failure = new Error('audit append failed')
+    const rollbackFailure = new Error('rollback failed')
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 9,
+            case_id: 2,
+            variant_id: 3,
+            per_case_comment: null,
+            starred: 1,
+            acmg_classification: null,
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060802000
+          }
+        ]
+      })
+      .mockRejectedValueOnce(failure)
+      .mockRejectedValueOnce(rollbackFailure)
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
+
+    await expect(
+      repository.upsertPerCaseAnnotationWithAudit(2, 3, {
+        starred: true,
+        user_name: 'reviewer'
+      })
+    ).rejects.toThrow('audit append failed')
+
+    expect(query).toHaveBeenNthCalledWith(5, 'ROLLBACK')
     expect(release).toHaveBeenCalledOnce()
   })
 

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -4,7 +4,7 @@ import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migratio
 
 describe('Postgres migration definitions', () => {
   it('loads the PostgreSQL migrations with SQL and sha256 checksums', () => {
-    expect(POSTGRES_MIGRATIONS).toHaveLength(7)
+    expect(POSTGRES_MIGRATIONS).toHaveLength(8)
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.version)).toEqual([
       '0001',
       '0002',
@@ -12,7 +12,8 @@ describe('Postgres migration definitions', () => {
       '0004',
       '0005',
       '0006',
-      '0007'
+      '0007',
+      '0008'
     ])
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.name)).toEqual([
       'create_cases',
@@ -21,7 +22,8 @@ describe('Postgres migration definitions', () => {
       'generated_search_documents',
       'create_workflow_tables',
       'create_audit_log',
-      'perf_indexes'
+      'perf_indexes',
+      'create_users_and_settings'
     ])
 
     for (const migration of POSTGRES_MIGRATIONS) {
@@ -36,5 +38,9 @@ describe('Postgres migration definitions', () => {
     expect(perfMigration?.sql).toContain(
       'ON "__schema__"."variants" USING GIN (gene_symbol gin_trgm_ops)'
     )
+
+    const authMigration = POSTGRES_MIGRATIONS.find((migration) => migration.version === '0008')
+    expect(authMigration?.name).toBe('create_users_and_settings')
+    expect(authMigration?.sql).toContain('CREATE TABLE IF NOT EXISTS "__schema__"."users"')
   })
 })

--- a/tests/main/storage/postgres-migration-runner.test.ts
+++ b/tests/main/storage/postgres-migration-runner.test.ts
@@ -6,9 +6,15 @@ import type { PostgresMigration } from '../../../src/main/storage/postgres/migra
 
 function poolWithAppliedRows(appliedRows: unknown[] = []) {
   const client = {
-    query: vi.fn(async (sql: string) => ({
-      rows: sql.includes('SELECT version, checksum') ? appliedRows : []
-    })),
+    query: vi.fn(async (sql: string) => {
+      if (sql.includes("current_setting('lock_timeout')")) {
+        return { rows: [{ lock_timeout: '5s' }] }
+      }
+
+      return {
+        rows: sql.includes('SELECT version, checksum') ? appliedRows : []
+      }
+    }),
     release: vi.fn()
   }
   const connect = vi.fn(async () => client)
@@ -66,6 +72,44 @@ describe('PostgresMigrationRunner', () => {
     expect(lockOrder).toBeLessThan(createSchemaOrder)
     expect(pool.client.query).toHaveBeenCalledWith(expect.stringContaining('COMMIT'))
     expect(pool.client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for advisory migration locks without the query lock timeout', async () => {
+    const pool = poolWithAppliedRows()
+    const runner = new PostgresMigrationRunner(pool as never, 'app_schema', migrations)
+
+    await runner.migrate()
+
+    expect(pool.client.query).toHaveBeenCalledWith(
+      "SELECT current_setting('lock_timeout') AS lock_timeout"
+    )
+    expect(pool.client.query).toHaveBeenCalledWith("SELECT set_config('lock_timeout', '0', true)")
+    expect(pool.client.query).toHaveBeenCalledWith("SELECT set_config('lock_timeout', $1, true)", [
+      '5s'
+    ])
+
+    const disableTimeoutOrder = pool.client.query.mock.invocationCallOrder.find((_, index) => {
+      const [sql] = pool.client.query.mock.calls[index] ?? []
+      return sql === "SELECT set_config('lock_timeout', '0', true)"
+    })
+    const schemaLockOrder = pool.client.query.mock.invocationCallOrder.find((_, index) => {
+      const [sql, params] = pool.client.query.mock.calls[index] ?? []
+      return (
+        typeof sql === 'string' && sql.includes('pg_advisory_xact_lock') && Array.isArray(params)
+      )
+    })
+    const restoreTimeoutOrder = pool.client.query.mock.invocationCallOrder.find((_, index) => {
+      const [sql] = pool.client.query.mock.calls[index] ?? []
+      return sql === "SELECT set_config('lock_timeout', $1, true)"
+    })
+    const createSchemaOrder = pool.client.query.mock.invocationCallOrder.find((_, index) => {
+      const [sql] = pool.client.query.mock.calls[index] ?? []
+      return typeof sql === 'string' && sql.includes('CREATE SCHEMA')
+    })
+
+    expect(disableTimeoutOrder).toBeLessThan(schemaLockOrder)
+    expect(schemaLockOrder).toBeLessThan(restoreTimeoutOrder)
+    expect(restoreTimeoutOrder).toBeLessThan(createSchemaOrder)
   })
 
   it.each(['workspace_a', 'Case Lab', 'clinical-1'])(

--- a/tests/main/storage/postgres-migrations-idempotent.test.ts
+++ b/tests/main/storage/postgres-migrations-idempotent.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Postgres migrations — real-instance idempotency check.
+ *
+ * Web ships on Postgres. Migration correctness against a real Postgres engine
+ * is therefore load-bearing and the existing migration tests (mock-only) do
+ * not cover it.
+ *
+ * This test boots a real schema, runs all migrations, captures the resulting
+ * schema state from information_schema, runs migrations again on the same
+ * schema, and asserts the captured state is identical. Catches:
+ *
+ *   - Migrations that produce different output on a second run (non-idempotent)
+ *   - Migrations that depend on Postgres extensions / GUC state we don't ship
+ *   - Type/grammar incompatibilities relative to SQLite that the mock tests miss
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client } from 'pg'
+import { randomBytes } from 'node:crypto'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { Pool } from 'pg'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+interface SchemaSnapshot {
+  tables: Array<{ table_name: string; columns: string[] }>
+  indexes: string[]
+  appliedVersions: number[]
+}
+
+async function captureSchema(client: Client, schema: string): Promise<SchemaSnapshot> {
+  const tablesRes = await client.query<{ table_name: string }>(
+    `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = $1 ORDER BY table_name`,
+    [schema]
+  )
+
+  const tables: SchemaSnapshot['tables'] = []
+  for (const row of tablesRes.rows) {
+    const colsRes = await client.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = $2
+         ORDER BY ordinal_position`,
+      [schema, row.table_name]
+    )
+    tables.push({
+      table_name: row.table_name,
+      columns: colsRes.rows.map((r) => r.column_name)
+    })
+  }
+
+  const indexRes = await client.query<{ indexname: string }>(
+    `SELECT indexname FROM pg_indexes
+       WHERE schemaname = $1 ORDER BY indexname`,
+    [schema]
+  )
+
+  const versionsRes = await client.query<{ version: number }>(
+    `SELECT version FROM "${schema}".schema_migrations ORDER BY version`
+  )
+
+  return {
+    tables,
+    indexes: indexRes.rows.map((r) => r.indexname),
+    appliedVersions: versionsRes.rows.map((r) => r.version)
+  }
+}
+
+describe.skipIf(!RUN)('Postgres migrations: real-instance idempotency', () => {
+  const schema = `varlens_test_mig_${Date.now()}_${randomBytes(4).toString('hex')}`
+  let pool: Pool
+  let probeClient: Client
+
+  beforeAll(async () => {
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probeClient = new Client({ connectionString: PG_URL })
+    await probeClient.connect()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (probeClient) await probeClient.end()
+    if (pool) await pool.end()
+
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  it('runs all migrations end-to-end and produces a non-empty schema', async () => {
+    const result = await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+    expect(result.applied.length).toBeGreaterThan(0)
+
+    const snapshot = await captureSchema(probeClient, schema)
+    expect(snapshot.tables.length).toBeGreaterThan(0)
+    expect(snapshot.appliedVersions).toEqual([...snapshot.appliedVersions].sort((a, b) => a - b))
+
+    // Auth tables must materialise after migration. PostgresWebAuthService
+    // depends on both being present with the columns the SQLite schema also has.
+    const tableNames = snapshot.tables.map((t) => t.table_name)
+    expect(tableNames).toContain('users')
+    expect(tableNames).toContain('database_settings')
+
+    // Asserting names alone is not enough: a future careless edit could flip
+    // is_active/must_change_password back to INTEGER, drop the role CHECK, or
+    // drop NOT NULL on password_hash, and this test would still pass.
+    // Pin types, nullability, defaults, and the role enum explicitly.
+    const colMeta = await probeClient.query<{
+      column_name: string
+      data_type: string
+      udt_name: string
+      is_nullable: string
+      column_default: string | null
+    }>(
+      `SELECT column_name, data_type, udt_name, is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'users'`,
+      [schema]
+    )
+    const cols = new Map(colMeta.rows.map((r) => [r.column_name, r]))
+    const expectColType = (
+      name: string,
+      udt: string,
+      nullable: 'YES' | 'NO',
+      hasDefault: boolean
+    ): void => {
+      const c = cols.get(name)
+      expect(c, `users.${name} must exist`).toBeDefined()
+      expect(c!.udt_name, `users.${name} udt`).toBe(udt)
+      expect(c!.is_nullable, `users.${name} nullability`).toBe(nullable)
+      if (hasDefault) {
+        expect(c!.column_default, `users.${name} must have a default`).not.toBeNull()
+      }
+    }
+    expectColType('id', 'int8', 'NO', true)
+    expectColType('username', 'text', 'NO', false)
+    expectColType('display_name', 'text', 'YES', false)
+    expectColType('password_hash', 'text', 'NO', false)
+    expectColType('role', 'text', 'NO', true)
+    expectColType('is_active', 'bool', 'NO', true)
+    expectColType('must_change_password', 'bool', 'NO', true)
+    expectColType('failed_login_count', 'int4', 'NO', true)
+    expectColType('locked_until', 'timestamptz', 'YES', false)
+    expectColType('password_changed_at', 'timestamptz', 'YES', false)
+    expectColType('created_at', 'timestamptz', 'NO', true)
+    expectColType('created_by', 'int8', 'YES', false)
+    expectColType('updated_at', 'timestamptz', 'YES', false)
+
+    // Role CHECK must enumerate exactly admin + user, the same enum as SQLite
+    // migrations.ts v12. The shared constants module is the cross-backend
+    // source of truth.
+    const checkRow = await probeClient.query<{ check_clause: string }>(
+      `SELECT cc.check_clause
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.check_constraints cc USING (constraint_schema, constraint_name)
+        WHERE tc.table_schema = $1 AND tc.table_name = 'users'
+          AND tc.constraint_type = 'CHECK'
+          AND cc.check_clause ILIKE '%role%'`,
+      [schema]
+    )
+    expect(checkRow.rows.length, 'users.role CHECK constraint must be present').toBeGreaterThan(0)
+    const clauses = checkRow.rows.map((r) => r.check_clause)
+    expect(clauses.some((c) => c.includes("'admin'") && c.includes("'user'"))).toBe(true)
+
+    // Unique constraint on username is the auth path's only defence
+    // against duplicate-account creation race conditions.
+    const uniques = await probeClient.query<{ index_name: string }>(
+      `SELECT i.relname AS index_name
+         FROM pg_index x
+         JOIN pg_class i ON i.oid = x.indexrelid
+         JOIN pg_class t ON t.oid = x.indrelid
+         JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = $1 AND t.relname = 'users' AND x.indisunique`,
+      [schema]
+    )
+    expect(
+      uniques.rows.length,
+      'users must have at least one UNIQUE constraint (username + PK)'
+    ).toBeGreaterThanOrEqual(2)
+  }, 60_000)
+
+  it('is idempotent — a second run produces the same schema state', async () => {
+    const before = await captureSchema(probeClient, schema)
+
+    const result = await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+    expect(result.applied.length).toBe(0) // nothing new to apply
+
+    const after = await captureSchema(probeClient, schema)
+    expect(after).toEqual(before)
+  }, 60_000)
+})
+
+describe.skipIf(RUN)('Postgres migrations: real-instance idempotency (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/postgres-migrations-registration.test.ts
+++ b/tests/main/storage/postgres-migrations-registration.test.ts
@@ -1,0 +1,86 @@
+import { readdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+
+/**
+ * Static gate over the Postgres migrations directory.
+ *
+ * The original docstring on this file claimed to guard against
+ * "forgetting to register a freshly-added .sql file" — but the test
+ * only asserted specific migration names. That was misleading: dropping a new
+ * `0008_*.sql` into the sql/ dir without a `definitions.ts` entry would
+ * still let the test pass, and registering an entry whose file was
+ * later deleted would fail only at runtime under VARLENS_RUN_POSTGRES_E2E.
+ *
+ * This implementation actually closes both directions:
+ *   - every `.sql` file on disk MUST have a matching registration entry
+ *   - every registration entry MUST have a matching `.sql` file on disk
+ *   - registered checksums are non-empty 64-hex (sha256 shape)
+ *   - the auth migration (0008 / create_users_and_settings) is present,
+ *     also containing the table DDL it claims to ship
+ */
+
+const SQL_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../src/main/storage/postgres/migrations/sql'
+)
+
+function listSqlFiles(): string[] {
+  return readdirSync(SQL_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+}
+
+describe('postgres migration registration', () => {
+  it('every registered migration has a matching file on disk', () => {
+    const onDisk = new Set(listSqlFiles())
+    for (const m of POSTGRES_MIGRATIONS) {
+      const expectedFile = `${m.version}_${m.name}.sql`
+      expect(
+        onDisk,
+        `registered migration ${m.version}/${m.name} expects ${expectedFile} on disk`
+      ).toContain(expectedFile)
+    }
+  })
+
+  it('every .sql file on disk is registered', () => {
+    const registered = new Set(POSTGRES_MIGRATIONS.map((m) => `${m.version}_${m.name}.sql`))
+    for (const file of listSqlFiles()) {
+      expect(
+        registered,
+        `${file} sits in sql/ but is not registered in definitions.ts — runner will silently skip it`
+      ).toContain(file)
+    }
+  })
+
+  it('registers the users + database_settings migration', () => {
+    const m = POSTGRES_MIGRATIONS.find((x) => x.version === '0008')
+    expect(m, 'migration 0008 must be registered').toBeDefined()
+    expect(m!.name).toBe('create_users_and_settings')
+    // Pin SQL content so an empty/stub file can't slip past.
+    expect(m!.sql, 'migration 0008 must declare the users table').toMatch(/CREATE TABLE.+users/i)
+    expect(m!.sql, 'migration 0008 must declare the database_settings table').toMatch(
+      /CREATE TABLE.+database_settings/i
+    )
+  })
+
+  it('registered migrations are sorted by zero-padded version', () => {
+    const versions = POSTGRES_MIGRATIONS.map((m) => m.version)
+    expect(versions).toEqual([...versions].sort())
+    // Encoded invariant: zero-padded 4-digit versions. Adding a 5-digit
+    // version would silently break lexical sort order.
+    for (const v of versions) {
+      expect(v, `migration version ${v} must be 4-digit zero-padded`).toMatch(/^\d{4}$/)
+    }
+  })
+
+  it('every registered migration carries a sha256-shaped checksum', () => {
+    for (const m of POSTGRES_MIGRATIONS) {
+      expect(m.checksum).toMatch(/^[0-9a-f]{64}$/)
+    }
+  })
+})

--- a/tests/main/storage/postgres-transcripts-repository.test.ts
+++ b/tests/main/storage/postgres-transcripts-repository.test.ts
@@ -44,6 +44,47 @@ describe('PostgresTranscriptsRepository', () => {
     ])
   })
 
+  it('maps pg-style string transcript flags to desktop boolean fields', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [
+          {
+            id: '2',
+            variant_id: '9',
+            transcript_id: 'NM_007294.4',
+            gene_symbol: 'BRCA1',
+            consequence: 'MODERATE',
+            cdna: null,
+            aa_change: null,
+            hpo_sim_score: null,
+            moi: null,
+            is_selected: 't',
+            is_mane_select: '1',
+            is_canonical: 'false'
+          }
+        ]
+      })
+    }
+    const repository = new PostgresTranscriptsRepository(pool as never, 'case_schema')
+
+    await expect(repository.list(9)).resolves.toEqual([
+      {
+        id: 2,
+        variant_id: 9,
+        transcript_id: 'NM_007294.4',
+        gene_symbol: 'BRCA1',
+        consequence: 'MODERATE',
+        cdna: null,
+        aa_change: null,
+        hpo_sim_score: null,
+        moi: null,
+        is_selected: true,
+        is_mane_select: true,
+        is_canonical: false
+      }
+    ])
+  })
+
   it('updates the parent variant when switching the selected transcript', async () => {
     const release = vi.fn()
     const query = vi

--- a/tests/main/web/auth/postgres-web-auth-service.test.ts
+++ b/tests/main/web/auth/postgres-web-auth-service.test.ts
@@ -1,0 +1,654 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { randomBytes } from 'node:crypto'
+import { Client } from 'pg'
+
+import {
+  assertArgon2idHashMatchesProviderPolicy,
+  isLikelyArgon2idHash,
+  PostgresWebAuthService
+} from '../../../../src/web/auth/PostgresWebAuthService'
+import {
+  LOCKOUT_DURATION_MINUTES,
+  MAX_FAILED_ATTEMPTS,
+  ROLE_ADMIN,
+  ROLE_USER
+} from '../../../../src/shared/auth/auth-constants'
+import {
+  ARGON2_POLICY,
+  defaultPasswordProvider,
+  type PasswordProvider
+} from '../../../../src/main/auth/providers/argon2-provider'
+import type { PostgresStorageConfig } from '../../../../src/main/storage/config'
+import { createPostgresStorageSession } from '../../../../src/main/storage/postgres/createPostgresStorageSession'
+
+/**
+ * PostgresWebAuthService unit tests with a FakePool.
+ *
+ * Covers SQL shape, parameter binding, branch matrix, atomic lockout,
+ * unique-violation translation on createFirstUser race, and the
+ * transactional rollback path. Real-instance tests against pg-up are gated by
+ * VARLENS_RUN_POSTGRES_E2E=1; this file is the everywhere-runs gate.
+ */
+
+// ---- Pool stub --------------------------------------------------------------
+
+interface QueryRecord {
+  text: string
+  values: unknown[]
+  // Whether this query came through `connect().query` (i.e. inside a
+  // transactional client) vs `pool.query` (outside). Used to assert
+  // createFirstUser actually opens a transaction rather than smearing
+  // INSERTs across pool checkouts.
+  viaClient: boolean
+}
+
+interface CannedRow {
+  [key: string]: unknown
+}
+
+interface CannedResponse {
+  rows: CannedRow[]
+  rowCount: number
+}
+
+class FakePool {
+  queries: QueryRecord[] = []
+  released = false
+  releasedCount = 0
+  // Each enqueueResponse caller can opt into a thrown error rather than
+  // a canned row set — used to simulate unique-violation during
+  // createFirstUser race translation and INSERT-failure rollback.
+  private responses: Array<CannedResponse | { error: Error }> = []
+
+  enqueueResponse(response: CannedResponse): void {
+    this.responses.push(response)
+  }
+
+  enqueueError(error: Error): void {
+    this.responses.push({ error })
+  }
+
+  private async runQuery(
+    text: string,
+    values: unknown[] = [],
+    viaClient: boolean
+  ): Promise<CannedResponse> {
+    this.queries.push({ text, values, viaClient })
+    if (this.responses.length === 0) {
+      throw new Error(
+        `FakePool: no canned response for query #${this.queries.length}:\n${text.slice(0, 200)}`
+      )
+    }
+    const next = this.responses.shift()!
+    if ('error' in next) throw next.error
+    return next
+  }
+
+  async query(text: string, values: unknown[] = []): Promise<CannedResponse> {
+    return this.runQuery(text, values, false)
+  }
+
+  async connect(): Promise<{
+    query: (text: string, values?: unknown[]) => Promise<CannedResponse>
+    release: () => void
+  }> {
+    return {
+      query: (text, values = []) => this.runQuery(text, values, true),
+      release: () => {
+        this.released = true
+        this.releasedCount += 1
+      }
+    }
+  }
+}
+
+// ---- PasswordProvider stub --------------------------------------------------
+
+const fakePasswordProvider: PasswordProvider = {
+  async hashPassword(password: string): Promise<string> {
+    return `hashed::${password}`
+  },
+  async verifyPassword(hash: string, password: string): Promise<boolean> {
+    return hash === `hashed::${password}`
+  }
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+function pgUserRow(overrides: Partial<CannedRow> = {}): CannedRow {
+  return {
+    id: '1',
+    username: 'alice',
+    display_name: 'Alice',
+    password_hash: 'hashed::pw',
+    role: 'user',
+    is_active: true,
+    must_change_password: false,
+    failed_login_count: 0,
+    locked_until: null,
+    password_changed_at: new Date('2026-05-01T10:00:00Z'),
+    created_at: new Date('2026-05-01T10:00:00Z'),
+    created_by: null,
+    updated_at: null,
+    ...overrides
+  }
+}
+
+const SCHEMA = 'auth_test'
+type SvcOpts = ConstructorParameters<typeof PostgresWebAuthService>[0]
+function newSvc(pool: FakePool): PostgresWebAuthService {
+  return new PostgresWebAuthService({
+    pool: pool as unknown as SvcOpts['pool'],
+    schema: SCHEMA,
+    passwordProvider: fakePasswordProvider
+  })
+}
+
+// createFirstUser requires a password >= 12 chars
+// (MIN_PASSWORD_LENGTH). Test fixtures use a fixed 12-char string so
+// the error path tests trip on the actual condition under test
+// rather than the policy check.
+const FIXTURE_PW = 'pw-1234567890'
+const FIXTURE_NEW_PW = 'rotated12345-fixture'
+const FIXTURE_ARGON2ID_HASH =
+  '$argon2id$v=19$m=65536,t=3,p=4$c2FsdHNhbHRzYWx0$dmFybGVuc2hhc2hmaXh0dXJl'
+const WEAK_ARGON2ID_HASH = '$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$dmFybGVucw'
+
+// Convenience: enqueue the four-query happy path of createFirstUser.
+// The recovery-key write was removed, so
+// the transaction is now BEGIN → UPSERT accounts_enabled → INSERT
+// user → COMMIT (4 queries instead of 5).
+function enqueueCreateFirstUserHappyPath(pool: FakePool, userId = '42'): void {
+  pool.enqueueResponse({ rows: [], rowCount: 1 }) // BEGIN
+  pool.enqueueResponse({ rows: [], rowCount: 1 }) // UPSERT accounts_enabled
+  pool.enqueueResponse({ rows: [{ id: userId }], rowCount: 1 }) // INSERT user
+  pool.enqueueResponse({ rows: [], rowCount: 0 }) // COMMIT
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+describe('PostgresWebAuthService — surface contract', () => {
+  it('exports a class instantiable with a pool, schema, and password provider', () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    expect(svc).toBeInstanceOf(PostgresWebAuthService)
+  })
+})
+
+describe('PostgresWebAuthService — createFirstUser', () => {
+  let pool: FakePool
+  let svc: PostgresWebAuthService
+
+  beforeEach(() => {
+    pool = new FakePool()
+    svc = newSvc(pool)
+  })
+
+  it('issues a transactional INSERT with ROLE_ADMIN — never inlines the role string', async () => {
+    enqueueCreateFirstUserHappyPath(pool)
+    const result = await svc.createFirstUser('alice', 'Alice', FIXTURE_PW)
+    expect(result.username).toBe('alice')
+    expect(result.role).toBe(ROLE_ADMIN)
+    expect(result.id).toBe(42)
+
+    const inserts = pool.queries.filter((q) => /INSERT INTO[\s\S]+users/i.test(q.text))
+    expect(inserts.length).toBe(1)
+    expect(inserts[0].text, 'role must be parameterised, not inlined').not.toMatch(/'admin'/)
+    expect(inserts[0].values).toContain(ROLE_ADMIN)
+  })
+
+  it('runs every write inside a transactional client (rollback semantics)', async () => {
+    enqueueCreateFirstUserHappyPath(pool)
+    await svc.createFirstUser('alice', 'Alice', FIXTURE_PW)
+
+    // BEGIN, the two settings INSERTs, the users INSERT, COMMIT — every
+    // one of these must be on the connected client (viaClient=true), not
+    // on the bare pool. A regression that smears writes across pool
+    // checkouts (no real transaction) would fail here.
+    const dml = pool.queries.filter((q) => /BEGIN|COMMIT|ROLLBACK|INSERT|UPDATE/i.test(q.text))
+    expect(dml.length).toBeGreaterThanOrEqual(4)
+    for (const q of dml) {
+      expect(
+        q.viaClient,
+        `query "${q.text.slice(0, 40)}" must run on the transactional client`
+      ).toBe(true)
+    }
+    expect(pool.queries.some((q) => /^BEGIN$/i.test(q.text))).toBe(true)
+    expect(pool.queries.some((q) => /^COMMIT$/i.test(q.text))).toBe(true)
+  })
+
+  it('quotes the configured schema in every users-touching query', async () => {
+    enqueueCreateFirstUserHappyPath(pool)
+    await svc.createFirstUser('alice', 'Alice', FIXTURE_PW)
+    for (const q of pool.queries) {
+      if (/INSERT|UPDATE|SELECT.*users/i.test(q.text)) {
+        expect(q.text).toContain(`"${SCHEMA}"`)
+      }
+    }
+  })
+
+  it('rejects passwords shorter than the policy minimum', async () => {
+    await expect(svc.createFirstUser('alice', 'Alice', 'short')).rejects.toThrow(
+      /at least 12 characters/i
+    )
+    expect(pool.queries.length, 'no DB writes happen when policy fails').toBe(0)
+  })
+
+  it('translates unique_violation (SQLSTATE 23505) into "Admin user already exists"', async () => {
+    pool.enqueueResponse({ rows: [], rowCount: 1 }) // BEGIN
+    pool.enqueueResponse({ rows: [], rowCount: 1 }) // UPSERT accounts_enabled
+    const uniqueViolation = Object.assign(new Error('duplicate key value'), { code: '23505' })
+    pool.enqueueError(uniqueViolation) // INSERT user fails on partial unique idx
+    pool.enqueueResponse({ rows: [], rowCount: 0 }) // ROLLBACK
+
+    await expect(svc.createFirstUser('alice', 'Alice', FIXTURE_PW)).rejects.toThrow(
+      /admin user already exists/i
+    )
+
+    expect(
+      pool.queries.some((q) => /^ROLLBACK$/i.test(q.text)),
+      'rollback must fire'
+    ).toBe(true)
+    expect(pool.releasedCount, 'client must be released after error').toBe(1)
+  })
+
+  it('rolls back and releases the client when a non-unique error fires mid-transaction', async () => {
+    pool.enqueueResponse({ rows: [], rowCount: 1 }) // BEGIN
+    pool.enqueueError(new Error('disk full')) // UPSERT accounts_enabled fails
+    pool.enqueueResponse({ rows: [], rowCount: 0 }) // ROLLBACK
+
+    await expect(svc.createFirstUser('alice', 'Alice', FIXTURE_PW)).rejects.toThrow(/disk full/)
+    expect(pool.queries.some((q) => /^ROLLBACK$/i.test(q.text))).toBe(true)
+    expect(pool.releasedCount).toBe(1)
+  })
+})
+
+describe('PostgresWebAuthService — production hash bootstrap', () => {
+  it('accepts a precomputed Argon2id hash without rehashing plaintext', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    enqueueCreateFirstUserHappyPath(pool)
+
+    const result = await svc.createFirstUserFromHash('alice', 'Alice', FIXTURE_ARGON2ID_HASH)
+
+    expect(result.role).toBe(ROLE_ADMIN)
+    const insert = pool.queries.find((q) => /INSERT INTO[\s\S]+users/i.test(q.text))
+    expect(insert?.values).toContain(FIXTURE_ARGON2ID_HASH)
+    expect(insert?.values).not.toContain(`hashed::${FIXTURE_ARGON2ID_HASH}`)
+  })
+
+  it('rejects non-Argon2id bootstrap values before any database write', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+
+    await expect(svc.createFirstUserFromHash('alice', 'Alice', 'plaintext')).rejects.toThrow(
+      /argon2id hash/i
+    )
+    expect(pool.queries.length).toBe(0)
+    expect(isLikelyArgon2idHash(FIXTURE_ARGON2ID_HASH)).toBe(true)
+    expect(isLikelyArgon2idHash('plaintext')).toBe(false)
+  })
+
+  it('rejects malformed Argon2id PHC strings before any database write', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    const malformed = '$argon2id$v=19$m=65536,t=3,p=4$abcde$dmFybGVuc2hhc2hmaXh0dXJl'
+
+    expect(isLikelyArgon2idHash(malformed)).toBe(false)
+    await expect(svc.createFirstUserFromHash('alice', 'Alice', malformed)).rejects.toThrow(
+      /argon2id hash/i
+    )
+    expect(pool.queries.length).toBe(0)
+  })
+
+  it('rejects Argon2id hashes whose parameters do not match the provider policy', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+
+    expect(ARGON2_POLICY).toEqual({ memoryCost: 65536, timeCost: 3, parallelism: 4 })
+    expect(() => assertArgon2idHashMatchesProviderPolicy(FIXTURE_ARGON2ID_HASH)).not.toThrow()
+    await expect(svc.createFirstUserFromHash('alice', 'Alice', WEAK_ARGON2ID_HASH)).rejects.toThrow(
+      /provider policy/i
+    )
+    expect(pool.queries.length).toBe(0)
+  })
+
+  it('reports whether an active admin already exists', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [{ '?column?': 1 }], rowCount: 1 })
+
+    await expect(svc.hasAdmin()).resolves.toBe(true)
+    expect(pool.queries[0].values).toContain(ROLE_ADMIN)
+  })
+})
+
+const RUN_POSTGRES_AUTH_E2E = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+function makePostgresConfig(schema: string): PostgresStorageConfig {
+  return {
+    url: PG_URL,
+    schema,
+    applicationName: 'varlens-auth-e2e',
+    sslMode: 'disable',
+    connectionTimeoutMillis: 5000,
+    statementTimeoutMs: 30_000,
+    queryTimeoutMs: 30_000,
+    lockTimeoutMs: 5_000,
+    idleInTransactionSessionTimeoutMs: 10_000,
+    poolMax: 2
+  }
+}
+
+describe.skipIf(!RUN_POSTGRES_AUTH_E2E)('PostgresWebAuthService — real Postgres', () => {
+  it('creates a bootstrap hash with the production provider and logs in', async () => {
+    const schema = `varlens_auth_e2e_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const password = 'real-postgres-auth-password-2026'
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    const session = await createPostgresStorageSession(makePostgresConfig(schema))
+    try {
+      const auth = new PostgresWebAuthService({
+        pool: session.getPool(),
+        schema
+      })
+      const passwordHash = await defaultPasswordProvider.hashPassword(password)
+
+      expect(isLikelyArgon2idHash(passwordHash)).toBe(true)
+      expect(() => assertArgon2idHashMatchesProviderPolicy(passwordHash)).not.toThrow()
+
+      await auth.createFirstUserFromHash('admin', 'Admin', passwordHash)
+      const result = await auth.authenticate('admin', password)
+
+      expect(result.success).toBe(true)
+      expect(result.user?.username).toBe('admin')
+      expect(result.mustChangePassword).toBe(true)
+    } finally {
+      await session.close()
+      const cleaner = new Client({ connectionString: PG_URL })
+      await cleaner.connect()
+      await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+      await cleaner.end()
+    }
+  }, 60_000)
+})
+
+describe('PostgresWebAuthService — authenticate', () => {
+  let pool: FakePool
+  let svc: PostgresWebAuthService
+
+  beforeEach(() => {
+    pool = new FakePool()
+    svc = newSvc(pool)
+  })
+
+  it('returns success: false for unknown username', async () => {
+    pool.enqueueResponse({ rows: [], rowCount: 0 })
+    const r = await svc.authenticate('ghost', 'pw')
+    expect(r.success).toBe(false)
+    expect(r.user).toBeNull()
+  })
+
+  it('returns success: true with safeUser (no password_hash)', async () => {
+    pool.enqueueResponse({ rows: [pgUserRow()], rowCount: 1 })
+    pool.enqueueResponse({ rows: [], rowCount: 1 }) // reset failed count
+    const r = await svc.authenticate('alice', 'pw')
+    expect(r.success).toBe(true)
+    expect(r.user).toBeDefined()
+    expect(r.user as object).not.toHaveProperty('password_hash')
+    expect((r.user as { username: string }).username).toBe('alice')
+  })
+
+  it('returns locked: true when locked_until is in the future', async () => {
+    const future = new Date(Date.now() + 60_000)
+    pool.enqueueResponse({ rows: [pgUserRow({ locked_until: future })], rowCount: 1 })
+    const r = await svc.authenticate('alice', 'pw')
+    expect(r.success).toBe(false)
+    expect(r.locked).toBe(true)
+  })
+
+  it('uses an atomic UPDATE+CASE on failed login (no read-modify-write race)', async () => {
+    pool.enqueueResponse({
+      rows: [pgUserRow({ failed_login_count: MAX_FAILED_ATTEMPTS - 1 })],
+      rowCount: 1
+    })
+    pool.enqueueResponse({ rows: [], rowCount: 1 })
+
+    await svc.authenticate('alice', 'wrong')
+
+    const update = pool.queries.find((q) =>
+      /failed_login_count\s*=\s*failed_login_count\s*\+\s*1/i.test(q.text)
+    )
+    expect(update, 'failed_login_count must be incremented atomically (server-side)').toBeDefined()
+    // CASE expression encodes the lockout threshold without a JS read.
+    expect(update!.text).toMatch(/CASE\s+WHEN[\s\S]+failed_login_count\s*\+\s*1\s*>=\s*\$1/i)
+    // First param is the threshold, second is the candidate lock-until,
+    // third is the user id. Verify the threshold matches the constant.
+    expect(update!.values[0]).toBe(MAX_FAILED_ATTEMPTS)
+    expect(update!.values[1]).toBeInstanceOf(Date)
+    const lockUntil = update!.values[1] as Date
+    const deltaMs = lockUntil.getTime() - Date.now()
+    expect(deltaMs).toBeGreaterThan((LOCKOUT_DURATION_MINUTES - 1) * 60_000)
+    expect(deltaMs).toBeLessThan((LOCKOUT_DURATION_MINUTES + 1) * 60_000)
+  })
+
+  it('row-maps PG types to the cross-backend User shape', async () => {
+    pool.enqueueResponse({
+      rows: [
+        pgUserRow({
+          id: '7',
+          is_active: true,
+          must_change_password: true,
+          locked_until: null,
+          password_changed_at: new Date('2026-05-01T10:00:00Z')
+        })
+      ],
+      rowCount: 1
+    })
+    pool.enqueueResponse({ rows: [], rowCount: 1 })
+
+    const r = await svc.authenticate('alice', 'pw')
+    expect(r.user).toBeDefined()
+    const u = r.user!
+    expect(typeof u.id).toBe('number')
+    expect(u.id).toBe(7)
+    expect(u.is_active).toBe(1)
+    expect(u.must_change_password).toBe(1)
+    expect(typeof u.password_changed_at).toBe('string')
+    expect(u.password_changed_at).toBe('2026-05-01T10:00:00.000Z')
+  })
+
+  it('row mapper accepts string-form booleans (custom pg type parsers)', async () => {
+    pool.enqueueResponse({
+      rows: [pgUserRow({ is_active: 't', must_change_password: 'f' })],
+      rowCount: 1
+    })
+    pool.enqueueResponse({ rows: [], rowCount: 1 })
+
+    const r = await svc.authenticate('alice', 'pw')
+    expect((r.user as { is_active: number }).is_active).toBe(1)
+    expect((r.user as { must_change_password: number }).must_change_password).toBe(0)
+  })
+})
+
+describe('PostgresWebAuthService — createUser', () => {
+  it('creates with ROLE_USER, parameterised, attributes creator id', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [pgUserRow({ id: '99', username: 'admin' })], rowCount: 1 }) // getUser(creator)
+    pool.enqueueResponse({ rows: [{ id: '7' }], rowCount: 1 }) // INSERT user
+
+    const r = await svc.createUser('bob', 'Bob', FIXTURE_PW, 'admin')
+    expect(r.id).toBe(7)
+    expect(r.role).toBe(ROLE_USER)
+    expect(r.must_change_password).toBe(1)
+
+    const insert = pool.queries.find((q) => /INSERT INTO[\s\S]+users/i.test(q.text))
+    expect(insert!.text, 'role must be parameterised').not.toMatch(/'user'/)
+    expect(insert!.values).toContain(ROLE_USER)
+    expect(insert!.values).toContain(99) // creator id propagated
+  })
+
+  it('coalesces unknown creator to NULL (parity with SQLite)', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [], rowCount: 0 }) // getUser returns nothing
+    pool.enqueueResponse({ rows: [{ id: '7' }], rowCount: 1 })
+
+    await svc.createUser('bob', 'Bob', FIXTURE_PW, 'ghost')
+    const insert = pool.queries.find((q) => /INSERT INTO[\s\S]+users/i.test(q.text))
+    expect(insert!.values).toContain(null)
+  })
+
+  it('rejects temporary passwords shorter than the policy minimum before database reads', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+
+    await expect(svc.createUser('bob', 'Bob', 'short', 'admin')).rejects.toThrow(
+      /at least 12 characters/i
+    )
+    expect(pool.queries.length).toBe(0)
+  })
+})
+
+describe('PostgresWebAuthService — getUser / listUsers / isAccountsEnabled', () => {
+  it('getUser returns undefined when missing', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [], rowCount: 0 })
+    expect(await svc.getUser('ghost')).toBeUndefined()
+  })
+
+  it('listUsers strips password_hash from every row', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({
+      rows: [pgUserRow(), pgUserRow({ id: '2', username: 'bob' })],
+      rowCount: 2
+    })
+    const users = await svc.listUsers()
+    expect(users.length).toBe(2)
+    for (const u of users) expect(u as object).not.toHaveProperty('password_hash')
+  })
+
+  it("isAccountsEnabled returns true when database_settings.accounts_enabled = 'true'", async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [{ value: 'true' }], rowCount: 1 })
+    expect(await svc.isAccountsEnabled()).toBe(true)
+  })
+
+  it('isAccountsEnabled returns false when missing or any other value', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [], rowCount: 0 })
+    expect(await svc.isAccountsEnabled()).toBe(false)
+  })
+})
+
+describe('PostgresWebAuthService — deactivateUser / resetPassword / changePassword', () => {
+  it('deactivateUser throws when user not found', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [], rowCount: 0 })
+    await expect(svc.deactivateUser('ghost')).rejects.toThrow(/user not found/i)
+  })
+
+  it('deactivateUser refuses to deactivate an admin user', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [{ role: ROLE_ADMIN }], rowCount: 1 })
+
+    await expect(svc.deactivateUser('admin')).rejects.toThrow(/cannot deactivate an admin/i)
+    expect(pool.queries).toHaveLength(1)
+  })
+
+  it('deactivateUser issues UPDATE is_active = FALSE for non-admin users', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [{ role: ROLE_USER }], rowCount: 1 })
+    pool.enqueueResponse({ rows: [], rowCount: 1 })
+    await svc.deactivateUser('alice')
+    const upd = pool.queries[1]
+    expect(upd.text).toMatch(/UPDATE[\s\S]+users[\s\S]+is_active\s*=\s*FALSE/i)
+    expect(upd.values).toContain('alice')
+  })
+
+  it('resetPassword clears lockout state and forces password change', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [], rowCount: 1 })
+    await svc.resetPassword('alice', FIXTURE_NEW_PW)
+    const upd = pool.queries[0]
+    expect(upd.text).toMatch(/must_change_password\s*=\s*TRUE/i)
+    expect(upd.text).toMatch(/failed_login_count\s*=\s*0/i)
+    expect(upd.text).toMatch(/locked_until\s*=\s*NULL/i)
+  })
+
+  it('resetPassword rejects new passwords shorter than the policy minimum', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+
+    await expect(svc.resetPassword('alice', 'short')).rejects.toThrow(/at least 12 characters/i)
+    expect(pool.queries.length).toBe(0)
+  })
+
+  it('changePassword returns false for unknown user', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({ rows: [], rowCount: 0 })
+    expect(await svc.changePassword('ghost', 'old-pwd-1234', FIXTURE_NEW_PW)).toBe(false)
+  })
+
+  it('changePassword returns false when old password does not verify', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    pool.enqueueResponse({
+      rows: [pgUserRow({ password_hash: 'hashed::differentpw' })],
+      rowCount: 1
+    })
+    expect(await svc.changePassword('alice', 'wrong-pwd-12', FIXTURE_NEW_PW)).toBe(false)
+  })
+
+  it('changePassword updates hash and clears must_change_password on valid old password', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    // Pretend the stored hash matches `FIXTURE_PW` under the fake provider.
+    pool.enqueueResponse({
+      rows: [pgUserRow({ password_hash: `hashed::${FIXTURE_PW}` })],
+      rowCount: 1
+    })
+    pool.enqueueResponse({ rows: [], rowCount: 1 })
+    expect(await svc.changePassword('alice', FIXTURE_PW, FIXTURE_NEW_PW)).toBe(true)
+    const upd = pool.queries[1]
+    expect(upd.text).toMatch(/must_change_password\s*=\s*FALSE/i)
+    expect(upd.values).toContain(`hashed::${FIXTURE_NEW_PW}`)
+  })
+
+  it('changePassword rejects new passwords shorter than the policy minimum', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    await expect(svc.changePassword('alice', FIXTURE_PW, 'short')).rejects.toThrow(
+      /at least 12 characters/i
+    )
+    expect(pool.queries.length, 'no DB read either when policy fails').toBe(0)
+  })
+
+  it('changePassword rejects new === old', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    await expect(svc.changePassword('alice', FIXTURE_PW, FIXTURE_PW)).rejects.toThrow(
+      /must differ from/i
+    )
+  })
+})
+
+afterAll(() => {
+  // Sanity: no real Pool leaks into other suites.
+})


### PR DESCRIPTION
Summary
- Adds Postgres-backed web auth service and auth tables.
- Enforces Argon2 bootstrap policy and single-tenant user creation refusal.
- Covers bootstrap hash creation, login, lockout, and admin safety paths.

Stack
- Follows #214.

Validation
- make ci
- npm run build:web
- VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-web-ci-secrets make web-gate-static
