### PR TITLE
web 06: add observability metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ FROM node:24.15.0-bookworm-slim AS runtime
 
 ENV NODE_ENV=production \
     VARLENS_WEB_PORT=8080 \
+    VARLENS_METRICS_PORT=9090 \
     VARLENS_LOG_LEVEL=info
 
 # Web mode is Postgres-only. The runtime must provide VARLENS_PG_URL.
@@ -102,7 +103,7 @@ COPY --from=builder \
 
 USER varlens
 
-EXPOSE 8080
+EXPOSE 8080 9090
 VOLUME ["/data"]
 
 # Self-describing liveness — operators do not have to re-encode the probe.

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -36,6 +36,12 @@ import { registerLoginRoute, resolveAppPathPrefix } from './server/login-route'
 import { registerPageGate } from './server/page-gate'
 import { registerOpenApi } from './server/routes/openapi'
 import { registerStatic } from './server/static'
+import {
+  type AppMetrics,
+  createAppMetricsFromEnv,
+  registerRequestMetrics,
+  startMetricsServer
+} from './server/metrics'
 import pkg from '../../package.json'
 
 /**
@@ -62,6 +68,7 @@ export interface AdminBootstrapOptions {
  */
 export interface BuildAppOptions {
   admin?: AdminBootstrapOptions
+  metrics?: AppMetrics
 }
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -81,6 +88,8 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
       level: process.env.VARLENS_LOG_LEVEL ?? 'info'
     }
   })
+  const metrics = options.metrics ?? createAppMetricsFromEnv()
+  registerRequestMetrics(app, metrics)
 
   const session: PostgresStorageSession = await createPostgresStorageSession(pgConfig)
   // Share the storage session's pool with the auth service so we open
