### PR TITLE
fix(web): rate-limit login surfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/secure-session": "^8.2.0",
         "@fastify/static": "^9.1.1",
         "@fastify/swagger": "^9.7.0",
@@ -1559,6 +1560,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@fastify/secure-session": {

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     }
   },
   "dependencies": {
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/secure-session": "^8.2.0",
     "@fastify/static": "^9.1.1",
     "@fastify/swagger": "^9.7.0",

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -34,6 +34,7 @@ import { registerSessions } from './server/auth'
 import { registerEventStream, WebEventHub } from './server/events'
 import { registerLoginRoute, resolveAppPathPrefix } from './server/login-route'
 import { registerPageGate } from './server/page-gate'
+import { registerWebRateLimit } from './server/rate-limit'
 import { registerOpenApi } from './server/routes/openapi'
 import { registerStatic } from './server/static'
 import {
@@ -90,6 +91,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   })
   const metrics = options.metrics ?? createAppMetricsFromEnv()
   registerRequestMetrics(app, metrics)
+  await registerWebRateLimit(app)
 
   const session: PostgresStorageSession = await createPostgresStorageSession(pgConfig)
   // Share the storage session's pool with the auth service so we open

--- a/src/web/server/auth.ts
+++ b/src/web/server/auth.ts
@@ -34,6 +34,7 @@ import type { FastifyInstance } from 'fastify'
 import secureSession from '@fastify/secure-session'
 
 import type { PostgresWebAuthService } from '../auth/PostgresWebAuthService'
+import { registerAuthLoginRateLimit } from './rate-limit'
 
 declare module '@fastify/secure-session' {
   interface SessionData {
@@ -240,4 +241,6 @@ export async function registerSessions(
       passwordChangedAt: liveUser.password_changed_at
     }
   })
+
+  registerAuthLoginRateLimit(app)
 }

--- a/src/web/server/login-route.ts
+++ b/src/web/server/login-route.ts
@@ -30,6 +30,8 @@ import { resolve } from 'node:path'
 
 import type { FastifyInstance } from 'fastify'
 
+import { buildLoginPageRateLimitConfig } from './rate-limit'
+
 const LOGIN_HTML_FILENAME = 'login.html'
 
 export const DEFAULT_APP_PATH_PREFIX = '/varlens'
@@ -148,6 +150,8 @@ export function renderLoginPage(appPathPrefix: string, redirectTo: string): stri
 
 export function registerLoginRoute(app: FastifyInstance): void {
   const appPathPrefix = resolveAppPathPrefix()
+  const loginPageRateLimit = buildLoginPageRateLimitConfig()
+  const loginPageRateLimiter = app.rateLimit(loginPageRateLimit)
 
   const handler = async (
     request: { query: unknown },
@@ -168,6 +172,20 @@ export function registerLoginRoute(app: FastifyInstance): void {
     return reply.send(html)
   }
 
-  app.get('/login', handler)
-  app.get('/login/', handler)
+  app.get(
+    '/login',
+    {
+      onRequest: [loginPageRateLimiter],
+      config: { rateLimit: loginPageRateLimit }
+    },
+    handler
+  )
+  app.get(
+    '/login/',
+    {
+      onRequest: [loginPageRateLimiter],
+      config: { rateLimit: loginPageRateLimit }
+    },
+    handler
+  )
 }

--- a/src/web/server/rate-limit.ts
+++ b/src/web/server/rate-limit.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance } from 'fastify'
+import rateLimit from '@fastify/rate-limit'
+
+const RATE_LIMIT_WINDOW_MS = 60_000
+const LOGIN_PAGE_RATE_LIMIT_MAX_ENV = 'VARLENS_LOGIN_PAGE_RATE_LIMIT_MAX'
+const AUTH_LOGIN_RATE_LIMIT_MAX_ENV = 'VARLENS_AUTH_LOGIN_RATE_LIMIT_MAX'
+
+function positiveIntegerFromEnv(params: {
+  env: NodeJS.ProcessEnv
+  name: string
+  fallback: number
+  max: number
+}): number {
+  const raw = params.env[params.name]
+  if (raw === undefined || raw.trim() === '') return params.fallback
+
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1 || value > params.max) {
+    throw new Error(`${params.name} must be an integer in [1, ${params.max}]; got ${raw}`)
+  }
+  return value
+}
+
+export function buildLoginPageRateLimitConfig(env: NodeJS.ProcessEnv = process.env): {
+  max: number
+  timeWindow: number
+  groupId: string
+} {
+  return {
+    max: positiveIntegerFromEnv({
+      env,
+      name: LOGIN_PAGE_RATE_LIMIT_MAX_ENV,
+      fallback: 120,
+      max: 10_000
+    }),
+    timeWindow: RATE_LIMIT_WINDOW_MS,
+    groupId: 'login-page'
+  }
+}
+
+export async function registerWebRateLimit(app: FastifyInstance): Promise<void> {
+  await app.register(rateLimit, {
+    global: false,
+    timeWindow: RATE_LIMIT_WINDOW_MS
+  })
+}
+
+export function registerAuthLoginRateLimit(
+  app: FastifyInstance,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  const checkRateLimit = app.createRateLimit({
+    max: positiveIntegerFromEnv({
+      env,
+      name: AUTH_LOGIN_RATE_LIMIT_MAX_ENV,
+      fallback: 10,
+      max: 10_000
+    }),
+    timeWindow: RATE_LIMIT_WINDOW_MS,
+    keyGenerator: (request) => `auth-login:${request.ip}`
+  })
+
+  app.addHook('preHandler', async (request, reply) => {
+    const path = request.url.split('?', 1)[0]
+    if (request.method !== 'POST' || path !== '/api/auth/login') return
+
+    const result = await checkRateLimit(request)
+    if (result.isExceeded !== true) return
+
+    reply.code(429)
+    reply.header('retry-after', String(Math.max(1, result.ttlInSeconds)))
+    return reply.send({
+      code: 'RATE_LIMITED',
+      message: 'login rate limit exceeded',
+      userMessage: 'Too many login attempts. Try again shortly.'
+    })
+  })
+}

