### PR TITLE
chore(release): bump version to 0.59.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.59.6",
+  "version": "0.59.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.59.6",
+      "version": "0.59.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.59.6",
+  "version": "0.59.7",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/berntpopp/VarLens",


### PR DESCRIPTION
## Summary
- bump package version from 0.59.6 to 0.59.7 after merging the vue-tsc patch update
- keep package-lock root metadata in sync

## Validation
- make ci