@@ -121,6 +130,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
 
   app.get('/healthz', async (_request, reply) => {
     const open = await isPostgresHealthy(pool)
+    metrics.setDatabaseHealthy(open)
     if (!open) {
       reply.code(503)
       return { status: 'unhealthy', version: pkg.version, db: { open: false } }
@@ -325,18 +335,48 @@ async function main(): Promise<void> {
     )
   }
   const host = process.env.VARLENS_WEB_HOST ?? '0.0.0.0'
+  const metricsPortRaw = process.env.VARLENS_METRICS_PORT ?? '9090'
+  const metricsPort = Number(metricsPortRaw)
+  if (!Number.isInteger(metricsPort) || metricsPort < 0 || metricsPort > 65535) {
+    throw new Error(
+      `VARLENS_METRICS_PORT must be an integer in [0, 65535]; got: ${JSON.stringify(metricsPortRaw)}`
+    )
+  }
+  const metricsHost = process.env.VARLENS_METRICS_HOST ?? '0.0.0.0'
+  const metricsPath = process.env.VARLENS_METRICS_PATH ?? '/metrics'
+  const metricsEnabled = process.env.VARLENS_METRICS_ENABLED !== '0'
+  const metrics = createAppMetricsFromEnv()
 
-  const app = await buildApp({ admin: readAdminEnv() })
+  const app = await buildApp({ admin: readAdminEnv(), metrics })
 
   await app.listen({ port, host })
+  const metricsServer = metricsEnabled
+    ? await startMetricsServer({ metrics, host: metricsHost, port: metricsPort, path: metricsPath })
+    : undefined
 
   const address = app.server.address()
   const boundPort = address !== null && typeof address === 'object' ? address.port : port
   app.log.info({ port: boundPort }, 'listening')
+  if (metricsServer !== undefined) {
+    const metricsAddress = metricsServer.address()
+    const boundMetricsPort =
+      metricsAddress !== null && typeof metricsAddress === 'object'
+        ? metricsAddress.port
+        : metricsPort
+    app.log.info({ port: boundMetricsPort, path: metricsPath }, 'metrics listening')
+  }
 
   const shutdown = async (signal: string): Promise<void> => {
     app.log.info({ signal }, 'shutting down')
     try {
+      if (metricsServer !== undefined) {
+        await new Promise<void>((resolve, reject) => {
+          metricsServer.close((error) => {
+            if (error !== undefined) reject(error)
+            else resolve()
+          })
+        })
+      }
       await app.close()
       process.exit(0)
     } catch (err) {

--- a/src/web/server/metrics.ts
+++ b/src/web/server/metrics.ts
@@ -1,0 +1,241 @@
+import { createServer, type Server } from 'http'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+
+import { buildDocumentedDispatcherPathSet } from './routes/openapi-paths'
+
+const DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+const documentedApiPaths = buildDocumentedDispatcherPathSet()
+
+type LabelValue = string | number
+type Labels = Record<string, LabelValue>
+
+interface HistogramState {
+  buckets: Map<number, number>
+  count: number
+  sum: number
+}
+
+function labelKey(labels: Labels): string {
+  return Object.keys(labels)
+    .sort()
+    .map((key) => `${key}=${String(labels[key])}`)
+    .join('\n')
+}
+
+function labelText(labels: Labels): string {
+  return Object.keys(labels)
+    .sort()
+    .map((key) => `${key}="${String(labels[key]).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)
+    .join(',')
+}
+
+function metricLine(name: string, labels: Labels, value: number): string {
+  const text = labelText(labels)
+  return `${name}${text === '' ? '' : `{${text}}`} ${value}`
+}
+
+function pathName(url: string): string {
+  try {
+    return new URL(url, 'http://varlens.local').pathname
+  } catch {
+    return 'unknown'
+  }
+}
+
+export function resolveMetricsRoute(method: string, url: string): string {
+  const pathname = pathName(url)
+  if (pathname === '/healthz' || pathname === '/api/openapi.json') return pathname
+
+  if (method === 'POST' && /^\/api\/[^/]+\/[^/]+$/.test(pathname)) {
+    return documentedApiPaths.has(pathname) ? pathname : 'unknown'
+  }
+
+  if (pathname.startsWith('/api/')) return 'unknown'
+  return 'static'
+}
+
+export class AppMetrics {
+  private readonly baseLabels: Labels
+  private readonly requests = new Map<string, { labels: Labels; value: number }>()
+  private readonly inFlight = new Map<string, { labels: Labels; value: number }>()
+  private readonly durations = new Map<string, { labels: Labels; state: HistogramState }>()
+  private dbHealthy = 0
+  private readonly startedAt = Date.now() / 1000
+
+  constructor(options: { app: string; environment: string }) {
+    this.baseLabels = {
+      app: options.app,
+      environment: options.environment
+    }
+  }
+
+  beginRequest(method: string, route: string): void {
+    const labels = { ...this.baseLabels, method, route }
+    const key = labelKey(labels)
+    const current = this.inFlight.get(key)
+    this.inFlight.set(key, { labels, value: (current?.value ?? 0) + 1 })
+  }
+
+  endRequest(method: string, route: string, status: number, durationSeconds: number): void {
+    const inFlightLabels = { ...this.baseLabels, method, route }
+    const inFlightKey = labelKey(inFlightLabels)
+    const current = this.inFlight.get(inFlightKey)
+    this.inFlight.set(inFlightKey, {
+      labels: inFlightLabels,
+      value: Math.max(0, (current?.value ?? 0) - 1)
+    })
+
+    const requestLabels = { ...this.baseLabels, method, route, status }
+    const requestKey = labelKey(requestLabels)
+    const request = this.requests.get(requestKey)
+    this.requests.set(requestKey, { labels: requestLabels, value: (request?.value ?? 0) + 1 })
+
+    const duration = this.durations.get(requestKey) ?? {
+      labels: requestLabels,
+      state: {
+        buckets: new Map(DEFAULT_BUCKETS.map((bucket) => [bucket, 0])),
+        count: 0,
+        sum: 0
+      }
+    }
+    duration.state.count += 1
+    duration.state.sum += durationSeconds
+    for (const bucket of DEFAULT_BUCKETS) {
+      if (durationSeconds <= bucket) {
+        duration.state.buckets.set(bucket, (duration.state.buckets.get(bucket) ?? 0) + 1)
+      }
+    }
+    this.durations.set(requestKey, duration)
+  }
+
+  setDatabaseHealthy(value: boolean): void {
+    this.dbHealthy = value ? 1 : 0
+  }
+
+  contentType(): string {
+    return 'text/plain; version=0.0.4; charset=utf-8'
+  }
+
+  metricsText(): string {
+    const lines: string[] = []
+    lines.push('# HELP http_requests_total Total HTTP requests.')
+    lines.push('# TYPE http_requests_total counter')
+    for (const metric of this.requests.values()) {
+      lines.push(metricLine('http_requests_total', metric.labels, metric.value))
+    }
+
+    lines.push('# HELP http_request_duration_seconds HTTP request duration.')
+    lines.push('# TYPE http_request_duration_seconds histogram')
+    for (const metric of this.durations.values()) {
+      for (const bucket of DEFAULT_BUCKETS) {
+        lines.push(
+          metricLine(
+            'http_request_duration_seconds_bucket',
+            { ...metric.labels, le: bucket },
+            metric.state.buckets.get(bucket) ?? 0
+          )
+        )
+      }
+      lines.push(
+        metricLine(
+          'http_request_duration_seconds_bucket',
+          { ...metric.labels, le: '+Inf' },
+          metric.state.count
+        )
+      )
+      lines.push(metricLine('http_request_duration_seconds_sum', metric.labels, metric.state.sum))
+      lines.push(
+        metricLine('http_request_duration_seconds_count', metric.labels, metric.state.count)
+      )
+    }
+
+    lines.push('# HELP http_requests_in_flight Current in-flight HTTP requests.')
+    lines.push('# TYPE http_requests_in_flight gauge')
+    for (const metric of this.inFlight.values()) {
+      lines.push(metricLine('http_requests_in_flight', metric.labels, metric.value))
+    }
+
+    lines.push('# HELP varlens_database_healthy Database health from the latest health check.')
+    lines.push('# TYPE varlens_database_healthy gauge')
+    lines.push(metricLine('varlens_database_healthy', this.baseLabels, this.dbHealthy))
+
+    lines.push('# HELP process_start_time_seconds Start time of the Node.js process.')
+    lines.push('# TYPE process_start_time_seconds gauge')
+    lines.push(metricLine('process_start_time_seconds', this.baseLabels, this.startedAt))
+
+    lines.push('# HELP process_uptime_seconds Uptime of the Node.js process.')
+    lines.push('# TYPE process_uptime_seconds gauge')
+    lines.push(metricLine('process_uptime_seconds', this.baseLabels, process.uptime()))
+
+    const memory = process.memoryUsage()
+    lines.push('# HELP process_resident_memory_bytes Resident memory size in bytes.')
+    lines.push('# TYPE process_resident_memory_bytes gauge')
+    lines.push(metricLine('process_resident_memory_bytes', this.baseLabels, memory.rss))
+    lines.push('# HELP nodejs_heap_size_used_bytes Node.js heap used in bytes.')
+    lines.push('# TYPE nodejs_heap_size_used_bytes gauge')
+    lines.push(metricLine('nodejs_heap_size_used_bytes', this.baseLabels, memory.heapUsed))
+
+    return `${lines.join('\n')}\n`
+  }
+}
+
+export function createAppMetricsFromEnv(env: NodeJS.ProcessEnv = process.env): AppMetrics {
+  return new AppMetrics({
+    app: env.VARLENS_OBSERVABILITY_APP?.trim() || 'varlens',
+    environment: env.VARLENS_OBSERVABILITY_ENVIRONMENT?.trim() || env.NODE_ENV || 'unknown'
+  })
+}
+
+export function registerRequestMetrics(app: FastifyInstance, metrics: AppMetrics): void {
+  const requests = new WeakMap<FastifyRequest, { start: bigint; method: string; route: string }>()
+
+  app.addHook('onRequest', async (request) => {
+    const method = request.method
+    const route = resolveMetricsRoute(method, request.url)
+    requests.set(request, { start: process.hrtime.bigint(), method, route })
+    metrics.beginRequest(method, route)
+  })
+
+  app.addHook('onResponse', async (request, reply) => {
+    recordResponse(metrics, requests, request, reply)
+  })
+}
+
+function recordResponse(
+  metrics: AppMetrics,
+  requests: WeakMap<FastifyRequest, { start: bigint; method: string; route: string }>,
+  request: FastifyRequest,
+  reply: FastifyReply
+): void {
+  const state = requests.get(request)
+  if (state === undefined) return
+  const durationSeconds = Number(process.hrtime.bigint() - state.start) / 1_000_000_000
+  metrics.endRequest(state.method, state.route, reply.statusCode, durationSeconds)
+  requests.delete(request)
+}
+
+export function startMetricsServer(options: {
+  metrics: AppMetrics
+  host: string
+  port: number
+  path?: string
+}): Promise<Server> {
+  const metricsPath = options.path ?? '/metrics'
+  const server = createServer((request, response) => {
+    if (request.method !== 'GET' || pathName(request.url ?? '/') !== metricsPath) {
+      response.writeHead(404, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ error: 'not found' }))
+      return
+    }
+    response.writeHead(200, { 'content-type': options.metrics.contentType() })
+    response.end(options.metrics.metricsText())
+  })
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(options.port, options.host, () => {
+      server.off('error', reject)
+      resolve(server)
+    })
+  })
+}

--- a/src/web/server/metrics.ts
+++ b/src/web/server/metrics.ts
@@ -22,10 +22,17 @@ function labelKey(labels: Labels): string {
     .join('\n')
 }
 
+function escapeLabelValue(value: LabelValue): string {
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/\r\n|\r|\n/g, '\\n')
+    .replace(/"/g, '\\"')
+}
+
 function labelText(labels: Labels): string {
   return Object.keys(labels)
     .sort()
-    .map((key) => `${key}="${String(labels[key]).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)
+    .map((key) => `${key}="${escapeLabelValue(labels[key])}"`)
     .join(',')
 }
 
@@ -40,6 +47,24 @@ function pathName(url: string): string {
   } catch {
     return 'unknown'
   }
+}
+
+function normalizeMetricsPath(path: string | undefined): string {
+  const raw = path ?? '/metrics'
+  const trimmed = raw.trim()
+  if (
+    trimmed === '' ||
+    !trimmed.startsWith('/') ||
+    trimmed.startsWith('//') ||
+    trimmed.includes('?') ||
+    trimmed.includes('#')
+  ) {
+    throw new Error(
+      'VARLENS_METRICS_PATH must be an absolute URL path without query or fragment, ' +
+        `got: ${JSON.stringify(raw)}`
+    )
+  }
+  return trimmed
 }
 
 export function resolveMetricsRoute(method: string, url: string): string {
@@ -180,10 +205,22 @@ export class AppMetrics {
 }
 
 export function createAppMetricsFromEnv(env: NodeJS.ProcessEnv = process.env): AppMetrics {
+  const app = nonEmptyTrimmed(env.VARLENS_OBSERVABILITY_APP) ?? 'varlens'
+  const environment =
+    nonEmptyTrimmed(env.VARLENS_OBSERVABILITY_ENVIRONMENT) ??
+    nonEmptyTrimmed(env.NODE_ENV) ??
+    'unknown'
+
   return new AppMetrics({
-    app: env.VARLENS_OBSERVABILITY_APP?.trim() || 'varlens',
-    environment: env.VARLENS_OBSERVABILITY_ENVIRONMENT?.trim() || env.NODE_ENV || 'unknown'
+    app,
+    environment
   })
+}
+
+function nonEmptyTrimmed(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (trimmed === undefined || trimmed === '') return undefined
+  return trimmed
 }
 
 export function registerRequestMetrics(app: FastifyInstance, metrics: AppMetrics): void {
@@ -214,13 +251,13 @@ function recordResponse(
   requests.delete(request)
 }
 
-export function startMetricsServer(options: {
+export async function startMetricsServer(options: {
   metrics: AppMetrics
   host: string
   port: number
   path?: string
 }): Promise<Server> {
-  const metricsPath = options.path ?? '/metrics'
+  const metricsPath = normalizeMetricsPath(options.path)
   const server = createServer((request, response) => {
     if (request.method !== 'GET' || pathName(request.url ?? '/') !== metricsPath) {
       response.writeHead(404, { 'content-type': 'application/json' })
@@ -231,7 +268,7 @@ export function startMetricsServer(options: {
     response.end(options.metrics.metricsText())
   })
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     server.once('error', reject)
     server.listen(options.port, options.host, () => {
       server.off('error', reject)

--- a/src/web/server/routes/openapi-paths.ts
+++ b/src/web/server/routes/openapi-paths.ts
@@ -46,3 +46,7 @@ export function appendDocumentedDispatcherPaths(document: OpenApiDocument): Open
     }
   }
 }
+
+export function buildDocumentedDispatcherPathSet(): Set<string> {
+  return new Set(Object.keys(appendDocumentedDispatcherPaths({ paths: {} }).paths ?? {}))
+}

--- a/tests/web-gate/helpers/web-driver.ts
+++ b/tests/web-gate/helpers/web-driver.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { Pool } from 'pg'
 import type { FastifyInstance } from 'fastify'
 
-import type { buildApp as buildAppType } from '../../../src/web/server'
+import type { buildApp as buildAppType, BuildAppOptions } from '../../../src/web/server'
 
 const BOOTSTRAP_PASSWORD = 'web-gate-bootstrap-password-2026'
 const ACTIVE_PASSWORD = 'web-gate-active-password-2026'
@@ -95,7 +95,9 @@ export async function startIsolatedWebSchema(prefix?: string): Promise<IsolatedW
   return { schema, recoveryDir, close }
 }
 
-export async function startWebDriver(): Promise<WebDriver> {
+export async function startWebDriver(
+  options: Pick<BuildAppOptions, 'metrics'> = {}
+): Promise<WebDriver> {
   const isolated = await startIsolatedWebSchema('web_driver')
 
   let app: FastifyInstance | undefined
@@ -124,7 +126,8 @@ export async function startWebDriver(): Promise<WebDriver> {
         username: 'web-gate-admin',
         passwordHash,
         displayName: 'Web Gate Admin'
-      }
+      },
+      metrics: options.metrics
     })
 
     const loginRes = (await app.inject({

--- a/tests/web-gate/integration/metrics.test.ts
+++ b/tests/web-gate/integration/metrics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+
+import { AppMetrics, startMetricsServer } from '../../../src/web/server/metrics'
+import { startWebDriver } from '../helpers/web-driver'
+
+const WEB_BUILD_PATH = resolve(process.cwd(), 'out/web/server.cjs')
+const isWebBuilt = existsSync(WEB_BUILD_PATH)
+const HAS_PG = typeof process.env.VARLENS_PG_URL === 'string' && process.env.VARLENS_PG_URL !== ''
+
+describe.skipIf(!isWebBuilt || !HAS_PG)('web metrics integration', () => {
+  test('records documented API calls with stable route labels', async () => {
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'test' })
+    const driver = await startWebDriver({ metrics })
+    try {
+      const res = await driver.app.inject({
+        method: 'POST',
+        url: '/api/auth/isAccountsEnabled',
+        headers: { cookie: driver.cookie, origin: 'http://localhost', host: 'localhost' }
+      })
+      expect(res.statusCode, res.body).toBe(200)
+
+      const text = metrics.metricsText()
+      expect(text).toContain('route="/api/auth/isAccountsEnabled"')
+      expect(text).not.toContain('/api/auth/isAccountsEnabled?')
+    } finally {
+      await driver.close()
+    }
+  })
+
+  test('serves metrics from a separate unauthenticated HTTP listener', async () => {
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'test' })
+    metrics.beginRequest('GET', '/healthz')
+    metrics.endRequest('GET', '/healthz', 200, 0.01)
+    const server = await startMetricsServer({
+      metrics,
+      host: '127.0.0.1',
+      port: 0,
+      path: '/metrics'
+    })
+    try {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        throw new Error('metrics server did not bind a TCP address')
+      }
+      const res = await fetch(`http://127.0.0.1:${address.port}/metrics`)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('text/plain')
+      expect(await res.text()).toContain('http_requests_total')
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error !== undefined) reject(error)
+          else resolve()
+        })
+      })
+    }
+  })
+})

--- a/tests/web-gate/metrics-labels.test.ts
+++ b/tests/web-gate/metrics-labels.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+
+import { AppMetrics, resolveMetricsRoute } from '../../src/web/server/metrics'
+
+describe('web metrics route labels', () => {
+  test('uses documented OpenAPI paths as stable API route labels', () => {
+    expect(resolveMetricsRoute('POST', '/api/auth/login')).toBe('/api/auth/login')
+    expect(resolveMetricsRoute('POST', '/api/cases/list')).toBe('/api/cases/list')
+    expect(resolveMetricsRoute('GET', '/api/openapi.json')).toBe('/api/openapi.json')
+  })
+
+  test('groups unknown API routes without raw-path cardinality', () => {
+    expect(resolveMetricsRoute('POST', '/api/not-a-domain/not-a-method')).toBe('unknown')
+    expect(resolveMetricsRoute('GET', '/api/cases/list')).toBe('unknown')
+    expect(resolveMetricsRoute('POST', '/api/cases/list/extra')).toBe('unknown')
+  })
+
+  test('renders Prometheus text with app and environment labels', () => {
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'test' })
+    metrics.beginRequest('POST', '/api/auth/login')
+    metrics.endRequest('POST', '/api/auth/login', 200, 0.021)
+    metrics.setDatabaseHealthy(true)
+
+    const text = metrics.metricsText()
+    expect(text).toContain(
+      'http_requests_total{app="varlens",environment="test",method="POST",route="/api/auth/login",status="200"} 1'
+    )
+    expect(text).toContain('http_request_duration_seconds_bucket')
+    expect(text).toContain('http_requests_in_flight')
+    expect(text).toContain('varlens_database_healthy{app="varlens",environment="test"} 1')
+    expect(text).toContain('process_resident_memory_bytes')
+  })
+})