--- a/tests/web-gate/integration/auth-gate.test.ts
+++ b/tests/web-gate/integration/auth-gate.test.ts
@@ -112,6 +112,46 @@ describe.skipIf(!isWebBuilt || !HAS_PG)('web auth gate', () => {
     }
   })
 
+  test('public auth login API is rate-limited by client address', async () => {
+    const isolated = await startIsolatedWebSchema('auth_gate_login_rate_limit')
+    const previousLimit = process.env.VARLENS_AUTH_LOGIN_RATE_LIMIT_MAX
+    process.env.VARLENS_AUTH_LOGIN_RATE_LIMIT_MAX = '2'
+    try {
+      const { defaultPasswordProvider } =
+        await import('../../../src/main/auth/providers/argon2-provider')
+      const passwordHash = await defaultPasswordProvider.hashPassword(PASSWORD)
+      const { buildApp } = await import('../../../src/web/server')
+      const app = await buildApp({
+        admin: { username: USERNAME, passwordHash, displayName: 'Rate Limit Admin' }
+      })
+      try {
+        const attempt = async (): Promise<InjectResult> =>
+          (await app.inject({
+            method: 'POST',
+            url: '/api/auth/login',
+            payload: { args: [USERNAME, 'wrong-password'] },
+            headers: SAME_ORIGIN_HEADERS
+          })) as unknown as InjectResult
+
+        expect((await attempt()).statusCode).toBe(200)
+        expect((await attempt()).statusCode).toBe(200)
+
+        const limited = await attempt()
+        expect(limited.statusCode, limited.body).toBe(429)
+        expect(limited.json()).toMatchObject({
+          code: 'RATE_LIMITED',
+          message: 'login rate limit exceeded'
+        })
+      } finally {
+        await app.close()
+      }
+    } finally {
+      if (previousLimit === undefined) delete process.env.VARLENS_AUTH_LOGIN_RATE_LIMIT_MAX
+      else process.env.VARLENS_AUTH_LOGIN_RATE_LIMIT_MAX = previousLimit
+      await isolated.close()
+    }
+  })
+
   test('production login sets a host-only secure strict session cookie', async () => {
     const isolated = await startIsolatedWebSchema('auth_gate_cookie')
     process.env.NODE_ENV = 'production'

--- a/tests/web-gate/integration/page-gate.test.ts
+++ b/tests/web-gate/integration/page-gate.test.ts
@@ -29,6 +29,10 @@ const HAS_PG = typeof process.env.VARLENS_PG_URL === 'string' && process.env.VAR
 // emitted `out/web/login/login.html`.
 const SOURCE_LOGIN_HTML = resolve(process.cwd(), 'src/web/login/login.html')
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+}
+
 describe.skipIf(!isWebBuilt || !HAS_PG)('login-wall integration', () => {
   let app: {
     inject: (
@@ -61,9 +65,7 @@ describe.skipIf(!isWebBuilt || !HAS_PG)('login-wall integration', () => {
     // next request lands at https://<host>/varlens/login on its way
     // back through Caddy.
     const prefix = (process.env.APP_PATH_PREFIX ?? '/varlens').replace(/\/$/, '')
-    expect(location).toMatch(
-      new RegExp('^' + prefix.replace(/\//g, '\\/') + '\\/login(\\?next=|$)')
-    )
+    expect(location).toMatch(new RegExp('^' + escapeRegExp(prefix) + '/login(\\?next=|$)'))
   })
 
   test('anonymous GET /assets/anything is also walled', async () => {

--- a/tests/web-gate/login-route.test.ts
+++ b/tests/web-gate/login-route.test.ts
@@ -9,14 +9,20 @@
  * gate suite.
  */
 import { describe, expect, test, beforeEach, afterEach } from 'vitest'
+import Fastify from 'fastify'
+import rateLimit from '@fastify/rate-limit'
+import { resolve } from 'path'
 
 import {
   DEFAULT_APP_PATH_PREFIX,
   LOGIN_PAGE_CSP,
+  registerLoginRoute,
   renderLoginPage,
   resolveAppPathPrefix,
   sanitizeNextParam
 } from '../../src/web/server/login-route'
+
+const SOURCE_LOGIN_HTML = resolve(process.cwd(), 'src/web/login/login.html')
 
 describe('resolveAppPathPrefix', () => {
   const original = process.env.APP_PATH_PREFIX
@@ -134,5 +140,30 @@ describe('login page CSP', () => {
     expect(LOGIN_PAGE_CSP).toContain("default-src 'none'")
     expect(LOGIN_PAGE_CSP).toContain("connect-src 'self'")
     expect(LOGIN_PAGE_CSP).toContain("frame-ancestors 'none'")
+  })
+})
+
+describe('login page rate limiting', () => {
+  test('limits /login and /login/ as one public-page group', async () => {
+    const previousHtmlPath = process.env.VARLENS_LOGIN_HTML_PATH
+    const previousMax = process.env.VARLENS_LOGIN_PAGE_RATE_LIMIT_MAX
+    process.env.VARLENS_LOGIN_HTML_PATH = SOURCE_LOGIN_HTML
+    process.env.VARLENS_LOGIN_PAGE_RATE_LIMIT_MAX = '2'
+
+    const app = Fastify({ logger: false })
+    try {
+      await app.register(rateLimit, { global: false })
+      registerLoginRoute(app)
+
+      expect((await app.inject({ method: 'GET', url: '/login' })).statusCode).toBe(200)
+      expect((await app.inject({ method: 'GET', url: '/login/' })).statusCode).toBe(200)
+      expect((await app.inject({ method: 'GET', url: '/login' })).statusCode).toBe(429)
+    } finally {
+      await app.close()
+      if (previousHtmlPath === undefined) delete process.env.VARLENS_LOGIN_HTML_PATH
+      else process.env.VARLENS_LOGIN_HTML_PATH = previousHtmlPath
+      if (previousMax === undefined) delete process.env.VARLENS_LOGIN_PAGE_RATE_LIMIT_MAX
+      else process.env.VARLENS_LOGIN_PAGE_RATE_LIMIT_MAX = previousMax
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add @fastify/rate-limit with route-level limits for the public /login page and /login/ alias
- add a custom JSON 429 limiter for POST /api/auth/login before password verification
- escape dynamic regex input in the page-gate test to satisfy CodeQL

Builds on merged Dependabot PR 237 (@fastify/static 9.1.1) and addresses CodeQL code scanning alerts 5, 6, and 7.

## Verification
- npx vitest run --project web-gate tests/web-gate/login-route.test.ts tests/web-gate/metrics-labels.test.ts
- VARLENS_PG_URL=... VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-security-rate-limit-auth npx vitest run --project web-gate tests/web-gate/integration/auth-gate.test.ts -t "rate-limited"
- VARLENS_PG_URL=... VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-security-rate-limit-page npx vitest run --project web-gate tests/web-gate/integration/page-gate.test.ts
- npx eslint src/web/server.ts src/web/server/auth.ts src/web/server/login-route.ts src/web/server/rate-limit.ts tests/web-gate/login-route.test.ts tests/web-gate/integration/auth-gate.test.ts tests/web-gate/integration/page-gate.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.node.json
- make agent-check
- VARLENS_PG_URL=... VARLENS_RECOVERY_KEY_DIR=/tmp/varlens-security-web-ci make web-ci
- make ci-full