### PR TITLE
chore: security + CI hygiene

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
               - 'tsconfig*.json'
               - 'eslint.config.js'
               - '.prettierignore'
-              - '.github/workflows/build.yml'
+              - '.github/workflows/**'
               - 'vitest.config.ts'
               - 'Makefile'
 
@@ -260,21 +260,36 @@ jobs:
 
   # ── 4. Required-status-check aggregator ────────────────────────────
   # Branch protection should require THIS job (and secrets-scan) only.
-  # It succeeds when all upstream jobs succeeded OR were correctly
-  # skipped (docs-only PRs). This avoids the `paths-ignore` pending-
-  # forever trap.
+  # It succeeds when all upstream jobs succeeded, except docs-only PRs
+  # where code-gated jobs were intentionally skipped. This avoids the
+  # `paths-ignore` pending-forever trap while still failing on cancelled
+  # or unexpectedly skipped upstream jobs.
   ci:
     name: CI
     needs: [changes, secrets-scan, checks, package]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if any required job failed
+      - name: Compute overall result
         run: |
-          if [[ "${{ needs.secrets-scan.result }}" == "failure" ]] \
-             || [[ "${{ needs.checks.result }}"       == "failure" ]] \
-             || [[ "${{ needs.package.result }}"      == "failure" ]]; then
-            echo "One or more required jobs failed"
-            exit 1
+          for r in \
+            "${{ needs.changes.result }}" \
+            "${{ needs.secrets-scan.result }}"; do
+            if [ "$r" != "success" ]; then
+              echo "::error::Required job result was '$r' (expected 'success'). Failing."
+              exit 1
+            fi
+          done
+          if [ "${{ needs.changes.outputs.code }}" = "false" ]; then
+            echo "No code changed; build jobs were intentionally skipped. PASS."
+            exit 0
           fi
-          echo "All required jobs passed or were correctly skipped"
+          for r in \
+            "${{ needs.checks.result }}" \
+            "${{ needs.package.result }}"; do
+            if [ "$r" != "success" ]; then
+              echo "::error::Required job result was '$r' (expected 'success'). Failing."
+              exit 1
+            fi
+          done
+          echo "All required jobs succeeded."

--- a/package-lock.json
+++ b/package-lock.json
@@ -5381,12 +5381,12 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
       "license": "ISC",
       "dependencies": {
-        "bn.js": "^5.2.2",
+        "bn.js": "^5.2.3",
         "browserify-rsa": "^4.1.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -12813,9 +12813,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { initAutoUpdater, scheduleUpdateChecks } from './services/AutoUpdater'
 import { APP_CONFIG } from '../shared/config'
 import { isUrlSafeForExternal } from './utils/url-validation'
 import { markMilestone } from './services/MainPerfTrace'
+import { isMainWindowNavigationAllowed } from './window-navigation-policy'
 
 if (process.env.VARLENS_APP_DATA_DIR !== undefined && process.env.VARLENS_APP_DATA_DIR !== '') {
   app.setPath('appData', process.env.VARLENS_APP_DATA_DIR)
@@ -73,6 +74,7 @@ function createWindow(): void {
       v8CacheOptions: 'bypassHeatCheck'
     }
   })
