### PR TITLE
chore(release): bump version to 0.59.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.59.5",
+  "version": "0.59.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.59.5",
+      "version": "0.59.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.59.5",
+  "version": "0.59.6",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/berntpopp/VarLens",


### PR DESCRIPTION
## Summary
- Bump VarLens package metadata from 0.59.5 to 0.59.6 after the dependency hardening PR #230.
- Updates package.json and package-lock.json only.

## Validation
- make ci

After this PR merges and build.yml passes on the merged SHA, tag v0.59.6 for release.