### PR TITLE
chore(release): bump version to 0.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.59.7",
+  "version": "0.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.59.7",
+      "version": "0.60.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.59.7",
+  "version": "0.60.0",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/berntpopp/VarLens",


### PR DESCRIPTION
## Summary
- bump package metadata from 0.59.7 to 0.60.0 after the minor-level #214 merge

## Verification
- make ci