### PR TITLE
fix(release): pre-0.60 release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,17 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Assert tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME implies version $TAG_VERSION but package.json reports $PKG_VERSION"
+            echo "::error::Bump package.json to match the tag (or retag) before releasing."
+            exit 1
+          fi
+          echo "Tag and package.json agree on $PKG_VERSION"
+
       # Belt-and-suspenders gate: refuse to release a tag whose SHA didn't
       # pass the Build workflow. Branch protection already blocks merges on failing
       # CI, but direct tag pushes bypass branch protection — this catches

--- a/.planning/docs/release-runbook.md
+++ b/.planning/docs/release-runbook.md
@@ -1,0 +1,26 @@
+# VarLens Release Runbook
+
+> One-page checklist for tagging a VarLens release.
+
+## Before bumping `package.json` version
+
+1. **Promote `## [Unreleased]` in `CHANGELOG.md`.**
+   - Rename the `[Unreleased]` heading to `[X.Y.Z] — YYYY-MM-DD`.
+   - Insert a new, empty `## [Unreleased]` block above it.
+   - Reviewer checks: every change merged since the previous tag is reflected.
+   - **Phase 1 chose runbook-line enforcement over a CI hook.** If a release
+     ships with a stale changelog, that is the failure mode to learn from.
+     Sprint A may add a `pre-tag` workflow step gating on a populated
+     `[X.Y.Z]` block.
+
+2. **Bump `package.json` version** to match the new heading.
+
+3. **Tag with the same version**, prefixed `v`:
+   `git tag -a vX.Y.Z -m "vX.Y.Z"`.
+   Before pushing the tag, confirm `package.json` contains `"version": "X.Y.Z"`.
+
+## After tagging
+
+- Push the tag: `git push origin vX.Y.Z`.
+- Watch `Build` workflow on the tagged SHA; release.yml waits for it.
+- Promote draft release once OS builds + signing complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,288 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.3] — 2026-05-21
+
+### Changed
+
+- **Agent-health guardrails added** (#209) to keep authored source files within
+  LLM-sustainable review bounds. The repository now has a Make target and
+  baseline-backed checks that flag oversized source growth before PRs land.
+- **LLM-sustainable coding rules documented** in `AGENTS.md`, making the
+  source-size, boundary, testing, and planning expectations explicit for all
+  coding agents.
+
+### Internal
+
+- **Dependabot maintenance releases consolidated** across runtime and
+  development dependencies (#203, #206).
+- **Agent-health planning and review notes archived** under `.planning/`,
+  including the derived-data consistency plan, the 2026-05-21 follow-up review,
+  and the implementation plan for guardrails.
+
+## [0.59.0] — 2026-04-30
+
+### Added
+
+- **PostgreSQL connection manager UI added** so users can configure and switch
+  hosted PostgreSQL workspaces from the app instead of relying only on local
+  development wiring.
+- **Hosted PostgreSQL smoke tooling added** for exercising the hosted-workspace
+  path and capturing WGS query readiness evidence before future query-index
+  work.
+
+### Changed
+
+- **PostgreSQL migration lifecycle hardened** so hosted and local PostgreSQL
+  workspaces can be brought forward through schema changes more reliably.
+- **Final PostgreSQL parity gates satisfied** across the product-parity work,
+  completing the storage-backend parity push that started in the 0.56.x series.
+
+### Security
+
+- **PostgreSQL profiling secret lifecycle cleaned up** so profiling support no
+  longer leaves sensitive connection material around longer than required.
+
+### Internal
+
+- **PostgreSQL product-parity specs and completed plans archived** under
+  `.planning/`, preserving the audit trail for the parity release work.
+
+## [0.58.3] — 2026-04-30
+
+### Added
+
+- **Clinical variant filter parity added for PostgreSQL** so clinical filtering
+  workflows can run against the PostgreSQL backend.
+- **Cohort, export, and audit-log parity added for PostgreSQL**, closing the
+  remaining high-level workflow gaps between SQLite and PostgreSQL-backed
+  workspaces.
+
+### Fixed
+
+- **Database picker now shows the active workspace** when PostgreSQL support is
+  enabled, reducing ambiguity during backend switching.
+- **Shortlist IPC errors are handled in the renderer** instead of surfacing as
+  unhandled failures.
+- **Shortlist behavior corrected for PostgreSQL workspaces.** Unsupported
+  shortlist states are hidden where needed, PostgreSQL shortlist parity is
+  implemented, and the SQLite shortlist read task is routed through the storage
+  executor.
+
+### Internal
+
+- **PostgreSQL parity roadmap status refreshed and final plans archived** under
+  `.planning/`.
+
+## [0.58.2] — 2026-04-30
+
+### Internal
+
+- **Dependency updates consolidated** into a single maintenance release.
+
+## [0.58.1] — 2026-04-30
+
+### Internal
+
+- **Compatible Dependabot updates consolidated** into one dependency-maintenance
+  release.
+
+## [0.58.0] — 2026-04-30
+
+### Added
+
+- **PostgreSQL VCF imports switched to `COPY FROM STDIN`.** The import path now
+  uses `pg-copy-streams`, reusable COPY text encoders, pre-reserved IDs, and
+  worker-thread orchestration for JSON, VCF, and multi-file imports.
+- **PostgreSQL generated search documents added** for variants and extension
+  tables, replacing the earlier per-batch bulk-update approach with STORED
+  generated columns.
+- **PostgreSQL backend capability matrix, schema migration lifecycle, variant
+  filter parity, export/delete overview parity, workflow-domain parity, and
+  hosted-operations foundation added** as the next product-parity layer.
+- **WGS import and query benchmark harnesses added** for PostgreSQL and SQLite,
+  including the GIAB HG002 fixture downloader and comparison scripts.
+
+### Changed
+
+- **PostgreSQL bulk-load performance tuned** through Docker PostgreSQL
+  configuration changes and batch-level worker commits. The recorded Phase
+  16/16.1/16.2 WGS state documents PostgreSQL imports at 1.85x SQLite for the
+  GIAB HG002 v4.2.1 benchmark.
+- **PostgreSQL import-worker contracts tightened** around cancellation,
+  transaction scoping, SSL config mapping, stream error handling, large-allele
+  handling, and hash-keyed `variant_frequency` joins.
+- **PostgreSQL storage-roadmap work advanced** from Phase 16 implementation
+  into the broader parity roadmap, with the completed phase archives moved into
+  `.planning/`.
+
+### Fixed
+
+- **PostgreSQL COPY worker bundling fixed** by using the named `pipeline`
+  import that survives the worker bundle.
+- **Large-allele frequency rebuilds fixed** by adding `coord_hash` generated
+  columns, hash-keyed indexes, and hash-only joins for `variant_frequency`.
+- **PostgreSQL parity review comments addressed** before the 0.58.0 tag.
+
+### Internal
+
+- **COPY text encoding gained property and boundary tests** with a dedicated
+  coverage gate for the encoder module.
+- **PostgreSQL import E2E coverage expanded** across COPY cancellation,
+  large-allele scenarios, VCF single-sample import, extension tables, BED
+  filtering, multi-file import, partial failure, pre-existing rejection, and
+  cancellation responsiveness.
+- **Phase 9, 9.1, 16, and roadmap planning artifacts archived** under
+  `.planning/`.
+
+## [0.56.14] — 2026-04-26
+
+### Added
+
+- **Storage import executor contract added** with SQLite and PostgreSQL
+  implementations for JSON imports, giving the active storage session ownership
+  of import writes.
+- **PostgreSQL import worker pipeline added** for JSON, VCF, and multi-file
+  imports, including worker-thread message contracts, transaction-scoped
+  repositories, BED filtering, pre-mapping filters, per-file transactions, and
+  post-loop bookkeeping.
+- **PostgreSQL VCF import support added** for single-sample, multi-file,
+  extension-table, large-allele, and cancellation scenarios.
+- **WGS import benchmark tooling added** with the GIAB HG002 fixture downloader,
+  PostgreSQL and SQLite benchmark tests, and comparison artifacts.
+- **Large-variant coordinate hashing added** for PostgreSQL via `coord_hash`
+  generated columns and hash-keyed indexes.
+
+### Changed
+
+- **Import start IPC now routes through the active storage session**, keeping
+  import execution aligned with the selected backend.
+- **PostgreSQL import repositories made transaction-scoped** and shared
+  PostgreSQL import configuration helpers extracted for reuse.
+- **PostgreSQL import worker commits per batch** to improve WGS import
+  performance while preserving cancellation and failure behavior.
+
+### Fixed
+
+- **Import-executor lifecycle and concurrency guards hardened** to avoid invalid
+  import states.
+- **PostgreSQL import worker stream errors handled** so unhandled worker errors
+  do not escape cancellation and failure paths.
+- **PostgreSQL large-allele frequency rebuilds fixed** by upserting and joining
+  `variant_frequency` through `coord_hash`.
+- **PostgreSQL worker review comments addressed** before release.
+
+### Internal
+
+- **PostgreSQL parity Phase 8 and Phase 9 planning artifacts archived and
+  refreshed** under `.planning/`, including the large-coordinate index design.
+- **WGS benchmark state documented** in `AGENTS.md`, and the GIAB fixture SHA256
+  pinned for reproducible performance runs.
+
+## [0.56.13] — 2026-04-24
+
+### Added
+
+- **PostgreSQL variant read schema and seed data added** for the storage parity
+  path.
+- **PostgreSQL variant read paths added** for small reads and query reads,
+  allowing variant lookup and query workflows to execute through PostgreSQL
+  storage sessions.
+
+### Changed
+
+- **SQLite variant reads now route through storage executors**, matching the
+  new backend-neutral read boundary.
+- **Variant read IPC now routes through storage sessions** instead of directly
+  coupling to the legacy SQLite path.
+
+### Fixed
+
+- **PostgreSQL variant-read review comments addressed** before release.
+
+### Internal
+
+- **Variant read executor contracts and E2E coverage added** for PostgreSQL
+  variant reads.
+- **PostgreSQL variant read parity planning archived** under `.planning/`, with
+  variant filter metadata explicitly deferred.
+
+## [0.56.12] — 2026-04-24
+
+### Added
+
+- **PostgreSQL case metadata repository added** with metadata filter support for
+  the storage parity path.
+
+### Changed
+
+- **Case metadata moved behind executor contracts** for both SQLite and
+  PostgreSQL, and IPC now routes case metadata through storage sessions.
+- **PostgreSQL write-executor dependencies narrowed** as the storage boundary
+  continued to separate read and write responsibilities.
+
+### Fixed
+
+- **PostgreSQL case metadata integers normalized** so metadata responses match
+  SQLite expectations.
+- **PostgreSQL distinct HPO responses aligned** with the existing SQLite
+  contract.
+
+### Internal
+
+- **PostgreSQL case metadata dev-mode E2E coverage added**.
+- **Phase 5 storage docs archived and Phase 6 PostgreSQL parity planning
+  added** under `.planning/`, along with a PostgreSQL WGS readiness inventory.
+
+## [0.56.11] — 2026-04-24
+
+### Added
+
+- **Storage session read-executor contract added** as the next backend-neutral
+  storage boundary.
+- **PostgreSQL cases query executor added**, enabling `cases:list` to run
+  through PostgreSQL-backed storage sessions.
+
+### Changed
+
+- **Legacy database-pool access bridged through storage sessions** so IPC paths
+  can migrate without breaking existing SQLite behavior.
+- **SQLite read execution and cases queries moved under storage executors**,
+  aligning SQLite with the new session boundary.
+- **Available builds migrated to the storage executor** and file-backed worker
+  writes marked SQLite-only.
+
+### Internal
+
+- **Storage executor files formatted** and completed phase docs archived.
+- **Branch and PR workflow requirements added to `AGENTS.md`**.
+- **Storage Phase 5 planning added** under `.planning/`.
+
+## [0.56.10] — 2026-04-24
+
+### Fixed
+
+- **Release workflow gate now uses the correct Build workflow name**, restoring
+  the tagged-release check that waits for the matching build workflow run.
+
+## [0.56.9] — 2026-04-24
+
+### Added
+
+- **`cases:list` PostgreSQL vertical slice added** (#174), extending the storage
+  session scaffold with the first user-facing read path backed by PostgreSQL.
+
+### Internal
+
+- **Completed storage planning documents archived** under `.planning/`.
+
+## [0.56.8] — 2026-04-23
+
+### Added
+
+- **PostgreSQL storage session Phase 2 scaffold added** (#173), continuing the
+  backend-neutral storage-session work after the initial 0.56.7 boundary landed.
+
 ## [0.56.7] — 2026-04-23
 
 ### Changed

--- a/src/main/services/MainLogger.ts
+++ b/src/main/services/MainLogger.ts
@@ -17,6 +17,7 @@
 
 import { isMainThread } from 'worker_threads'
 import type { LogMessage } from '../../shared/types/log'
+import { sanitizeLogMessage } from '../../shared/utils/sanitizers'
 
 // Lazy-loaded references — only populated in the main thread
 let log: typeof import('electron-log/main').default | null = null
@@ -95,40 +96,44 @@ export class MainLogger {
   }
 
   debug(message: string, source = 'main'): void {
+    const safeMessage = sanitizeLogMessage(message)
     if (log) {
-      log.debug(`[${source}] ${message}`)
+      log.debug(`[${source}] ${safeMessage}`)
     } else {
       // Worker thread: console is the only option (allowed per CLAUDE.md)
-      console.debug(`[${source}] ${message}`)
+      console.debug(`[${source}] ${safeMessage}`)
     }
-    this.emit('debug', message, source)
+    this.emit('debug', safeMessage, source)
   }
 
   info(message: string, source = 'main'): void {
+    const safeMessage = sanitizeLogMessage(message)
     if (log) {
-      log.info(`[${source}] ${message}`)
+      log.info(`[${source}] ${safeMessage}`)
     } else {
-      console.info(`[${source}] ${message}`)
+      console.info(`[${source}] ${safeMessage}`)
     }
-    this.emit('info', message, source)
+    this.emit('info', safeMessage, source)
   }
 
   warn(message: string, source = 'main'): void {
+    const safeMessage = sanitizeLogMessage(message)
     if (log) {
-      log.warn(`[${source}] ${message}`)
+      log.warn(`[${source}] ${safeMessage}`)
     } else {
-      console.warn(`[${source}] ${message}`)
+      console.warn(`[${source}] ${safeMessage}`)
     }
-    this.emit('warn', message, source)
+    this.emit('warn', safeMessage, source)
   }
 
   error(message: string, source = 'main'): void {
+    const safeMessage = sanitizeLogMessage(message)
     if (log) {
-      log.error(`[${source}] ${message}`)
+      log.error(`[${source}] ${safeMessage}`)
     } else {
-      console.error(`[${source}] ${message}`)
+      console.error(`[${source}] ${safeMessage}`)
     }
-    this.emit('error', message, source)
+    this.emit('error', safeMessage, source)
   }
 }
 

--- a/src/renderer/src/utils/sanitizers.ts
+++ b/src/renderer/src/utils/sanitizers.ts
@@ -1,48 +1,5 @@
 /**
- * Sanitizer utilities for redacting sensitive genetic and medical data from logs
+ * Re-export of the shared sanitizer. See src/shared/utils/sanitizers.ts.
+ * Kept for backwards-compatible imports across the renderer.
  */
-
-/**
- * Regex pattern for HGVS notation
- * Matches: c.123A>G, p.Arg459*, g.12345C>T, n.123+5G>A, m.1555A>G
- */
-const HGVS_PATTERN = /\b[cgpmn]\.\d+[+-]?\d*([A-Z][a-z]{2})?\d*[*>_]?\S*/gi
-
-/**
- * Regex pattern for genomic coordinates
- * Matches: chr1:12345, chr1:12345-67890, X:12345, 1:12345-67890
- */
-const GENOMIC_COORD_PATTERN = /\b(chr)?([0-9]{1,2}|X|Y|M|MT):(\d+)(-\d+)?\b/gi
-
-/**
- * Regex pattern for patient/sample identifiers
- * Matches: PATIENT-12345, SAMPLE_ABC123, SUBJECT:XYZ789, ID-ABC123
- */
-const PATIENT_ID_PATTERN = /\b(PATIENT|SAMPLE|SUBJECT|ID)[_:-]?[A-Z0-9]{3,}\b/gi
-
-/**
- * Sanitizes log messages by redacting sensitive genetic and medical data
- *
- * @param message - The log message to sanitize
- * @returns The sanitized message with sensitive data replaced by redaction markers
- */
-export function sanitizeLogMessage(message: string): string {
-  let sanitized = message
-
-  // Quick pre-check for HGVS notation (contains '.' followed by digit)
-  if (/[cgpmn]\.\d/i.test(sanitized) === true) {
-    sanitized = sanitized.replace(HGVS_PATTERN, '[REDACTED:HGVS]')
-  }
-
-  // Quick pre-check for genomic coordinates (contains ':' with digits)
-  if (/:\d/.test(sanitized) === true) {
-    sanitized = sanitized.replace(GENOMIC_COORD_PATTERN, '[REDACTED:COORD]')
-  }
-
-  // Quick pre-check for patient IDs (contains known prefixes)
-  if (/\b(PATIENT|SAMPLE|SUBJECT|ID)[_:-]/i.test(sanitized) === true) {
-    sanitized = sanitized.replace(PATIENT_ID_PATTERN, '[REDACTED:ID]')
-  }
-
-  return sanitized
-}
+export { sanitizeLogMessage } from '../../../shared/utils/sanitizers'

--- a/src/shared/utils/sanitizers.ts
+++ b/src/shared/utils/sanitizers.ts
@@ -1,0 +1,48 @@
+/**
+ * Sanitizer utilities for redacting sensitive genetic and medical data from logs
+ */
+
+/**
+ * Regex pattern for HGVS notation
+ * Matches: c.123A>G, p.Arg459*, g.12345C>T, n.123+5G>A, m.1555A>G
+ */
+const HGVS_PATTERN = /\b[cgpmn]\.\d+[+-]?\d*([A-Z][a-z]{2})?\d*[*>_]?\S*/gi
+
+/**
+ * Regex pattern for genomic coordinates
+ * Matches: chr1:12345, chr1:12345-67890, X:12345, 1:12345-67890
+ */
+const GENOMIC_COORD_PATTERN = /\b(chr)?([0-9]{1,2}|X|Y|M|MT):(\d+)(-\d+)?\b/gi
+
+/**
+ * Regex pattern for patient/sample identifiers
+ * Matches: PATIENT-12345, SAMPLE_ABC123, SUBJECT:XYZ789, ID-ABC123
+ */
+const PATIENT_ID_PATTERN = /\b(PATIENT|SAMPLE|SUBJECT|ID)[_:-]?[A-Z0-9]{3,}\b/gi
+
+/**
+ * Sanitizes log messages by redacting sensitive genetic and medical data
+ *
+ * @param message - The log message to sanitize
+ * @returns The sanitized message with sensitive data replaced by redaction markers
+ */
+export function sanitizeLogMessage(message: string): string {
+  let sanitized = message
+
+  // Quick pre-check for HGVS notation (contains '.' followed by digit)
+  if (/[cgpmn]\.\d/i.test(sanitized) === true) {
+    sanitized = sanitized.replace(HGVS_PATTERN, '[REDACTED:HGVS]')
+  }
+
+  // Quick pre-check for genomic coordinates (contains ':' with digits)
+  if (/:\d/.test(sanitized) === true) {
+    sanitized = sanitized.replace(GENOMIC_COORD_PATTERN, '[REDACTED:COORD]')
+  }
+
+  // Quick pre-check for patient IDs (contains known prefixes)
+  if (/\b(PATIENT|SAMPLE|SUBJECT|ID)[_:-]/i.test(sanitized) === true) {
+    sanitized = sanitized.replace(PATIENT_ID_PATTERN, '[REDACTED:ID]')
+  }
+
+  return sanitized
+}

--- a/tests/main/services/main-logger-redaction.test.ts
+++ b/tests/main/services/main-logger-redaction.test.ts
@@ -1,0 +1,88 @@
+import Module from 'node:module'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// MainLogger.ts uses guarded CommonJS require() so worker-thread imports don't
+// load Electron. Patch Node's loader directly for this test boundary.
+const mockWebContentsSend = vi.fn()
+const mockGetAllWindows = vi.fn(() => [
+  { isDestroyed: () => false, webContents: { send: mockWebContentsSend } }
+])
+const mockFileLog = {
+  initialize: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  transports: {
+    file: {
+      level: '',
+      maxSize: 0,
+      format: '',
+      getFile: () => ({ path: '/tmp/varlens-test.log' })
+    },
+    console: { level: '' }
+  }
+}
+
+const originalLoad = Module._load
+
+describe('MainLogger PHI redaction', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.spyOn(Module, '_load').mockImplementation((request, parent, isMain) => {
+      if (request === 'electron') {
+        return { BrowserWindow: { getAllWindows: mockGetAllWindows } }
+      }
+      if (request === 'electron-log/main') {
+        return mockFileLog
+      }
+      return originalLoad(request, parent, isMain)
+    })
+    mockFileLog.initialize.mockReset()
+    mockFileLog.error.mockReset()
+    mockFileLog.info.mockReset()
+    mockWebContentsSend.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('redacts HGVS, coords, and patient IDs from the file-write path', async () => {
+    const { mainLogger } = await import('../../../src/main/services/MainLogger')
+    mainLogger.error('variant chr1:12345 c.123A>G failed for PATIENT-001', 'import')
+
+    expect(mockFileLog.error).toHaveBeenCalledOnce()
+    const writtenLine = mockFileLog.error.mock.calls[0][0] as string
+    expect(writtenLine).toContain('[REDACTED:COORD]')
+    expect(writtenLine).toContain('[REDACTED:HGVS]')
+    expect(writtenLine).toContain('[REDACTED:ID]')
+    expect(writtenLine).not.toContain('chr1:12345')
+    expect(writtenLine).not.toContain('c.123A>G')
+    expect(writtenLine).not.toContain('PATIENT-001')
+  })
+
+  it('redacts the webContents.send payload too', async () => {
+    const { mainLogger } = await import('../../../src/main/services/MainLogger')
+    mainLogger.error('variant chr1:12345 c.123A>G failed for PATIENT-001', 'import')
+
+    expect(mockWebContentsSend).toHaveBeenCalledOnce()
+    const [channel, payload] = mockWebContentsSend.mock.calls[0]
+    expect(channel).toBe('logs:message')
+    expect(payload.message).toContain('[REDACTED:COORD]')
+    expect(payload.message).toContain('[REDACTED:HGVS]')
+    expect(payload.message).toContain('[REDACTED:ID]')
+    expect(payload.message).not.toContain('chr1:12345')
+    expect(payload.message).not.toContain('c.123A>G')
+    expect(payload.message).not.toContain('PATIENT-001')
+  })
+
+  it('does not redact a benign control message', async () => {
+    const { mainLogger } = await import('../../../src/main/services/MainLogger')
+    mainLogger.info('startup complete in 1.42s', 'main')
+
+    const writtenLine = mockFileLog.info.mock.calls[0][0] as string
+    expect(writtenLine).toContain('startup complete in 1.42s')
+    expect(writtenLine).not.toContain('[REDACTED:')
+  })
+})


### PR DESCRIPTION
## Summary

- QW-1: hoist sanitizer to `src/shared/utils/sanitizers.ts` (relative import — no `@shared` alias in this repo), wire into MainLogger file + IPC paths, new redaction test
- QW-2: backfill CHANGELOG for 13 undocumented tags (v0.56.8-v0.56.14, v0.58.0-v0.58.3, v0.59.0, v0.59.3); add release-runbook line gating package.json bumps on [Unreleased] promotion
- QW-3: assert tag matches package.json in release workflow

Spec: `.planning/specs/2026-05-26-pre-060-hardening.md`

## Test plan

- [x] `make ci-full` green
- [x] `npx vitest run tests/main/services/main-logger-redaction.test.ts` — 3/3 pass
- [x] CHANGELOG gate: all 13 required headings present, `## [Unreleased]` remains, no v0.57.x or v0.59.1/2/4 headings, runbook exists
- [ ] **Post-merge** synthetic mismatched-tag dry run on a throwaway branch (gate 4 — destructive, cannot run pre-merge)

## Gate 4 dry-run plan

Verification of acceptance gate 4 will be executed on the PR feature branch after merge because it is destructive on main:

1. On a throwaway branch with package.json reverted to a stale version, push a tag whose ref does NOT match: `git tag vTEST-9.9.9 && git push origin vTEST-9.9.9`.
2. Expected: create-release job fails at the new assertion step with the "Tag X implies version Y but package.json reports Z" error.
3. Delete the draft release if any, and delete the tag both locally and on origin.