+  const rendererUrl = process.env['ELECTRON_RENDERER_URL']
 
   mainWindow.on('ready-to-show', () => {
     mainWindow.show()
@@ -90,9 +92,16 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    const allowed = isMainWindowNavigationAllowed(url, rendererUrl)
+    if (!allowed) {
+      mainLogger.warn(`Blocked in-page navigation to disallowed URL: ${url}`, 'main-window')
+      event.preventDefault()
+    }
+  })
+
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
-  const rendererUrl = process.env['ELECTRON_RENDERER_URL']
   if (is.dev && rendererUrl !== undefined && rendererUrl !== '') {
     mainWindow.loadURL(rendererUrl)
   } else {

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -153,10 +153,28 @@ class InsecureLocalPostgresSecretStore implements SecretStore {
 }
 
 let defaultPostgresProfileStore: PostgresProfileStore | null = null
+let insecureSecretStoreWarned = false
+
+function warnIfInsecureSecretStore(): void {
+  if (insecureSecretStoreWarned) {
+    return
+  }
+
+  if (process.env.VARLENS_POSTGRES_PROFILE_SECRET_STORE === 'insecure-local') {
+    mainLogger.warn(
+      'VARLENS_POSTGRES_PROFILE_SECRET_STORE=insecure-local is active. ' +
+        'PostgreSQL profile credentials are stored in plaintext. ' +
+        'Unset this env var or set it to a secure backend before any production-like workflow.',
+      'database-handler'
+    )
+    insecureSecretStoreWarned = true
+  }
+}
 
 function getDefaultPostgresProfileStore(): PostgresProfileStore {
   if (defaultPostgresProfileStore === null) {
     const userDataPath = app.getPath('userData')
+    warnIfInsecureSecretStore()
     const secretStore =
       process.env.VARLENS_POSTGRES_PROFILE_SECRET_STORE === 'insecure-local'
         ? createInsecureLocalPostgresSecretStore(userDataPath)

--- a/src/main/window-navigation-policy.ts
+++ b/src/main/window-navigation-policy.ts
@@ -1,0 +1,9 @@
+export function isMainWindowNavigationAllowed(
+  url: string,
+  rendererUrl: string | undefined
+): boolean {
+  return (
+    (rendererUrl !== undefined && rendererUrl !== '' && url.startsWith(rendererUrl)) ||
+    url.startsWith('file://')
+  )
+}

--- a/tests/main/handlers/database-handlers.test.ts
+++ b/tests/main/handlers/database-handlers.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 import { mainLogger } from '../../../src/main/services/MainLogger'
 import { ErrorCode } from '../../../src/shared/types/errors'
@@ -7,9 +11,18 @@ import type {
 } from '../../../src/shared/types/postgres-profile'
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => process.env.VARLENS_TEST_USER_DATA_PATH ?? tmpdir()),
+    isPackaged: false
+  },
   dialog: {
     showOpenDialog: vi.fn(),
     showSaveDialog: vi.fn()
+  },
+  safeStorage: {
+    decryptString: vi.fn(),
+    encryptString: vi.fn(),
+    isEncryptionAvailable: vi.fn(() => true)
   },
   shell: {
     showItemInFolder: vi.fn()
@@ -232,5 +245,48 @@ describe('database IPC handlers', () => {
     })
 
     expect(openPostgresSession).toHaveBeenCalledWith(session)
+  })
+
+  it('warns once when the insecure postgres profile secret store is activated', async () => {
+    const previousSecretStore = process.env.VARLENS_POSTGRES_PROFILE_SECRET_STORE
+    const previousUserDataPath = process.env.VARLENS_TEST_USER_DATA_PATH
+    const userDataPath = await mkdtemp(join(tmpdir(), 'varlens-profile-store-'))
+    const warnSpy = vi.spyOn(mainLogger, 'warn').mockImplementation(() => undefined)
+
+    process.env.VARLENS_POSTGRES_PROFILE_SECRET_STORE = 'insecure-local'
+    process.env.VARLENS_TEST_USER_DATA_PATH = userDataPath
+
+    try {
+      const { handlers } = await createHandlerMap()
+
+      await expect(handlers.get('database:postgresProfilesList')!()).resolves.toEqual([])
+      await expect(handlers.get('database:postgresProfilesList')!()).resolves.toEqual([])
+
+      expect(warnSpy).toHaveBeenCalledOnce()
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'VARLENS_POSTGRES_PROFILE_SECRET_STORE=insecure-local is active. ' +
+            'PostgreSQL profile credentials are stored in plaintext. ' +
+            'Unset this env var or set it to a secure backend before any production-like workflow.'
+        ),
+        'database-handler'
+      )
+    } finally {
+      if (previousSecretStore === undefined) {
+        delete process.env.VARLENS_POSTGRES_PROFILE_SECRET_STORE
+      } else {
+        process.env.VARLENS_POSTGRES_PROFILE_SECRET_STORE = previousSecretStore
+      }
+
+      if (previousUserDataPath === undefined) {
+        delete process.env.VARLENS_TEST_USER_DATA_PATH
+      } else {
+        process.env.VARLENS_TEST_USER_DATA_PATH = previousUserDataPath
+      }
+
+      warnSpy.mockRestore()
+      await rm(userDataPath, { recursive: true, force: true })
+      vi.resetModules()
+    }
   })
 })

--- a/tests/main/window-navigation-policy.test.ts
+++ b/tests/main/window-navigation-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isMainWindowNavigationAllowed } from '../../src/main/window-navigation-policy'
+
+describe('main window navigation policy', () => {
+  it('allows navigation within the development renderer URL', () => {
+    expect(
+      isMainWindowNavigationAllowed(
+        'http://localhost:5173/assets/index.js',
+        'http://localhost:5173'
+      )
+    ).toBe(true)
+  })
+
+  it('allows file URLs for the packaged renderer', () => {
+    expect(isMainWindowNavigationAllowed('file:///app/renderer/index.html', undefined)).toBe(true)
+  })
+
+  it('blocks non-file URLs when no development renderer URL is configured', () => {
+    expect(isMainWindowNavigationAllowed('https://example.com', undefined)).toBe(false)
+    expect(isMainWindowNavigationAllowed('https://example.com', '')).toBe(false)
+  })
+
+  it('blocks external URLs outside the development renderer URL', () => {
+    expect(isMainWindowNavigationAllowed('https://example.com', 'http://localhost:5173')).toBe(
+      false
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- fixes the remaining moderate production audit finding by refreshing the `qs` transitive under `pg`
- blocks renderer-initiated in-page navigation with the QW-6 main-window policy helper
- tightens Build workflow gating so workflow-only edits run CI and cancelled/skipped required jobs fail
- warns once per session when `VARLENS_POSTGRES_PROFILE_SECRET_STORE=insecure-local` activates plaintext PostgreSQL profile secret storage

## Validation
- `make ci-full` passed: checks, startup smoke, Linux package, packaged smoke
- `make agent-check` passed
- `git diff --check origin/main..HEAD` passed
- `npm audit --omit=dev` reports 0 moderate / 0 high / 0 critical findings
- focused reviewer checks passed for navigation policy and database handler warning tests

## Accepted Residual Audit Lows
`npm audit --omit=dev` still exits nonzero because the spec accepts the remaining 5 low advisories from the `elliptic` / `pdbe-molstar` chain:
- `elliptic`
- `browserify-sign`
- `crypto-browserify`
- `create-ecdh`
- `pdbe-molstar`

Fixing those requires the out-of-scope breaking `pdbe-molstar` update.

Refs `.planning/plans/2026-05-26-pre-060-hardening-plan.md` PR-3 / QW-4, QW-6, QW-12, QW-13, QW-15.