--- a/tests/web-gate/metrics-labels.test.ts
+++ b/tests/web-gate/metrics-labels.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { AppMetrics, resolveMetricsRoute } from '../../src/web/server/metrics'
+import { AppMetrics, resolveMetricsRoute, startMetricsServer } from '../../src/web/server/metrics'
 
 describe('web metrics route labels', () => {
   test('uses documented OpenAPI paths as stable API route labels', () => {
@@ -29,5 +29,38 @@ describe('web metrics route labels', () => {
     expect(text).toContain('http_requests_in_flight')
     expect(text).toContain('varlens_database_healthy{app="varlens",environment="test"} 1')
     expect(text).toContain('process_resident_memory_bytes')
+  })
+
+  test('escapes line breaks in label values', () => {
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'prod\ncanary' })
+    metrics.beginRequest('POST', '/api/auth/login')
+    metrics.endRequest('POST', '/api/auth/login', 200, 0.021)
+
+    const text = metrics.metricsText()
+    expect(text).toContain('environment="prod\\ncanary"')
+    expect(text).not.toContain('environment="prod\ncanary"')
+  })
+
+  test('rejects invalid metrics scrape paths before binding', async () => {
+    const result = await startMetricsServer({
+      metrics: new AppMetrics({ app: 'varlens', environment: 'test' }),
+      host: '127.0.0.1',
+      port: 0,
+      path: 'metrics'
+    }).then(
+      async (server) => {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error !== undefined) reject(error)
+            else resolve()
+          })
+        })
+        return 'resolved'
+      },
+      (error: unknown) => error
+    )
+
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error).message).toContain('VARLENS_METRICS_PATH')
   })
 })


### PR DESCRIPTION
## Summary
- add internal VarLens /metrics listener on the non-public metrics port
- instrument Fastify requests with stable Swagger/OpenAPI-aware route labels
- expose app/environment metrics labels and database health gauge
- add focused metrics route-label and integration coverage

## Validation
- vitest web-gate metrics-labels test passed locally
- metrics integration test is present and skips when no local Postgres/web build is configured
- Docker web image build passed locally during platform validation