### PR TITLE
perf: hot-path cleanup

### DIFF
--- a/scripts/perf/compare-wgs-import.mjs
+++ b/scripts/perf/compare-wgs-import.mjs
@@ -19,6 +19,7 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 const ARTIFACT_DIR = resolve(process.cwd(), '.planning/artifacts/perf/wgs-import')
+const BUDGET = 2.0
 
 function listBaselines() {
   let entries
@@ -64,10 +65,10 @@ function main() {
   const ts = new Date().toISOString().replace(/[:.]/g, '-')
   const out = resolve(ARTIFACT_DIR, `${ts}-comparison.md`)
 
-  const escalates = ratio > 2.0
+  const escalates = ratio > BUDGET
   const escalationLine = escalates
-    ? `- escalation triggered: postgres / sqlite = ${ratio.toFixed(2)}× (> 2.0×). Open a follow-up phase to switch postgres to COPY FROM STDIN via pg-copy-streams.`
-    : `- escalation rule: postgres / sqlite must stay ≤ 2.0×; current ratio is within budget.`
+    ? `- escalation triggered: postgres / sqlite = ${ratio.toFixed(2)}× (> ${BUDGET.toFixed(1)}×). Open a follow-up phase to switch postgres to COPY FROM STDIN via pg-copy-streams.`
+    : `- escalation rule: postgres / sqlite must stay ≤ ${BUDGET.toFixed(1)}×; current ratio is within budget.`
 
   writeFileSync(
     out,
@@ -82,6 +83,12 @@ function main() {
     ].join('\n')
   )
   globalThis.console.log(`Wrote ${out}`)
+  if (escalates) {
+    globalThis.console.error(
+      `::error::WGS import budget breach: ratio ${ratio.toFixed(2)} exceeds budget ${BUDGET.toFixed(2)}`
+    )
+    process.exit(1)
+  }
 }
 
 main()

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -42,6 +42,7 @@ import { BUILT_IN_SHORTLIST_PRESETS } from './built-in-shortlist-presets'
  * - 25: Multi-variant type support (SV/CNV/STR extension tables, case_import_files)
  * - 26: v0.55.0 FTS5 virtual tables for variant_sv + variant_str (multi-variant filter/sort/search)
  * - 27: filter_presets.kind discriminator + built-in shortlist preset seeds (unified Shortlist tab)
+ * - 28: idx_variants_case_type for case_id-first cohort scans
  *
  * @param db - better-sqlite3-multiple-ciphers Database instance
  */
@@ -1716,5 +1717,14 @@ export function runMigrations(db: Database.Database): void {
     }
 
     db.exec('PRAGMA user_version = 27')
+  }
+
+  // Migration v28: add idx_variants_case_type for case_id-first cohort scans
+  // QW-10 (Phase 1 Pre-0.60 Hardening, audit Perf-01 #4/#10)
+  // Keeps the existing idx_variants_type_case (variant_type, case_id) intact
+  // because the variant-extension-registry planner reasoning depends on it.
+  if (currentVersion < 28) {
+    db.exec('CREATE INDEX IF NOT EXISTS idx_variants_case_type ON variants(case_id, variant_type)')
+    db.exec('PRAGMA user_version = 28')
   }
 }

--- a/src/main/storage/postgres/migrations/definitions.ts
+++ b/src/main/storage/postgres/migrations/definitions.ts
@@ -33,6 +33,11 @@ const MIGRATION_FILES: readonly MigrationFile[] = [
     version: '0006',
     name: 'create_audit_log',
     fileName: '0006_create_audit_log.sql'
+  },
+  {
+    version: '0007',
+    name: 'perf_indexes',
+    fileName: '0007_perf_indexes.sql'
   }
 ]
 

--- a/src/main/storage/postgres/migrations/sql/0007_perf_indexes.sql
+++ b/src/main/storage/postgres/migrations/sql/0007_perf_indexes.sql
@@ -1,0 +1,19 @@
+-- QW-16 (Phase 1 Pre-0.60 Hardening, audit Sch-03 F3, BP-05 §5)
+-- Adds the two cheapest cohort-scan indexes that PostgreSQL is missing today.
+-- The JSONB GIN on info_json is deferred to Sprint B per the audit, bundled
+-- with the partitioning work.
+--
+-- "__schema__" is the template placeholder replaced by the migration runner
+-- at execution time (see 0001_create_cases.sql and friends for the pattern).
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- BRIN on (chr, pos): cohort scans are positional and the table is
+-- naturally clustered by load order, which is the BRIN sweet spot.
+CREATE INDEX IF NOT EXISTS variants_brin_chr_pos
+  ON "__schema__"."variants" USING BRIN (chr, pos);
+
+-- Trigram GIN on gene_symbol: substring/case-insensitive gene-name
+-- lookups from the cohort filter UI go through this index.
+CREATE INDEX IF NOT EXISTS variants_gene_trgm
+  ON "__schema__"."variants" USING GIN (gene_symbol gin_trgm_ops);

--- a/src/main/workers/import-finalization.ts
+++ b/src/main/workers/import-finalization.ts
@@ -1,0 +1,40 @@
+import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
+
+import { rebuildFts } from './worker-db'
+
+export interface ImportFtsFinalizationState {
+  ftsTriggersDropped: boolean
+  ftsRebuilt: boolean
+}
+
+type RebuildFtsFn = (db: DatabaseType) => void
+type CleanupFn = () => void
+type PostMessageFn<T> = (message: T) => void
+
+export function finalizeInterruptedImportFts(
+  db: DatabaseType,
+  state: ImportFtsFinalizationState,
+  rebuild: RebuildFtsFn = rebuildFts
+): boolean {
+  if (!state.ftsTriggersDropped || state.ftsRebuilt) return false
+
+  try {
+    rebuild(db)
+    state.ftsRebuilt = true
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function postTerminalMessageAfterCleanup<T>(
+  terminalMessage: T | null | undefined,
+  cleanup: CleanupFn,
+  postMessage: PostMessageFn<T>
+): void {
+  cleanup()
+
+  if (terminalMessage !== null && terminalMessage !== undefined) {
+    postMessage(terminalMessage)
+  }
+}

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -19,7 +19,6 @@ import { createFieldMapper } from '../import/transforms/FieldMapper'
 import { createObjectFormatMapper } from '../import/transforms/ObjectFormatMapper'
 import { resolveColumnIndices } from '../import/config/fieldMapping'
 import { createDecompressedStream, isGzipped } from '../import/stream-utils'
-import { createFTSTriggers } from '../database/schema'
 import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
 import { parseVcfLine } from '../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../import/vcf/VcfMapper'
@@ -240,29 +239,11 @@ export function prepareStatements(db: DatabaseType) {
     db.exec(DROP_FTS_TRIGGERS)
   }
 
-  /**
-   * Rebuild FTS, recreate triggers, and update the case variant_count
-   * after all batches for one file have been inserted.
-   */
   function finishBulkInsert(caseId: number, totalInserted: number): void {
+    // QW-11: Per-file FTS rebuild + trigger recreate removed (audit Perf-01 #8).
+    // Session-end rebuildFts(db) in import-worker.ts handles the single FTS
+    // rebuild for the whole import session.
     updateVariantCountStmt.run(totalInserted, caseId)
-
-    try {
-      db.exec("INSERT INTO variants_fts(variants_fts) VALUES('rebuild')")
-    } catch (e) {
-      console.warn(
-        '[import-pipeline] Failed to rebuild FTS index during finishBulkInsert:',
-        e instanceof Error ? e.message : String(e)
-      )
-    }
-    try {
-      db.exec(createFTSTriggers)
-    } catch (e) {
-      console.warn(
-        '[import-pipeline] Failed to recreate FTS triggers during finishBulkInsert:',
-        e instanceof Error ? e.message : String(e)
-      )
-    }
   }
 
   return {

--- a/src/main/workers/import-worker.ts
+++ b/src/main/workers/import-worker.ts
@@ -9,6 +9,11 @@ import { detectFormat } from '../import/format-detection'
 import { MARK_STALE_SQL } from '../../shared/sql/cohort-summary-rebuild'
 import { openWorkerDatabase, rebuildFts, rebuildCohortSummary } from './worker-db'
 import {
+  finalizeInterruptedImportFts,
+  postTerminalMessageAfterCleanup,
+  type ImportFtsFinalizationState
+} from './import-finalization'
+import {
   DROP_FTS_TRIGGERS,
   DROP_INDEXES,
   RECREATE_INDEXES,
@@ -32,6 +37,11 @@ port.on('message', async (msg: MainMessage) => {
   if (msg.type === 'start') {
     cancelled = false
     let db: DatabaseType | null = null
+    let terminalMessage: WorkerMessage | undefined
+    const ftsFinalizationState: ImportFtsFinalizationState = {
+      ftsTriggersDropped: false,
+      ftsRebuilt: false
+    }
 
     try {
       db = openWorkerDatabase(msg.dbPath, msg.encryptionKey)
@@ -40,6 +50,7 @@ port.on('message', async (msg: MainMessage) => {
 
       // Drop FTS triggers and non-essential indexes at start (batch optimization)
       db.exec(DROP_FTS_TRIGGERS)
+      ftsFinalizationState.ftsTriggersDropped = true
       db.exec(DROP_INDEXES)
 
       // Mark cohort summary as stale before import
@@ -250,61 +261,68 @@ port.on('message', async (msg: MainMessage) => {
       // FTS rebuild + ANALYZE + optimize
       sendProgress(totalFiles, totalFiles, '', 99, 'finalizing', 0, 0)
       rebuildFts(db)
+      ftsFinalizationState.ftsRebuilt = true
       rebuildCohortSummary(db)
 
       const completeMsg: WorkerMessage = {
         type: 'complete',
         results: { succeeded, failed, skipped, cancelled, details: results }
       }
-      port.postMessage(completeMsg)
+      terminalMessage = completeMsg
     } catch (fatalError) {
       // Index/trigger recreation is handled unconditionally in the finally block below
 
-      const errorMsg: WorkerMessage = {
+      terminalMessage = {
         type: 'error',
         fileIndex: -1,
         error: fatalError instanceof Error ? fatalError.message : String(fatalError),
         phase: 'fatal',
         stack: fatalError instanceof Error ? fatalError.stack : undefined
       }
-      port.postMessage(errorMsg)
     } finally {
-      if (db) {
-        try {
-          db.exec(RECREATE_INDEXES)
-        } catch (e) {
-          console.warn(
-            '[import-worker] Failed to recreate indexes (will be recreated on next app start):',
-            e instanceof Error ? e.message : String(e)
-          )
-        }
-        try {
-          db.pragma('wal_checkpoint(TRUNCATE)')
-        } catch (e) {
-          console.warn(
-            '[import-worker] Failed to truncate WAL checkpoint:',
-            e instanceof Error ? e.message : String(e)
-          )
-        }
-        try {
-          db.pragma('synchronous = NORMAL')
-          db.pragma('wal_autocheckpoint = 1000')
-          db.pragma('foreign_keys = ON')
-        } catch (e) {
-          console.warn(
-            '[import-worker] Failed to restore pragmas after import:',
-            e instanceof Error ? e.message : String(e)
-          )
-        }
-        try {
-          db.close()
-        } catch (e) {
-          console.warn(
-            '[import-worker] Failed to close database:',
-            e instanceof Error ? e.message : String(e)
-          )
-        }
-      }
+      postTerminalMessageAfterCleanup(
+        terminalMessage,
+        () => {
+          if (db) {
+            finalizeInterruptedImportFts(db, ftsFinalizationState)
+            try {
+              db.exec(RECREATE_INDEXES)
+            } catch (e) {
+              console.warn(
+                '[import-worker] Failed to recreate indexes (will be recreated on next app start):',
+                e instanceof Error ? e.message : String(e)
+              )
+            }
+            try {
+              db.pragma('wal_checkpoint(TRUNCATE)')
+            } catch (e) {
+              console.warn(
+                '[import-worker] Failed to truncate WAL checkpoint:',
+                e instanceof Error ? e.message : String(e)
+              )
+            }
+            try {
+              db.pragma('synchronous = NORMAL')
+              db.pragma('wal_autocheckpoint = 1000')
+              db.pragma('foreign_keys = ON')
+            } catch (e) {
+              console.warn(
+                '[import-worker] Failed to restore pragmas after import:',
+                e instanceof Error ? e.message : String(e)
+              )
+            }
+            try {
+              db.close()
+            } catch (e) {
+              console.warn(
+                '[import-worker] Failed to close database:',
+                e instanceof Error ? e.message : String(e)
+              )
+            }
+          }
+        },
+        (message) => port.postMessage(message)
+      )
     }
   }
 })

--- a/tests/main/database/FilterPresetRepository.test.ts
+++ b/tests/main/database/FilterPresetRepository.test.ts
@@ -30,7 +30,7 @@ describe('migration v15 - filter_presets', () => {
 
   it('sets user_version to latest', () => {
     const version = db.pragma('user_version', { simple: true })
-    expect(version).toBe(27)
+    expect(version).toBe(28)
   })
 
   it('creates unique index on name', () => {

--- a/tests/main/database/PanelRepository.test.ts
+++ b/tests/main/database/PanelRepository.test.ts
@@ -54,7 +54,7 @@ describe('PanelRepository', () => {
 
     it('sets user_version to latest', () => {
       const version = db.pragma('user_version', { simple: true })
-      expect(version).toBe(27)
+      expect(version).toBe(28)
     })
   })
 

--- a/tests/main/database/migration-v13.test.ts
+++ b/tests/main/database/migration-v13.test.ts
@@ -67,6 +67,6 @@ describe('Migration v13-v14: cohort summary tables', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const version = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(version.user_version).toBe(27)
+    expect(version.user_version).toBe(28)
   })
 })

--- a/tests/main/database/migration-v8.test.ts
+++ b/tests/main/database/migration-v8.test.ts
@@ -40,6 +40,6 @@ describe('Migration v8: age and date_of_birth', () => {
 
   it('sets schema version to latest after all migrations', () => {
     const result = db.pragma('user_version') as Array<{ user_version: number }>
-    expect(result[0].user_version).toBe(27)
+    expect(result[0].user_version).toBe(28)
   })
 })

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -131,7 +131,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(27)
+      expect(versionResult.user_version).toBe(28)
 
       service.close()
 
@@ -141,7 +141,7 @@ describe('Schema Migrations', () => {
       const versionAfterReopen = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionAfterReopen.user_version).toBe(27)
+      expect(versionAfterReopen.user_version).toBe(28)
 
       service.close()
     })
@@ -468,7 +468,7 @@ describe('Schema Migrations', () => {
       let versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(27)
+      expect(versionResult.user_version).toBe(28)
 
       service.close()
 
@@ -484,11 +484,11 @@ describe('Schema Migrations', () => {
       expect(tableNamesAfterReopen).toContain('variant_annotations')
       expect(tableNamesAfterReopen).toContain('case_variant_annotations')
 
-      // Verify user_version is latest (v15 creates filter_presets, v16 reseeds, v17 adds perf indexes, v18 adds covering index, …, v27 adds shortlist seeds)
+      // Verify user_version is latest (v15 creates filter_presets, v16 reseeds, v17 adds perf indexes, v18 adds covering index, …, v28 adds case/type index)
       versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(27)
+      expect(versionResult.user_version).toBe(28)
 
       service.close()
     })
@@ -522,7 +522,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(27)
+      expect(versionResult.user_version).toBe(28)
 
       service.close()
     })
@@ -760,7 +760,7 @@ describe('Schema Migrations', () => {
       const version = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(version.user_version).toBe(27)
+      expect(version.user_version).toBe(28)
 
       service.close()
     })
@@ -799,9 +799,9 @@ describe('Schema Migrations', () => {
       const indexNames = indexes.map((i) => i.name)
       expect(indexNames).toContain('idx_cvs_cohort_freq')
 
-      // Verify user_version = latest (v15 + v16 + v17 + v18 + … + v27 all run)
+      // Verify user_version = latest (v15 + v16 + v17 + v18 + … + v28 all run)
       const version = db.pragma('user_version', { simple: true }) as number
-      expect(version).toBe(27)
+      expect(version).toBe(28)
 
       service.close()
     })
@@ -1257,8 +1257,35 @@ describe('migration v27 — filter_presets.kind + shortlist seeds', () => {
     expect(idx).toBeTruthy()
   })
 
-  it('PRAGMA user_version = 27 after migration', () => {
+  it('PRAGMA user_version = 28 after migration', () => {
     const v = db.pragma('user_version', { simple: true })
-    expect(v).toBe(27)
+    expect(v).toBe(28)
+  })
+})
+
+describe('migration v28 — variants case/type index', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    initializeSchema(db)
+    runMigrations(db)
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  it('creates case/type index while retaining type/case index column order', () => {
+    const indexColumns = (indexName: string): string[] => {
+      const rows = db.prepare(`PRAGMA index_info('${indexName}')`).all() as Array<{
+        seqno: number
+        name: string
+      }>
+      return rows.sort((a, b) => a.seqno - b.seqno).map((row) => row.name)
+    }
+
+    expect(indexColumns('idx_variants_case_type')).toEqual(['case_id', 'variant_type'])
+    expect(indexColumns('idx_variants_type_case')).toEqual(['variant_type', 'case_id'])
   })
 })

--- a/tests/main/database/vcf-migration.test.ts
+++ b/tests/main/database/vcf-migration.test.ts
@@ -46,14 +46,14 @@ describe('Migration v23: VCF import columns', () => {
   it('sets user_version to latest', () => {
     runMigrations(db)
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(27)
+    expect(result.user_version).toBe(28)
   })
 
   it('is idempotent — running migrations twice does not fail', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(27)
+    expect(result.user_version).toBe(28)
   })
 
   it('new variant columns are nullable and default to NULL', () => {

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -3,15 +3,16 @@ import { describe, expect, it } from 'vitest'
 import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
 
 describe('Postgres migration definitions', () => {
-  it('loads the initial PostgreSQL migrations with SQL and sha256 checksums', () => {
-    expect(POSTGRES_MIGRATIONS).toHaveLength(6)
+  it('loads the PostgreSQL migrations with SQL and sha256 checksums', () => {
+    expect(POSTGRES_MIGRATIONS).toHaveLength(7)
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.version)).toEqual([
       '0001',
       '0002',
       '0003',
       '0004',
       '0005',
-      '0006'
+      '0006',
+      '0007'
     ])
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.name)).toEqual([
       'create_cases',
@@ -19,7 +20,8 @@ describe('Postgres migration definitions', () => {
       'create_variants',
       'generated_search_documents',
       'create_workflow_tables',
-      'create_audit_log'
+      'create_audit_log',
+      'perf_indexes'
     ])
 
     for (const migration of POSTGRES_MIGRATIONS) {
@@ -27,5 +29,12 @@ describe('Postgres migration definitions', () => {
       expect(migration.sql.trim()).not.toHaveLength(0)
       expect(migration.checksum).toMatch(/^[a-f0-9]{64}$/)
     }
+
+    const perfMigration = POSTGRES_MIGRATIONS.find((migration) => migration.version === '0007')
+    expect(perfMigration?.sql).toContain('CREATE EXTENSION IF NOT EXISTS pg_trgm')
+    expect(perfMigration?.sql).toContain('ON "__schema__"."variants" USING BRIN (chr, pos)')
+    expect(perfMigration?.sql).toContain(
+      'ON "__schema__"."variants" USING GIN (gene_symbol gin_trgm_ops)'
+    )
   })
 })

--- a/tests/main/workers/import-finalization.test.ts
+++ b/tests/main/workers/import-finalization.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
+
+import {
+  finalizeInterruptedImportFts,
+  postTerminalMessageAfterCleanup,
+  type ImportFtsFinalizationState
+} from '../../../src/main/workers/import-finalization'
+
+describe('finalizeInterruptedImportFts', () => {
+  it('rebuilds FTS when triggers were dropped and normal rebuild did not run', () => {
+    const db = {} as DatabaseType
+    const state: ImportFtsFinalizationState = {
+      ftsTriggersDropped: true,
+      ftsRebuilt: false
+    }
+    const rebuildFts = vi.fn()
+
+    const rebuilt = finalizeInterruptedImportFts(db, state, rebuildFts)
+
+    expect(rebuilt).toBe(true)
+    expect(rebuildFts).toHaveBeenCalledExactlyOnceWith(db)
+    expect(state.ftsRebuilt).toBe(true)
+  })
+
+  it('does not rebuild FTS when normal rebuild already ran', () => {
+    const db = {} as DatabaseType
+    const state: ImportFtsFinalizationState = {
+      ftsTriggersDropped: true,
+      ftsRebuilt: true
+    }
+    const rebuildFts = vi.fn()
+
+    const rebuilt = finalizeInterruptedImportFts(db, state, rebuildFts)
+
+    expect(rebuilt).toBe(false)
+    expect(rebuildFts).not.toHaveBeenCalled()
+  })
+})
+
+describe('postTerminalMessageAfterCleanup', () => {
+  it('runs cleanup before posting a terminal message', () => {
+    const events: string[] = []
+
+    postTerminalMessageAfterCleanup(
+      { type: 'error', fileIndex: -1 },
+      () => {
+        events.push('cleanup')
+      },
+      (msg) => {
+        events.push(`post:${msg.type}:${msg.fileIndex}`)
+      }
+    )
+
+    expect(events).toEqual(['cleanup', 'post:error:-1'])
+  })
+
+  it('runs cleanup without posting when there is no terminal message', () => {
+    const cleanup = vi.fn()
+    const postMessage = vi.fn()
+
+    postTerminalMessageAfterCleanup(null, cleanup, postMessage)
+
+    expect(cleanup).toHaveBeenCalledOnce()
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+})

--- a/tests/main/workers/import-pipeline.test.ts
+++ b/tests/main/workers/import-pipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { join } from 'node:path'
 import Database from 'better-sqlite3-multiple-ciphers'
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
@@ -22,6 +22,7 @@ describe('prepareStatements', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     db.close()
   })
 
@@ -98,6 +99,17 @@ describe('prepareStatements', () => {
       variant_count: number
     }
     expect(row.variant_count).toBe(42)
+  })
+
+  it('finishBulkInsert does not rebuild FTS or recreate FTS triggers per file', () => {
+    const stmts = prepareStatements(db)
+    const execSpy = vi.spyOn(db, 'exec')
+    const caseResult = stmts.insertCase.run('test', '/path', 100, Date.now(), 'GRCh38')
+    const caseId = Number(caseResult.lastInsertRowid)
+
+    stmts.finishBulkInsert(caseId, 42)
+
+    expect(execSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/main/workers/streaming-import.test.ts
+++ b/tests/main/workers/streaming-import.test.ts
@@ -30,7 +30,6 @@ import { parseVcfHeaderFromLines } from '../../../src/main/import/vcf/vcf-header
 import { parseVcfLine } from '../../../src/main/import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../../../src/main/import/vcf/VcfMapper'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../../../src/main/import/vcf/info-field-registry'
-import { createFTSTriggers } from '../../../src/main/database/schema'
 import type { VcfHeader } from '../../../src/main/import/vcf/types'
 
 // Fixtures
@@ -153,16 +152,6 @@ function buildStmts(db: DatabaseType) {
 
   function finishBulkInsert(caseId: number, totalInserted: number): void {
     updateVariantCountStmt.run(totalInserted, caseId)
-    try {
-      db.exec("INSERT INTO variants_fts(variants_fts) VALUES('rebuild')")
-    } catch {
-      // best effort
-    }
-    try {
-      db.exec(createFTSTriggers)
-    } catch {
-      // best effort
-    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- QW-10: add SQLite migration v28, `idx_variants_case_type (case_id, variant_type)`, while keeping `idx_variants_type_case` for variant-type-first reads.
- QW-11: drop per-file FTS rebuild / trigger recreation from `finishBulkInsert`; session-end `rebuildFts(db)` remains before `rebuildCohortSummary(db)`.
- QW-14: make `scripts/perf/compare-wgs-import.mjs` exit non-zero on WGS budget breach; script-only, no Makefile change.
- QW-16: add PG migration `0007_perf_indexes` with BRIN `(chr, pos)` and `pg_trgm` GIN on `gene_symbol`, using quoted `"__schema__"."variants"`.

QW-5 (`cloneForIpc` -> `structuredClone`) remains dropped from Phase 1; the JSON round-trip keeps stripping Vue proxies intentionally.

Spec: `.planning/specs/2026-05-26-pre-060-hardening.md`

## Test plan

- [x] `make agent-check`
- [x] `make ci-full`
- [x] `make build`
- [x] `TMPDIR=/home/bernt-popp/development VARLENS_PERF_OUTPUT=.planning/artifacts/perf/phase1/post-change-final npx playwright test tests/e2e/renderer-perf-phase1.e2e.ts --workers=1`
- [x] `node scripts/perf/compare-phase1.mjs .planning/artifacts/perf/phase1/baseline-fresh .planning/artifacts/perf/phase1/post-change-final`
- [x] Temporary isolated Postgres 18 migration smoke: applied SQL migrations `0001` through `0007` with `"__schema__"` -> `"public"`; verified `pg_trgm`, `variants_brin_chr_pos`, and `variants_gene_trgm` exist.
- [x] `make rebuild-node && npx vitest run tests/main/import/ tests/main/workers/`
- [x] `npx vitest run tests/main/storage/`

## EXPLAIN evidence

`EXPLAIN QUERY PLAN SELECT * FROM variants WHERE case_id = 1 AND variant_type = 'snv';`

- Before v28: `SEARCH variants USING INDEX idx_variants_type_case (variant_type=? AND case_id=?)`
- After v28: `SEARCH variants USING INDEX idx_variants_case_type (case_id=? AND variant_type=?)`

## Renderer perf

Final same-session comparison used fresh `main` control artifacts and final branch artifacts:

Baseline: `.planning/artifacts/perf/phase1/baseline-fresh` (`28142f264aa47ea3358594635faf1dc80044d422`)
Post-change: `.planning/artifacts/perf/phase1/post-change-final` (`618fba4a51da3575caf61aa7f45812211f71676a`)
Comparison: `.planning/artifacts/perf/phase1/comparison/summary-final.md`

| Workflow | Baseline p50 | Post-change p50 | Delta p50 | Baseline p95 | Post-change p95 | Delta p95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| startup-shell | 998.72 | 901.71 | -97.01 | 1180.75 | 1080.55 | -100.20 |
| case-select-visible-rows | 1041.48 | 1019.73 | -21.75 | 1108.19 | 1085.97 | -22.22 |
| filter-apply | 815.53 | 832.89 | +17.36 | 860.35 | 869.50 | +9.15 |
| page-next-prev | 639.44 | 658.59 | +19.15 | 719.89 | 743.36 | +23.47 |
| cohort-toggle | 218.32 | 239.24 | +20.92 | 312.71 | 320.02 | +7.31 |
| keyboard-nav-burst | 82.40 | 81.59 | -0.81 | 87.10 | 95.88 | +8.78 |

Readout: no material renderer regression. The small positive p50 deltas are within observed harness variance; a same-SHA baseline rerun showed p50 drift up to +45.14 ms.