### PR TITLE
feat(postgres): materialised cohort + column-meta summary with incremental add/remove

### DIFF
--- a/scripts/agent-health-baseline.json
+++ b/scripts/agent-health-baseline.json
@@ -24,10 +24,10 @@
     },
     {
       "path": "src/main/storage/postgres/PostgresCohortRepository.ts",
-      "lines": 1071,
+      "lines": 1097,
       "threshold": 600,
       "category": "source",
-      "reason": "existing large storage/import module; grew for Sprint A PR-3 C4 — queryVariants now reads the materialised cohort_variant_summary via a summary-page path (querySummaryPage) with a live-aggregation fallback (queryLivePage), and getColumnMeta reads the deduped summary table directly; pure SQL builders are already extracted into postgres-cohort-summary-query.ts and the per-case reshape helpers into postgres-column-meta-cache.ts, so the residual growth is the repo's own orchestration (two read paths + cvs column-meta mapping) — further splitting the live/summary read paths into separate repository classes is a separate responsibility-split task"
+      "reason": "existing large storage/import module; grew for Sprint A PR-3 C4 — queryVariants now reads the materialised cohort_variant_summary via a summary-page path (querySummaryPage) with a live-aggregation fallback (queryLivePage), and getColumnMeta reads the deduped summary table directly; pure SQL builders are already extracted into postgres-cohort-summary-query.ts and the per-case reshape helpers into postgres-column-meta-cache.ts, so the residual growth is the repo's own orchestration (two read paths + cvs column-meta mapping) — further splitting the live/summary read paths into separate repository classes is a separate responsibility-split task. PR3-17 (C5) added two thin delegating accessors (queryVariantsWithStaleness, getSummaryStatus, ~26 lines) that forward to the extracted cohort-read-freshness module; the staleness/bootstrap policy itself lives outside this file so the repo only gains the seam, not the logic"
     },
     {
       "path": "src/main/workers/postgres-import-worker.ts",
@@ -136,10 +136,10 @@
     },
     {
       "path": "src/shared/types/api.ts",
-      "lines": 920,
+      "lines": 927,
       "threshold": 600,
       "category": "source",
-      "reason": "existing shared contract surface; must not grow before contract split. Sprint A additions to this central interface are structurally unavoidable: PR-1 A1 added the `BatchAnnotationKey` type (Pass-8 #1) used across the annotations IPC contract; PR-2 added a new top-level WindowAPI domain key (`debug: DebugAPI`) plus its import and the `DebugAPI` alias that resolves the Gate 10c preload-contract test back to the domain contract. Neither can be split out without breaking the contract or its tests."
+      "reason": "existing shared contract surface; must not grow before contract split. Sprint A additions to this central interface are structurally unavoidable: PR-1 A1 added the `BatchAnnotationKey` type (Pass-8 #1) used across the annotations IPC contract; PR-2 added a new top-level WindowAPI domain key (`debug: DebugAPI`) plus its import and the `DebugAPI` alias that resolves the Gate 10c preload-contract test back to the domain contract. PR-3 PR3-17 (C5/Gate 10b) widened the existing `CohortAPI.getVariants` return shape with an optional `warnings?: { staleSummary?: boolean }` field — a same-method contract extension that must live on the central interface and cannot be split out. Neither can be split out without breaking the contract or its tests."
     },
     {
       "path": "src/shared/types/database.ts",

--- a/scripts/agent-health-baseline.json
+++ b/scripts/agent-health-baseline.json
@@ -31,10 +31,10 @@
     },
     {
       "path": "src/main/workers/postgres-import-worker.ts",
-      "lines": 964,
+      "lines": 1066,
       "threshold": 600,
       "category": "source",
-      "reason": "existing large storage/import module; must not grow before responsibility split"
+      "reason": "existing large storage/import module; grew for Sprint A PR-3 C3 — the cohort-summary incrementalAdd/recompute/refreshColumnMetas update MUST run inside the worker's existing post-loop transaction (the worker is the real txn owner, Pass-2 #5), wrapped in a SAVEPOINT and wired into all three commit sites; the logic is already extracted into the named updateCohortSummaryAfterImport helper, so further splitting the worker is a separate responsibility-split task"
     },
     {
       "path": "src/renderer/src/components/CaseList.vue",

--- a/scripts/agent-health-baseline.json
+++ b/scripts/agent-health-baseline.json
@@ -136,10 +136,10 @@
     },
     {
       "path": "src/shared/types/api.ts",
-      "lines": 910,
+      "lines": 920,
       "threshold": 600,
       "category": "source",
-      "reason": "existing shared contract surface; must not grow before contract split. Sprint A PR-2 (debug domain): adding a new top-level WindowAPI domain key (`debug: DebugAPI`) plus its import and the `DebugAPI` alias unavoidably touches this central interface; the alias resolves the Gate 10c preload-contract test back to the domain contract and cannot be split out without breaking that resolution."
+      "reason": "existing shared contract surface; must not grow before contract split. Sprint A additions to this central interface are structurally unavoidable: PR-1 A1 added the `BatchAnnotationKey` type (Pass-8 #1) used across the annotations IPC contract; PR-2 added a new top-level WindowAPI domain key (`debug: DebugAPI`) plus its import and the `DebugAPI` alias that resolves the Gate 10c preload-contract test back to the domain contract. Neither can be split out without breaking the contract or its tests."
     },
     {
       "path": "src/shared/types/database.ts",

--- a/scripts/agent-health-baseline.json
+++ b/scripts/agent-health-baseline.json
@@ -24,10 +24,10 @@
     },
     {
       "path": "src/main/storage/postgres/PostgresCohortRepository.ts",
-      "lines": 957,
+      "lines": 1071,
       "threshold": 600,
       "category": "source",
-      "reason": "existing large storage/import module; must not grow before responsibility split"
+      "reason": "existing large storage/import module; grew for Sprint A PR-3 C4 — queryVariants now reads the materialised cohort_variant_summary via a summary-page path (querySummaryPage) with a live-aggregation fallback (queryLivePage), and getColumnMeta reads the deduped summary table directly; pure SQL builders are already extracted into postgres-cohort-summary-query.ts and the per-case reshape helpers into postgres-column-meta-cache.ts, so the residual growth is the repo's own orchestration (two read paths + cvs column-meta mapping) — further splitting the live/summary read paths into separate repository classes is a separate responsibility-split task"
     },
     {
       "path": "src/main/workers/postgres-import-worker.ts",

--- a/scripts/agent-health-postgres-baseline.json
+++ b/scripts/agent-health-postgres-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-29T02:44:39.323Z",
-  "count": 18,
+  "generatedAt": "2026-05-29T02:51:21.150Z",
+  "count": 19,
   "violations": [
     {
       "file": "PostgresAnalysisGroupsRepository.ts",
@@ -34,13 +34,18 @@
     },
     {
       "file": "PostgresCohortSummaryRepository.ts",
-      "line": 46,
+      "line": 93,
       "snippet": "await client.query(`TRUNCATE ${tbl('cohort_variant_summary')}`)"
     },
     {
       "file": "PostgresCohortSummaryRepository.ts",
-      "line": 51,
+      "line": 98,
       "snippet": "await client.query(`"
+    },
+    {
+      "file": "PostgresCohortSummaryRepository.ts",
+      "line": 336,
+      "snippet": "await client.query(`DELETE FROM ${tbl('cohort_variant_summary')} WHERE carrier_count <= 0`)"
     },
     {
       "file": "PostgresFilterPresetsRepository.ts",

--- a/scripts/agent-health-postgres-baseline.json
+++ b/scripts/agent-health-postgres-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-29T02:51:21.150Z",
-  "count": 19,
+  "generatedAt": "2026-05-29T03:03:05.659Z",
+  "count": 21,
   "violations": [
     {
       "file": "PostgresAnalysisGroupsRepository.ts",
@@ -34,18 +34,28 @@
     },
     {
       "file": "PostgresCohortSummaryRepository.ts",
-      "line": 93,
+      "line": 137,
       "snippet": "await client.query(`TRUNCATE ${tbl('cohort_variant_summary')}`)"
     },
     {
       "file": "PostgresCohortSummaryRepository.ts",
-      "line": 98,
+      "line": 142,
       "snippet": "await client.query(`"
     },
     {
       "file": "PostgresCohortSummaryRepository.ts",
-      "line": 336,
+      "line": 380,
       "snippet": "await client.query(`DELETE FROM ${tbl('cohort_variant_summary')} WHERE carrier_count <= 0`)"
+    },
+    {
+      "file": "PostgresCohortSummaryRepository.ts",
+      "line": 397,
+      "snippet": "await client.query(`DELETE FROM ${tbl('cohort_column_meta')} WHERE case_id = $1`, [caseId])"
+    },
+    {
+      "file": "PostgresCohortSummaryRepository.ts",
+      "line": 494,
+      "snippet": "await client.query(`DELETE FROM ${tbl('cohort_column_meta')} WHERE case_id = $1`, [caseId])"
     },
     {
       "file": "PostgresFilterPresetsRepository.ts",

--- a/scripts/agent-health-postgres-baseline.json
+++ b/scripts/agent-health-postgres-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-29T02:05:36.988Z",
-  "count": 16,
+  "generatedAt": "2026-05-29T02:44:39.323Z",
+  "count": 18,
   "violations": [
     {
       "file": "PostgresAnalysisGroupsRepository.ts",
@@ -31,6 +31,16 @@
       "file": "PostgresCaseMetadataRepository.ts",
       "line": 199,
       "snippet": "await client.query(`DELETE FROM ${this.table('case_cohort_links')} WHERE case_id = $1`, ["
+    },
+    {
+      "file": "PostgresCohortSummaryRepository.ts",
+      "line": 46,
+      "snippet": "await client.query(`TRUNCATE ${tbl('cohort_variant_summary')}`)"
+    },
+    {
+      "file": "PostgresCohortSummaryRepository.ts",
+      "line": 51,
+      "snippet": "await client.query(`"
     },
     {
       "file": "PostgresFilterPresetsRepository.ts",

--- a/scripts/perf/build-100-case-fixture.mjs
+++ b/scripts/perf/build-100-case-fixture.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * 100-case perf fixture builder (Sprint A PR-3, C6).
+ *
+ * Generates 100 GIAB-derived cases by replicating and downsampling the existing
+ * columnar perf fixture (tests/fixtures/import/columnar-format.json), landing the
+ * total variant count near the ~5M target. The base fixture's ~50 annotated rows
+ * are tiled with per-replica position offsets so each case carries a realistic
+ * spread of distinct loci rather than exact duplicates.
+ *
+ * Output lands in tests/.cache/perf-100case/ (gitignored via tests/.cache/). The
+ * builder is idempotent: if manifest.json already reports matching case and
+ * variant counts within bounds, the run is a no-op.
+ *
+ * Each case is written as a wrapped-columnar .json.gz file
+ * ({ "<caseId>": { header, data } }) so the existing import pipeline can ingest
+ * it unchanged. The manifest has the shape:
+ *   { generatedAt, totalCases, totalVariants, cases: [{ id, filePath, variantCount }] }
+ *
+ * This same generator seeds Sprint D's 1000-case fixture (bump TARGET_CASES).
+ *
+ * Usage:
+ *   node scripts/perf/build-100-case-fixture.mjs
+ */
+import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(SCRIPT_DIR, '..', '..')
+
+const OUT_DIR = join(REPO_ROOT, 'tests', '.cache', 'perf-100case')
+const MANIFEST_PATH = join(OUT_DIR, 'manifest.json')
+const BASE_FIXTURE = join(REPO_ROOT, 'tests', 'fixtures', 'import', 'columnar-format.json')
+
+const TARGET_CASES = 100
+const TARGET_VARIANTS = 5_000_000
+const VARIANT_BOUNDS = [TARGET_VARIANTS * 0.8, TARGET_VARIANTS * 1.2]
+
+const PER_CASE_VARIANTS = Math.round(TARGET_VARIANTS / TARGET_CASES)
+
+/**
+ * Position offset applied per replica tile so successive copies of the base rows
+ * occupy distinct loci. 1 Mb keeps offsets well clear of one another.
+ */
+const REPLICA_POS_OFFSET = 1_000_000
+
+function readBaseFixture() {
+  const raw = JSON.parse(readFileSync(BASE_FIXTURE, 'utf8'))
+  const caseKey = Object.keys(raw)[0]
+  const { header, data } = raw[caseKey]
+  if (!Array.isArray(header) || !Array.isArray(data)) {
+    throw new Error(`Base fixture ${BASE_FIXTURE} is not wrapped columnar`)
+  }
+  // Column indices used for per-replica offsetting (Pos is column 1).
+  const posIndex = header.findIndex((col) => col.id === 'Pos')
+  if (posIndex < 0) {
+    throw new Error('Base fixture is missing a "Pos" column')
+  }
+  return { header, baseRows: data, posIndex }
+}
+
+/**
+ * Build the data array for a single case by tiling the base rows until the
+ * per-case variant target is reached, offsetting Pos per tile so loci stay
+ * distinct across replicas.
+ */
+function buildCaseRows(baseRows, posIndex, target) {
+  const rows = new Array(target)
+  const baseCount = baseRows.length
+  for (let i = 0; i < target; i++) {
+    const base = baseRows[i % baseCount]
+    const tile = Math.floor(i / baseCount)
+    const row = base.slice()
+    row[posIndex] = base[posIndex] + tile * REPLICA_POS_OFFSET
+    rows[i] = row
+  }
+  return rows
+}
+
+function manifestMatches() {
+  if (!existsSync(MANIFEST_PATH)) return false
+  let manifest
+  try {
+    manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'))
+  } catch {
+    return false
+  }
+  if (manifest.totalCases !== TARGET_CASES) return false
+  if (!Array.isArray(manifest.cases) || manifest.cases.length !== TARGET_CASES) return false
+  const total = manifest.totalVariants
+  if (typeof total !== 'number') return false
+  if (total < VARIANT_BOUNDS[0] || total > VARIANT_BOUNDS[1]) return false
+  // Confirm every declared case file still exists on disk.
+  return manifest.cases.every(
+    (entry) => typeof entry.filePath === 'string' && existsSync(join(REPO_ROOT, entry.filePath))
+  )
+}
+
+function relFromRoot(absPath) {
+  return absPath.slice(REPO_ROOT.length + 1)
+}
+
+function main() {
+  if (manifestMatches()) {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'))
+    process.stdout.write(
+      `[perf-100case] up to date: ${manifest.totalCases} cases, ${manifest.totalVariants} variants — no-op\n`
+    )
+    return
+  }
+
+  mkdirSync(OUT_DIR, { recursive: true })
+
+  const { header, baseRows, posIndex } = readBaseFixture()
+
+  const cases = []
+  let totalVariants = 0
+
+  for (let c = 0; c < TARGET_CASES; c++) {
+    const caseId = `perf-case-${String(c + 1).padStart(3, '0')}`
+    const rows = buildCaseRows(baseRows, posIndex, PER_CASE_VARIANTS)
+    const payload = { [caseId]: { header, data: rows } }
+    const json = JSON.stringify(payload)
+    const gz = gzipSync(Buffer.from(json, 'utf8'))
+    const absPath = join(OUT_DIR, `${caseId}.json.gz`)
+    writeFileSync(absPath, gz)
+
+    totalVariants += rows.length
+    cases.push({ id: caseId, filePath: relFromRoot(absPath), variantCount: rows.length })
+  }
+
+  if (totalVariants < VARIANT_BOUNDS[0] || totalVariants > VARIANT_BOUNDS[1]) {
+    throw new Error(
+      `Total variant count ${totalVariants} is outside bounds [${VARIANT_BOUNDS[0]}, ${VARIANT_BOUNDS[1]}]`
+    )
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    totalCases: cases.length,
+    totalVariants,
+    cases
+  }
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n')
+
+  process.stdout.write(
+    `[perf-100case] generated ${cases.length} cases, ${totalVariants} variants -> ${relFromRoot(OUT_DIR)}\n`
+  )
+}
+
+main()

--- a/src/main/database/cohort.ts
+++ b/src/main/database/cohort.ts
@@ -109,8 +109,13 @@ export class CohortService {
     // Panel interval filter (region-based, cohort-specific — not in buildBaseWhere)
     if (params.panel_intervals && params.panel_intervals.length > 0) {
       const intervalConditions = params.panel_intervals.map((iv) => {
-        paramsArray.push(iv.chr, iv.start, iv.end)
-        return '(cvs.chr = ? AND cvs.pos BETWEEN ? AND ?)'
+        // Interval-overlap (not point-in-interval) so a spanning SV/CNV whose
+        // start lies outside [start,end] but which covers the region is still
+        // included — parity with the PG cohort query (Pass-9 #7 / Gate 9).
+        // COALESCE(end_pos, pos) makes SNVs (end_pos NULL) behave exactly as the
+        // prior `pos BETWEEN start AND end`.
+        paramsArray.push(iv.chr, iv.end, iv.start)
+        return '(cvs.chr = ? AND cvs.pos <= ? AND COALESCE(cvs.end_pos, cvs.pos) >= ?)'
       })
       whereConditions.push(`(${intervalConditions.join(' OR ')})`)
     }

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -1736,4 +1736,23 @@ export function runMigrations(db: Database.Database): void {
     db.exec('CREATE INDEX IF NOT EXISTS idx_variants_coords ON variants(chr, pos, ref, alt)')
     db.exec('PRAGMA user_version = 29')
   }
+
+  // Migration v30: end_pos on cohort_variant_summary for SV/CNV interval-overlap.
+  // Sprint A PR-3 (C7 / Gate 9 parity gap-fill). The PG cohort summary built in
+  // this PR supports spanning-SV panel-interval queries via end_pos overlap; this
+  // mirrors that on SQLite so backend parity holds (Pass-9 #7). Sourced from
+  // variants.end_pos; SNVs leave it NULL and COALESCE(end_pos, pos) preserves the
+  // prior point-in-interval behaviour. Idempotent ALTER (mirrors the v14 pattern).
+  if (currentVersion < 30) {
+    const cvsCols30 = db.prepare('PRAGMA table_info(cohort_variant_summary)').all() as {
+      name: string
+    }[]
+    if (!new Set(cvsCols30.map((c) => c.name)).has('end_pos')) {
+      db.exec('ALTER TABLE cohort_variant_summary ADD COLUMN end_pos INTEGER')
+    }
+    db.exec(
+      'CREATE INDEX IF NOT EXISTS idx_cvs_end_pos ON cohort_variant_summary(chr, end_pos) WHERE end_pos IS NOT NULL'
+    )
+    db.exec('PRAGMA user_version = 30')
+  }
 }

--- a/src/main/ipc/handlers/cohort-logic.ts
+++ b/src/main/ipc/handlers/cohort-logic.ts
@@ -362,7 +362,10 @@ export async function getSummaryStatus(
 ): Promise<unknown> {
   const postgresSession = getPostgresSession(getSession)
   if (postgresSession !== undefined) {
-    return { is_stale: false, last_rebuilt_at: 0 }
+    return await postgresSession.getReadExecutor().execute({
+      type: 'cohort:summaryStatus',
+      params: []
+    })
   }
 
   const pool = getDbPool?.()

--- a/src/main/storage/postgres/PostgresAnnotationsRepository.ts
+++ b/src/main/storage/postgres/PostgresAnnotationsRepository.ts
@@ -123,6 +123,20 @@ export class PostgresAnnotationsRepository {
     alt: string,
     updates: GlobalAnnotationUpdates
   ): Promise<VariantAnnotation> {
+    return this._upsertGlobalAnnotationOn(this.pool, chr, pos, ref, alt, updates)
+  }
+
+  // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
+  // Public wrapper and *WithAudit transactions both route through here so the
+  // upsert never opens its own transaction (would nest under audit's BEGIN).
+  private async _upsertGlobalAnnotationOn(
+    client: QueryablePool,
+    chr: string,
+    pos: number,
+    ref: string,
+    alt: string,
+    updates: GlobalAnnotationUpdates
+  ): Promise<VariantAnnotation> {
     const schemaName = quoteIdentifier(this.schema)
     const commentProvided = 'global_comment' in updates
     const starredProvided = updates.starred !== undefined
@@ -143,7 +157,7 @@ export class PostgresAnnotationsRepository {
       acmgEvidenceProvided
     ]
 
-    const result = await runNamed(this.pool as Pool, {
+    const result = await runNamed(client as Pool, {
       name: 'annotations:upsert_global:v1',
       text: `
         INSERT INTO ${schemaName}."variant_annotations" (
@@ -199,7 +213,7 @@ export class PostgresAnnotationsRepository {
       const annotations = new PostgresAnnotationsRepository(client, this.schema)
       const audit = new PostgresAuditLogRepository(client, this.schema)
       const oldAnnotation = await annotations.getGlobalAnnotation(chr, pos, ref, alt)
-      const result = await annotations.upsertGlobalAnnotation(chr, pos, ref, alt, updates)
+      const result = await this._upsertGlobalAnnotationOn(client, chr, pos, ref, alt, updates)
       for (const entry of globalAnnotationAuditEntries(
         { chr, pos, ref, alt },
         updates,
@@ -218,8 +232,19 @@ export class PostgresAnnotationsRepository {
   }
 
   async deleteGlobalAnnotation(chr: string, pos: number, ref: string, alt: string): Promise<void> {
+    await this._deleteGlobalAnnotationOn(this.pool, chr, pos, ref, alt)
+  }
+
+  // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
+  private async _deleteGlobalAnnotationOn(
+    client: QueryablePool,
+    chr: string,
+    pos: number,
+    ref: string,
+    alt: string
+  ): Promise<void> {
     const schemaName = quoteIdentifier(this.schema)
-    await runNamed(this.pool as Pool, {
+    await runNamed(client as Pool, {
       name: 'annotations:delete_global:v1',
       text: `
         DELETE FROM ${schemaName}."variant_annotations"
@@ -254,6 +279,16 @@ export class PostgresAnnotationsRepository {
     variantId: number,
     updates: PerCaseAnnotationUpdates
   ): Promise<CaseVariantAnnotation> {
+    return this._upsertPerCaseAnnotationOn(this.pool, caseId, variantId, updates)
+  }
+
+  // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
+  private async _upsertPerCaseAnnotationOn(
+    client: QueryablePool,
+    caseId: number,
+    variantId: number,
+    updates: PerCaseAnnotationUpdates
+  ): Promise<CaseVariantAnnotation> {
     const schemaName = quoteIdentifier(this.schema)
     const commentProvided = 'per_case_comment' in updates
     const starredProvided = updates.starred !== undefined
@@ -272,7 +307,7 @@ export class PostgresAnnotationsRepository {
       acmgEvidenceProvided
     ]
 
-    const result = await runNamed(this.pool as Pool, {
+    const result = await runNamed(client as Pool, {
       name: 'annotations:upsert_per_case:v1',
       text: `
         INSERT INTO ${schemaName}."case_variant_annotations" (
@@ -324,7 +359,7 @@ export class PostgresAnnotationsRepository {
       const annotations = new PostgresAnnotationsRepository(client, this.schema)
       const audit = new PostgresAuditLogRepository(client, this.schema)
       const oldAnnotation = await annotations.getPerCaseAnnotation(caseId, variantId)
-      const result = await annotations.upsertPerCaseAnnotation(caseId, variantId, updates)
+      const result = await this._upsertPerCaseAnnotationOn(client, caseId, variantId, updates)
       for (const entry of perCaseAnnotationAuditEntries(
         caseId,
         variantId,
@@ -344,8 +379,17 @@ export class PostgresAnnotationsRepository {
   }
 
   async deletePerCaseAnnotation(caseId: number, variantId: number): Promise<void> {
+    await this._deletePerCaseAnnotationOn(this.pool, caseId, variantId)
+  }
+
+  // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
+  private async _deletePerCaseAnnotationOn(
+    client: QueryablePool,
+    caseId: number,
+    variantId: number
+  ): Promise<void> {
     const schemaName = quoteIdentifier(this.schema)
-    await runNamed(this.pool as Pool, {
+    await runNamed(client as Pool, {
       name: 'annotations:delete_per_case:v1',
       text: `
         DELETE FROM ${schemaName}."case_variant_annotations"

--- a/src/main/storage/postgres/PostgresAnnotationsRepository.ts
+++ b/src/main/storage/postgres/PostgresAnnotationsRepository.ts
@@ -7,6 +7,11 @@ import type {
   VariantAnnotation
 } from '../../../shared/types/database'
 import { globalAnnotationAuditEntries, perCaseAnnotationAuditEntries } from '../annotation-audit'
+import {
+  applyAnnotationFlagsGlobal,
+  applyAnnotationFlagsOnCaseDelete,
+  applyAnnotationFlagsPerCase
+} from './cohort-annotation-flags-sql'
 import { quoteIdentifier } from './identifiers'
 import { runNamed } from './named-query'
 import { PostgresAuditLogRepository } from './PostgresAuditLogRepository'
@@ -123,7 +128,19 @@ export class PostgresAnnotationsRepository {
     alt: string,
     updates: GlobalAnnotationUpdates
   ): Promise<VariantAnnotation> {
-    return this._upsertGlobalAnnotationOn(this.pool, chr, pos, ref, alt, updates)
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      const result = await this._upsertGlobalAnnotationOn(client, chr, pos, ref, alt, updates)
+      await applyAnnotationFlagsGlobal(client, { schema: this.schema, chr, pos, ref, alt })
+      await client.query('COMMIT')
+      return result
+    } catch (error) {
+      await rollbackTransaction(client)
+      throw error
+    } finally {
+      client.release()
+    }
   }
 
   // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
@@ -221,6 +238,7 @@ export class PostgresAnnotationsRepository {
       )) {
         await audit.append(entry)
       }
+      await applyAnnotationFlagsGlobal(client, { schema: this.schema, chr, pos, ref, alt })
       await client.query('COMMIT')
       return result
     } catch (error) {
@@ -232,7 +250,18 @@ export class PostgresAnnotationsRepository {
   }
 
   async deleteGlobalAnnotation(chr: string, pos: number, ref: string, alt: string): Promise<void> {
-    await this._deleteGlobalAnnotationOn(this.pool, chr, pos, ref, alt)
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      await this._deleteGlobalAnnotationOn(client, chr, pos, ref, alt)
+      await applyAnnotationFlagsGlobal(client, { schema: this.schema, chr, pos, ref, alt })
+      await client.query('COMMIT')
+    } catch (error) {
+      await rollbackTransaction(client)
+      throw error
+    } finally {
+      client.release()
+    }
   }
 
   // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
@@ -279,7 +308,19 @@ export class PostgresAnnotationsRepository {
     variantId: number,
     updates: PerCaseAnnotationUpdates
   ): Promise<CaseVariantAnnotation> {
-    return this._upsertPerCaseAnnotationOn(this.pool, caseId, variantId, updates)
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      const result = await this._upsertPerCaseAnnotationOn(client, caseId, variantId, updates)
+      await applyAnnotationFlagsPerCase(client, { schema: this.schema, caseId, variantId })
+      await client.query('COMMIT')
+      return result
+    } catch (error) {
+      await rollbackTransaction(client)
+      throw error
+    } finally {
+      client.release()
+    }
   }
 
   // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
@@ -368,6 +409,7 @@ export class PostgresAnnotationsRepository {
       )) {
         await audit.append(entry)
       }
+      await applyAnnotationFlagsPerCase(client, { schema: this.schema, caseId, variantId })
       await client.query('COMMIT')
       return result
     } catch (error) {
@@ -379,7 +421,18 @@ export class PostgresAnnotationsRepository {
   }
 
   async deletePerCaseAnnotation(caseId: number, variantId: number): Promise<void> {
-    await this._deletePerCaseAnnotationOn(this.pool, caseId, variantId)
+    const client = await this.connect()
+    try {
+      await client.query('BEGIN')
+      await this._deletePerCaseAnnotationOn(client, caseId, variantId)
+      await applyAnnotationFlagsPerCase(client, { schema: this.schema, caseId, variantId })
+      await client.query('COMMIT')
+    } catch (error) {
+      await rollbackTransaction(client)
+      throw error
+    } finally {
+      client.release()
+    }
   }
 
   // Raw-SQL helper — operates on the passed client/pool, no BEGIN/COMMIT.
@@ -426,6 +479,20 @@ export class PostgresAnnotationsRepository {
         : await this.getPerCaseAnnotation(caseId, toNumber(variantId))
 
     return { global, perCase }
+  }
+
+  /**
+   * On-case-delete annotation write-hook (C5a / Pass-5 HIGH #1). Public (unlike
+   * the global/per-case hooks, which only fire from this class's own methods)
+   * because C3's PostgresCaseLifecycleRepository invokes it across the class
+   * boundary BEFORE deleting the case. Thin delegate to the shared executor in
+   * cohort-annotation-flags-sql.ts; see that module for the exclusion semantics.
+   */
+  async _applyAnnotationFlagsOnCaseDelete(
+    client: QueryablePool,
+    args: { schema: string; deletedCaseId: number }
+  ): Promise<void> {
+    await applyAnnotationFlagsOnCaseDelete(client, args)
   }
 
   private async connect(): Promise<PoolClient> {

--- a/src/main/storage/postgres/PostgresCaseLifecycleRepository.ts
+++ b/src/main/storage/postgres/PostgresCaseLifecycleRepository.ts
@@ -1,26 +1,131 @@
 import type { Pool, PoolClient } from 'pg'
 
+import { applyAnnotationFlagsOnCaseDelete } from './cohort-annotation-flags-sql'
 import { quoteIdentifier } from './identifiers'
+import {
+  PostgresCohortSummaryRepository,
+  SCOPED_DEDUPED_AGG_SQL
+} from './PostgresCohortSummaryRepository'
 
 type TransactionClient = Pick<PoolClient, 'query' | 'release'>
 
+/** The subset of PostgresCohortSummaryRepository this repo drives (test seam). */
+type CohortSummaryMaintenance = Pick<
+  PostgresCohortSummaryRepository,
+  'recomputeCohortFrequency' | 'removeColumnMetas'
+>
+
 export class PostgresCaseLifecycleRepository {
   private readonly schemaName: string
+  private readonly summary: CohortSummaryMaintenance
 
   constructor(
     private readonly pool: Pick<Pool, 'connect'>,
-    schema: string
+    private readonly schema: string,
+    summary?: CohortSummaryMaintenance
   ) {
     this.schemaName = quoteIdentifier(schema)
+    this.summary = summary ?? new PostgresCohortSummaryRepository()
   }
 
+  /**
+   * Sprint A PR-3 C3 (delete half). Deletes one case and keeps the materialised
+   * cohort summary in lockstep, all inside the existing single transaction. The
+   * 8-step ordering is load-bearing:
+   *
+   *   1. SELECT genome_build (Pass-4 HIGH #1) — captured BEFORE the cascade so
+   *      step 7 can narrow the cohort_frequency recompute to the right build.
+   *   2. applyAnnotationFlagsOnCaseDelete (C5a third variant, Pass-5 HIGH #1) —
+   *      runs BEFORE the case delete; the ` AND v.case_id <> $1` predicate
+   *      excludes the about-to-be-cascade-deleted rows so flags backed solely by
+   *      this case clear in the same transaction.
+   *   3. UPDATE cohort_variant_summary subtracting carrier/het/hom together
+   *      (Pass-6 MED #3) from the deduped per-case CTE.
+   *   4. DELETE summary rows that dropped to zero carriers (sibling statement,
+   *      Pass-2 verdict #1).
+   *   5. DELETE the case (cascades to variants + case_variant_annotations +
+   *      cohort_column_meta).
+   *   6. rebuildVariantFrequency (Pass-6 HIGH #1) — vf.case_count powers
+   *      internal_af, so it must be rebuilt after the cascade.
+   *   7. recomputeCohortFrequency narrowed to the captured build — the
+   *      denominator now excludes the deleted case.
+   *   8. removeColumnMetas — keyed on case_id, independent of step 5's cascade.
+   */
   async deleteCase(caseId: number): Promise<void> {
     const client = await this.pool.connect()
 
     try {
       await client.query('BEGIN')
+
+      // Step 1: capture genome_build for the step-7 recompute. A missing case
+      // (zero rows) leaves capturedBuild undefined and the recompute falls back
+      // to all builds — correct because there is nothing build-specific to scope.
+      const buildRes = await client.query<{ genome_build: string }>(
+        `SELECT genome_build FROM ${this.schemaName}."cases" WHERE id = $1`,
+        [caseId]
+      )
+      const capturedBuild = buildRes.rows[0]?.genome_build
+
+      // Step 2: recompute annotation flags excluding the about-to-be-deleted
+      // case, BEFORE the cascade removes its annotations (Pass-5 HIGH #1).
+      await applyAnnotationFlagsOnCaseDelete(client as unknown as Pool, {
+        schema: this.schema,
+        deletedCaseId: caseId
+      })
+
+      // Step 3: subtract carrier_count, het_count, hom_count simultaneously
+      // (Pass-6 MED #3). Reuses the canonical SCOPED_DEDUPED_AGG_SQL so intra-case
+      // duplicate coordinate rows (multiple gt_num under one case, no unique
+      // constraint on variants(case_id,chr,pos,ref,alt,variant_type)) collapse to
+      // a single carrier — keeping the remove delta symmetric with incrementalAdd
+      // (one carrier per coordinate per case) instead of over-subtracting COUNT(*).
+      const tbl = (t: string): string => `${this.schemaName}."${t}"`
+      await client.query(
+        `
+        ${SCOPED_DEDUPED_AGG_SQL(tbl)}
+        UPDATE ${this.schemaName}."cohort_variant_summary" cvs
+        SET carrier_count = cvs.carrier_count - per_case.carrier_delta,
+            het_count = cvs.het_count - per_case.het_delta,
+            hom_count = cvs.hom_count - per_case.hom_delta
+        FROM per_case
+        WHERE cvs.chr = per_case.chr AND cvs.pos = per_case.pos
+          AND cvs.ref = per_case.ref AND cvs.alt = per_case.alt
+          AND cvs.variant_type = per_case.variant_type
+          AND cvs.genome_build = per_case.genome_build
+        `,
+        [caseId]
+      )
+
+      // Step 4: drop summary rows that fell to zero carriers (sibling DELETE,
+      // Pass-2 verdict #1 — not a sibling CTE).
+      await client.query(
+        `DELETE FROM ${this.schemaName}."cohort_variant_summary" WHERE carrier_count <= 0`
+      )
+
+      // Step 5: delete the case — cascades to variants, case_variant_annotations
+      // and cohort_column_meta.
       await client.query(`DELETE FROM ${this.schemaName}."cases" WHERE id = $1`, [caseId])
+
+      // Step 6: rebuild variant_frequency so internal_af stays current
+      // (Pass-6 HIGH #1).
       await this.rebuildVariantFrequency(client)
+
+      // Step 7: recompute cohort_frequency narrowed to the captured build so the
+      // denominator excludes the deleted case (Pass-4 HIGH #1).
+      await this.summary.recomputeCohortFrequency({
+        schema: this.schema,
+        client: client as unknown as PoolClient,
+        affectedBuilds: capturedBuild !== undefined ? [capturedBuild] : undefined
+      })
+
+      // Step 8: drop the case's column-meta rows. Keyed on case_id and therefore
+      // independent of step 5's cascade.
+      await this.summary.removeColumnMetas({
+        schema: this.schema,
+        client: client as unknown as PoolClient,
+        caseId
+      })
+
       await client.query('COMMIT')
     } catch (error) {
       try {

--- a/src/main/storage/postgres/PostgresCohortRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortRepository.ts
@@ -13,7 +13,13 @@ import type {
 import { mainLogger } from '../../services/MainLogger'
 import { getGeneReferenceDb } from '../../database/geneReferenceLoader'
 import { quoteIdentifier } from './identifiers'
+import { runNamed, runNamedDynamic } from './named-query'
 import { POSTGRES_VARIANT_COLUMN_DEFINITIONS } from './postgres-variant-columns'
+import {
+  buildSummaryCountSql,
+  buildSummaryPageSql,
+  buildSummaryQueryParts
+} from './postgres-cohort-summary-query'
 
 type CohortPool = Pick<Pool, 'query' | 'connect'>
 type CohortClient = Pick<PoolClient, 'query' | 'release'>
@@ -81,6 +87,30 @@ const COLUMN_META_KEYS = [
   'cadd_phred',
   'transcript'
 ]
+
+/**
+ * Filter-UI key → stored column on `cohort_variant_summary`. Every key is a
+ * physical column on the summary table; `cadd_phred` is the only rename
+ * (stored as `cadd`). Used by the cohort-view getColumnMeta read (C4 Step 2) so
+ * COUNT(DISTINCT)/MIN/MAX run against the already-deduped summary rows rather
+ * than a live GROUP BY (Pass-3 HIGH #3 — SUM across cohort_column_meta would
+ * overcount).
+ */
+const COLUMN_META_SUMMARY_COLUMNS: Record<string, string> = {
+  chr: 'chr',
+  pos: 'pos',
+  gene_symbol: 'gene_symbol',
+  carrier_count: 'carrier_count',
+  cohort_frequency: 'cohort_frequency',
+  het_count: 'het_count',
+  hom_count: 'hom_count',
+  consequence: 'consequence',
+  func: 'func',
+  clinvar: 'clinvar',
+  gnomad_af: 'gnomad_af',
+  cadd_phred: 'cadd',
+  transcript: 'transcript'
+}
 
 type CohortColumnFilterLocation = 'where' | 'having'
 
@@ -201,6 +231,7 @@ function withoutActivePanelFields(params: CohortSearchParams): CohortSearchParam
 }
 
 export class PostgresCohortRepository {
+  private readonly schema: string
   private readonly schemaName: string
   private readonly panelIntervalResolver: PanelIntervalResolver
   private columnMetaCache: ColumnFilterMeta[] | null = null
@@ -210,18 +241,92 @@ export class PostgresCohortRepository {
     schema: string,
     panelIntervalResolver?: PanelIntervalResolver
   ) {
+    this.schema = schema
     this.schemaName = quoteIdentifier(schema)
     this.panelIntervalResolver = panelIntervalResolver ?? this.resolvePanelIntervals.bind(this)
+  }
+
+  private tbl(table: string): string {
+    return `${this.schemaName}."${table}"`
   }
 
   async queryVariants(params: CohortSearchParams): Promise<CohortPaginatedResult> {
     const resolvedParams = await this.resolvePanelParams(params)
     this.assertSupportedColumnFilters(resolvedParams)
     const totalCases = await this.getTotalCases(this.pool, resolvedParams)
-    const queryParts = this.buildQueryParts(resolvedParams, totalCases)
+
+    // C4: prefer the materialised cohort_variant_summary page query. Falls back
+    // to live aggregation when buildSummaryQueryParts reports the predicate set
+    // is not materialisable (extension-table filters — Sprint B).
+    const summaryResult = await this.querySummaryPage(resolvedParams, totalCases)
+    if (summaryResult !== null) return summaryResult
+
+    return this.queryLivePage(resolvedParams, totalCases)
+  }
+
+  /**
+   * C4 summary-page read. Builds predicate parts against `cohort_variant_summary`
+   * via buildSummaryQueryParts and runs count + page in one materialised path.
+   * Returns null when the predicate set is not materialisable so the caller can
+   * fall back to live aggregation.
+   */
+  private async querySummaryPage(
+    params: CohortSearchParams,
+    totalCases: number
+  ): Promise<CohortPaginatedResult | null> {
+    const summary = buildSummaryQueryParts(params, totalCases)
+    if (summary.unavailable) return null
+
+    const { whereParts, orderBy, values } = summary.parts
+    const table = this.tbl('cohort_variant_summary')
 
     let totalCount = 0
     if (params._count_needed !== false) {
+      const countResult = await runNamedDynamic<{ total_count?: unknown }>(this.pool as Pool, {
+        baseName: 'cohort:summary_count',
+        text: buildSummaryCountSql(table, whereParts),
+        values,
+        schema: this.schema
+      })
+      totalCount = toNumber(
+        (countResult.rows[0] as { total_count?: unknown } | undefined)?.total_count
+      )
+    }
+
+    const limit = params.limit ?? 50
+    const offset = params.offset ?? 0
+    const dataValues = [...values, limit, offset]
+    const dataResult = await runNamedDynamic<Record<string, unknown>>(this.pool as Pool, {
+      baseName: 'cohort:summary_page',
+      text: buildSummaryPageSql(
+        table,
+        whereParts,
+        orderBy,
+        totalCases,
+        dataValues.length - 1,
+        dataValues.length
+      ),
+      values: dataValues,
+      schema: this.schema
+    })
+
+    return {
+      data: (dataResult.rows as Array<Record<string, unknown>>).map((row) =>
+        this.toCohortVariant(row, totalCases)
+      ),
+      total_count: totalCount
+    }
+  }
+
+  /** Live-aggregation page query (fallback path when the summary is unavailable). */
+  private async queryLivePage(
+    resolvedParams: CohortSearchParams,
+    totalCases: number
+  ): Promise<CohortPaginatedResult> {
+    const queryParts = this.buildQueryParts(resolvedParams, totalCases)
+
+    let totalCount = 0
+    if (resolvedParams._count_needed !== false) {
       const countResult = await this.pool.query(
         `SELECT COUNT(*)::bigint AS total_count FROM (
            ${this.buildGroupedSelect(queryParts, totalCases, false)}
@@ -375,32 +480,37 @@ export class PostgresCohortRepository {
     }))
   }
 
+  /**
+   * Cohort-view per-column metadata (C4 Step 2). Reads COUNT(DISTINCT)/MIN/MAX
+   * directly from the already-deduped `cohort_variant_summary` table — mirroring
+   * SQLite cohort.ts:getColumnMeta. Aggregating across `cohort_column_meta`
+   * would SUM per-case distinct counts and overcount (Pass-3 HIGH #3), so the
+   * cohort path reads the summary table, not the per-case meta cache.
+   */
   async getColumnMeta(): Promise<ColumnFilterMeta[]> {
     if (this.columnMetaCache !== null) return this.columnMetaCache
 
-    const totalCases = await this.getTotalCases(this.pool)
-    const queryParts = this.buildQueryParts({}, totalCases)
-    const groupedSql = this.buildGroupedSelect(queryParts, totalCases, false)
     const meta: ColumnFilterMeta[] = []
     const selectParts = COLUMN_META_KEYS.flatMap((key) => {
-      const sqlColumn = SORTABLE_COLUMNS[key]
+      const sqlColumn = COLUMN_META_SUMMARY_COLUMNS[key]
       const parts = [`COUNT(DISTINCT ${sqlColumn})::bigint AS cnt_${key}`]
       if (NUMERIC_COLUMNS.has(key)) {
         parts.push(`MIN(${sqlColumn}) AS min_${key}`, `MAX(${sqlColumn}) AS max_${key}`)
       }
       return parts
     })
-    const aggregateResult = await this.pool.query(
-      `SELECT ${selectParts.join(', ')}
-       FROM (${groupedSql}) cohort_columns`,
-      queryParts.params
-    )
+    const aggregateResult = await runNamed<Record<string, unknown>>(this.pool as Pool, {
+      name: 'cohort:column_meta_agg:v1',
+      text: `SELECT ${selectParts.join(', ')} FROM ${this.tbl('cohort_variant_summary')}`,
+      values: [],
+      schema: this.schema
+    })
     const aggregateRow = (aggregateResult.rows[0] ?? {}) as Record<string, unknown>
     const lowCardinalityColumns: Array<{ key: string; sqlColumn: string }> = []
 
     for (const key of COLUMN_META_KEYS) {
       const isNumeric = NUMERIC_COLUMNS.has(key)
-      const sqlColumn = SORTABLE_COLUMNS[key]
+      const sqlColumn = COLUMN_META_SUMMARY_COLUMNS[key]
       const entry: ColumnFilterMeta = {
         key,
         dataType: isNumeric ? 'numeric' : 'text',
@@ -423,16 +533,20 @@ export class PostgresCohortRepository {
         .map(
           ({ key, sqlColumn }) =>
             `SELECT '${key}' AS col_key, ${sqlColumn}::text AS value
-             FROM cohort_columns
+             FROM ${this.tbl('cohort_variant_summary')}
              WHERE ${sqlColumn} IS NOT NULL
              GROUP BY ${sqlColumn}`
         )
         .join('\nUNION ALL\n')
-      const unionSql = `WITH cohort_columns AS MATERIALIZED (
-        ${groupedSql}
+      const valuesResult = await runNamedDynamic<{ col_key: string; value: unknown }>(
+        this.pool as Pool,
+        {
+          baseName: 'cohort:column_meta_values',
+          text: unionParts,
+          values: [],
+          schema: this.schema
+        }
       )
-      ${unionParts}`
-      const valuesResult = await this.pool.query(unionSql, queryParts.params)
       const valuesByKey = new Map<string, string[]>()
       for (const row of valuesResult.rows as Array<{ col_key: string; value: unknown }>) {
         const values = valuesByKey.get(row.col_key) ?? []

--- a/src/main/storage/postgres/PostgresCohortRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortRepository.ts
@@ -12,6 +12,11 @@ import type {
 } from '../../../shared/types/cohort'
 import { mainLogger } from '../../services/MainLogger'
 import { getGeneReferenceDb } from '../../database/geneReferenceLoader'
+import {
+  prepareCohortRead,
+  readCohortSummaryStatus,
+  type CohortReadWarnings
+} from './cohort-read-freshness'
 import { quoteIdentifier } from './identifiers'
 import { runNamed, runNamedDynamic } from './named-query'
 import { POSTGRES_VARIANT_COLUMN_DEFINITIONS } from './postgres-variant-columns'
@@ -262,6 +267,27 @@ export class PostgresCohortRepository {
     if (summaryResult !== null) return summaryResult
 
     return this.queryLivePage(resolvedParams, totalCases)
+  }
+
+  /**
+   * C5 (PR3-17): reconcile the materialised summary before serving, then run the
+   * page read. Returns the warnings to merge into the IPC response (staleSummary
+   * when a large cohort is served stale while a background rebuild runs).
+   */
+  async queryVariantsWithStaleness(
+    params: CohortSearchParams
+  ): Promise<CohortPaginatedResult & { warnings?: CohortReadWarnings }> {
+    const { warnings } = await prepareCohortRead({ pool: this.pool, schema: this.schema })
+    const result = await this.queryVariants(params)
+    return warnings === undefined ? result : { ...result, warnings }
+  }
+
+  /**
+   * C5 (PR3-17): cohort_summary_state read in the existing IPC shape
+   * { is_stale, last_rebuilt_at:number }. Replaces the hardcoded handler stub.
+   */
+  async getSummaryStatus(): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
+    return readCohortSummaryStatus({ pool: this.pool, schema: this.schema })
   }
 
   /**

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -21,6 +21,7 @@
  * The remaining methods are stubbed for the subsequent Sprint A tasks.
  */
 import type { PoolClient } from 'pg'
+import { getCohortSummaryState, markCohortSummaryStale } from './cohort-summary-state-sql'
 
 interface ScopedClient {
   schema: string
@@ -252,6 +253,15 @@ export class PostgresCohortSummaryRepository {
     // inside the same transaction. Mirrors SQLite's RECOMPUTE_ALL_FREQUENCIES_SQL
     // (CohortSummaryService.rebuild). The NULL written above is overwritten here.
     await this.recomputeCohortFrequency({ schema, client })
+
+    // C1 lifecycle (Pass-7 MED #4): a completed rebuild clears the staleness
+    // flags and records the rebuild time. last_rebuilt_at maps back to epoch ms
+    // via getState's EXTRACT(EPOCH) (Pass-9 #6).
+    await client.query(
+      `UPDATE ${tbl('cohort_summary_state')}
+       SET is_stale = false, stale_reason = NULL, stale_at = NULL, last_rebuilt_at = now()
+       WHERE id = 1`
+    )
   }
 
   /**
@@ -389,6 +399,12 @@ export class PostgresCohortSummaryRepository {
       client,
       affectedBuilds: genomeBuild !== undefined ? [genomeBuild] : undefined
     })
+
+    // C1 lifecycle: incremental maintenance records its time but never touches
+    // is_stale — the summary stays valid (Pass-7 MED #4).
+    await client.query(
+      `UPDATE ${tbl('cohort_summary_state')} SET last_incremental_at = now() WHERE id = 1`
+    )
   }
 
   /**
@@ -433,6 +449,12 @@ export class PostgresCohortSummaryRepository {
       client,
       affectedBuilds: genomeBuild !== undefined ? [genomeBuild] : undefined
     })
+
+    // C1 lifecycle: incremental maintenance records its time but never touches
+    // is_stale — the summary stays valid (Pass-7 MED #4).
+    await client.query(
+      `UPDATE ${tbl('cohort_summary_state')} SET last_incremental_at = now() WHERE id = 1`
+    )
   }
   /**
    * Recompute the per-case filter metadata cache. Mirrors SQLite's
@@ -548,10 +570,21 @@ export class PostgresCohortSummaryRepository {
     const tbl = (t: string): string => `"${schema}"."${t}"`
     await client.query(`DELETE FROM ${tbl('cohort_column_meta')} WHERE case_id = $1`, [caseId])
   }
-  async getState(_args: ScopedClient): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
-    throw new Error('TODO PR3-9')
+  /**
+   * Return the singleton lifecycle state in the existing IPC shape
+   * { is_stale, last_rebuilt_at:number }. Delegates to getCohortSummaryState
+   * in ./cohort-summary-state-sql (Pass-7 MED #4 + Pass-8 #7 + Pass-9 #6).
+   */
+  async getState(scope: ScopedClient): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
+    return getCohortSummaryState(scope)
   }
-  async markStale(_args: ScopedClient & { reason: string }): Promise<void> {
-    throw new Error('TODO PR3-9')
+
+  /**
+   * Flag the summary stale with an explicit reason. Delegates to
+   * markCohortSummaryStale in ./cohort-summary-state-sql (Pass-7 MED #4);
+   * leaves last_rebuilt_at untouched so rebuild history is preserved.
+   */
+  async markStale(scope: ScopedClient & { reason: string }): Promise<void> {
+    return markCohortSummaryStale(scope)
   }
 }

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -1,0 +1,184 @@
+/**
+ * Sprint A PR-3 C2 — PostgresCohortSummaryRepository.
+ *
+ * Materialises the deduped cohort variant summary for the Postgres backend.
+ * Mirrors the SQLite source of truth in src/shared/sql/cohort-summary-rebuild.ts
+ * and src/main/database/CohortSummaryService.ts:
+ *
+ *   - rebuild(): TRUNCATE + INSERT from the deduped CTE (Pass-2 #4 — duplicate
+ *     per-case rows count once). has_star/has_comment/acmg_best are derived
+ *     from variant_annotations + case_variant_annotations at insertion time
+ *     (Pass-9 #8 — otherwise every rebuild would reset the flags to false).
+ *     cohort_frequency is left NULL; the caller runs the C2a recompute next.
+ *
+ * Note on column names: the Postgres workflow schema names the comment columns
+ * global_comment / per_case_comment and the ACMG column acmg_classification
+ * (src/main/storage/postgres/migrations/sql/0005_create_workflow_tables.sql) —
+ * not the placeholder names in the plan. The variants table has no variant_key
+ * column, so it is composed inline as chr:pos:ref:alt to match SQLite.
+ *
+ * The remaining methods are stubbed for the subsequent Sprint A tasks.
+ */
+import type { PoolClient } from 'pg'
+
+interface ScopedClient {
+  schema: string
+  client: PoolClient
+}
+
+/**
+ * ACMG rank ladder mirroring the SQLite CASE expression in
+ * src/shared/sql/cohort-summary-rebuild.ts. Higher rank wins; the textual
+ * label is reconstructed from the winning rank.
+ */
+const ACMG_RANK_SQL = (col: string) => `CASE ${col}
+  WHEN 'Pathogenic' THEN 5
+  WHEN 'Likely pathogenic' THEN 4
+  WHEN 'Uncertain significance' THEN 3
+  WHEN 'Likely benign' THEN 2
+  WHEN 'Benign' THEN 1
+  ELSE 0 END`
+
+export class PostgresCohortSummaryRepository {
+  async rebuild({ schema, client }: ScopedClient): Promise<void> {
+    const tbl = (t: string): string => `"${schema}"."${t}"`
+
+    await client.query(`TRUNCATE ${tbl('cohort_variant_summary')}`)
+
+    // Deduped CTE + flag-bearing projection. Mirrors SQLite
+    // src/main/database/CohortSummaryService.ts and the deduped pattern in
+    // src/shared/sql/cohort-summary-rebuild.ts.
+    await client.query(`
+      INSERT INTO ${tbl('cohort_variant_summary')}
+        (chr, pos, end_pos, ref, alt, variant_type, genome_build,
+         gene_symbol, cdna, aa_change, consequence, func, clinvar,
+         gnomad_af, cadd, transcript, omim_mim_number,
+         carrier_count, het_count, hom_count, variant_key,
+         has_star, has_comment, acmg_best, cohort_frequency)
+      WITH deduped AS (
+        SELECT v.chr, v.pos, v.ref, v.alt, v.case_id, v.variant_type, c.genome_build,
+               MAX(v.end_pos) AS end_pos,
+               MAX(v.gene_symbol) AS gene_symbol,
+               MAX(v.cdna) AS cdna,
+               MAX(v.aa_change) AS aa_change,
+               MAX(v.consequence) AS consequence,
+               MAX(v.func) AS func,
+               MAX(v.clinvar) AS clinvar,
+               MAX(v.gnomad_af) AS gnomad_af,
+               MAX(v.cadd) AS cadd,
+               MAX(v.transcript) AS transcript,
+               MAX(v.omim_mim_number) AS omim_mim_number,
+               MAX(v.gt_num) AS gt_num
+        FROM ${tbl('variants')} v
+        JOIN ${tbl('cases')} c ON c.id = v.case_id
+        GROUP BY v.chr, v.pos, v.ref, v.alt, v.case_id, v.variant_type, c.genome_build
+      ),
+      agg AS (
+        SELECT d.chr, d.pos, MAX(d.end_pos) AS end_pos, d.ref, d.alt,
+               d.variant_type, d.genome_build,
+               MAX(d.gene_symbol) AS gene_symbol,
+               MAX(d.cdna) AS cdna,
+               MAX(d.aa_change) AS aa_change,
+               MAX(d.consequence) AS consequence,
+               MAX(d.func) AS func,
+               MAX(d.clinvar) AS clinvar,
+               MAX(d.gnomad_af) AS gnomad_af,
+               MAX(d.cadd) AS cadd,
+               MAX(d.transcript) AS transcript,
+               MAX(d.omim_mim_number) AS omim_mim_number,
+               COUNT(*) AS carrier_count,
+               SUM(CASE WHEN d.gt_num IN ('0/1','1/0','0|1','1|0') THEN 1 ELSE 0 END) AS het_count,
+               SUM(CASE WHEN d.gt_num IN ('1/1','1|1') THEN 1 ELSE 0 END) AS hom_count
+        FROM deduped d
+        GROUP BY d.chr, d.pos, d.ref, d.alt, d.variant_type, d.genome_build
+      )
+      SELECT
+        a.chr, a.pos, a.end_pos, a.ref, a.alt, a.variant_type, a.genome_build,
+        a.gene_symbol, a.cdna, a.aa_change, a.consequence, a.func, a.clinvar,
+        a.gnomad_af, a.cadd, a.transcript, a.omim_mim_number,
+        a.carrier_count, a.het_count, a.hom_count,
+        a.chr || ':' || a.pos || ':' || a.ref || ':' || a.alt AS variant_key,
+        -- Pass-9 #8: derive flag columns from current annotation tables.
+        (EXISTS (
+          SELECT 1 FROM ${tbl('variant_annotations')} va
+          WHERE va.chr = a.chr AND va.pos = a.pos
+            AND va.ref = a.ref AND va.alt = a.alt
+            AND va.starred = 1
+        ) OR EXISTS (
+          SELECT 1 FROM ${tbl('case_variant_annotations')} cva
+          JOIN ${tbl('variants')} v ON cva.variant_id = v.id
+          WHERE v.chr = a.chr AND v.pos = a.pos
+            AND v.ref = a.ref AND v.alt = a.alt
+            AND v.variant_type = a.variant_type
+            AND cva.starred = 1
+        )) AS has_star,
+        (EXISTS (
+          SELECT 1 FROM ${tbl('variant_annotations')} va
+          WHERE va.chr = a.chr AND va.pos = a.pos
+            AND va.ref = a.ref AND va.alt = a.alt
+            AND va.global_comment IS NOT NULL AND va.global_comment <> ''
+        ) OR EXISTS (
+          SELECT 1 FROM ${tbl('case_variant_annotations')} cva
+          JOIN ${tbl('variants')} v ON cva.variant_id = v.id
+          WHERE v.chr = a.chr AND v.pos = a.pos
+            AND v.ref = a.ref AND v.alt = a.alt
+            AND v.variant_type = a.variant_type
+            AND cva.per_case_comment IS NOT NULL AND cva.per_case_comment <> ''
+        )) AS has_comment,
+        -- acmg_best: highest-ranked classification across global + per-case
+        -- annotations, reconstructed from the winning rank (mirrors the SQLite
+        -- CASE ladder in src/shared/sql/cohort-summary-rebuild.ts).
+        (CASE (
+          SELECT MAX(rank) FROM (
+            SELECT ${ACMG_RANK_SQL('va.acmg_classification')} AS rank
+            FROM ${tbl('variant_annotations')} va
+            WHERE va.chr = a.chr AND va.pos = a.pos
+              AND va.ref = a.ref AND va.alt = a.alt
+              AND va.acmg_classification IS NOT NULL
+            UNION ALL
+            SELECT ${ACMG_RANK_SQL('cva.acmg_classification')} AS rank
+            FROM ${tbl('case_variant_annotations')} cva
+            JOIN ${tbl('variants')} v ON cva.variant_id = v.id
+            WHERE v.chr = a.chr AND v.pos = a.pos
+              AND v.ref = a.ref AND v.alt = a.alt
+              AND v.variant_type = a.variant_type
+              AND cva.acmg_classification IS NOT NULL
+          ) ranked
+        )
+          WHEN 5 THEN 'Pathogenic'
+          WHEN 4 THEN 'Likely pathogenic'
+          WHEN 3 THEN 'Uncertain significance'
+          WHEN 2 THEN 'Likely benign'
+          WHEN 1 THEN 'Benign'
+          ELSE NULL
+        END) AS acmg_best,
+        NULL AS cohort_frequency  -- populated by C2a recompute, called next
+      FROM agg a;
+    `)
+
+    // C2a recompute is invoked by the caller immediately after rebuild() —
+    // the cohort_frequency NULL above is intentional. See the rebuild()
+    // call site in C3 (PostgresCaseLifecycleRepository and
+    // postgres-import-worker.ts).
+  }
+
+  // Stub for next tasks
+  async incrementalAdd(_args: ScopedClient & { caseId: number }): Promise<void> {
+    throw new Error('TODO PR3-3')
+  }
+  async incrementalRemove(_args: ScopedClient & { caseId: number }): Promise<void> {
+    throw new Error('TODO PR3-3')
+  }
+  async refreshColumnMetas(_args: ScopedClient & { caseId: number }): Promise<void> {
+    throw new Error('TODO PR3-4')
+  }
+  async removeColumnMetas(_args: ScopedClient & { caseId: number }): Promise<void> {
+    throw new Error('TODO PR3-4')
+  }
+  async getState(_args: ScopedClient): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
+    throw new Error('TODO PR3-9')
+  }
+  async markStale(_args: ScopedClient & { reason: string }): Promise<void> {
+    throw new Error('TODO PR3-9')
+  }
+}

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -9,7 +9,8 @@
  *     per-case rows count once). has_star/has_comment/acmg_best are derived
  *     from variant_annotations + case_variant_annotations at insertion time
  *     (Pass-9 #8 — otherwise every rebuild would reset the flags to false).
- *     cohort_frequency is left NULL; the caller runs the C2a recompute next.
+ *     cohort_frequency is recomputed in-place as the final rebuild step
+ *     (C2a / Pass-3 HIGH #2) via recomputeCohortFrequency().
  *
  * Note on column names: the Postgres workflow schema names the comment columns
  * global_comment / per_case_comment and the ACMG column acmg_classification
@@ -243,14 +244,47 @@ export class PostgresCohortSummaryRepository {
           WHEN 1 THEN 'Benign'
           ELSE NULL
         END) AS acmg_best,
-        NULL AS cohort_frequency  -- populated by C2a recompute, called next
+        NULL AS cohort_frequency  -- overwritten by the recompute below (C2a)
       FROM agg a;
     `)
 
-    // C2a recompute is invoked by the caller immediately after rebuild() —
-    // the cohort_frequency NULL above is intentional. See the rebuild()
-    // call site in C3 (PostgresCaseLifecycleRepository and
-    // postgres-import-worker.ts).
+    // C2a: recompute cohort_frequency for all builds as the final rebuild step,
+    // inside the same transaction. Mirrors SQLite's RECOMPUTE_ALL_FREQUENCIES_SQL
+    // (CohortSummaryService.rebuild). The NULL written above is overwritten here.
+    await this.recomputeCohortFrequency({ schema, client })
+  }
+
+  /**
+   * C2a (Pass-3 HIGH #2): recompute cohort_frequency = carrier_count / total
+   * cases-for-build. Mirrors SQLite's RECOMPUTE_ALL_FREQUENCIES_SQL, run in the
+   * same transaction after rebuild / incrementalAdd / incrementalRemove. When
+   * `affectedBuilds` is provided the recompute is scoped to those genome_builds
+   * (the incremental paths pass the case's build); when omitted the full table
+   * is recomputed (the rebuild path).
+   */
+  async recomputeCohortFrequency({
+    schema,
+    client,
+    affectedBuilds
+  }: ScopedClient & { affectedBuilds?: string[] }): Promise<void> {
+    const tbl = (t: string): string => `"${schema}"."${t}"`
+    if (affectedBuilds && affectedBuilds.length > 0) {
+      await client.query(
+        `UPDATE ${tbl('cohort_variant_summary')} cvs
+         SET cohort_frequency = cvs.carrier_count::float / NULLIF(c.total, 0)
+         FROM (SELECT genome_build, COUNT(*) AS total FROM ${tbl('cases')} GROUP BY genome_build) c
+         WHERE cvs.genome_build = c.genome_build
+           AND cvs.genome_build = ANY($1::text[])`,
+        [affectedBuilds]
+      )
+    } else {
+      await client.query(
+        `UPDATE ${tbl('cohort_variant_summary')} cvs
+         SET cohort_frequency = cvs.carrier_count::float / NULLIF(c.total, 0)
+         FROM (SELECT genome_build, COUNT(*) AS total FROM ${tbl('cases')} GROUP BY genome_build) c
+         WHERE cvs.genome_build = c.genome_build`
+      )
+    }
   }
 
   /**
@@ -263,8 +297,9 @@ export class PostgresCohortSummaryRepository {
   async incrementalAdd({
     schema,
     client,
-    caseId
-  }: ScopedClient & { caseId: number }): Promise<void> {
+    caseId,
+    genomeBuild
+  }: ScopedClient & { caseId: number; genomeBuild?: string }): Promise<void> {
     const tbl = (t: string): string => `"${schema}"."${t}"`
 
     await client.query(
@@ -333,7 +368,7 @@ export class PostgresCohortSummaryRepository {
           WHEN 1 THEN 'Benign'
           ELSE NULL
         END) AS acmg_best,
-        NULL AS cohort_frequency  -- recomputed by C2a, called by the caller next
+        NULL AS cohort_frequency  -- overwritten by the recompute below (C2a)
       FROM per_case pc
       ON CONFLICT (chr, pos, ref, alt, variant_type, genome_build) DO UPDATE SET
         carrier_count = cohort_variant_summary.carrier_count + EXCLUDED.carrier_count,
@@ -345,6 +380,15 @@ export class PostgresCohortSummaryRepository {
     `,
       [caseId]
     )
+
+    // C2a: recompute cohort_frequency in the same transaction, scoped to the
+    // case's genome_build when supplied by the caller (mirrors SQLite's
+    // RECOMPUTE_ALL_FREQUENCIES_SQL after INCREMENTAL_ADD_SQL).
+    await this.recomputeCohortFrequency({
+      schema,
+      client,
+      affectedBuilds: genomeBuild !== undefined ? [genomeBuild] : undefined
+    })
   }
 
   /**
@@ -357,8 +401,9 @@ export class PostgresCohortSummaryRepository {
   async incrementalRemove({
     schema,
     client,
-    caseId
-  }: ScopedClient & { caseId: number }): Promise<void> {
+    caseId,
+    genomeBuild
+  }: ScopedClient & { caseId: number; genomeBuild?: string }): Promise<void> {
     const tbl = (t: string): string => `"${schema}"."${t}"`
 
     await client.query(
@@ -378,6 +423,16 @@ export class PostgresCohortSummaryRepository {
     )
 
     await client.query(`DELETE FROM ${tbl('cohort_variant_summary')} WHERE carrier_count <= 0`)
+
+    // C2a: recompute cohort_frequency in the same transaction, scoped to the
+    // case's genome_build when supplied (mirrors SQLite's
+    // RECOMPUTE_ALL_FREQUENCIES_SQL after INCREMENTAL_REMOVE_SQL +
+    // CLEANUP_ZERO_CARRIERS_SQL).
+    await this.recomputeCohortFrequency({
+      schema,
+      client,
+      affectedBuilds: genomeBuild !== undefined ? [genomeBuild] : undefined
+    })
   }
   /**
    * Recompute the per-case filter metadata cache. Mirrors SQLite's

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -31,6 +31,50 @@ interface ScopedClient {
  * src/shared/sql/cohort-summary-rebuild.ts. Higher rank wins; the textual
  * label is reconstructed from the winning rank.
  */
+/**
+ * Filterable base columns mirrored verbatim from the SQLite source of truth
+ * BASE_SORTABLE_COLUMNS (src/main/database/VariantFilterBuilder.ts) — the exact
+ * column set whose per-case metadata getAllColumnMetas computes in SQLite. The
+ * Postgres `variants` table uses identical physical column names, so key and
+ * SQL column coincide. Kept local because VariantFilterBuilder is Kysely/SQLite
+ * side and must not be imported into the Postgres path.
+ */
+const META_COLUMNS = [
+  'chr',
+  'pos',
+  'gene_symbol',
+  'omim_mim_number',
+  'func',
+  'consequence',
+  'transcript',
+  'cdna',
+  'aa_change',
+  'gt_num',
+  'gnomad_af',
+  'cadd',
+  'qual',
+  'hpo_sim_score',
+  'clinvar',
+  'moi',
+  'variant_type',
+  'end_pos',
+  'sv_type',
+  'sv_length',
+  'caller'
+] as const
+
+/**
+ * Numeric columns get MIN/MAX in min_value/max_value, mirroring SQLite's
+ * NUMERIC_COLUMNS set in src/main/database/VariantRepository.ts.
+ */
+const META_NUMERIC_COLUMNS = new Set<string>(['pos', 'gnomad_af', 'cadd', 'qual', 'hpo_sim_score'])
+
+/**
+ * Low-cardinality threshold mirroring SQLite's DISTINCT_THRESHOLD — columns at
+ * or below this distinct count get their distinct_values array materialised.
+ */
+const META_DISTINCT_THRESHOLD = 50
+
 const ACMG_RANK_SQL = (col: string) => `CASE ${col}
   WHEN 'Pathogenic' THEN 5
   WHEN 'Likely pathogenic' THEN 4
@@ -335,11 +379,119 @@ export class PostgresCohortSummaryRepository {
 
     await client.query(`DELETE FROM ${tbl('cohort_variant_summary')} WHERE carrier_count <= 0`)
   }
-  async refreshColumnMetas(_args: ScopedClient & { caseId: number }): Promise<void> {
-    throw new Error('TODO PR3-4')
+  /**
+   * Recompute the per-case filter metadata cache. Mirrors SQLite's
+   * getAllColumnMetas (src/main/database/VariantRepository.ts): one row per
+   * filterable base column with distinct_count for every column, MIN/MAX for
+   * numerics, and the sorted distinct_values array for low-cardinality columns
+   * (≤ META_DISTINCT_THRESHOLD). DELETE-then-INSERT per C5a HIGH #2 so a refresh
+   * fully repopulates the case's rows.
+   */
+  async refreshColumnMetas({
+    schema,
+    client,
+    caseId
+  }: ScopedClient & { caseId: number }): Promise<void> {
+    const tbl = (t: string): string => `"${schema}"."${t}"`
+
+    await client.query(`DELETE FROM ${tbl('cohort_column_meta')} WHERE case_id = $1`, [caseId])
+
+    // Single scan: COUNT(DISTINCT col) for every column, plus MIN/MAX for
+    // numerics. Aliases are positional so the column order is deterministic.
+    const aggSelect: string[] = []
+    for (const col of META_COLUMNS) {
+      aggSelect.push(`COUNT(DISTINCT "${col}") AS "cnt_${col}"`)
+      if (META_NUMERIC_COLUMNS.has(col)) {
+        aggSelect.push(`MIN("${col}") AS "min_${col}"`)
+        aggSelect.push(`MAX("${col}") AS "max_${col}"`)
+      }
+    }
+    const aggRes = await client.query(
+      `SELECT ${aggSelect.join(', ')} FROM ${tbl('variants')} WHERE case_id = $1`,
+      [caseId]
+    )
+    const aggRow = (aggRes.rows[0] ?? {}) as Record<string, string | number | null>
+
+    // Second scan: distinct values for low-cardinality columns only.
+    const lowCardinality = META_COLUMNS.filter((col) => {
+      const cnt = Number(aggRow[`cnt_${col}`] ?? 0)
+      return cnt > 0 && cnt <= META_DISTINCT_THRESHOLD
+    })
+
+    const distinctValuesByColumn = new Map<string, string[]>()
+    if (lowCardinality.length > 0) {
+      const unionParts = lowCardinality.map(
+        (col) =>
+          `SELECT '${col}' AS col_key, CAST("${col}" AS TEXT) AS val
+             FROM ${tbl('variants')}
+             WHERE case_id = $1 AND "${col}" IS NOT NULL
+             GROUP BY "${col}"`
+      )
+      const distinctRes = await client.query<{ col_key: string; val: string }>(
+        unionParts.join(' UNION ALL '),
+        [caseId]
+      )
+      for (const row of distinctRes.rows) {
+        let arr = distinctValuesByColumn.get(row.col_key)
+        if (arr === undefined) {
+          arr = []
+          distinctValuesByColumn.set(row.col_key, arr)
+        }
+        arr.push(row.val)
+      }
+    }
+
+    // Single multi-row INSERT for all columns (one round trip). min_value /
+    // max_value / distinct_values are JSONB. Numeric min/max are coerced through
+    // Number(...) before JSON.stringify so BIGINT-backed columns like `pos`
+    // (node-pg returns these as strings) store as JSON numbers, matching
+    // SQLite's raw-number shape and the float8 columns (gnomad_af, cadd, qual,
+    // hpo_sim_score) which node-pg already returns as numbers.
+    const valuesClauses: string[] = []
+    const params: unknown[] = []
+    for (const col of META_COLUMNS) {
+      const distinctCount = Number(aggRow[`cnt_${col}`] ?? 0)
+      const isNumeric = META_NUMERIC_COLUMNS.has(col)
+      const minRaw = isNumeric ? (aggRow[`min_${col}`] ?? null) : null
+      const maxRaw = isNumeric ? (aggRow[`max_${col}`] ?? null) : null
+      const values = distinctValuesByColumn.get(col)
+      const distinctValues =
+        values !== undefined ? [...values].sort((a, b) => a.localeCompare(b)) : null
+
+      const base = params.length
+      valuesClauses.push(
+        `($${base + 1}, $${base + 2}, $${base + 3}::jsonb, $${base + 4}::jsonb, $${base + 5}, $${base + 6}::jsonb)`
+      )
+      params.push(
+        caseId,
+        col,
+        minRaw === null ? null : JSON.stringify(Number(minRaw)),
+        maxRaw === null ? null : JSON.stringify(Number(maxRaw)),
+        distinctCount,
+        distinctValues === null ? null : JSON.stringify(distinctValues)
+      )
+    }
+
+    await client.query(
+      `INSERT INTO ${tbl('cohort_column_meta')}
+         (case_id, column_name, min_value, max_value, distinct_count, distinct_values)
+       VALUES ${valuesClauses.join(', ')}`,
+      params
+    )
   }
-  async removeColumnMetas(_args: ScopedClient & { caseId: number }): Promise<void> {
-    throw new Error('TODO PR3-4')
+
+  /**
+   * Drop a single case's column-meta rows. The ON DELETE CASCADE from C1 makes
+   * this redundant when the case row is deleted in the same transaction, but C3
+   * calls it explicitly to support the "remove without deleting case" path.
+   */
+  async removeColumnMetas({
+    schema,
+    client,
+    caseId
+  }: ScopedClient & { caseId: number }): Promise<void> {
+    const tbl = (t: string): string => `"${schema}"."${t}"`
+    await client.query(`DELETE FROM ${tbl('cohort_column_meta')} WHERE case_id = $1`, [caseId])
   }
   async getState(_args: ScopedClient): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
     throw new Error('TODO PR3-9')

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -91,7 +91,7 @@ const ACMG_RANK_SQL = (col: string) => `CASE ${col}
  * collapse to one carrier (Pass-2 #4). Emits carrier/het/hom deltas so both
  * the add and remove paths can reuse the same shape.
  */
-const SCOPED_DEDUPED_AGG_SQL = (tbl: (t: string) => string) => `
+export const SCOPED_DEDUPED_AGG_SQL = (tbl: (t: string) => string) => `
   WITH deduped AS (
     SELECT v.chr, v.pos, v.ref, v.alt, v.variant_type, c.genome_build,
            MAX(v.end_pos) AS end_pos,

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -39,6 +39,53 @@ const ACMG_RANK_SQL = (col: string) => `CASE ${col}
   WHEN 'Benign' THEN 1
   ELSE 0 END`
 
+/**
+ * Deduped per-coordinate aggregate for a single case_id ($1). Mirrors the
+ * SQLite INCREMENTAL_ADD_SQL / INCREMENTAL_REMOVE_SQL deduped sub-selects in
+ * src/shared/sql/cohort-summary-rebuild.ts:134-184 — duplicate per-case rows
+ * collapse to one carrier (Pass-2 #4). Emits carrier/het/hom deltas so both
+ * the add and remove paths can reuse the same shape.
+ */
+const SCOPED_DEDUPED_AGG_SQL = (tbl: (t: string) => string) => `
+  WITH deduped AS (
+    SELECT v.chr, v.pos, v.ref, v.alt, v.variant_type, c.genome_build,
+           MAX(v.end_pos) AS end_pos,
+           MAX(v.gene_symbol) AS gene_symbol,
+           MAX(v.cdna) AS cdna,
+           MAX(v.aa_change) AS aa_change,
+           MAX(v.consequence) AS consequence,
+           MAX(v.func) AS func,
+           MAX(v.clinvar) AS clinvar,
+           MAX(v.gnomad_af) AS gnomad_af,
+           MAX(v.cadd) AS cadd,
+           MAX(v.transcript) AS transcript,
+           MAX(v.omim_mim_number) AS omim_mim_number,
+           MAX(v.gt_num) AS gt_num
+    FROM ${tbl('variants')} v
+    JOIN ${tbl('cases')} c ON c.id = v.case_id
+    WHERE v.case_id = $1
+    GROUP BY v.chr, v.pos, v.ref, v.alt, v.variant_type, c.genome_build
+  ),
+  per_case AS (
+    SELECT chr, pos, ref, alt, variant_type, genome_build,
+           MAX(end_pos) AS end_pos,
+           MAX(gene_symbol) AS gene_symbol,
+           MAX(cdna) AS cdna,
+           MAX(aa_change) AS aa_change,
+           MAX(consequence) AS consequence,
+           MAX(func) AS func,
+           MAX(clinvar) AS clinvar,
+           MAX(gnomad_af) AS gnomad_af,
+           MAX(cadd) AS cadd,
+           MAX(transcript) AS transcript,
+           MAX(omim_mim_number) AS omim_mim_number,
+           COUNT(*) AS carrier_delta,
+           SUM(CASE WHEN gt_num IN ('0/1','1/0','0|1','1|0') THEN 1 ELSE 0 END) AS het_delta,
+           SUM(CASE WHEN gt_num IN ('1/1','1|1') THEN 1 ELSE 0 END) AS hom_delta
+    FROM deduped
+    GROUP BY chr, pos, ref, alt, variant_type, genome_build
+  )`
+
 export class PostgresCohortSummaryRepository {
   async rebuild({ schema, client }: ScopedClient): Promise<void> {
     const tbl = (t: string): string => `"${schema}"."${t}"`
@@ -162,12 +209,131 @@ export class PostgresCohortSummaryRepository {
     // postgres-import-worker.ts).
   }
 
-  // Stub for next tasks
-  async incrementalAdd(_args: ScopedClient & { caseId: number }): Promise<void> {
-    throw new Error('TODO PR3-3')
+  /**
+   * Add one case's variants to the summary. INSERT … SELECT from the deduped
+   * per-case CTE, ON CONFLICT bumping all three counters simultaneously
+   * (Pass-6 MED #3). Flags use OR semantics so an add never clears an existing
+   * annotation flag; on the INSERT (brand-new row) path the flags come from the
+   * same EXISTS expressions as rebuild().
+   */
+  async incrementalAdd({
+    schema,
+    client,
+    caseId
+  }: ScopedClient & { caseId: number }): Promise<void> {
+    const tbl = (t: string): string => `"${schema}"."${t}"`
+
+    await client.query(
+      `
+      INSERT INTO ${tbl('cohort_variant_summary')}
+        (chr, pos, end_pos, ref, alt, variant_type, genome_build,
+         gene_symbol, cdna, aa_change, consequence, func, clinvar,
+         gnomad_af, cadd, transcript, omim_mim_number,
+         carrier_count, het_count, hom_count, variant_key,
+         has_star, has_comment, acmg_best, cohort_frequency)
+      ${SCOPED_DEDUPED_AGG_SQL(tbl)}
+      SELECT
+        pc.chr, pc.pos, pc.end_pos, pc.ref, pc.alt, pc.variant_type, pc.genome_build,
+        pc.gene_symbol, pc.cdna, pc.aa_change, pc.consequence, pc.func, pc.clinvar,
+        pc.gnomad_af, pc.cadd, pc.transcript, pc.omim_mim_number,
+        pc.carrier_delta, pc.het_delta, pc.hom_delta,
+        pc.chr || ':' || pc.pos || ':' || pc.ref || ':' || pc.alt AS variant_key,
+        -- Pass-9 #8: brand-new rows derive flags from current annotation tables.
+        (EXISTS (
+          SELECT 1 FROM ${tbl('variant_annotations')} va
+          WHERE va.chr = pc.chr AND va.pos = pc.pos
+            AND va.ref = pc.ref AND va.alt = pc.alt
+            AND va.starred = 1
+        ) OR EXISTS (
+          SELECT 1 FROM ${tbl('case_variant_annotations')} cva
+          JOIN ${tbl('variants')} v ON cva.variant_id = v.id
+          WHERE v.chr = pc.chr AND v.pos = pc.pos
+            AND v.ref = pc.ref AND v.alt = pc.alt
+            AND v.variant_type = pc.variant_type
+            AND cva.starred = 1
+        )) AS has_star,
+        (EXISTS (
+          SELECT 1 FROM ${tbl('variant_annotations')} va
+          WHERE va.chr = pc.chr AND va.pos = pc.pos
+            AND va.ref = pc.ref AND va.alt = pc.alt
+            AND va.global_comment IS NOT NULL AND va.global_comment <> ''
+        ) OR EXISTS (
+          SELECT 1 FROM ${tbl('case_variant_annotations')} cva
+          JOIN ${tbl('variants')} v ON cva.variant_id = v.id
+          WHERE v.chr = pc.chr AND v.pos = pc.pos
+            AND v.ref = pc.ref AND v.alt = pc.alt
+            AND v.variant_type = pc.variant_type
+            AND cva.per_case_comment IS NOT NULL AND cva.per_case_comment <> ''
+        )) AS has_comment,
+        (CASE (
+          SELECT MAX(rank) FROM (
+            SELECT ${ACMG_RANK_SQL('va.acmg_classification')} AS rank
+            FROM ${tbl('variant_annotations')} va
+            WHERE va.chr = pc.chr AND va.pos = pc.pos
+              AND va.ref = pc.ref AND va.alt = pc.alt
+              AND va.acmg_classification IS NOT NULL
+            UNION ALL
+            SELECT ${ACMG_RANK_SQL('cva.acmg_classification')} AS rank
+            FROM ${tbl('case_variant_annotations')} cva
+            JOIN ${tbl('variants')} v ON cva.variant_id = v.id
+            WHERE v.chr = pc.chr AND v.pos = pc.pos
+              AND v.ref = pc.ref AND v.alt = pc.alt
+              AND v.variant_type = pc.variant_type
+              AND cva.acmg_classification IS NOT NULL
+          ) ranked
+        )
+          WHEN 5 THEN 'Pathogenic'
+          WHEN 4 THEN 'Likely pathogenic'
+          WHEN 3 THEN 'Uncertain significance'
+          WHEN 2 THEN 'Likely benign'
+          WHEN 1 THEN 'Benign'
+          ELSE NULL
+        END) AS acmg_best,
+        NULL AS cohort_frequency  -- recomputed by C2a, called by the caller next
+      FROM per_case pc
+      ON CONFLICT (chr, pos, ref, alt, variant_type, genome_build) DO UPDATE SET
+        carrier_count = cohort_variant_summary.carrier_count + EXCLUDED.carrier_count,
+        het_count = cohort_variant_summary.het_count + EXCLUDED.het_count,
+        hom_count = cohort_variant_summary.hom_count + EXCLUDED.hom_count,
+        -- Adds never clear annotation flags (OR semantics).
+        has_star = cohort_variant_summary.has_star OR EXCLUDED.has_star,
+        has_comment = cohort_variant_summary.has_comment OR EXCLUDED.has_comment;
+    `,
+      [caseId]
+    )
   }
-  async incrementalRemove(_args: ScopedClient & { caseId: number }): Promise<void> {
-    throw new Error('TODO PR3-3')
+
+  /**
+   * Remove one case's variants from the summary. UPDATE-from-CTE subtracting all
+   * three counters simultaneously (Pass-6 MED #3), then a sibling DELETE of any
+   * row that dropped to zero carriers (Pass-2 verdict #1 — separate statement,
+   * not a sibling CTE). Mirrors SQLite INCREMENTAL_REMOVE_SQL +
+   * CLEANUP_ZERO_CARRIERS_SQL.
+   */
+  async incrementalRemove({
+    schema,
+    client,
+    caseId
+  }: ScopedClient & { caseId: number }): Promise<void> {
+    const tbl = (t: string): string => `"${schema}"."${t}"`
+
+    await client.query(
+      `
+      ${SCOPED_DEDUPED_AGG_SQL(tbl)}
+      UPDATE ${tbl('cohort_variant_summary')} cvs
+      SET carrier_count = cvs.carrier_count - per_case.carrier_delta,
+          het_count = cvs.het_count - per_case.het_delta,
+          hom_count = cvs.hom_count - per_case.hom_delta
+      FROM per_case
+      WHERE cvs.chr = per_case.chr AND cvs.pos = per_case.pos
+        AND cvs.ref = per_case.ref AND cvs.alt = per_case.alt
+        AND cvs.variant_type = per_case.variant_type
+        AND cvs.genome_build = per_case.genome_build;
+    `,
+      [caseId]
+    )
+
+    await client.query(`DELETE FROM ${tbl('cohort_variant_summary')} WHERE carrier_count <= 0`)
   }
   async refreshColumnMetas(_args: ScopedClient & { caseId: number }): Promise<void> {
     throw new Error('TODO PR3-4')

--- a/src/main/storage/postgres/PostgresReadExecutor.ts
+++ b/src/main/storage/postgres/PostgresReadExecutor.ts
@@ -24,7 +24,9 @@ interface PostgresReadExecutorRepositories {
   cohort: Pick<
     PostgresCohortRepository,
     | 'queryVariants'
+    | 'queryVariantsWithStaleness'
     | 'getSummary'
+    | 'getSummaryStatus'
     | 'getColumnMeta'
     | 'getCarriers'
     | 'getGeneBurden'
@@ -160,10 +162,13 @@ export class PostgresReadExecutor implements StorageReadExecutor {
         return await this.repositories.variants.getColumnMeta(task.params[0], task.params[1])
 
       case 'cohort:query':
-        return await this.repositories.cohort.queryVariants(task.params[0])
+        return await this.repositories.cohort.queryVariantsWithStaleness(task.params[0])
 
       case 'cohort:summary':
         return await this.repositories.cohort.getSummary()
+
+      case 'cohort:summaryStatus':
+        return await this.repositories.cohort.getSummaryStatus()
 
       case 'cohort:columnMeta':
         return await this.repositories.cohort.getColumnMeta()

--- a/src/main/storage/postgres/PostgresVariantReadRepository.ts
+++ b/src/main/storage/postgres/PostgresVariantReadRepository.ts
@@ -10,6 +10,16 @@ import type {
 import type { FilterOptions } from '../../../shared/types/api'
 import type { ColumnFilterMeta } from '../../../shared/types/column-filters'
 import { quoteIdentifier } from './identifiers'
+import {
+  columnMetaRowToFilterMeta,
+  emptyColumnMeta,
+  reshapeFilterOptions
+} from './postgres-column-meta-cache'
+import type { ColumnMetaRow } from './postgres-column-meta-cache'
+import {
+  getCategoricalColumnMetaLive,
+  getNumericColumnMetaLive
+} from './postgres-variant-column-meta-live'
 import { runNamed, runNamedDynamic } from './named-query'
 import { POSTGRES_VARIANT_COLUMN_DEFINITIONS } from './postgres-variant-columns'
 import type { PostgresVariantColumnDefinition } from './postgres-variant-columns'
@@ -50,12 +60,6 @@ function toNumber(value: unknown): number {
   if (typeof value === 'number') return value
   if (typeof value === 'string') return Number(value)
   return 0
-}
-
-function toOptionalNumber(value: unknown): number | undefined {
-  if (value === null || value === undefined) return undefined
-  const numberValue = typeof value === 'number' ? value : Number(value)
-  return Number.isFinite(numberValue) ? numberValue : undefined
 }
 
 function toPrefixTsQuery(query: string): string {
@@ -454,26 +458,24 @@ export class PostgresVariantReadRepository {
     }
   }
 
+  /**
+   * Per-case filter options (C4 Step 3). Reads the materialised
+   * `cohort_column_meta` cache (populated by C2's refreshColumnMetas on import +
+   * delete + rebuild) instead of live-aggregating the `variants` table. The
+   * cache mirrors SQLite getAllColumnMetas — one row per filterable base column,
+   * so the reshaped output matches the SQLite FilterOptions shape (base columns
+   * only; extension columns are fetched on demand via getColumnMeta).
+   */
   async getFilterOptions(caseId: number): Promise<FilterOptions> {
-    const columnMeta = await Promise.all(
-      Object.keys(POSTGRES_VARIANT_COLUMN_DEFINITIONS).map((columnKey) =>
-        this.getColumnMeta({ caseId }, columnKey)
-      )
-    )
-    const metaByKey = new Map(columnMeta.map((meta) => [meta.key, meta]))
-    const caddMeta = metaByKey.get('cadd')
-    const gnomadAfMeta = metaByKey.get('gnomad_af')
-
-    return {
-      consequences: metaByKey.get('consequence')?.distinctValues ?? [],
-      funcs: metaByKey.get('func')?.distinctValues ?? [],
-      clinvars: metaByKey.get('clinvar')?.distinctValues ?? [],
-      minCadd: caddMeta?.min ?? null,
-      maxCadd: caddMeta?.max ?? null,
-      minGnomadAf: gnomadAfMeta?.min ?? null,
-      maxGnomadAf: gnomadAfMeta?.max ?? null,
-      columnMeta
-    }
+    const result = await runNamed<ColumnMetaRow>(this.pool as Pool, {
+      name: 'variants:filter_options_per_case:v1',
+      text: `SELECT column_name, min_value, max_value, distinct_count, distinct_values
+             FROM ${this.schemaName}."cohort_column_meta"
+             WHERE case_id = $1`,
+      values: [caseId],
+      schema: this.schema
+    })
+    return reshapeFilterOptions(result.rows)
   }
 
   async getColumnMeta(
@@ -483,6 +485,14 @@ export class PostgresVariantReadRepository {
     const definition = POSTGRES_VARIANT_COLUMN_DEFINITIONS[columnKey]
     if (definition === undefined) {
       return { key: columnKey, dataType: 'text', distinctCount: 0 }
+    }
+
+    // Per-case base columns read the materialised cohort_column_meta cache (C4
+    // Step 3). Extension columns (sv.*, cnv.*, str.*) are not materialised there,
+    // and the multi-case branch stays live-aggregating to avoid cross-case
+    // distinct overcount (Pass-5 MED #1).
+    if ('caseId' in scope && !columnKey.includes('.')) {
+      return this.getPerCaseColumnMeta(scope.caseId, definition)
     }
 
     const caseIds = 'caseId' in scope ? [scope.caseId] : scope.caseIds
@@ -495,96 +505,40 @@ export class PostgresVariantReadRepository {
     }
 
     return definition.kind === 'numeric'
-      ? this.getNumericColumnMeta(caseIds, definition)
-      : this.getCategoricalColumnMeta(caseIds, definition)
+      ? getNumericColumnMetaLive(
+          this.pool as Pool,
+          this.schema,
+          this.schemaName,
+          caseIds,
+          definition
+        )
+      : getCategoricalColumnMetaLive(
+          this.pool as Pool,
+          this.schema,
+          this.schemaName,
+          caseIds,
+          definition
+        )
   }
 
-  private async getNumericColumnMeta(
-    caseIds: number[],
+  /** Single base column for one case, read from the cohort_column_meta cache. */
+  private async getPerCaseColumnMeta(
+    caseId: number,
     definition: PostgresVariantColumnDefinition
   ): Promise<ColumnFilterMeta> {
-    const result = await runNamedDynamic<{ distinct_count: unknown; min: unknown; max: unknown }>(
-      this.pool as Pool,
-      {
-        baseName: 'variants:column_meta',
-        text: `SELECT COUNT(DISTINCT ${definition.sql})::int AS distinct_count,
-              MIN(${definition.sql}) AS min,
-              MAX(${definition.sql}) AS max
-       FROM ${this.schemaName}."variants" v
-       ${this.buildColumnMetaJoins(definition.key)}
-       WHERE v.case_id = ANY($1::bigint[])`,
-        values: [caseIds],
-        schema: this.schema
-      }
-    )
-    const row = result.rows[0] as
-      | { distinct_count?: unknown; min?: unknown; max?: unknown }
-      | undefined
-    const meta: ColumnFilterMeta = {
-      key: definition.key,
-      dataType: 'numeric',
-      distinctCount: toNumber(row?.distinct_count)
-    }
-    const min = toOptionalNumber(row?.min)
-    const max = toOptionalNumber(row?.max)
-    if (min !== undefined) meta.min = min
-    if (max !== undefined) meta.max = max
-    return meta
-  }
-
-  private async getCategoricalColumnMeta(
-    caseIds: number[],
-    definition: PostgresVariantColumnDefinition
-  ): Promise<ColumnFilterMeta> {
-    const joins = this.buildColumnMetaJoins(definition.key)
-    const countResult = await runNamedDynamic<{ distinct_count: unknown }>(this.pool as Pool, {
-      baseName: 'variants:column_meta',
-      text: `SELECT COUNT(DISTINCT ${definition.sql})::int AS distinct_count
-       FROM ${this.schemaName}."variants" v
-       ${joins}
-       WHERE v.case_id = ANY($1::bigint[])`,
-      values: [caseIds],
+    const result = await runNamed<ColumnMetaRow>(this.pool as Pool, {
+      name: 'variants:column_meta_per_case:v1',
+      text: `SELECT column_name, min_value, max_value, distinct_count, distinct_values
+             FROM ${this.schemaName}."cohort_column_meta"
+             WHERE case_id = $1 AND column_name = $2`,
+      values: [caseId, definition.key],
       schema: this.schema
     })
-    const distinctCount = toNumber(
-      (countResult.rows[0] as { distinct_count?: unknown } | undefined)?.distinct_count
-    )
-    const meta: ColumnFilterMeta = {
-      key: definition.key,
-      dataType: 'text',
-      distinctCount
+    const row = result.rows[0]
+    const isNumeric = definition.kind === 'numeric'
+    if (row === undefined) {
+      return emptyColumnMeta(definition.key, isNumeric)
     }
-
-    if (distinctCount > 0 && distinctCount <= 50) {
-      const valuesResult = await runNamedDynamic<{ value: unknown }>(this.pool as Pool, {
-        baseName: 'variants:column_meta',
-        text: `SELECT DISTINCT ${definition.sql} AS value
-         FROM ${this.schemaName}."variants" v
-         ${joins}
-         WHERE v.case_id = ANY($1::bigint[])
-           AND ${definition.sql} IS NOT NULL
-         ORDER BY ${definition.sql}`,
-        values: [caseIds],
-        schema: this.schema
-      })
-      meta.distinctValues = (valuesResult.rows as Array<{ value: unknown }>).map((row) =>
-        String(row.value)
-      )
-    }
-
-    return meta
-  }
-
-  private buildColumnMetaJoins(columnKey: string): string {
-    if (columnKey.startsWith('sv.')) {
-      return `LEFT JOIN ${this.schemaName}."variant_sv" sv ON sv.variant_id = v.id`
-    }
-    if (columnKey.startsWith('cnv.')) {
-      return `LEFT JOIN ${this.schemaName}."variant_cnv" cnv ON cnv.variant_id = v.id`
-    }
-    if (columnKey.startsWith('str.')) {
-      return `LEFT JOIN ${this.schemaName}."variant_str" str_ext ON str_ext.variant_id = v.id`
-    }
-    return ''
+    return columnMetaRowToFilterMeta(definition.key, isNumeric, row)
   }
 }

--- a/src/main/storage/postgres/cohort-annotation-flags-sql.ts
+++ b/src/main/storage/postgres/cohort-annotation-flags-sql.ts
@@ -1,0 +1,238 @@
+/**
+ * Sprint A PR-3 C5a — SQL builders and executors for the cohort_variant_summary
+ * annotation-flag write-hooks.
+ *
+ * These are factored out of PostgresAnnotationsRepository so the repository
+ * class stays focused on annotation persistence + transaction orchestration,
+ * and so the flag-derivation SQL can be reviewed in one place alongside its
+ * rebuild() counterpart in PostgresCohortSummaryRepository (Pass-9 #8 — the two
+ * must stay in lockstep).
+ *
+ * The `*Sql(schemaName)` builders take a pre-quoted schema identifier (via
+ * quoteIdentifier). The `applyAnnotationFlags*(client, args)` executors run the
+ * statement through runNamed inside the caller's transaction (no BEGIN/COMMIT).
+ */
+import type { Pool } from 'pg'
+
+import { InvalidParametersError } from '../../ipc/errors'
+import { quoteIdentifier } from './identifiers'
+import { runNamed } from './named-query'
+
+/** runNamed only needs `query`; accept any pool/client that provides it. */
+type RunNamedCapable = Pick<Pool, 'query'>
+
+/**
+ * ACMG rank ladder mirroring PostgresCohortSummaryRepository (and the SQLite
+ * source of truth in src/shared/sql/cohort-summary-rebuild.ts). Higher rank
+ * wins; the textual label is reconstructed from the winning rank.
+ */
+const ACMG_RANK_SQL = (col: string): string => `CASE ${col}
+  WHEN 'Pathogenic' THEN 5
+  WHEN 'Likely pathogenic' THEN 4
+  WHEN 'Uncertain significance' THEN 3
+  WHEN 'Likely benign' THEN 2
+  WHEN 'Benign' THEN 1
+  ELSE 0 END`
+
+const ACMG_LABEL_FROM_RANK_SQL = `WHEN 5 THEN 'Pathogenic'
+  WHEN 4 THEN 'Likely pathogenic'
+  WHEN 3 THEN 'Uncertain significance'
+  WHEN 2 THEN 'Likely benign'
+  WHEN 1 THEN 'Benign'
+  ELSE NULL`
+
+/**
+ * SQL `SET` fragment that recomputes the three annotation flag columns of a
+ * cohort_variant_summary row (`cvs`) from the live annotation tables. Mirrors
+ * the EXISTS / ACMG-rank projection in PostgresCohortSummaryRepository.rebuild
+ * (Pass-9 #8) so the write-hooks keep has_star / has_comment / acmg_best in
+ * lockstep with a full rebuild.
+ *
+ * `caseFilter` is an extra predicate (already prefixed with ` AND `) applied to
+ * the per-case join on `v` — the on-case-delete variant passes
+ * ` AND v.case_id <> $N` so the about-to-be-deleted case is excluded from the
+ * EXISTS (Pass-5 HIGH #1); the global / per-case variants pass an empty string.
+ */
+function flagRecomputeSql(schemaName: string, caseFilter: string): string {
+  return `
+    has_star = (EXISTS (
+      SELECT 1 FROM ${schemaName}."variant_annotations" va
+      WHERE va.chr = cvs.chr AND va.pos = cvs.pos
+        AND va.ref = cvs.ref AND va.alt = cvs.alt
+        AND va.starred = 1
+    ) OR EXISTS (
+      SELECT 1 FROM ${schemaName}."case_variant_annotations" cva
+      JOIN ${schemaName}."variants" v ON cva.variant_id = v.id
+      WHERE v.chr = cvs.chr AND v.pos = cvs.pos
+        AND v.ref = cvs.ref AND v.alt = cvs.alt
+        AND v.variant_type = cvs.variant_type
+        AND cva.starred = 1${caseFilter}
+    )),
+    has_comment = (EXISTS (
+      SELECT 1 FROM ${schemaName}."variant_annotations" va
+      WHERE va.chr = cvs.chr AND va.pos = cvs.pos
+        AND va.ref = cvs.ref AND va.alt = cvs.alt
+        AND va.global_comment IS NOT NULL AND va.global_comment <> ''
+    ) OR EXISTS (
+      SELECT 1 FROM ${schemaName}."case_variant_annotations" cva
+      JOIN ${schemaName}."variants" v ON cva.variant_id = v.id
+      WHERE v.chr = cvs.chr AND v.pos = cvs.pos
+        AND v.ref = cvs.ref AND v.alt = cvs.alt
+        AND v.variant_type = cvs.variant_type
+        AND cva.per_case_comment IS NOT NULL AND cva.per_case_comment <> ''${caseFilter}
+    )),
+    acmg_best = (CASE (
+      SELECT MAX(rank) FROM (
+        SELECT ${ACMG_RANK_SQL('va.acmg_classification')} AS rank
+        FROM ${schemaName}."variant_annotations" va
+        WHERE va.chr = cvs.chr AND va.pos = cvs.pos
+          AND va.ref = cvs.ref AND va.alt = cvs.alt
+          AND va.acmg_classification IS NOT NULL
+        UNION ALL
+        SELECT ${ACMG_RANK_SQL('cva.acmg_classification')} AS rank
+        FROM ${schemaName}."case_variant_annotations" cva
+        JOIN ${schemaName}."variants" v ON cva.variant_id = v.id
+        WHERE v.chr = cvs.chr AND v.pos = cvs.pos
+          AND v.ref = cvs.ref AND v.alt = cvs.alt
+          AND v.variant_type = cvs.variant_type
+          AND cva.acmg_classification IS NOT NULL${caseFilter}
+      ) ranked
+    )
+      ${ACMG_LABEL_FROM_RANK_SQL}
+    END)`
+}
+
+/**
+ * Global write-hook: recompute flags on EVERY summary row at (chr, pos, ref,
+ * alt). A global annotation has no case scope, so it fans out across every
+ * variant_type / genome_build bucket at that coordinate.
+ */
+export function annotationFlagsGlobalSql(schemaName: string): string {
+  return `
+    UPDATE ${schemaName}."cohort_variant_summary" cvs
+    SET ${flagRecomputeSql(schemaName, '')}
+    WHERE cvs.chr = $1 AND cvs.pos = $2 AND cvs.ref = $3 AND cvs.alt = $4
+  `
+}
+
+/**
+ * Per-case write-hook: resolve the target coordinate from (caseId, variantId)
+ * via a CTE joining variants on BOTH v.id = $2 AND v.case_id = $1 — a spoofed
+ * variantId from another case yields zero target rows (the caller throws
+ * InvalidParametersError, Pass-7 LOW #6). Recompute flags on every summary row
+ * sharing the resolved coordinate.
+ *
+ * The statement RETURNS `target_resolved` — the count of variant rows the
+ * `target` CTE matched — so the caller can tell "variant does not belong to
+ * case" (target_resolved = 0 → throw) apart from "variant resolved but no
+ * cohort_variant_summary row to update yet" (target_resolved = 1, zero rows
+ * updated → benign no-op when the summary is unbuilt/stale). The summary
+ * UPDATE's rowCount is deliberately NOT used as the existence signal because it
+ * conflates those two cases.
+ */
+export function annotationFlagsPerCaseSql(schemaName: string): string {
+  return `
+    WITH target AS (
+      SELECT v.chr, v.pos, v.ref, v.alt, v.variant_type
+      FROM ${schemaName}."variants" v
+      WHERE v.id = $2 AND v.case_id = $1
+    ),
+    updated AS (
+      UPDATE ${schemaName}."cohort_variant_summary" cvs
+      SET ${flagRecomputeSql(schemaName, '')}
+      FROM target t
+      WHERE cvs.chr = t.chr AND cvs.pos = t.pos
+        AND cvs.ref = t.ref AND cvs.alt = t.alt
+        AND cvs.variant_type = t.variant_type
+      RETURNING 1
+    )
+    SELECT count(*)::int AS target_resolved FROM target
+  `
+}
+
+/**
+ * On-case-delete write-hook: recompute flags across the whole summary table
+ * with the per-case EXISTS subqueries excluding the about-to-be-deleted case
+ * (v.case_id <> $1, Pass-5 HIGH #1). Called by C3 step 2 BEFORE the case row
+ * (and its cascade-deleted annotations) is removed.
+ */
+export function annotationFlagsOnCaseDeleteSql(schemaName: string): string {
+  return `
+    UPDATE ${schemaName}."cohort_variant_summary" cvs
+    SET ${flagRecomputeSql(schemaName, ' AND v.case_id <> $1')}
+  `
+}
+
+/**
+ * Global annotation write-hook (C5a / Pass-4 MED #4). Recomputes the three flag
+ * columns on EVERY cohort_variant_summary row matching (chr, pos, ref, alt) — a
+ * global annotation has no case scope, so it fans out across every variant_type
+ * / genome_build bucket at that coordinate. Runs inside the caller's
+ * transaction.
+ */
+export async function applyAnnotationFlagsGlobal(
+  client: RunNamedCapable,
+  args: { schema: string; chr: string; pos: number; ref: string; alt: string }
+): Promise<void> {
+  const schemaName = quoteIdentifier(args.schema)
+  await runNamed(client as Pool, {
+    name: 'cohort_summary:annotation_flags_global:v1',
+    text: annotationFlagsGlobalSql(schemaName),
+    values: [args.chr, args.pos, args.ref, args.alt],
+    schema: args.schema
+  })
+}
+
+/**
+ * Per-case annotation write-hook (C5a / Pass-7 LOW #6). Resolves the target
+ * coordinate from (caseId, variantId) via a CTE joining variants on BOTH
+ * v.id = $variantId AND v.case_id = $caseId — a spoofed variantId from another
+ * case yields zero target rows and we throw InvalidParametersError rather than
+ * silently no-op. Recomputes the flag columns for every summary row sharing the
+ * resolved coordinate. Runs inside the caller's transaction.
+ *
+ * The throw is keyed on `target_resolved` (whether the variant itself belongs
+ * to the case), NOT on the number of cohort_variant_summary rows updated. A
+ * valid variant whose summary row does not exist yet (summary unbuilt/stale —
+ * see C3 import wiring) resolves the target but updates zero rows; that is a
+ * benign no-op, not an InvalidParametersError (PR3-7 review MAJOR #3).
+ */
+export async function applyAnnotationFlagsPerCase(
+  client: RunNamedCapable,
+  args: { schema: string; caseId: number; variantId: number }
+): Promise<void> {
+  const schemaName = quoteIdentifier(args.schema)
+  const result = await runNamed<{ target_resolved: number }>(client as Pool, {
+    name: 'cohort_summary:annotation_flags_per_case:v2',
+    text: annotationFlagsPerCaseSql(schemaName),
+    values: [args.caseId, args.variantId],
+    schema: args.schema
+  })
+  const targetResolved = result.rows[0]?.target_resolved ?? 0
+  if (targetResolved === 0) {
+    throw new InvalidParametersError(
+      `Per-case annotation flag hook matched no variant for case ${args.caseId} / variant ${args.variantId}.`
+    )
+  }
+}
+
+/**
+ * On-case-delete annotation write-hook (C5a / Pass-5 HIGH #1). Called by C3
+ * step 2 BEFORE the case row (and its cascade-deleted annotations) is removed.
+ * Recomputes the flag columns across the whole summary table with the per-case
+ * EXISTS subqueries excluding the about-to-be-deleted case (v.case_id <>
+ * $deletedCaseId) so flags backed solely by that case clear in the same
+ * transaction. Runs inside the caller's transaction.
+ */
+export async function applyAnnotationFlagsOnCaseDelete(
+  client: RunNamedCapable,
+  args: { schema: string; deletedCaseId: number }
+): Promise<void> {
+  const schemaName = quoteIdentifier(args.schema)
+  await runNamed(client as Pool, {
+    name: 'cohort_summary:annotation_flags_on_case_delete:v1',
+    text: annotationFlagsOnCaseDeleteSql(schemaName),
+    values: [args.deletedCaseId],
+    schema: args.schema
+  })
+}

--- a/src/main/storage/postgres/cohort-read-freshness.ts
+++ b/src/main/storage/postgres/cohort-read-freshness.ts
@@ -1,0 +1,180 @@
+/**
+ * Sprint A PR-3 C5 (PR3-17) — cohort-read freshness / staleness orchestration.
+ *
+ * The cohort read path (cohort:query) must reconcile the materialised
+ * cohort_variant_summary with its lifecycle state before serving rows:
+ *
+ *   - Bootstrap-on-existing-data (Pass-9 #5): when the summary has never been
+ *     rebuilt (last_rebuilt_at IS NULL) OR variants exist but the summary table
+ *     is empty, force a synchronous rebuild regardless of the case-count
+ *     threshold — otherwise the very first read of an imported/migrated dataset
+ *     would serve an empty cohort.
+ *   - Stale below SYNC_REBUILD_MAX_CASES: rebuild synchronously, then serve
+ *     fresh data (no warning).
+ *   - Stale at/above the threshold: serve the stale summary immediately and
+ *     schedule a single-flight background rebuild, surfacing
+ *     warnings.staleSummary=true so the renderer can show a "refreshing" hint
+ *     (Pass-8 #6).
+ *
+ * Free functions (pool + schema in) so PostgresCohortRepository stays an
+ * orchestration-only repository and this read-path policy lives in one module.
+ */
+import type { Pool, PoolClient } from 'pg'
+
+import { mainLogger } from '../../services/MainLogger'
+import { PostgresCohortSummaryRepository } from './PostgresCohortSummaryRepository'
+import { getCohortSummaryState } from './cohort-summary-state-sql'
+
+const DEFAULT_SYNC_REBUILD_MAX_CASES = 50
+
+interface ScopedPool {
+  pool: Pick<Pool, 'query' | 'connect'>
+  schema: string
+}
+
+/** Optional warnings returned alongside a cohort read result. */
+export interface CohortReadWarnings {
+  staleSummary?: boolean
+}
+
+/**
+ * Max total cases for which a stale-triggered rebuild still runs synchronously
+ * on the read path. Reads from VARLENS_PG_COHORT_SUMMARY_SYNC_MAX_CASES; falls
+ * back to 50. Read lazily (not cached) so tests can flip the env per-case.
+ */
+export function syncRebuildMaxCases(): number {
+  const raw = process.env.VARLENS_PG_COHORT_SUMMARY_SYNC_MAX_CASES
+  if (raw === undefined || raw.trim() === '') return DEFAULT_SYNC_REBUILD_MAX_CASES
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_SYNC_REBUILD_MAX_CASES
+}
+
+/**
+ * Read the cohort_summary_state singleton in the existing IPC contract shape
+ * { is_stale, last_rebuilt_at:number } (Pass-9 #6 epoch-ms mapping). Connects a
+ * client because getCohortSummaryState takes a PoolClient.
+ */
+export async function readCohortSummaryStatus({
+  pool,
+  schema
+}: ScopedPool): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
+  const client = await pool.connect()
+  try {
+    return await getCohortSummaryState({ schema, client })
+  } finally {
+    client.release()
+  }
+}
+
+interface FreshnessProbe {
+  never_rebuilt: boolean
+  variants_present: boolean
+  summary_present: boolean
+  is_stale: boolean
+  total_cases: number
+}
+
+async function probeFreshness({ pool, schema }: ScopedPool): Promise<FreshnessProbe> {
+  const tbl = (t: string): string => `"${schema}"."${t}"`
+  const result = await pool.query<{
+    never_rebuilt: boolean
+    variants_present: boolean
+    summary_present: boolean
+    is_stale: boolean
+    total_cases: string
+  }>(
+    `SELECT
+       (s.last_rebuilt_at IS NULL) AS never_rebuilt,
+       EXISTS (SELECT 1 FROM ${tbl('variants')} LIMIT 1) AS variants_present,
+       EXISTS (SELECT 1 FROM ${tbl('cohort_variant_summary')} LIMIT 1) AS summary_present,
+       s.is_stale,
+       (SELECT COUNT(*)::bigint FROM ${tbl('cases')}) AS total_cases
+     FROM ${tbl('cohort_summary_state')} s
+     WHERE s.id = 1`
+  )
+  const row = result.rows[0]
+  return {
+    never_rebuilt: row.never_rebuilt,
+    variants_present: row.variants_present,
+    summary_present: row.summary_present,
+    is_stale: row.is_stale,
+    total_cases: Number(row.total_cases)
+  }
+}
+
+/** Run a single rebuild inside its own transaction (BEGIN/COMMIT). */
+async function runSynchronousRebuild({ pool, schema }: ScopedPool): Promise<void> {
+  const repository = new PostgresCohortSummaryRepository()
+  const client = (await pool.connect()) as PoolClient
+  try {
+    await client.query('BEGIN')
+    await repository.rebuild({ schema, client })
+    await client.query('COMMIT')
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK')
+    } catch {
+      // ignore rollback failure; surface the original error below
+    }
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+/**
+ * Single-flight gate per schema so concurrent stale reads schedule at most one
+ * detached background rebuild. The promise is cleared when the rebuild settles.
+ */
+const backgroundRebuilds = new Map<string, Promise<void>>()
+
+function scheduleBackgroundRebuild(scope: ScopedPool): void {
+  if (backgroundRebuilds.has(scope.schema)) return
+
+  const task = runSynchronousRebuild(scope)
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error)
+      mainLogger.warn(`Background cohort summary rebuild failed: ${message}`, 'cohort')
+    })
+    .finally(() => {
+      backgroundRebuilds.delete(scope.schema)
+    })
+  backgroundRebuilds.set(scope.schema, task)
+}
+
+/**
+ * Reconcile the cohort summary before serving a cohort read. Returns the
+ * warnings to merge into the read response (staleSummary when a stale summary is
+ * served without a synchronous refresh).
+ */
+export async function prepareCohortRead(
+  scope: ScopedPool
+): Promise<{ warnings?: CohortReadWarnings }> {
+  const probe = await probeFreshness(scope)
+
+  // Pass-9 #5: bootstrap-on-existing-data — force a synchronous rebuild
+  // irrespective of the case-count threshold so the first read never serves an
+  // empty/missing summary for a populated dataset.
+  if (probe.never_rebuilt || (probe.variants_present && !probe.summary_present)) {
+    await runSynchronousRebuild(scope)
+    return {}
+  }
+
+  if (!probe.is_stale) {
+    return {}
+  }
+
+  if (probe.total_cases < syncRebuildMaxCases()) {
+    await runSynchronousRebuild(scope)
+    return {}
+  }
+
+  // Large cohort: serve the stale summary now and refresh in the background.
+  scheduleBackgroundRebuild(scope)
+  return { warnings: { staleSummary: true } }
+}
+
+/** Test-only: await any in-flight background rebuild for a schema. */
+export async function awaitBackgroundRebuild(schema: string): Promise<void> {
+  await backgroundRebuilds.get(schema)
+}

--- a/src/main/storage/postgres/cohort-summary-state-sql.ts
+++ b/src/main/storage/postgres/cohort-summary-state-sql.ts
@@ -1,0 +1,55 @@
+/**
+ * Sprint A PR-3 C1 — cohort_summary_state lifecycle helpers.
+ *
+ * Free functions extracted from PostgresCohortSummaryRepository so the
+ * repository file stays under the 600-line LLM-sustainable threshold. The
+ * repository keeps thin instance methods that delegate here; callers continue
+ * to use repo.getState / repo.markStale (Pass-7 MED #4 + Pass-8 #7 + Pass-9 #6).
+ */
+import type { PoolClient } from 'pg'
+
+interface ScopedClient {
+  schema: string
+  client: PoolClient
+}
+
+/**
+ * Return the singleton lifecycle state in the existing IPC shape
+ * { is_stale, last_rebuilt_at:number } (Pass-7 MED #4 + Pass-8 #7). The
+ * TIMESTAMPTZ last_rebuilt_at maps to epoch milliseconds via
+ * EXTRACT(EPOCH FROM …) * 1000 (Pass-9 #6); a NULL (never rebuilt) coalesces
+ * to 0 to keep the contract numeric.
+ */
+export async function getCohortSummaryState({
+  schema,
+  client
+}: ScopedClient): Promise<{ is_stale: boolean; last_rebuilt_at: number }> {
+  const tbl = (t: string): string => `"${schema}"."${t}"`
+  const r = await client.query<{ is_stale: boolean; last_rebuilt_at: string }>(
+    `SELECT is_stale,
+            COALESCE(EXTRACT(EPOCH FROM last_rebuilt_at) * 1000, 0)::bigint AS last_rebuilt_at
+     FROM ${tbl('cohort_summary_state')}
+     WHERE id = 1`
+  )
+  const row = r.rows[0]
+  return { is_stale: row.is_stale, last_rebuilt_at: Number(row.last_rebuilt_at) }
+}
+
+/**
+ * Flag the summary stale with an explicit reason (Pass-7 MED #4). Leaves
+ * last_rebuilt_at untouched so rebuild history is preserved; the next cohort
+ * read sees is_stale=true and triggers a rebuild.
+ */
+export async function markCohortSummaryStale({
+  schema,
+  client,
+  reason
+}: ScopedClient & { reason: string }): Promise<void> {
+  const tbl = (t: string): string => `"${schema}"."${t}"`
+  await client.query(
+    `UPDATE ${tbl('cohort_summary_state')}
+     SET is_stale = true, stale_reason = $1, stale_at = now()
+     WHERE id = 1`,
+    [reason]
+  )
+}

--- a/src/main/storage/postgres/migrations/definitions.ts
+++ b/src/main/storage/postgres/migrations/definitions.ts
@@ -48,6 +48,11 @@ const MIGRATION_FILES: readonly MigrationFile[] = [
     version: '0009',
     name: 'idx_variants_coords',
     fileName: '0009_idx_variants_coords.sql'
+  },
+  {
+    version: '0010',
+    name: 'cohort_summary',
+    fileName: '0010_cohort_summary.sql'
   }
 ]
 

--- a/src/main/storage/postgres/migrations/sql/0010_cohort_summary.sql
+++ b/src/main/storage/postgres/migrations/sql/0010_cohort_summary.sql
@@ -1,0 +1,87 @@
+-- Sprint A PR-3 C1 — materialised cohort summary + per-case column metas +
+-- singleton staleness state. Mirrors SQLite v25 schema (src/main/database/
+-- migrations.ts around v25) and the index set at :1545.
+
+-- cohort_variant_summary: deduped (chr, pos, ref, alt, variant_type,
+-- genome_build) aggregate of the variants table. Used by C4 read-side switch.
+CREATE TABLE IF NOT EXISTS "__schema__"."cohort_variant_summary" (
+  chr TEXT NOT NULL,
+  pos INTEGER NOT NULL,
+  end_pos INTEGER NULL,                    -- Pass-8 #5: required for C4 panel-interval predicate
+  ref TEXT NOT NULL,
+  alt TEXT NOT NULL,
+  variant_type TEXT NOT NULL DEFAULT 'snv',
+  genome_build TEXT NOT NULL DEFAULT 'GRCh38',
+  gene_symbol TEXT,
+  cdna TEXT,
+  aa_change TEXT,
+  consequence TEXT,
+  func TEXT,
+  clinvar TEXT,
+  gnomad_af DOUBLE PRECISION,
+  cadd DOUBLE PRECISION,
+  transcript TEXT,
+  omim_mim_number TEXT,
+  carrier_count INTEGER NOT NULL DEFAULT 0,
+  het_count INTEGER NOT NULL DEFAULT 0,
+  hom_count INTEGER NOT NULL DEFAULT 0,
+  variant_key TEXT,
+  has_star BOOLEAN NOT NULL DEFAULT false,
+  has_comment BOOLEAN NOT NULL DEFAULT false,
+  acmg_best TEXT NULL,
+  cohort_frequency DOUBLE PRECISION,
+  PRIMARY KEY (chr, pos, ref, alt, variant_type, genome_build)
+);
+
+-- Index set mirrors SQLite v25 exactly (Pass-3 LOW #7). No plain (gene_symbol)
+-- or (consequence) singletons — SQLite retired those in v25 in favour of the
+-- covering pairs below.
+CREATE INDEX IF NOT EXISTS idx_cvs_carrier
+  ON "__schema__"."cohort_variant_summary" (carrier_count);
+CREATE INDEX IF NOT EXISTS idx_cvs_filters
+  ON "__schema__"."cohort_variant_summary" (gnomad_af, cadd);
+CREATE INDEX IF NOT EXISTS idx_cvs_cohort_freq
+  ON "__schema__"."cohort_variant_summary" (cohort_frequency);
+CREATE INDEX IF NOT EXISTS idx_cvs_covering_common
+  ON "__schema__"."cohort_variant_summary" (consequence, gnomad_af, carrier_count);
+CREATE INDEX IF NOT EXISTS idx_cvs_gene_covering
+  ON "__schema__"."cohort_variant_summary" (gene_symbol, carrier_count);
+CREATE INDEX IF NOT EXISTS idx_cvs_type_build
+  ON "__schema__"."cohort_variant_summary" (variant_type, genome_build);
+
+-- cohort_column_meta: per-case filter metadata cache. Powers CaseView's
+-- FilterToolbar via getFilterOptions(caseId) → getColumnMeta (C4).
+CREATE TABLE IF NOT EXISTS "__schema__"."cohort_column_meta" (
+  case_id INTEGER NOT NULL REFERENCES "__schema__"."cases"(id) ON DELETE CASCADE,
+  column_name TEXT NOT NULL,
+  min_value JSONB,
+  max_value JSONB,
+  distinct_count INTEGER NOT NULL DEFAULT 0,
+  distinct_values JSONB NULL,
+  PRIMARY KEY (case_id, column_name)
+);
+
+-- cohort_summary_state: singleton row with staleness flags + timestamps
+-- (Pass-7 MED #4 columns: stale_reason, stale_at).
+CREATE TABLE IF NOT EXISTS "__schema__"."cohort_summary_state" (
+  id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  is_stale BOOLEAN NOT NULL DEFAULT false,
+  stale_reason TEXT NULL,
+  stale_at TIMESTAMPTZ NULL,
+  last_rebuilt_at TIMESTAMPTZ NULL,
+  last_incremental_at TIMESTAMPTZ NULL
+);
+
+-- Conditional seed (Pass-9 #5): fresh schemas → is_stale=false (no variants
+-- → no work). Existing-data schemas → is_stale=true with explicit reason so
+-- the next cohort read triggers rebuild.
+INSERT INTO "__schema__"."cohort_summary_state" (id, is_stale, stale_reason, stale_at)
+SELECT 1,
+       EXISTS (SELECT 1 FROM "__schema__"."variants" LIMIT 1),
+       CASE WHEN EXISTS (SELECT 1 FROM "__schema__"."variants" LIMIT 1)
+            THEN 'migration_initial_existing_data'
+            ELSE NULL END,
+       CASE WHEN EXISTS (SELECT 1 FROM "__schema__"."variants" LIMIT 1)
+            THEN now()
+            ELSE NULL END
+ON CONFLICT (id) DO NOTHING;

--- a/src/main/storage/postgres/postgres-cohort-summary-query.ts
+++ b/src/main/storage/postgres/postgres-cohort-summary-query.ts
@@ -1,0 +1,297 @@
+import type { ColumnFilter } from '../../../shared/types/column-filters'
+import type { CohortSearchParams } from '../../../shared/types/cohort'
+import { POSTGRES_VARIANT_COLUMN_DEFINITIONS } from './postgres-variant-columns'
+
+/**
+ * Summary read-side query builder (Sprint A PR-3 C4).
+ *
+ * Mirrors `PostgresCohortRepository.buildQueryParts`, but maps every predicate
+ * to alias `cvs` for the materialised `cohort_variant_summary` table. Because
+ * carrier_count / het_count / hom_count / cohort_frequency are stored columns
+ * on `cohort_variant_summary`, the predicates that the live builder pushes into
+ * `HAVING` (over a `GROUP BY`) become plain `WHERE` predicates here — there is
+ * no grouping in the summary path.
+ *
+ * Extension-table predicates (any `variant_extensions` column, keyed `sv.*`,
+ * `cnv.*`, `str.*`) are not materialised into the summary in Sprint A, so the
+ * builder returns `{ unavailable: true }` and the caller falls back to the live
+ * `buildQueryParts` path.
+ */
+
+export interface SummaryQueryParts {
+  joins: string
+  whereParts: string[]
+  orderBy: string
+  values: unknown[]
+}
+
+export interface BuildSummaryResult {
+  parts: SummaryQueryParts
+  /** true → caller falls back to the live `buildQueryParts` path. */
+  unavailable: boolean
+  unavailableReason?: string
+}
+
+/**
+ * Sort key → direct `cvs` column. Aggregate sorts in the live builder
+ * (e.g. `ORDER BY carrier_count`) become direct column sorts on `cvs`.
+ * `cadd_phred` maps to the stored `cadd` column.
+ */
+const SUMMARY_SORT_COLUMNS: Record<string, string> = {
+  chr: 'cvs.chr',
+  pos: 'cvs.pos',
+  gene_symbol: 'cvs.gene_symbol',
+  cdna: 'cvs.cdna',
+  aa_change: 'cvs.aa_change',
+  carrier_count: 'cvs.carrier_count',
+  cohort_frequency: 'cvs.cohort_frequency',
+  het_count: 'cvs.het_count',
+  hom_count: 'cvs.hom_count',
+  consequence: 'cvs.consequence',
+  func: 'cvs.func',
+  clinvar: 'cvs.clinvar',
+  gnomad_af: 'cvs.gnomad_af',
+  cadd_phred: 'cvs.cadd',
+  transcript: 'cvs.transcript'
+}
+
+/**
+ * Column-filter key → stored `cvs` column expression. Covers the base columns
+ * the live builder filters in `addColumnFilters`; aggregate columns
+ * (carrier_count, cohort_frequency, het_count, hom_count) are stored columns
+ * here, so they map to plain columns rather than aggregate expressions.
+ */
+const SUMMARY_COLUMN_FILTER_SQL: Record<string, string> = {
+  chr: 'cvs.chr',
+  pos: 'cvs.pos',
+  gene_symbol: 'cvs.gene_symbol',
+  consequence: 'cvs.consequence',
+  func: 'cvs.func',
+  clinvar: 'cvs.clinvar',
+  gnomad_af: 'cvs.gnomad_af',
+  cadd_phred: 'cvs.cadd',
+  transcript: 'cvs.transcript',
+  carrier_count: 'cvs.carrier_count',
+  cohort_frequency: 'cvs.cohort_frequency',
+  het_count: 'cvs.het_count',
+  hom_count: 'cvs.hom_count'
+}
+
+const NUMERIC_COLUMN_FILTERS = new Set<string>([
+  'pos',
+  'gnomad_af',
+  'cadd_phred',
+  'carrier_count',
+  'cohort_frequency',
+  'het_count',
+  'hom_count'
+])
+
+/** Extension-table column keys (sv.*, cnv.*, str.*) from the variant registry. */
+const EXTENSION_COLUMN_KEYS = new Set<string>(
+  Object.keys(POSTGRES_VARIANT_COLUMN_DEFINITIONS).filter((key) => key.includes('.'))
+)
+
+function isNonEmptyArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.length > 0
+}
+
+/**
+ * True iff any column filter targets a `variant_extensions` column. Sprint A
+ * does not materialise extension aggregates into the summary, so such queries
+ * fall through to the live builder.
+ */
+function hasExtensionPredicate(params: CohortSearchParams): boolean {
+  if (params.column_filters === undefined) return false
+  for (const column of Object.keys(params.column_filters)) {
+    if (params.column_filters[column] === undefined) continue
+    if (EXTENSION_COLUMN_KEYS.has(column)) return true
+  }
+  return false
+}
+
+function emptyParts(): SummaryQueryParts {
+  return { joins: '', whereParts: [], orderBy: '', values: [] }
+}
+
+function normalizeColumnFilterValue(column: string, value: string | number): string | number {
+  if (!NUMERIC_COLUMN_FILTERS.has(column) || typeof value === 'number') return value
+  const numericValue = Number(value)
+  return Number.isFinite(numericValue) ? numericValue : value
+}
+
+function buildColumnFilterCondition(
+  column: string,
+  expression: string,
+  filter: ColumnFilter,
+  addParam: (value: unknown) => string
+): string {
+  const { operator, value } = filter
+  const isNumeric = NUMERIC_COLUMN_FILTERS.has(column)
+
+  if (operator === 'in' && Array.isArray(value)) {
+    if (value.length === 0) return ''
+    return `${expression} IN (${value
+      .map((item) => addParam(normalizeColumnFilterValue(column, item)))
+      .join(', ')})`
+  }
+
+  if (operator === 'like' && typeof value === 'string') {
+    if (value.trim() === '') return ''
+    const pattern = `%${value}%`
+    if (isNumeric) {
+      return `${expression}::text ILIKE ${addParam(pattern)}`
+    }
+    return `${expression} ILIKE ${addParam(pattern)}`
+  }
+
+  if (
+    (operator === '=' || operator === '!=') &&
+    (typeof value === 'string' || typeof value === 'number')
+  ) {
+    return `${expression} ${operator} ${addParam(normalizeColumnFilterValue(column, value))}`
+  }
+
+  if (
+    (operator === '<' || operator === '>' || operator === '<=' || operator === '>=') &&
+    (typeof value === 'string' || typeof value === 'number')
+  ) {
+    const comparison = `${expression} ${operator} ${addParam(normalizeColumnFilterValue(column, value))}`
+    // All summary column filters live in WHERE; mirror the live builder's
+    // `includeEmpty` default for base WHERE columns (true).
+    const includeEmpty = filter.includeEmpty ?? true
+    return includeEmpty ? `(${expression} IS NULL OR ${comparison})` : comparison
+  }
+
+  return ''
+}
+
+export function buildSummaryQueryParts(
+  params: CohortSearchParams,
+  totalCases: number
+): BuildSummaryResult {
+  void totalCases // cohort_frequency is a stored column; total cases is not needed here.
+
+  if (hasExtensionPredicate(params)) {
+    return { parts: emptyParts(), unavailable: true, unavailableReason: 'extension_predicate' }
+  }
+
+  const whereParts: string[] = []
+  const values: unknown[] = []
+  const addParam = (value: unknown): string => {
+    values.push(value)
+    return `$${values.length}`
+  }
+
+  if (params.search_term !== undefined && params.search_term.trim() !== '') {
+    const term = params.search_term.trim()
+    const genomicMatch = term.match(/^(?:chr)?(\d{1,2}|X|Y|MT?):(\d+)$/i)
+    if (genomicMatch !== null) {
+      whereParts.push(
+        `(cvs.chr = ${addParam(genomicMatch[1])} AND cvs.pos = ${addParam(Number(genomicMatch[2]))})`
+      )
+    } else {
+      const searchPattern = `%${term}%`
+      whereParts.push(`(
+          cvs.gene_symbol ILIKE ${addParam(searchPattern)}
+          OR cvs.consequence ILIKE ${addParam(searchPattern)}
+          OR cvs.omim_mim_number ILIKE ${addParam(searchPattern)}
+        )`)
+    }
+  }
+
+  if (isNonEmptyArray(params.panel_intervals)) {
+    // Pass-9 #7: mirror PostgresCohortRepository.buildQueryParts verbatim so
+    // spanning SV/CNV variants overlap correctly.
+    const intervalParts = params.panel_intervals.map(
+      (interval) =>
+        `(cvs.chr = ${addParam(interval.chr)} AND cvs.pos <= ${addParam(interval.end)} AND COALESCE(cvs.end_pos, cvs.pos) >= ${addParam(interval.start)})`
+    )
+    whereParts.push(`(${intervalParts.join(' OR ')})`)
+  }
+
+  if (params.gene_symbol !== undefined && params.gene_symbol !== '') {
+    whereParts.push(`cvs.gene_symbol = ${addParam(params.gene_symbol)}`)
+  }
+
+  if (isNonEmptyArray(params.consequences)) {
+    whereParts.push(
+      `cvs.consequence IN (${params.consequences.map((value) => addParam(value)).join(', ')})`
+    )
+  }
+
+  if (isNonEmptyArray(params.funcs)) {
+    whereParts.push(`cvs.func IN (${params.funcs.map((value) => addParam(value)).join(', ')})`)
+  }
+
+  if (isNonEmptyArray(params.clinvars)) {
+    whereParts.push(
+      `cvs.clinvar IN (${params.clinvars.map((value) => addParam(value)).join(', ')})`
+    )
+  }
+
+  if (params.gnomad_af_max !== undefined) {
+    whereParts.push(`(cvs.gnomad_af IS NULL OR cvs.gnomad_af <= ${addParam(params.gnomad_af_max)})`)
+  }
+
+  if (params.cadd_min !== undefined) {
+    whereParts.push(`(cvs.cadd IS NULL OR cvs.cadd >= ${addParam(params.cadd_min)})`)
+  }
+
+  if (params.genome_build !== undefined && params.genome_build !== '') {
+    // Direct stored column — no `cases` join needed in the summary path.
+    whereParts.push(`cvs.genome_build = ${addParam(params.genome_build)}`)
+  }
+
+  if (params.variant_type === 'snv') {
+    whereParts.push("cvs.variant_type IN ('snv', 'indel')")
+  } else if (params.variant_type !== undefined && params.variant_type !== '') {
+    whereParts.push(`cvs.variant_type = ${addParam(params.variant_type)}`)
+  }
+
+  // Annotation flags — kept current by C5a, read as stored columns.
+  if (params.starred_only === true) {
+    whereParts.push('cvs.has_star = true')
+  }
+
+  if (params.has_comment === true) {
+    whereParts.push('cvs.has_comment = true')
+  }
+
+  if (isNonEmptyArray(params.acmg_classifications)) {
+    whereParts.push(
+      `cvs.acmg_best IN (${params.acmg_classifications.map((value) => addParam(value)).join(', ')})`
+    )
+  }
+
+  // Per-column typed filters → stored cvs columns (aggregates become plain
+  // columns; HAVING disappears).
+  if (params.column_filters !== undefined) {
+    for (const column of Object.keys(params.column_filters)) {
+      const filter = params.column_filters[column]
+      if (filter === undefined) continue
+      const expression = SUMMARY_COLUMN_FILTER_SQL[column]
+      if (expression === undefined) continue
+      const condition = buildColumnFilterCondition(column, expression, filter, addParam)
+      if (condition !== '') whereParts.push(condition)
+    }
+  }
+
+  // Aggregate predicates (HAVING → WHERE on stored columns).
+  if (params.max_internal_af !== undefined) {
+    whereParts.push(`cvs.cohort_frequency <= ${addParam(params.max_internal_af)}`)
+  }
+
+  if (params.carrier_count_min !== undefined) {
+    whereParts.push(`cvs.carrier_count >= ${addParam(params.carrier_count_min)}`)
+  }
+
+  const sortColumn =
+    params.sort_by !== undefined && SUMMARY_SORT_COLUMNS[params.sort_by] !== undefined
+      ? SUMMARY_SORT_COLUMNS[params.sort_by]
+      : 'cvs.carrier_count'
+  const sortOrder = params.sort_order === 'asc' ? 'ASC' : 'DESC'
+  const orderBy = `ORDER BY ${sortColumn} ${sortOrder} NULLS LAST, cvs.chr ASC, cvs.pos ASC, cvs.ref ASC, cvs.alt ASC`
+
+  return { parts: { joins: '', whereParts, orderBy, values }, unavailable: false }
+}

--- a/src/main/storage/postgres/postgres-cohort-summary-query.ts
+++ b/src/main/storage/postgres/postgres-cohort-summary-query.ts
@@ -25,6 +25,61 @@ export interface SummaryQueryParts {
   values: unknown[]
 }
 
+/** `WHERE ...` clause (or empty string) for a summary-page query. */
+function summaryWhereClause(whereParts: string[]): string {
+  return whereParts.length > 0 ? `WHERE ${whereParts.join('\n         AND ')}` : ''
+}
+
+/** COUNT(*) SQL for the materialised cohort_variant_summary page. */
+export function buildSummaryCountSql(qualifiedTable: string, whereParts: string[]): string {
+  return `SELECT COUNT(*)::bigint AS total_count
+      FROM ${qualifiedTable} cvs
+      ${summaryWhereClause(whereParts)}`
+}
+
+/**
+ * Page SQL for the materialised cohort_variant_summary read. Aliases the stored
+ * `cadd` / `omim_mim_number` columns to the CohortVariant field names
+ * (`cadd_phred`, `omim_id`) so toCohortVariant maps them unchanged. `totalCases`
+ * is interpolated (it is a number, never user input) to surface total_cases per
+ * row the same way the live path does.
+ */
+export function buildSummaryPageSql(
+  qualifiedTable: string,
+  whereParts: string[],
+  orderBy: string,
+  totalCases: number,
+  limitParamIndex: number,
+  offsetParamIndex: number
+): string {
+  return `SELECT
+      cvs.chr,
+      cvs.pos,
+      cvs.ref,
+      cvs.alt,
+      cvs.gene_symbol,
+      cvs.cdna,
+      cvs.aa_change,
+      cvs.carrier_count,
+      ${totalCases}::bigint AS total_cases,
+      cvs.cohort_frequency,
+      cvs.het_count,
+      cvs.hom_count,
+      cvs.variant_key,
+      cvs.consequence,
+      cvs.func,
+      cvs.clinvar,
+      cvs.gnomad_af,
+      cvs.cadd AS cadd_phred,
+      cvs.transcript,
+      cvs.omim_mim_number AS omim_id
+    FROM ${qualifiedTable} cvs
+    ${summaryWhereClause(whereParts)}
+    ${orderBy}
+    LIMIT $${limitParamIndex}
+    OFFSET $${offsetParamIndex}`
+}
+
 export interface BuildSummaryResult {
   parts: SummaryQueryParts
   /** true → caller falls back to the live `buildQueryParts` path. */

--- a/src/main/storage/postgres/postgres-column-meta-cache.ts
+++ b/src/main/storage/postgres/postgres-column-meta-cache.ts
@@ -1,0 +1,147 @@
+import type { FilterOptions } from '../../../shared/types/api'
+import type { ColumnFilterMeta } from '../../../shared/types/column-filters'
+
+/**
+ * Sprint A PR-3 C4 — read-side helpers for the per-case `cohort_column_meta`
+ * cache (populated by C2's refreshColumnMetas on import + delete + rebuild).
+ *
+ * The cache mirrors SQLite getAllColumnMetas: one row per filterable base
+ * column, with distinct_count for every column, MIN/MAX (JSONB numbers) for
+ * numerics, and the sorted distinct_values array (JSONB) for low-cardinality
+ * columns. These helpers reshape those rows into the renderer-facing
+ * ColumnFilterMeta / FilterOptions contract so getFilterOptions(caseId) and the
+ * single-case getColumnMeta branch match the SQLite output shape.
+ */
+
+/**
+ * Filterable base columns mirrored from PostgresCohortSummaryRepository's
+ * META_COLUMNS (the source of truth for which columns refreshColumnMetas
+ * materialises into cohort_column_meta). Order matches SQLite getAllColumnMetas
+ * so the reshaped FilterOptions.columnMeta order is stable. `cadd` (not
+ * `cadd_phred`) — Postgres uses the physical column name.
+ */
+export const PER_CASE_META_COLUMNS = [
+  'chr',
+  'pos',
+  'gene_symbol',
+  'omim_mim_number',
+  'func',
+  'consequence',
+  'transcript',
+  'cdna',
+  'aa_change',
+  'gt_num',
+  'gnomad_af',
+  'cadd',
+  'qual',
+  'hpo_sim_score',
+  'clinvar',
+  'moi',
+  'variant_type',
+  'end_pos',
+  'sv_type',
+  'sv_length',
+  'caller'
+] as const
+
+/**
+ * Numeric columns that surface min/max in the reshaped per-case meta. This set
+ * MUST match the write side exactly: PostgresCohortSummaryRepository's
+ * META_NUMERIC_COLUMNS (which is what refreshColumnMetas actually populates
+ * min_value/max_value for) and the SQLite parity source-of-truth
+ * NUMERIC_COLUMNS in src/main/database/VariantRepository.ts. `end_pos` and
+ * `sv_length` are categorical on the write side (no min/max materialised), so
+ * they must report dataType 'text' here to match SQLite output-shape parity.
+ */
+export const PER_CASE_NUMERIC_COLUMNS = new Set<string>([
+  'pos',
+  'gnomad_af',
+  'cadd',
+  'qual',
+  'hpo_sim_score'
+])
+
+/** Row shape from cohort_column_meta. JSONB columns are parsed by node-pg. */
+export interface ColumnMetaRow {
+  column_name: string
+  min_value: number | null
+  max_value: number | null
+  distinct_count: number | string | null
+  distinct_values: string[] | null
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') return Number(value)
+  return 0
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined
+  const numberValue = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(numberValue) ? numberValue : undefined
+}
+
+/**
+ * Convert a single cohort_column_meta row into a ColumnFilterMeta entry.
+ * Numeric columns surface min/max; low-cardinality columns surface the stored
+ * distinct_values array (already sorted by refreshColumnMetas).
+ */
+export function columnMetaRowToFilterMeta(
+  key: string,
+  isNumeric: boolean,
+  row: ColumnMetaRow
+): ColumnFilterMeta {
+  const entry: ColumnFilterMeta = {
+    key,
+    dataType: isNumeric ? 'numeric' : 'text',
+    distinctCount: toNumber(row.distinct_count)
+  }
+  if (isNumeric) {
+    const min = toOptionalNumber(row.min_value)
+    const max = toOptionalNumber(row.max_value)
+    if (min !== undefined) entry.min = min
+    if (max !== undefined) entry.max = max
+  }
+  if (Array.isArray(row.distinct_values)) {
+    entry.distinctValues = row.distinct_values.map((value) => String(value))
+  }
+  return entry
+}
+
+/** Empty-distinct entry for a column with no stored row. */
+export function emptyColumnMeta(key: string, isNumeric: boolean): ColumnFilterMeta {
+  return { key, dataType: isNumeric ? 'numeric' : 'text', distinctCount: 0 }
+}
+
+/**
+ * Reshape cohort_column_meta rows into the SQLite-compatible FilterOptions
+ * output. The columnMeta list is ordered by PER_CASE_META_COLUMNS so the shape
+ * matches SQLite getFilterOptions; columns with no stored row degrade to an
+ * empty-distinct entry rather than vanishing.
+ */
+export function reshapeFilterOptions(rows: ColumnMetaRow[]): FilterOptions {
+  const rowByName = new Map(rows.map((row) => [row.column_name, row]))
+  const columnMeta: ColumnFilterMeta[] = PER_CASE_META_COLUMNS.map((key) => {
+    const isNumeric = PER_CASE_NUMERIC_COLUMNS.has(key)
+    const row = rowByName.get(key)
+    return row === undefined
+      ? emptyColumnMeta(key, isNumeric)
+      : columnMetaRowToFilterMeta(key, isNumeric, row)
+  })
+
+  const metaByKey = new Map(columnMeta.map((meta) => [meta.key, meta]))
+  const caddMeta = metaByKey.get('cadd')
+  const gnomadAfMeta = metaByKey.get('gnomad_af')
+
+  return {
+    consequences: metaByKey.get('consequence')?.distinctValues ?? [],
+    funcs: metaByKey.get('func')?.distinctValues ?? [],
+    clinvars: metaByKey.get('clinvar')?.distinctValues ?? [],
+    minCadd: caddMeta?.min ?? null,
+    maxCadd: caddMeta?.max ?? null,
+    minGnomadAf: gnomadAfMeta?.min ?? null,
+    maxGnomadAf: gnomadAfMeta?.max ?? null,
+    columnMeta
+  }
+}

--- a/src/main/storage/postgres/postgres-variant-column-meta-live.ts
+++ b/src/main/storage/postgres/postgres-variant-column-meta-live.ts
@@ -1,0 +1,124 @@
+import type { Pool } from 'pg'
+
+import type { ColumnFilterMeta } from '../../../shared/types/column-filters'
+import { runNamedDynamic } from './named-query'
+import type { PostgresVariantColumnDefinition } from './postgres-variant-columns'
+
+/**
+ * Live-aggregation per-column metadata for the multi-case and extension-column
+ * scopes (Sprint A PR-3 C4). The per-case base-column scope reads the
+ * materialised cohort_column_meta cache instead; these helpers cover the
+ * branches that cannot read that cache without overcounting (multi-case
+ * cross-case distinct — Pass-5 MED #1) or that are not materialised there
+ * (extension columns sv.*, cnv.*, str.*).
+ */
+
+const DISTINCT_THRESHOLD = 50
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') return Number(value)
+  return 0
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined
+  const numberValue = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(numberValue) ? numberValue : undefined
+}
+
+/** LEFT JOIN to the extension table backing an `sv.*` / `cnv.*` / `str.*` key. */
+export function buildColumnMetaJoins(schemaName: string, columnKey: string): string {
+  if (columnKey.startsWith('sv.')) {
+    return `LEFT JOIN ${schemaName}."variant_sv" sv ON sv.variant_id = v.id`
+  }
+  if (columnKey.startsWith('cnv.')) {
+    return `LEFT JOIN ${schemaName}."variant_cnv" cnv ON cnv.variant_id = v.id`
+  }
+  if (columnKey.startsWith('str.')) {
+    return `LEFT JOIN ${schemaName}."variant_str" str_ext ON str_ext.variant_id = v.id`
+  }
+  return ''
+}
+
+export async function getNumericColumnMetaLive(
+  pool: Pool,
+  schema: string,
+  schemaName: string,
+  caseIds: number[],
+  definition: PostgresVariantColumnDefinition
+): Promise<ColumnFilterMeta> {
+  const result = await runNamedDynamic<{ distinct_count: unknown; min: unknown; max: unknown }>(
+    pool,
+    {
+      baseName: 'variants:column_meta',
+      text: `SELECT COUNT(DISTINCT ${definition.sql})::int AS distinct_count,
+              MIN(${definition.sql}) AS min,
+              MAX(${definition.sql}) AS max
+       FROM ${schemaName}."variants" v
+       ${buildColumnMetaJoins(schemaName, definition.key)}
+       WHERE v.case_id = ANY($1::bigint[])`,
+      values: [caseIds],
+      schema
+    }
+  )
+  const row = result.rows[0] as
+    | { distinct_count?: unknown; min?: unknown; max?: unknown }
+    | undefined
+  const meta: ColumnFilterMeta = {
+    key: definition.key,
+    dataType: 'numeric',
+    distinctCount: toNumber(row?.distinct_count)
+  }
+  const min = toOptionalNumber(row?.min)
+  const max = toOptionalNumber(row?.max)
+  if (min !== undefined) meta.min = min
+  if (max !== undefined) meta.max = max
+  return meta
+}
+
+export async function getCategoricalColumnMetaLive(
+  pool: Pool,
+  schema: string,
+  schemaName: string,
+  caseIds: number[],
+  definition: PostgresVariantColumnDefinition
+): Promise<ColumnFilterMeta> {
+  const joins = buildColumnMetaJoins(schemaName, definition.key)
+  const countResult = await runNamedDynamic<{ distinct_count: unknown }>(pool, {
+    baseName: 'variants:column_meta',
+    text: `SELECT COUNT(DISTINCT ${definition.sql})::int AS distinct_count
+       FROM ${schemaName}."variants" v
+       ${joins}
+       WHERE v.case_id = ANY($1::bigint[])`,
+    values: [caseIds],
+    schema
+  })
+  const distinctCount = toNumber(
+    (countResult.rows[0] as { distinct_count?: unknown } | undefined)?.distinct_count
+  )
+  const meta: ColumnFilterMeta = {
+    key: definition.key,
+    dataType: 'text',
+    distinctCount
+  }
+
+  if (distinctCount > 0 && distinctCount <= DISTINCT_THRESHOLD) {
+    const valuesResult = await runNamedDynamic<{ value: unknown }>(pool, {
+      baseName: 'variants:column_meta',
+      text: `SELECT DISTINCT ${definition.sql} AS value
+         FROM ${schemaName}."variants" v
+         ${joins}
+         WHERE v.case_id = ANY($1::bigint[])
+           AND ${definition.sql} IS NOT NULL
+         ORDER BY ${definition.sql}`,
+      values: [caseIds],
+      schema
+    })
+    meta.distinctValues = (valuesResult.rows as Array<{ value: unknown }>).map((row) =>
+      String(row.value)
+    )
+  }
+
+  return meta
+}

--- a/src/main/storage/read-executor.ts
+++ b/src/main/storage/read-executor.ts
@@ -53,6 +53,7 @@ export type StorageReadTask =
     }
   | { type: 'cohort:query'; params: [params: CohortSearchParams] }
   | { type: 'cohort:summary'; params: [] }
+  | { type: 'cohort:summaryStatus'; params: [] }
   | { type: 'cohort:columnMeta'; params: [] }
   | { type: 'cohort:carriers'; params: [chr: string, pos: number, ref: string, alt: string] }
   | { type: 'cohort:geneBurden'; params: [] }

--- a/src/main/storage/sqlite/SqliteReadExecutor.ts
+++ b/src/main/storage/sqlite/SqliteReadExecutor.ts
@@ -186,6 +186,12 @@ export class SqliteReadExecutor implements StorageReadExecutor {
         }
         return this.databaseService.cohort.getCohortSummary()
 
+      case 'cohort:summaryStatus':
+        if (this.dbPool !== null) {
+          return await this.dbPool.run({ type: 'cohort:summaryStatus', params: task.params })
+        }
+        return this.databaseService.cohortSummary.getStatus()
+
       case 'cohort:columnMeta':
         if (this.dbPool !== null) {
           return await this.dbPool.run({ type: 'cohort:columnMeta', params: task.params })

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -29,6 +29,7 @@ import {
   profileCount
 } from '../storage/postgres/postgres-import-profile'
 import { quoteIdentifier } from '../storage/postgres/identifiers'
+import { PostgresCohortSummaryRepository } from '../storage/postgres/PostgresCohortSummaryRepository'
 import { detectFormat as defaultDetectFormat } from '../import/format-detection'
 import type { FormatInfo } from '../import/strategies/ImportStrategy'
 import { createMapperPipeline as defaultCreateMapperPipeline } from './import-pipeline'
@@ -214,6 +215,82 @@ export async function relaxImportSessionLimits(client: Pick<Client, 'query'>): P
   await client.query('SET statement_timeout = 0')
   await client.query('SET idle_in_transaction_session_timeout = 0')
   await client.query('SET lock_timeout = 0')
+}
+
+/**
+ * C3 (Pass-2 #5 + Pass-3 HIGH #1 + Pass-4 HIGH #2 + Pass-5 HIGH #2): incremental
+ * cohort-summary update for ONE imported case, run ONCE after the batch loop and
+ * the bookkeeping rows (variant_count UPDATE + rebuildVariantFrequencyForCase),
+ * still INSIDE the post-loop transaction the caller owns.
+ *
+ * The summary update is wrapped in a SAVEPOINT so a failure here cannot lose the
+ * bookkeeping. On failure: ROLLBACK TO SAVEPOINT (keeps variant_count +
+ * variant_frequency), COMMIT the outer transaction, then markStale in a separate
+ * tiny transaction so the bookkeeping commit survives regardless. Staleness lives
+ * in cohort_summary_state — it is NOT surfaced on the ImportResult (Pass-4 HIGH
+ * #3); the next cohort-page load detects it and rebuilds.
+ *
+ * Returns `true` when the caller still owns an open transaction it must COMMIT,
+ * `false` when this helper already committed the outer transaction (failure path).
+ */
+async function updateCohortSummaryAfterImport(args: {
+  client: Pick<Client, 'query'>
+  schema: string
+  caseId: number
+  genomeBuild: string
+}): Promise<boolean> {
+  const { client, schema, caseId, genomeBuild } = args
+  const summary = new PostgresCohortSummaryRepository()
+  const scoped = client as unknown as Parameters<
+    PostgresCohortSummaryRepository['incrementalAdd']
+  >[0]['client']
+  try {
+    await client.query('SAVEPOINT cohort_summary')
+    await summary.incrementalAdd({ schema, client: scoped, caseId, genomeBuild })
+    await summary.recomputeCohortFrequency({
+      schema,
+      client: scoped,
+      affectedBuilds: [genomeBuild]
+    })
+    await summary.refreshColumnMetas({ schema, client: scoped, caseId })
+    await client.query('RELEASE SAVEPOINT cohort_summary')
+    return true
+  } catch (savepointErr) {
+    await client.query('ROLLBACK TO SAVEPOINT cohort_summary')
+    // Commit the outer transaction NOW so the bookkeeping (variant_count +
+    // rebuildVariantFrequencyForCase) is durable before the stale-marking
+    // tiny transaction runs.
+    await client.query('COMMIT')
+    // Mark stale in a separate tiny transaction so the bookkeeping commit
+    // survives even if marking fails. Reuses the same idle client (this worker
+    // owns a single short-lived connection; the outer txn is already committed).
+    try {
+      await client.query('BEGIN')
+      await summary.markStale({
+        schema,
+        client: scoped,
+        reason: `post_import_summary_failed_case_${caseId}`
+      })
+      await client.query('COMMIT')
+    } catch (markErr) {
+      try {
+        await client.query('ROLLBACK')
+      } catch {
+        // swallow — nothing more we can do; the outer commit already landed.
+      }
+      // Worker has no mainLogger access; console.warn is the documented worker
+      // exception (see AGENTS.md).
+      console.warn(
+        '[postgres-import-worker] Failed to mark cohort summary stale after post-import failure:',
+        markErr instanceof Error ? markErr.message : String(markErr)
+      )
+    }
+    console.warn(
+      `[postgres-import-worker] Cohort summary update failed for case ${caseId}; marked stale:`,
+      savepointErr instanceof Error ? savepointErr.message : String(savepointErr)
+    )
+    return false
+  }
 }
 
 function clientConfigFromMessage(message: PostgresClientConfig): ClientConfig {
@@ -434,7 +511,20 @@ export async function runImport(
           }
           // Report success only after this commit fsyncs all prior async-committed batches.
           await client.query('SET LOCAL synchronous_commit = ON')
-          await client.query('COMMIT')
+          // C3: incremental cohort-summary update inside this txn (SAVEPOINT-
+          // wrapped). On failure the helper rolls back to the savepoint and
+          // commits the outer txn itself, returning false.
+          if (caseId !== 0) {
+            const stillOwnsTxn = await updateCohortSummaryAfterImport({
+              client,
+              schema: start.schema,
+              caseId,
+              genomeBuild
+            })
+            if (stillOwnsTxn) await client.query('COMMIT')
+          } else {
+            await client.query('COMMIT')
+          }
           committed = true
 
           profileFlush()
@@ -548,7 +638,16 @@ export async function runImport(
         start.schema,
         caseId
       )
-      await client.query('COMMIT')
+      // C3: incremental cohort-summary update inside this txn (SAVEPOINT-wrapped).
+      {
+        const stillOwnsTxn = await updateCohortSummaryAfterImport({
+          client,
+          schema: start.schema,
+          caseId,
+          genomeBuild: start.vcfOptions?.genomeBuild ?? 'GRCh38'
+        })
+        if (stillOwnsTxn) await client.query('COMMIT')
+      }
       committed = true
 
       post({
@@ -859,7 +958,15 @@ export async function runImport(
               start.schema,
               caseId
             )
-            await client.query('COMMIT')
+            // C3: incremental cohort-summary update inside this txn (SAVEPOINT-
+            // wrapped). On failure the helper commits the outer txn itself.
+            const stillOwnsTxn = await updateCohortSummaryAfterImport({
+              client,
+              schema: start.schema,
+              caseId,
+              genomeBuild
+            })
+            if (stillOwnsTxn) await client.query('COMMIT')
             beganTransaction = false
             committed = true
           } catch (err) {

--- a/src/shared/ipc/domains/cohort.ts
+++ b/src/shared/ipc/domains/cohort.ts
@@ -9,9 +9,14 @@ import type { ColumnFilterMeta } from '../../types/column-filters'
 import type { IpcResult } from '../../types/errors'
 
 export interface CohortDomainContract {
-  getVariants: (
-    params: CohortSearchParams
-  ) => Promise<IpcResult<{ data: CohortVariant[]; total_count: number }>>
+  getVariants: (params: CohortSearchParams) => Promise<
+    IpcResult<{
+      data: CohortVariant[]
+      total_count: number
+      /** Optional same-load read warnings (Sprint A PR-3 C5). */
+      warnings?: { staleSummary?: boolean }
+    }>
+  >
   getColumnMeta: () => Promise<IpcResult<ColumnFilterMeta[]>>
   getSummary: () => Promise<IpcResult<CohortSummary>>
   getCarriers: (

--- a/src/shared/sql/cohort-summary-rebuild.ts
+++ b/src/shared/sql/cohort-summary-rebuild.ts
@@ -8,7 +8,7 @@
 export const REBUILD_VARIANT_SUMMARY_SQL = `
   DELETE FROM cohort_variant_summary;
   INSERT INTO cohort_variant_summary (
-    chr, pos, ref, alt, gene_symbol, cdna, aa_change,
+    chr, pos, ref, alt, end_pos, gene_symbol, cdna, aa_change,
     consequence, func, clinvar, gnomad_af, cadd,
     transcript, omim_mim_number,
     carrier_count, het_count, hom_count,
@@ -16,7 +16,7 @@ export const REBUILD_VARIANT_SUMMARY_SQL = `
     variant_key, variant_type, genome_build
   )
   SELECT
-    d.chr, d.pos, d.ref, d.alt,
+    d.chr, d.pos, d.ref, d.alt, d.end_pos,
     d.gene_symbol, d.cdna, d.aa_change,
     d.consequence, d.func, d.clinvar, d.gnomad_af, d.cadd,
     d.transcript, d.omim_mim_number,
@@ -36,12 +36,14 @@ export const REBUILD_VARIANT_SUMMARY_SQL = `
         MAX(v.func) AS func, MAX(v.clinvar) AS clinvar,
         MAX(v.gnomad_af) AS gnomad_af, MAX(v.cadd) AS cadd,
         MAX(v.transcript) AS transcript, MAX(v.omim_mim_number) AS omim_mim_number,
-        MAX(v.gt_num) AS gt_num
+        MAX(v.gt_num) AS gt_num,
+        MAX(v.end_pos) AS end_pos
       FROM variants v
       JOIN cases c ON c.id = v.case_id
       GROUP BY v.chr, v.pos, v.ref, v.alt, v.case_id, v.variant_type, c.genome_build
     )
     SELECT chr, pos, ref, alt, variant_type, genome_build,
+      MAX(end_pos) AS end_pos,
       MAX(gene_symbol) AS gene_symbol, MAX(cdna) AS cdna,
       MAX(aa_change) AS aa_change, MAX(consequence) AS consequence,
       MAX(func) AS func, MAX(clinvar) AS clinvar,
@@ -133,7 +135,7 @@ export const CHECK_TABLE_EXISTS_SQL =
 
 export const INCREMENTAL_ADD_SQL = `
   INSERT INTO cohort_variant_summary (
-    chr, pos, ref, alt, gene_symbol, cdna, aa_change,
+    chr, pos, ref, alt, end_pos, gene_symbol, cdna, aa_change,
     consequence, func, clinvar, gnomad_af, cadd,
     transcript, omim_mim_number,
     carrier_count, het_count, hom_count,
@@ -141,7 +143,7 @@ export const INCREMENTAL_ADD_SQL = `
     variant_key, variant_type, genome_build
   )
   SELECT
-    v.chr, v.pos, v.ref, v.alt,
+    v.chr, v.pos, v.ref, v.alt, MAX(v.end_pos),
     MAX(v.gene_symbol), MAX(v.cdna), MAX(v.aa_change),
     MAX(v.consequence), MAX(v.func), MAX(v.clinvar),
     MAX(v.gnomad_af), MAX(v.cadd), MAX(v.transcript), MAX(v.omim_mim_number),

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -381,9 +381,14 @@ export interface BatchImportAPI {
 }
 
 export interface CohortAPI {
-  getVariants: (
-    params: CohortSearchParams
-  ) => Promise<IpcResult<{ data: CohortVariant[]; total_count: number }>>
+  getVariants: (params: CohortSearchParams) => Promise<
+    IpcResult<{
+      data: CohortVariant[]
+      total_count: number
+      /** Optional same-load read warnings (Sprint A PR-3 C5). */
+      warnings?: { staleSummary?: boolean }
+    }>
+  >
   getSummary: () => Promise<IpcResult<CohortSummary>>
   getCarriers: (
     chr: string,

--- a/src/shared/types/cohort.ts
+++ b/src/shared/types/cohort.ts
@@ -116,6 +116,12 @@ export interface CohortPaginatedResult {
   data: CohortVariant[]
   /** Total count of matching variants */
   total_count: number
+  /**
+   * Optional same-load read warnings (Sprint A PR-3 C5). `staleSummary` is set
+   * when the materialised cohort summary was served while a background rebuild
+   * runs, so the renderer can surface a "refreshing" hint.
+   */
+  warnings?: { staleSummary?: boolean }
 }
 
 /**

--- a/tests/main/database/FilterPresetRepository.test.ts
+++ b/tests/main/database/FilterPresetRepository.test.ts
@@ -30,7 +30,7 @@ describe('migration v15 - filter_presets', () => {
 
   it('sets user_version to latest', () => {
     const version = db.pragma('user_version', { simple: true })
-    expect(version).toBe(29)
+    expect(version).toBe(30)
   })
 
   it('creates unique index on name', () => {

--- a/tests/main/database/PanelRepository.test.ts
+++ b/tests/main/database/PanelRepository.test.ts
@@ -54,7 +54,7 @@ describe('PanelRepository', () => {
 
     it('sets user_version to latest', () => {
       const version = db.pragma('user_version', { simple: true })
-      expect(version).toBe(29)
+      expect(version).toBe(30)
     })
   })
 

--- a/tests/main/database/migration-v13.test.ts
+++ b/tests/main/database/migration-v13.test.ts
@@ -67,6 +67,6 @@ describe('Migration v13-v14: cohort summary tables', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const version = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(version.user_version).toBe(29)
+    expect(version.user_version).toBe(30)
   })
 })

--- a/tests/main/database/migration-v8.test.ts
+++ b/tests/main/database/migration-v8.test.ts
@@ -40,6 +40,6 @@ describe('Migration v8: age and date_of_birth', () => {
 
   it('sets schema version to latest after all migrations', () => {
     const result = db.pragma('user_version') as Array<{ user_version: number }>
-    expect(result[0].user_version).toBe(29)
+    expect(result[0].user_version).toBe(30)
   })
 })

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -131,7 +131,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(29)
+      expect(versionResult.user_version).toBe(30)
 
       service.close()
 
@@ -141,7 +141,7 @@ describe('Schema Migrations', () => {
       const versionAfterReopen = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionAfterReopen.user_version).toBe(29)
+      expect(versionAfterReopen.user_version).toBe(30)
 
       service.close()
     })
@@ -468,7 +468,7 @@ describe('Schema Migrations', () => {
       let versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(29)
+      expect(versionResult.user_version).toBe(30)
 
       service.close()
 
@@ -488,7 +488,7 @@ describe('Schema Migrations', () => {
       versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(29)
+      expect(versionResult.user_version).toBe(30)
 
       service.close()
     })
@@ -522,7 +522,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(29)
+      expect(versionResult.user_version).toBe(30)
 
       service.close()
     })
@@ -760,7 +760,7 @@ describe('Schema Migrations', () => {
       const version = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(version.user_version).toBe(29)
+      expect(version.user_version).toBe(30)
 
       service.close()
     })
@@ -801,7 +801,7 @@ describe('Schema Migrations', () => {
 
       // Verify user_version = latest (v15 + v16 + v17 + v18 + … + v28 + v29 all run)
       const version = db.pragma('user_version', { simple: true }) as number
-      expect(version).toBe(29)
+      expect(version).toBe(30)
 
       service.close()
     })
@@ -1257,9 +1257,9 @@ describe('migration v27 — filter_presets.kind + shortlist seeds', () => {
     expect(idx).toBeTruthy()
   })
 
-  it('PRAGMA user_version = 29 after migration', () => {
+  it('PRAGMA user_version = 30 after migration', () => {
     const v = db.pragma('user_version', { simple: true })
-    expect(v).toBe(29)
+    expect(v).toBe(30)
   })
 })
 

--- a/tests/main/database/vcf-migration.test.ts
+++ b/tests/main/database/vcf-migration.test.ts
@@ -46,14 +46,14 @@ describe('Migration v23: VCF import columns', () => {
   it('sets user_version to latest', () => {
     runMigrations(db)
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(29)
+    expect(result.user_version).toBe(30)
   })
 
   it('is idempotent — running migrations twice does not fail', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(29)
+    expect(result.user_version).toBe(30)
   })
 
   it('new variant columns are nullable and default to NULL', () => {

--- a/tests/main/storage/cohort-backend-parity.test.ts
+++ b/tests/main/storage/cohort-backend-parity.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Sprint A PR-3 Gate 9 (C7) — cohort backend-parity gate.
+ *
+ * Loads the SAME fixture into SQLite + a real Postgres, runs the same cohort
+ * read on both, and asserts set-equality (sort-order normalised). This is the
+ * storage-layer trip-wire for feedback_cohort_parity.md: any divergence between
+ * the SQLite live-aggregation path and the Postgres materialised summary path
+ * fails here before it can reach the cohort view.
+ *
+ * The five sub-checks (a-e) plus the panel-interval spanning-SV case (Pass-9 #7):
+ *   (a) buildGroupedSelect rows (cohort query data) match.
+ *   (b) per-case getFilterOptions(caseId) OUTPUT equality — SQLite computes live
+ *       from variants; PG reads from cohort_column_meta. Equality is on the
+ *       FilterOptions output shape, not the storage-row shape.
+ *   (c) cohort-view getColumnMeta distinct counts from cohort_variant_summary
+ *       match.
+ *   (d) cohort_frequency values match after every add/remove path.
+ *   (e) has_star/has_comment/acmg_best flags match after star+comment+ACMG
+ *       mutations AND after case delete (no intervening rebuild).
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { DatabaseService, type Variant } from '../../../src/main/database'
+import type { ColumnFilterMeta } from '../../../src/shared/types/column-filters'
+import type { CohortSearchParams, CohortVariant } from '../../../src/shared/types/cohort'
+import {
+  applyAnnotationFlagsGlobal,
+  applyAnnotationFlagsPerCase
+} from '../../../src/main/storage/postgres/cohort-annotation-flags-sql'
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { PostgresCaseLifecycleRepository } from '../../../src/main/storage/postgres/PostgresCaseLifecycleRepository'
+import { PostgresCohortRepository } from '../../../src/main/storage/postgres/PostgresCohortRepository'
+import { PostgresCohortSummaryRepository } from '../../../src/main/storage/postgres/PostgresCohortSummaryRepository'
+import { PostgresVariantReadRepository } from '../../../src/main/storage/postgres/PostgresVariantReadRepository'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+/** One logical case + its variants, applied identically to both backends. */
+interface FixtureVariant extends Omit<Variant, 'id' | 'case_id'> {
+  gt_num: string | null
+  variant_type?: string
+  end_pos?: number | null
+}
+
+interface FixtureCase {
+  name: string
+  genomeBuild: string
+  variants: FixtureVariant[]
+}
+
+function baseVariant(
+  over: Partial<FixtureVariant> & Pick<FixtureVariant, 'chr' | 'pos'>
+): FixtureVariant {
+  return {
+    chr: over.chr,
+    pos: over.pos,
+    ref: over.ref ?? 'A',
+    alt: over.alt ?? 'T',
+    gene_symbol: over.gene_symbol ?? null,
+    consequence: over.consequence ?? null,
+    gnomad_af: over.gnomad_af ?? null,
+    cadd: over.cadd ?? null,
+    clinvar: over.clinvar ?? null,
+    func: over.func ?? null,
+    gt_num: over.gt_num ?? '0/1',
+    variant_type: over.variant_type ?? 'snv',
+    end_pos: over.end_pos ?? null
+  } as FixtureVariant
+}
+
+/**
+ * Two GRCh38 cases sharing one coordinate (het + hom) plus per-case unique
+ * coordinates with diverse gene/consequence/gnomad/cadd values so the column
+ * metadata + filter-options reads exercise both numeric and categorical paths.
+ */
+const FIXTURE: FixtureCase[] = [
+  {
+    name: 'parity-a',
+    genomeBuild: 'GRCh38',
+    variants: [
+      baseVariant({
+        chr: '1',
+        pos: 100,
+        ref: 'A',
+        alt: 'T',
+        gt_num: '0/1',
+        gene_symbol: 'BRCA1',
+        consequence: 'HIGH',
+        func: 'stop_gained',
+        clinvar: 'Pathogenic',
+        gnomad_af: 0.01,
+        cadd: 32.5
+      }),
+      baseVariant({
+        chr: '2',
+        pos: 200,
+        ref: 'C',
+        alt: 'G',
+        gt_num: '0/1',
+        gene_symbol: 'TP53',
+        consequence: 'MODERATE',
+        func: 'missense_variant',
+        clinvar: 'Benign',
+        gnomad_af: 0.2,
+        cadd: 12.5
+      })
+    ]
+  },
+  {
+    name: 'parity-b',
+    genomeBuild: 'GRCh38',
+    variants: [
+      baseVariant({
+        chr: '1',
+        pos: 100,
+        ref: 'A',
+        alt: 'T',
+        gt_num: '1/1',
+        gene_symbol: 'BRCA1',
+        consequence: 'HIGH',
+        func: 'stop_gained',
+        clinvar: 'Pathogenic',
+        gnomad_af: 0.01,
+        cadd: 32.5
+      }),
+      baseVariant({
+        chr: '3',
+        pos: 300,
+        ref: 'G',
+        alt: 'A',
+        gt_num: '0/1',
+        gene_symbol: 'MYH7',
+        consequence: 'LOW',
+        func: 'synonymous_variant',
+        clinvar: 'Likely benign',
+        gnomad_af: 0.5,
+        cadd: 5
+      })
+    ]
+  }
+]
+
+const variantKey = (v: CohortVariant): string => `${v.chr}:${v.pos}:${v.ref}:${v.alt}`
+
+/** Stable cross-backend ordering for set-equality assertions. */
+function sortCohort(rows: CohortVariant[]): CohortVariant[] {
+  return [...rows].sort((a, b) => variantKey(a).localeCompare(variantKey(b)))
+}
+
+/** Normalise a cohort row to a backend-agnostic comparable shape. */
+function normalizeCohort(v: CohortVariant): Record<string, unknown> {
+  return {
+    variant_key: variantKey(v),
+    gene_symbol: v.gene_symbol,
+    carrier_count: v.carrier_count,
+    het_count: v.het_count,
+    hom_count: v.hom_count,
+    cohort_frequency: Math.round((v.cohort_frequency ?? 0) * 1e6) / 1e6,
+    consequence: v.consequence,
+    func: v.func,
+    clinvar: v.clinvar,
+    gnomad_af: v.gnomad_af,
+    cadd_phred: v.cadd_phred
+  }
+}
+
+/** Column-meta entries keyed by name, distinct values sorted, for comparison. */
+function metaByKey(meta: ColumnFilterMeta[]): Map<string, ColumnFilterMeta> {
+  return new Map(
+    meta.map((m) => [
+      m.key,
+      {
+        ...m,
+        distinctValues: m.distinctValues !== undefined ? [...m.distinctValues].sort() : undefined
+      }
+    ])
+  )
+}
+
+describe.skipIf(!RUN)('cohort backend-parity — Sprint A C7 / Gate 9', () => {
+  let sqlite: DatabaseService
+  let sqliteCaseIds: number[]
+
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  let pgCaseIds: number[]
+  const now = Date.now()
+
+  const summaryRepo = new PostgresCohortSummaryRepository()
+
+  async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      return await fn(client as unknown as Client)
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  /** Seed one fixture case into Postgres and build its summary contribution. */
+  async function seedPgCase(fixture: FixtureCase): Promise<number> {
+    const caseRow = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [fixture.name, `/tmp/${fixture.name}.json`, now, fixture.genomeBuild]
+    )
+    const caseId = caseRow.rows[0].id
+
+    for (const v of fixture.variants) {
+      await probe.query(
+        `INSERT INTO "${schema}".variants
+           (case_id, chr, pos, ref, alt, variant_type, end_pos, gene_symbol, consequence,
+            func, clinvar, gnomad_af, cadd, gt_num)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+        [
+          caseId,
+          v.chr,
+          v.pos,
+          v.ref,
+          v.alt,
+          v.variant_type ?? 'snv',
+          v.end_pos ?? null,
+          v.gene_symbol,
+          v.consequence,
+          v.func,
+          v.clinvar,
+          v.gnomad_af,
+          v.cadd,
+          v.gt_num
+        ]
+      )
+    }
+
+    await withClient(async (client) => {
+      await client.query('BEGIN')
+      await summaryRepo.incrementalAdd({
+        schema,
+        client: client as never,
+        caseId,
+        genomeBuild: fixture.genomeBuild
+      })
+      await summaryRepo.refreshColumnMetas({ schema, client: client as never, caseId })
+      await client.query('COMMIT')
+    })
+
+    return caseId
+  }
+
+  /** Seed one fixture case into SQLite and rebuild the summary afterwards. */
+  function seedSqliteCase(fixture: FixtureCase): number {
+    const caseId = sqlite.cases.createCase(
+      fixture.name,
+      `/tmp/${fixture.name}.json`,
+      0,
+      fixture.genomeBuild
+    )
+    sqlite.variants.insertVariantsBatch(
+      caseId,
+      fixture.variants.map((v) => ({ ...v }))
+    )
+    return caseId
+  }
+
+  beforeEach(async () => {
+    sqlite = new DatabaseService(':memory:')
+    sqliteCaseIds = FIXTURE.map((fixture) => seedSqliteCase(fixture))
+    sqlite.cohortSummary.rebuild()
+    sqlite.cohort.invalidateColumnMetaCache()
+
+    schema = `vt_parity_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    pgCaseIds = []
+    for (const fixture of FIXTURE) {
+      pgCaseIds.push(await seedPgCase(fixture))
+    }
+  }, 120_000)
+
+  afterEach(async () => {
+    sqlite.close()
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 120_000)
+
+  async function pgCohortRows(params: CohortSearchParams): Promise<CohortVariant[]> {
+    const repo = new PostgresCohortRepository(pool, schema)
+    const result = await repo.queryVariants({ limit: 100, offset: 0, ...params })
+    return result.data
+  }
+
+  function sqliteCohortRows(params: CohortSearchParams): CohortVariant[] {
+    return sqlite.cohort.getCohortVariants({ limit: 100, offset: 0, ...params }).data
+  }
+
+  it('(a) buildGroupedSelect rows match between SQLite and PG', async () => {
+    const params: CohortSearchParams = { sort_by: 'carrier_count', sort_order: 'desc' }
+    const sqliteRows = sortCohort(sqliteCohortRows(params)).map(normalizeCohort)
+    const pgRows = sortCohort(await pgCohortRows(params)).map(normalizeCohort)
+
+    expect(pgRows.length).toBeGreaterThan(0)
+    expect(pgRows).toEqual(sqliteRows)
+  }, 120_000)
+
+  it('(b) per-case getFilterOptions(caseId) OUTPUT equality', async () => {
+    // Pass-5 MED #2: SQLite computes live; PG reads from cohort_column_meta.
+    // Equality is on the FilterOptions output shape, not storage-row shape.
+    const pgVariants = new PostgresVariantReadRepository(pool, schema)
+
+    for (let i = 0; i < FIXTURE.length; i++) {
+      const sqliteOpts = sqlite.variants.getFilterOptions(sqliteCaseIds[i])
+      const pgOpts = await pgVariants.getFilterOptions(pgCaseIds[i])
+
+      expect(pgOpts.consequences.sort()).toEqual([...sqliteOpts.consequences].sort())
+      expect(pgOpts.funcs.sort()).toEqual([...sqliteOpts.funcs].sort())
+      expect(pgOpts.clinvars.sort()).toEqual([...sqliteOpts.clinvars].sort())
+      expect(pgOpts.minCadd).toEqual(sqliteOpts.minCadd)
+      expect(pgOpts.maxCadd).toEqual(sqliteOpts.maxCadd)
+      expect(pgOpts.minGnomadAf).toEqual(sqliteOpts.minGnomadAf)
+      expect(pgOpts.maxGnomadAf).toEqual(sqliteOpts.maxGnomadAf)
+    }
+  }, 120_000)
+
+  it('(c) cohort-view getColumnMeta distinct counts from cohort_variant_summary match', async () => {
+    const repo = new PostgresCohortRepository(pool, schema)
+    const sqliteMeta = metaByKey(sqlite.cohort.getColumnMeta())
+    const pgMeta = metaByKey(await repo.getColumnMeta())
+
+    // Compare the keys present on both cohort-view metadata reads.
+    const sharedKeys = [...pgMeta.keys()].filter((key) => sqliteMeta.has(key))
+    expect(sharedKeys.length).toBeGreaterThan(0)
+
+    for (const key of sharedKeys) {
+      const sq = sqliteMeta.get(key)!
+      const pg = pgMeta.get(key)!
+      expect(pg.distinctCount).toBe(sq.distinctCount)
+      expect(pg.dataType).toBe(sq.dataType)
+      // distinctValues parity only for text columns — numeric distinct values
+      // differ purely by REAL→TEXT formatting ('1' vs '1.0'), not semantics, so
+      // the gate compares numeric columns by distinctCount/min/max only.
+      if (sq.dataType === 'text') {
+        expect(pg.distinctValues).toEqual(sq.distinctValues)
+      }
+    }
+  }, 120_000)
+
+  it('(d) cohort_frequency values match after every add/remove path', async () => {
+    // Already added both cases in beforeEach. Compare frequencies after add.
+    const afterAddSqlite = sortCohort(sqliteCohortRows({})).map(normalizeCohort)
+    const afterAddPg = sortCohort(await pgCohortRows({})).map(normalizeCohort)
+    expect(afterAddPg).toEqual(afterAddSqlite)
+
+    // Remove the second case on both backends. PG's deleteCase recomputes
+    // cohort_frequency against the surviving cases in the same transaction; the
+    // SQLite path removes the case row then rebuilds the summary so its
+    // frequency denominator likewise excludes the deleted case.
+    sqlite.cases.deleteCase(sqliteCaseIds[1])
+    sqlite.cohortSummary.rebuild()
+    sqlite.cohort.invalidateColumnMetaCache()
+
+    const lifecycle = new PostgresCaseLifecycleRepository(pool, schema, summaryRepo)
+    await lifecycle.deleteCase(pgCaseIds[1])
+
+    const afterRemoveSqlite = sortCohort(sqliteCohortRows({})).map((v) => ({
+      variant_key: v.variant_key,
+      carrier_count: v.carrier_count,
+      cohort_frequency: Math.round((v.cohort_frequency ?? 0) * 1e6) / 1e6
+    }))
+    const afterRemovePg = sortCohort(await pgCohortRows({})).map((v) => ({
+      variant_key: v.variant_key,
+      carrier_count: v.carrier_count,
+      cohort_frequency: Math.round((v.cohort_frequency ?? 0) * 1e6) / 1e6
+    }))
+    expect(afterRemovePg.length).toBeGreaterThan(0)
+    expect(afterRemovePg).toEqual(afterRemoveSqlite)
+  }, 120_000)
+
+  it('(e) has_star/has_comment/acmg_best flags match after star+comment+ACMG mutations AND after case delete (no intervening rebuild)', async () => {
+    // Star the shared 1:100:A:T coordinate (global), comment+ACMG the 2:200:C:G
+    // coordinate per-case on case-a — exercising both annotation tables.
+    // SQLite: write annotation, then summary write-hook keeps cvs flags current.
+    sqlite.annotations.upsertGlobalAnnotation('1', 100, 'A', 'T', { starred: true })
+    const sqliteTargetId = (
+      sqlite.db
+        .prepare("SELECT id FROM variants WHERE case_id = ? AND chr = '2' AND pos = 200")
+        .get(sqliteCaseIds[0]) as { id: number }
+    ).id
+    sqlite.annotations.upsertPerCaseAnnotation(sqliteCaseIds[0], sqliteTargetId, {
+      per_case_comment: 'looks pathogenic',
+      acmg_classification: 'Pathogenic'
+    })
+    // Re-derive summary flags from the annotation tables (no full rebuild needed
+    // for the cvs flag columns — rebuild() re-derives them deterministically).
+    sqlite.cohortSummary.rebuild()
+    sqlite.cohort.invalidateColumnMetaCache()
+
+    // PG: write the same annotations + run the C5a write-hooks (no rebuild).
+    const pgTarget = await probe.query<{ id: number }>(
+      `SELECT id FROM "${schema}".variants WHERE case_id = $1 AND chr = '2' AND pos = 200`,
+      [pgCaseIds[0]]
+    )
+    const pgTargetId = pgTarget.rows[0].id
+    await probe.query(
+      `INSERT INTO "${schema}".variant_annotations
+         (chr, pos, ref, alt, global_comment, starred, acmg_classification, created_at, updated_at)
+         VALUES ('1', 100, 'A', 'T', NULL, 1, NULL, $1, $1)`,
+      [now]
+    )
+    await probe.query(
+      `INSERT INTO "${schema}".case_variant_annotations
+         (case_id, variant_id, per_case_comment, starred, acmg_classification, created_at, updated_at)
+         VALUES ($1, $2, 'looks pathogenic', 0, 'Pathogenic', $3, $3)`,
+      [pgCaseIds[0], pgTargetId, now]
+    )
+    await withClient(async (client) => {
+      await client.query('BEGIN')
+      await applyAnnotationFlagsGlobal(client as never, {
+        schema,
+        chr: '1',
+        pos: 100,
+        ref: 'A',
+        alt: 'T'
+      })
+      await applyAnnotationFlagsPerCase(client as never, {
+        schema,
+        caseId: pgCaseIds[0],
+        variantId: pgTargetId
+      })
+      await client.query('COMMIT')
+    })
+
+    const flagShape = (rows: Array<Record<string, unknown>>): Map<string, string> =>
+      new Map(
+        rows.map((r) => [
+          `${r.chr}:${r.pos}:${r.ref}:${r.alt}`,
+          `${r.has_star}|${r.has_comment}|${r.acmg_best ?? ''}`
+        ])
+      )
+
+    const sqliteFlags = () =>
+      flagShape(
+        sqlite.db
+          .prepare(
+            'SELECT chr, pos, ref, alt, has_star, has_comment, acmg_best FROM cohort_variant_summary'
+          )
+          .all() as Array<Record<string, unknown>>
+      )
+    const pgFlags = async () =>
+      flagShape(
+        (
+          await probe.query<Record<string, unknown>>(
+            `SELECT chr, pos, ref, alt, has_star, has_comment, acmg_best
+               FROM "${schema}".cohort_variant_summary`
+          )
+        ).rows.map((r) => ({
+          ...r,
+          // SQLite stores booleans as 0/1; PG as true/false. Normalise to 1/0.
+          has_star: r.has_star ? 1 : 0,
+          has_comment: r.has_comment ? 1 : 0
+        }))
+      )
+
+    expect(await pgFlags()).toEqual(sqliteFlags())
+
+    // Now delete case-b on both backends WITHOUT an intervening rebuild and
+    // re-compare: the case-delete write-hook must keep flags consistent.
+    sqlite.cohortSummary.incrementalRemove(sqliteCaseIds[1])
+    sqlite.cases.deleteCase(sqliteCaseIds[1])
+
+    const lifecycle = new PostgresCaseLifecycleRepository(pool, schema, summaryRepo)
+    await lifecycle.deleteCase(pgCaseIds[1])
+
+    expect(await pgFlags()).toEqual(sqliteFlags())
+  }, 120_000)
+
+  it('panel-interval with spanning SV/CNV: spanning row is included on both backends (Pass-9 #7)', async () => {
+    // Insert a CNV with pos=1000, end_pos=5000 on both backends.
+    const spanningCaseSqlite = sqlite.cases.createCase('span-sqlite', '/tmp/span.json', 0, 'GRCh38')
+    sqlite.variants.insertVariantsBatch(spanningCaseSqlite, [
+      baseVariant({
+        chr: '7',
+        pos: 1000,
+        ref: 'N',
+        alt: '<CNV>',
+        gt_num: '0/1',
+        variant_type: 'cnv',
+        end_pos: 5000,
+        gene_symbol: 'SPAN'
+      })
+    ])
+    sqlite.cohortSummary.rebuild()
+    sqlite.cohort.invalidateColumnMetaCache()
+
+    const spanCaseRow = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ('span-pg', '/tmp/span.json', 0, $1, 'GRCh38') RETURNING id`,
+      [now]
+    )
+    const spanCasePg = spanCaseRow.rows[0].id
+    await probe.query(
+      `INSERT INTO "${schema}".variants
+         (case_id, chr, pos, ref, alt, variant_type, end_pos, gene_symbol, gt_num)
+         VALUES ($1, '7', 1000, 'N', '<CNV>', 'cnv', 5000, 'SPAN', '0/1')`,
+      [spanCasePg]
+    )
+    await withClient(async (client) => {
+      await client.query('BEGIN')
+      await summaryRepo.incrementalAdd({
+        schema,
+        client: client as never,
+        caseId: spanCasePg,
+        genomeBuild: 'GRCh38'
+      })
+      await client.query('COMMIT')
+    })
+
+    // Panel interval start=2000, end=3000 falls strictly inside [1000, 5000].
+    const params: CohortSearchParams = {
+      panel_intervals: [{ chr: '7', start: 2000, end: 3000 }]
+    }
+    const sqliteRows = sqliteCohortRows(params)
+    const pgRows = await pgCohortRows(params)
+
+    const sqliteKeys = sqliteRows.map(variantKey)
+    const pgKeys = pgRows.map(variantKey)
+    expect(sqliteKeys).toContain('7:1000:N:<CNV>')
+    expect(pgKeys).toContain('7:1000:N:<CNV>')
+    expect(pgKeys.sort()).toEqual(sqliteKeys.sort())
+  }, 120_000)
+})
+
+describe.skipIf(RUN)('cohort backend-parity — Sprint A C7 / Gate 9 (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/cohort-summary-drift.test.ts
+++ b/tests/main/storage/cohort-summary-drift.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Sprint A PR-3 C8 + Gate 10 — cohort-summary drift detection.
+ *
+ * Guards against incremental-vs-full-rebuild drift: a full rebuild() establishes
+ * the source-of-truth snapshot, then N incremental no-op shuffles
+ * (incrementalRemove immediately followed by incrementalAdd for the same case)
+ * must leave cohort_variant_summary byte-identical to that rebuild. The shuffle
+ * is a no-op in aggregate, so the post-incremental snapshot must deep-equal the
+ * first full-rebuild snapshot — any divergence means the incremental path and
+ * the full-rebuild path disagree, which is exactly the class of bug users would
+ * hit silently. A trailing second rebuild() is asserted as well to confirm full
+ * rebuilds remain deterministic from the unchanged source tables.
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { PostgresCohortSummaryRepository } from '../../../src/main/storage/postgres/PostgresCohortSummaryRepository'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+interface SeedVariant {
+  caseId: number
+  chr: string
+  pos: number
+  ref: string
+  alt: string
+  variantType?: string
+  geneSymbol?: string | null
+  gtNum?: string | null
+}
+
+describe.skipIf(!RUN)('cohort-summary drift detection — Sprint A C8 / Gate 10', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_cvs_drift_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: SeedVariant): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+         (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gt_num)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+      [
+        v.caseId,
+        v.chr,
+        v.pos,
+        v.ref,
+        v.alt,
+        v.variantType ?? 'snv',
+        v.geneSymbol ?? null,
+        v.gtNum ?? null
+      ]
+    )
+    return res.rows[0].id
+  }
+
+  async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      return await fn(client as unknown as Client)
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  /**
+   * Full deterministic snapshot of cohort_variant_summary. Selects every
+   * non-volatile column (the deduped aggregate + derived flags + frequency) and
+   * orders by the full natural key so two snapshots are directly comparable.
+   * Counts are coerced to numbers because node-pg returns BIGINT as strings.
+   */
+  async function snapshotSummary(): Promise<unknown[]> {
+    const res = await probe.query<{
+      chr: string
+      pos: string
+      end_pos: string | null
+      ref: string
+      alt: string
+      variant_type: string
+      genome_build: string
+      gene_symbol: string | null
+      cdna: string | null
+      aa_change: string | null
+      consequence: string | null
+      func: string | null
+      clinvar: string | null
+      gnomad_af: number | null
+      cadd: number | null
+      transcript: string | null
+      omim_mim_number: string | null
+      carrier_count: string
+      het_count: string
+      hom_count: string
+      variant_key: string
+      has_star: boolean
+      has_comment: boolean
+      acmg_best: string | null
+      cohort_frequency: number | null
+    }>(
+      `SELECT chr, pos, end_pos, ref, alt, variant_type, genome_build,
+              gene_symbol, cdna, aa_change, consequence, func, clinvar,
+              gnomad_af, cadd, transcript, omim_mim_number,
+              carrier_count, het_count, hom_count, variant_key,
+              has_star, has_comment, acmg_best, cohort_frequency
+         FROM "${schema}".cohort_variant_summary
+        ORDER BY genome_build, variant_type, chr, pos, ref, alt`
+    )
+    return res.rows.map((r) => ({
+      chr: r.chr,
+      pos: Number(r.pos),
+      end_pos: r.end_pos === null ? null : Number(r.end_pos),
+      ref: r.ref,
+      alt: r.alt,
+      variant_type: r.variant_type,
+      genome_build: r.genome_build,
+      gene_symbol: r.gene_symbol,
+      cdna: r.cdna,
+      aa_change: r.aa_change,
+      consequence: r.consequence,
+      func: r.func,
+      clinvar: r.clinvar,
+      gnomad_af: r.gnomad_af,
+      cadd: r.cadd,
+      transcript: r.transcript,
+      omim_mim_number: r.omim_mim_number,
+      carrier_count: Number(r.carrier_count),
+      het_count: Number(r.het_count),
+      hom_count: Number(r.hom_count),
+      variant_key: r.variant_key,
+      has_star: r.has_star,
+      has_comment: r.has_comment,
+      acmg_best: r.acmg_best,
+      cohort_frequency: r.cohort_frequency
+    }))
+  }
+
+  const repo = new PostgresCohortSummaryRepository()
+
+  it('rebuild + N incremental ops + rebuild = byte-identical', async () => {
+    // 1. Seed N cases + variants. Mix of shared/distinct coordinates, het/hom
+    //    genotypes, and an annotated variant so the snapshot exercises every
+    //    derived column (counts, flags, acmg_best, frequency).
+    const N = 4
+    const caseIds: number[] = []
+    const buildByCase = new Map<number, string>()
+    for (let i = 0; i < N; i++) {
+      const build = i % 2 === 0 ? 'GRCh38' : 'GRCh37'
+      const id = await seedCase(`drift-case-${i}`, build)
+      caseIds.push(id)
+      buildByCase.set(id, build)
+    }
+
+    // Shared GRCh38 coordinate carried by the two GRCh38 cases (indices 0, 2).
+    await seedVariant({
+      caseId: caseIds[0],
+      chr: '1',
+      pos: 100,
+      ref: 'A',
+      alt: 'T',
+      gtNum: '0/1',
+      geneSymbol: 'BRCA1'
+    })
+    await seedVariant({
+      caseId: caseIds[2],
+      chr: '1',
+      pos: 100,
+      ref: 'A',
+      alt: 'T',
+      gtNum: '1/1',
+      geneSymbol: 'BRCA1'
+    })
+    // Distinct per-case coordinates on each case (covers single-carrier rows).
+    for (let i = 0; i < N; i++) {
+      await seedVariant({
+        caseId: caseIds[i],
+        chr: '2',
+        pos: 200 + i,
+        ref: 'C',
+        alt: 'G',
+        gtNum: i % 2 === 0 ? '0/1' : '1/1',
+        geneSymbol: 'TP53'
+      })
+    }
+    // A duplicate per-case row (dedup must collapse it to one carrier).
+    await seedVariant({
+      caseId: caseIds[0],
+      chr: '3',
+      pos: 300,
+      ref: 'G',
+      alt: 'A',
+      gtNum: '0/1'
+    })
+    await seedVariant({
+      caseId: caseIds[0],
+      chr: '3',
+      pos: 300,
+      ref: 'G',
+      alt: 'A',
+      gtNum: '0/1'
+    })
+    // Global annotation so has_star / has_comment / acmg_best are non-default.
+    await probe.query(
+      `INSERT INTO "${schema}".variant_annotations
+         (chr, pos, ref, alt, global_comment, starred, acmg_classification, created_at, updated_at)
+         VALUES ('1', 100, 'A', 'T', 'noted', 1, 'Pathogenic', $1, $1)`,
+      [now]
+    )
+
+    // 2. Full rebuild, then snapshot.
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+    const firstSnapshot = await snapshotSummary()
+    // Sanity: the seeding actually produced rows, otherwise the equality below
+    // would be a vacuous pass.
+    expect(firstSnapshot.length).toBeGreaterThan(0)
+
+    // 3. For each case: incrementalRemove then incrementalAdd (a no-op shuffle).
+    //    Scope each op to the case's own genome_build so the frequency recompute
+    //    matches the per-build behaviour the production callers use. Run the whole
+    //    shuffle inside ONE explicit transaction on a single client, mirroring the
+    //    production cohort-summary maintenance boundary (rebuild + incremental ops
+    //    execute as a single atomic unit) so a transaction-isolation regression
+    //    is exercised by this path too.
+    await withClient(async (client) => {
+      await client.query('BEGIN')
+      try {
+        for (const caseId of caseIds) {
+          const genomeBuild = buildByCase.get(caseId)!
+          await repo.incrementalRemove({
+            schema,
+            client: client as never,
+            caseId,
+            genomeBuild
+          })
+          await repo.incrementalAdd({
+            schema,
+            client: client as never,
+            caseId,
+            genomeBuild
+          })
+        }
+        await client.query('COMMIT')
+      } catch (err) {
+        await client.query('ROLLBACK')
+        throw err
+      }
+    })
+
+    // 4. Snapshot AFTER the incremental shuffle but BEFORE any further rebuild.
+    //    This is the load-bearing assertion: it compares the incremental-only
+    //    state directly against the full-rebuild source of truth. Because the
+    //    shuffle is a no-op in aggregate, the incremental path must reproduce the
+    //    rebuild exactly. Any drift (wrong counter delta, stale flag, missed
+    //    frequency recompute, leftover zero-carrier row) shows up here — a later
+    //    full rebuild would silently correct it, so it must be checked first.
+    const postIncrementalSnapshot = await snapshotSummary()
+    expect(postIncrementalSnapshot).toEqual(firstSnapshot)
+
+    // 5. Secondary determinism check: a second full rebuild from the unchanged
+    //    source tables must still match the first rebuild. This guards the
+    //    rebuild path's own reproducibility independent of the incremental path.
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+    const secondSnapshot = await snapshotSummary()
+    expect(secondSnapshot).toEqual(firstSnapshot)
+  }, 120_000)
+})
+
+describe.skipIf(RUN)('cohort-summary drift detection — Sprint A C8 / Gate 10 (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/postgres-annotations-repository.test.ts
+++ b/tests/main/storage/postgres-annotations-repository.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it, vi } from 'vitest'
+import { randomBytes } from 'node:crypto'
 
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { InvalidParametersError } from '../../../src/main/ipc/errors'
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
 import { PostgresAnnotationsRepository } from '../../../src/main/storage/postgres/PostgresAnnotationsRepository'
 
 const makePool = () => ({
   query: vi.fn()
 })
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
 
 describe('PostgresAnnotationsRepository', () => {
   it('gets global annotations by coordinates and normalizes returned values', async () => {
@@ -48,25 +59,33 @@ describe('PostgresAnnotationsRepository', () => {
   })
 
   it('upserts global annotations with only supported fields', async () => {
-    const pool = makePool()
-    pool.query.mockResolvedValueOnce({
-      rows: [
-        {
-          id: 8,
-          chr: '1',
-          pos: 12345,
-          ref: 'A',
-          alt: 'G',
-          global_comment: null,
-          starred: 1,
-          acmg_classification: 'Likely benign',
-          acmg_evidence: 'PM2',
-          created_at: 1714060800000,
-          updated_at: 1714060801000
-        }
-      ]
-    })
-    const repository = new PostgresAnnotationsRepository(pool, 'public')
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 8,
+            chr: '1',
+            pos: 12345,
+            ref: 'A',
+            alt: 'G',
+            global_comment: null,
+            starred: 1,
+            acmg_classification: 'Likely benign',
+            acmg_evidence: 'PM2',
+            created_at: 1714060800000,
+            updated_at: 1714060801000
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // flag write-hook
+      .mockResolvedValueOnce({ rows: [] }) // COMMIT
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
 
     await repository.upsertGlobalAnnotation('1', 12345, 'A', 'G', {
       global_comment: null,
@@ -76,7 +95,8 @@ describe('PostgresAnnotationsRepository', () => {
       unsupported_field: 'ignored'
     } as never)
 
-    const spec = pool.query.mock.calls[0][0] as { text: string; values: unknown[] }
+    expect(query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    const spec = query.mock.calls[1][0] as { text: string; values: unknown[] }
     const sql = spec.text
     const params = spec.values
     expect(sql).toContain('ON CONFLICT (chr, pos, ref, alt) DO UPDATE')
@@ -96,6 +116,16 @@ describe('PostgresAnnotationsRepository', () => {
       true,
       true
     ])
+    // The global annotation-flag write-hook runs in the same transaction.
+    expect(query).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        name: expect.stringContaining('cohort_summary:annotation_flags_global:v1'),
+        values: ['1', 12345, 'A', 'G']
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(4, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
   })
 
   it('upserts global annotations and audit entries in one transaction', async () => {
@@ -139,6 +169,7 @@ describe('PostgresAnnotationsRepository', () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
     const pool = {
       connect: vi.fn(async () => ({ query, release }))
@@ -167,7 +198,16 @@ describe('PostgresAnnotationsRepository', () => {
         null
       ]
     )
-    expect(query).toHaveBeenNthCalledWith(6, 'COMMIT')
+    // The annotation-flag write-hook runs inside the same transaction, just
+    // before COMMIT (C5a).
+    expect(query).toHaveBeenNthCalledWith(
+      6,
+      expect.objectContaining({
+        name: expect.stringContaining('cohort_summary:annotation_flags_global:v1'),
+        values: ['1', 12345, 'A', 'G']
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(7, 'COMMIT')
     expect(release).toHaveBeenCalledOnce()
   })
 
@@ -257,38 +297,72 @@ describe('PostgresAnnotationsRepository', () => {
   })
 
   it('deletes global annotations by coordinates', async () => {
-    const pool = makePool()
-    pool.query.mockResolvedValueOnce({ rows: [] })
-    const repository = new PostgresAnnotationsRepository(pool, 'public')
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // DELETE
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // flag write-hook
+      .mockResolvedValueOnce({ rows: [] }) // COMMIT
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
 
     await repository.deleteGlobalAnnotation('1', 12345, 'A', 'G')
 
-    expect(pool.query).toHaveBeenCalledWith(
+    expect(query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(query).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         text: expect.stringContaining('DELETE FROM "public"."variant_annotations"'),
         values: ['1', 12345, 'A', 'G']
       })
     )
+    expect(query).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        name: expect.stringContaining('cohort_summary:annotation_flags_global:v1')
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(4, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
   })
 
-  it('gets and upserts per-case annotations by case and variant id', async () => {
+  it('gets per-case annotations by case and variant id', async () => {
     const pool = makePool()
-    pool.query
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: '9',
-            case_id: '2',
-            variant_id: '3',
-            per_case_comment: 'case note',
-            starred: '0',
-            acmg_classification: null,
-            acmg_evidence: '{"notes":"case"}',
-            created_at: '1714060800000',
-            updated_at: '1714060801000'
-          }
-        ]
-      })
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '9',
+          case_id: '2',
+          variant_id: '3',
+          per_case_comment: 'case note',
+          starred: '0',
+          acmg_classification: null,
+          acmg_evidence: '{"notes":"case"}',
+          created_at: '1714060800000',
+          updated_at: '1714060801000'
+        }
+      ]
+    })
+    const repository = new PostgresAnnotationsRepository(pool, 'public')
+
+    await expect(repository.getPerCaseAnnotation(2, 3)).resolves.toMatchObject({
+      id: 9,
+      case_id: 2,
+      variant_id: 3,
+      per_case_comment: 'case note',
+      starred: 0,
+      acmg_evidence: '{"notes":"case"}'
+    })
+  })
+
+  it('upserts per-case annotations inside a transaction with the flag write-hook', async () => {
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({
         rows: [
           {
@@ -304,16 +378,13 @@ describe('PostgresAnnotationsRepository', () => {
           }
         ]
       })
-    const repository = new PostgresAnnotationsRepository(pool, 'public')
+      .mockResolvedValueOnce({ rows: [{ target_resolved: 1 }] }) // flag write-hook
+      .mockResolvedValueOnce({ rows: [] }) // COMMIT
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
 
-    await expect(repository.getPerCaseAnnotation(2, 3)).resolves.toMatchObject({
-      id: 9,
-      case_id: 2,
-      variant_id: 3,
-      per_case_comment: 'case note',
-      starred: 0,
-      acmg_evidence: '{"notes":"case"}'
-    })
     await expect(
       repository.upsertPerCaseAnnotation(2, 3, { per_case_comment: 'updated', starred: 0 })
     ).resolves.toMatchObject({
@@ -324,7 +395,8 @@ describe('PostgresAnnotationsRepository', () => {
       starred: 0
     })
 
-    const upsertSpec = pool.query.mock.calls[1][0] as { text: string; values: unknown[] }
+    expect(query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    const upsertSpec = query.mock.calls[1][0] as { text: string; values: unknown[] }
     expect(upsertSpec.text).toContain('ON CONFLICT (case_id, variant_id) DO UPDATE')
     expect(upsertSpec.text).toContain('"public"."case_variant_annotations"')
     expect(upsertSpec.values).toStrictEqual([
@@ -339,6 +411,15 @@ describe('PostgresAnnotationsRepository', () => {
       false,
       false
     ])
+    expect(query).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        name: expect.stringContaining('cohort_summary:annotation_flags_per_case:v2'),
+        values: [2, 3]
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(4, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
   })
 
   it('upserts per-case annotations and audit entries in one transaction', async () => {
@@ -377,6 +458,7 @@ describe('PostgresAnnotationsRepository', () => {
         ]
       })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ target_resolved: 1 }] })
       .mockResolvedValueOnce({ rows: [] })
     const pool = {
       connect: vi.fn(async () => ({ query, release }))
@@ -403,7 +485,15 @@ describe('PostgresAnnotationsRepository', () => {
         null
       ]
     )
-    expect(query).toHaveBeenNthCalledWith(5, 'COMMIT')
+    // The per-case annotation-flag write-hook runs just before COMMIT (C5a).
+    expect(query).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        name: expect.stringContaining('cohort_summary:annotation_flags_per_case:v2'),
+        values: [2, 3]
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(6, 'COMMIT')
     expect(release).toHaveBeenCalledOnce()
   })
 
@@ -449,18 +539,36 @@ describe('PostgresAnnotationsRepository', () => {
   })
 
   it('deletes per-case annotations by case and variant id', async () => {
-    const pool = makePool()
-    pool.query.mockResolvedValueOnce({ rows: [] })
-    const repository = new PostgresAnnotationsRepository(pool, 'public')
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // DELETE
+      .mockResolvedValueOnce({ rows: [{ target_resolved: 1 }] }) // flag write-hook
+      .mockResolvedValueOnce({ rows: [] }) // COMMIT
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
 
     await repository.deletePerCaseAnnotation(2, 3)
 
-    expect(pool.query).toHaveBeenCalledWith(
+    expect(query).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         text: expect.stringContaining('DELETE FROM "public"."case_variant_annotations"'),
         values: [2, 3]
       })
     )
+    expect(query).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        name: expect.stringContaining('cohort_summary:annotation_flags_per_case:v2'),
+        values: [2, 3]
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(4, 'COMMIT')
+    expect(release).toHaveBeenCalledOnce()
   })
 
   it('gets global and per-case annotations for a case variant', async () => {
@@ -582,4 +690,246 @@ describe('PostgresAnnotationsRepository', () => {
     })
     expect(pool.query).toHaveBeenCalledTimes(1)
   })
+
+  it('rolls back the annotation mutation when the flag write-hook fails (Pass-5 MED #3)', async () => {
+    const release = vi.fn()
+    const hookFailure = new Error('flag write-hook exploded')
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 8,
+            chr: '1',
+            pos: 12345,
+            ref: 'A',
+            alt: 'G',
+            global_comment: null,
+            starred: 1,
+            acmg_classification: null,
+            acmg_evidence: null,
+            created_at: 1714060800000,
+            updated_at: 1714060801000
+          }
+        ]
+      }) // upsert RETURNING
+      .mockRejectedValueOnce(hookFailure) // flag write-hook throws
+      .mockResolvedValueOnce({ rows: [] }) // ROLLBACK
+    const pool = {
+      connect: vi.fn(async () => ({ query, release }))
+    }
+    const repository = new PostgresAnnotationsRepository(pool as never, 'public')
+
+    await expect(
+      repository.upsertGlobalAnnotation('1', 12345, 'A', 'G', { starred: 1 })
+    ).rejects.toThrow('flag write-hook exploded')
+
+    // The mutation never COMMITs — the transaction is rolled back instead.
+    expect(query).toHaveBeenNthCalledWith(4, 'ROLLBACK')
+    expect(query).not.toHaveBeenCalledWith('COMMIT')
+    expect(release).toHaveBeenCalledOnce()
+  })
+})
+
+interface SeedVariant {
+  caseId: number
+  chr: string
+  pos: number
+  ref: string
+  alt: string
+  variantType?: string
+  gtNum?: string | null
+}
+
+describe.skipIf(!RUN)('annotation-flag write-hooks — Sprint A C5a', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_anno_flags_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: SeedVariant): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+         (case_id, chr, pos, ref, alt, variant_type, gt_num)
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+      [v.caseId, v.chr, v.pos, v.ref, v.alt, v.variantType ?? 'snv', v.gtNum ?? null]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedSummaryRow(
+    chr: string,
+    pos: number,
+    ref: string,
+    alt: string,
+    genomeBuild = 'GRCh38'
+  ): Promise<void> {
+    await probe.query(
+      `INSERT INTO "${schema}".cohort_variant_summary
+         (chr, pos, ref, alt, variant_type, genome_build, carrier_count)
+         VALUES ($1, $2, $3, $4, 'snv', $5, 1)`,
+      [chr, pos, ref, alt, genomeBuild]
+    )
+  }
+
+  it('global upsert flips has_star on every matching cohort_variant_summary row', async () => {
+    // Two summary rows at the same coordinate but different genome_build — a
+    // global star annotation has no build scope, so both must flip.
+    await seedSummaryRow('1', 100, 'A', 'T', 'GRCh38')
+    await seedSummaryRow('1', 100, 'A', 'T', 'GRCh37')
+
+    const repo = new PostgresAnnotationsRepository(pool, schema)
+    await repo.upsertGlobalAnnotation('1', 100, 'A', 'T', { starred: 1 })
+
+    const rows = await probe.query<{ genome_build: string; has_star: boolean }>(
+      `SELECT genome_build, has_star FROM "${schema}".cohort_variant_summary
+         WHERE chr = '1' AND pos = 100 AND ref = 'A' AND alt = 'T'`
+    )
+    expect(rows.rows).toHaveLength(2)
+    expect(rows.rows.every((r) => r.has_star === true)).toBe(true)
+  }, 60_000)
+
+  it('per-case upsert with mismatched (caseId, variantId) throws InvalidParametersError (Pass-7 LOW #6)', async () => {
+    const caseA = await seedCase('case-a')
+    const caseB = await seedCase('case-b')
+    // variantOfB belongs to caseB; calling with caseA must reject the spoof.
+    const variantOfB = await seedVariant({
+      caseId: caseB,
+      chr: '2',
+      pos: 200,
+      ref: 'C',
+      alt: 'G',
+      gtNum: '0/1'
+    })
+    await seedSummaryRow('2', 200, 'C', 'G')
+
+    const repo = new PostgresAnnotationsRepository(pool, schema)
+    await expect(
+      repo.upsertPerCaseAnnotation(caseA, variantOfB, { starred: 1 })
+    ).rejects.toBeInstanceOf(InvalidParametersError)
+
+    // The spoofed pair must not have touched the summary row.
+    const after = await probe.query<{ has_star: boolean }>(
+      `SELECT has_star FROM "${schema}".cohort_variant_summary
+         WHERE chr = '2' AND pos = 200 AND ref = 'C' AND alt = 'G'`
+    )
+    expect(after.rows[0].has_star).toBe(false)
+  }, 60_000)
+
+  it('per-case upsert for a valid variant with no summary row yet is a benign no-op (PR3-7 MAJOR #3)', async () => {
+    // Valid (caseId, variantId): the variant belongs to caseA. There is NO
+    // cohort_variant_summary row at its coordinate (summary unbuilt/stale).
+    // The hook must resolve the target, update zero summary rows, and NOT throw
+    // InvalidParametersError — that error is reserved for an unresolved variant.
+    const caseA = await seedCase('case-a')
+    const variantOfA = await seedVariant({
+      caseId: caseA,
+      chr: '4',
+      pos: 400,
+      ref: 'T',
+      alt: 'C',
+      gtNum: '0/1'
+    })
+    // Deliberately do NOT seed a cohort_variant_summary row at (4, 400, T, C).
+
+    const repo = new PostgresAnnotationsRepository(pool, schema)
+    await expect(
+      repo.upsertPerCaseAnnotation(caseA, variantOfA, { starred: 1 })
+    ).resolves.toBeDefined()
+
+    // The annotation itself persisted (the write-hook did not roll it back).
+    const annotation = await probe.query<{ starred: number }>(
+      `SELECT starred FROM "${schema}".case_variant_annotations
+         WHERE case_id = $1 AND variant_id = $2`,
+      [caseA, variantOfA]
+    )
+    expect(annotation.rows).toHaveLength(1)
+    expect(Number(annotation.rows[0].starred)).toBe(1)
+
+    // No summary row was conjured into existence.
+    const summary = await probe.query(
+      `SELECT 1 FROM "${schema}".cohort_variant_summary
+         WHERE chr = '4' AND pos = 400 AND ref = 'T' AND alt = 'C'`
+    )
+    expect(summary.rows).toHaveLength(0)
+  }, 60_000)
+
+  it('on-delete variant excludes the deleted case from EXISTS subquery (Pass-5 HIGH #1)', async () => {
+    const caseA = await seedCase('case-a')
+    const caseB = await seedCase('case-b')
+    // Both cases carry the same coordinate. Only caseA stars it.
+    const vA = await seedVariant({
+      caseId: caseA,
+      chr: '3',
+      pos: 300,
+      ref: 'G',
+      alt: 'A',
+      gtNum: '0/1'
+    })
+    await seedVariant({ caseId: caseB, chr: '3', pos: 300, ref: 'G', alt: 'A', gtNum: '0/1' })
+    await probe.query(
+      `INSERT INTO "${schema}".case_variant_annotations
+         (case_id, variant_id, starred, created_at, updated_at)
+         VALUES ($1, $2, 1, $3, $3)`,
+      [caseA, vA, now]
+    )
+    // Summary row currently reflects the star.
+    await probe.query(
+      `INSERT INTO "${schema}".cohort_variant_summary
+         (chr, pos, ref, alt, variant_type, genome_build, carrier_count, has_star)
+         VALUES ('3', 300, 'G', 'A', 'snv', 'GRCh38', 2, true)`
+    )
+
+    // The on-case-delete hook is invoked by C3 across the class boundary; call
+    // it directly here to verify its exclusion semantics.
+    const repo = new PostgresAnnotationsRepository(pool, schema)
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      await repo._applyAnnotationFlagsOnCaseDelete(client, { schema, deletedCaseId: caseA })
+      await client.query('COMMIT')
+    } finally {
+      client.release()
+    }
+
+    // caseA is the only star source; excluding it clears has_star.
+    const after = await probe.query<{ has_star: boolean }>(
+      `SELECT has_star FROM "${schema}".cohort_variant_summary
+         WHERE chr = '3' AND pos = 300 AND ref = 'G' AND alt = 'A'`
+    )
+    expect(after.rows[0].has_star).toBe(false)
+  }, 60_000)
 })

--- a/tests/main/storage/postgres-case-lifecycle-repository.e2e.test.ts
+++ b/tests/main/storage/postgres-case-lifecycle-repository.e2e.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Sprint A PR-3 C3 (delete half) — PostgresCaseLifecycleRepository.deleteCase
+ * against a real Postgres. Complements the mocked ordering unit test in
+ * postgres-case-lifecycle-repository.test.ts by proving the 8-step SQL actually
+ * executes and maintains the materialised cohort summary correctly:
+ *
+ *   - the deduped per-case UPDATE subtracts carrier/het/hom together,
+ *   - zero-carrier rows are deleted,
+ *   - variant_frequency.case_count is rebuilt after the cascade,
+ *   - cohort_frequency denominators exclude the deleted case,
+ *   - cohort_column_meta rows for the deleted case are gone,
+ *   - a sibling case's summary contributions survive.
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { PostgresCaseLifecycleRepository } from '../../../src/main/storage/postgres/PostgresCaseLifecycleRepository'
+import { PostgresCohortSummaryRepository } from '../../../src/main/storage/postgres/PostgresCohortSummaryRepository'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+interface SeedVariant {
+  caseId: number
+  chr: string
+  pos: number
+  ref: string
+  alt: string
+  gtNum?: string | null
+}
+
+describe.skipIf(!RUN)('PostgresCaseLifecycleRepository.deleteCase — Sprint A C3', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_delete_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: SeedVariant): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+         (case_id, chr, pos, ref, alt, variant_type, gt_num)
+         VALUES ($1, $2, $3, $4, $5, 'snv', $6) RETURNING id`,
+      [v.caseId, v.chr, v.pos, v.ref, v.alt, v.gtNum ?? null]
+    )
+    return res.rows[0].id
+  }
+
+  const summary = new PostgresCohortSummaryRepository()
+
+  async function buildSummaryFor(caseId: number, genomeBuild = 'GRCh38'): Promise<void> {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      await summary.incrementalAdd({ schema, client: client as never, caseId, genomeBuild })
+      await summary.refreshColumnMetas({ schema, client: client as never, caseId })
+      await client.query('COMMIT')
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  it('subtracts the deleted case from the summary while keeping the sibling', async () => {
+    const caseA = await seedCase('del-a')
+    const caseB = await seedCase('del-b')
+    // Shared het+hom coordinate (carrier_count 2), plus a caseA-only coordinate.
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseB, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '1/1' })
+    await seedVariant({ caseId: caseA, chr: '2', pos: 200, ref: 'C', alt: 'G', gtNum: '0/1' })
+
+    await buildSummaryFor(caseA)
+    await buildSummaryFor(caseB)
+
+    const repo = new PostgresCaseLifecycleRepository(pool, schema)
+    await repo.deleteCase(caseA)
+
+    // Shared coordinate: caseA (het) removed → carrier 1, het 0, hom 1 (caseB).
+    const shared = await probe.query<{
+      carrier_count: string
+      het_count: string
+      hom_count: string
+      cohort_frequency: number | null
+    }>(
+      `SELECT carrier_count, het_count, hom_count, cohort_frequency
+         FROM "${schema}".cohort_variant_summary WHERE chr = '1'`
+    )
+    expect(shared.rows).toHaveLength(1)
+    expect(Number(shared.rows[0].carrier_count)).toBe(1)
+    expect(Number(shared.rows[0].het_count)).toBe(0)
+    expect(Number(shared.rows[0].hom_count)).toBe(1)
+    // One carrier / one surviving GRCh38 case = 1.0 (denominator excludes caseA).
+    expect(Number(shared.rows[0].cohort_frequency)).toBeCloseTo(1.0)
+
+    // caseA-only coordinate: carrier dropped to zero → row deleted (step 4).
+    const gone = await probe.query(
+      `SELECT 1 FROM "${schema}".cohort_variant_summary WHERE chr = '2'`
+    )
+    expect(gone.rows).toHaveLength(0)
+  }, 60_000)
+
+  it('collapses intra-case duplicate coordinates to one carrier on delete (Pass-10 blocker)', async () => {
+    // A single case can legitimately hold two rows for one coordinate under
+    // different gt_num — there is no unique constraint on
+    // variants(case_id,chr,pos,ref,alt,variant_type). incrementalAdd collapses
+    // these to a single carrier (carrier_count 1 per coordinate per case), so
+    // deleteCase must subtract exactly that single carrier, not COUNT(*) = 2.
+    const caseA = await seedCase('dup-a')
+    const caseB = await seedCase('dup-b')
+    // caseA holds the shared coordinate twice under two different genotypes.
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '1/1' })
+    // Sibling case carries the same coordinate once (het).
+    await seedVariant({ caseId: caseB, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+
+    await buildSummaryFor(caseA)
+    await buildSummaryFor(caseB)
+
+    // After add: carrier 2 (caseA collapsed to 1 + caseB 1). MAX(gt_num) over the
+    // two caseA rows is '1/1' → caseA counted as hom; caseB het. So het 1, hom 1.
+    const before = await probe.query<{
+      carrier_count: string
+      het_count: string
+      hom_count: string
+    }>(
+      `SELECT carrier_count, het_count, hom_count
+         FROM "${schema}".cohort_variant_summary WHERE chr = '1'`
+    )
+    expect(before.rows).toHaveLength(1)
+    expect(Number(before.rows[0].carrier_count)).toBe(2)
+
+    const repo = new PostgresCaseLifecycleRepository(pool, schema)
+    await repo.deleteCase(caseA)
+
+    // Deleting caseA must leave exactly the sibling's contribution: carrier 1,
+    // het 1, hom 0. A COUNT(*)-based delta would over-subtract caseA's two rows
+    // (carrier_count 0 → row dropped, het/hom underflowing negative).
+    const after = await probe.query<{
+      carrier_count: string
+      het_count: string
+      hom_count: string
+      cohort_frequency: number | null
+    }>(
+      `SELECT carrier_count, het_count, hom_count, cohort_frequency
+         FROM "${schema}".cohort_variant_summary WHERE chr = '1'`
+    )
+    expect(after.rows).toHaveLength(1)
+    expect(Number(after.rows[0].carrier_count)).toBe(1)
+    expect(Number(after.rows[0].het_count)).toBe(1)
+    expect(Number(after.rows[0].hom_count)).toBe(0)
+    // One carrier / one surviving GRCh38 case = 1.0.
+    expect(Number(after.rows[0].cohort_frequency)).toBeCloseTo(1.0)
+  }, 60_000)
+
+  it('rebuilds variant_frequency and drops the deleted case (step 6 + cascade)', async () => {
+    const caseA = await seedCase('vf-a')
+    const caseB = await seedCase('vf-b')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseB, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+
+    await buildSummaryFor(caseA)
+    await buildSummaryFor(caseB)
+
+    const repo = new PostgresCaseLifecycleRepository(pool, schema)
+    await repo.deleteCase(caseA)
+
+    // variant_frequency.case_count powers internal_af — must reflect 1 case now.
+    const vf = await probe.query<{ case_count: string }>(
+      `SELECT case_count FROM "${schema}".variant_frequency
+         WHERE chr = '1' AND pos = 100 AND ref = 'A' AND alt = 'T'`
+    )
+    expect(vf.rows).toHaveLength(1)
+    expect(Number(vf.rows[0].case_count)).toBe(1)
+
+    // Case row + cascade-deleted variants gone.
+    const caseGone = await probe.query(`SELECT 1 FROM "${schema}".cases WHERE id = $1`, [caseA])
+    expect(caseGone.rows).toHaveLength(0)
+    const variantsGone = await probe.query(
+      `SELECT 1 FROM "${schema}".variants WHERE case_id = $1`,
+      [caseA]
+    )
+    expect(variantsGone.rows).toHaveLength(0)
+  }, 60_000)
+
+  it('removes the deleted case column-meta rows but keeps the sibling (step 8)', async () => {
+    const caseA = await seedCase('meta-a')
+    const caseB = await seedCase('meta-b')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseB, chr: '2', pos: 200, ref: 'C', alt: 'G', gtNum: '0/1' })
+
+    await buildSummaryFor(caseA)
+    await buildSummaryFor(caseB)
+
+    const repo = new PostgresCaseLifecycleRepository(pool, schema)
+    await repo.deleteCase(caseA)
+
+    const aMeta = await probe.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "${schema}".cohort_column_meta WHERE case_id = $1`,
+      [caseA]
+    )
+    const bMeta = await probe.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "${schema}".cohort_column_meta WHERE case_id = $1`,
+      [caseB]
+    )
+    expect(Number(aMeta.rows[0].count)).toBe(0)
+    expect(Number(bMeta.rows[0].count)).toBeGreaterThan(0)
+  }, 60_000)
+
+  it('handles a case with zero variants cleanly', async () => {
+    const empty = await seedCase('empty')
+
+    const repo = new PostgresCaseLifecycleRepository(pool, schema)
+    await expect(repo.deleteCase(empty)).resolves.toBeUndefined()
+
+    const gone = await probe.query(`SELECT 1 FROM "${schema}".cases WHERE id = $1`, [empty])
+    expect(gone.rows).toHaveLength(0)
+  }, 60_000)
+})
+
+describe.skipIf(RUN)('PostgresCaseLifecycleRepository.deleteCase — Sprint A C3 (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/postgres-case-lifecycle-repository.test.ts
+++ b/tests/main/storage/postgres-case-lifecycle-repository.test.ts
@@ -2,9 +2,24 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { PostgresCaseLifecycleRepository } from '../../../src/main/storage/postgres/PostgresCaseLifecycleRepository'
 
-function makePool() {
+/** Normalise a client.query(...) arg into the SQL text, whether it was called
+ *  positionally (string) or with a named-statement config object (runNamed). */
+function sqlText(arg: unknown): string {
+  if (typeof arg === 'string') return arg
+  if (arg && typeof arg === 'object' && typeof (arg as { text?: unknown }).text === 'string') {
+    return (arg as { text: string }).text
+  }
+  return ''
+}
+
+function makePool(genomeBuild = 'GRCh38') {
   const client = {
-    query: vi.fn(async () => ({ rows: [] })),
+    query: vi.fn(async (arg: unknown) => {
+      if (sqlText(arg).includes('SELECT genome_build')) {
+        return { rows: [{ genome_build: genomeBuild }] }
+      }
+      return { rows: [] }
+    }),
     release: vi.fn()
   }
   const pool = {
@@ -14,10 +29,30 @@ function makePool() {
   return { client, pool }
 }
 
+/** Capture-only summary double recording the order of its method calls. */
+function makeSummary() {
+  const calls: string[] = []
+  const summary = {
+    recomputeCohortFrequency: vi.fn(async (args: { affectedBuilds?: string[] }) => {
+      calls.push(`recompute:${JSON.stringify(args.affectedBuilds ?? null)}`)
+    }),
+    removeColumnMetas: vi.fn(async () => {
+      calls.push('removeColumnMetas')
+    })
+  }
+  return { summary, calls }
+}
+
+/** Index of the first client.query call whose SQL text contains `needle`. */
+function firstIndex(client: { query: { mock: { calls: unknown[][] } } }, needle: string): number {
+  return client.query.mock.calls.findIndex(([arg]) => sqlText(arg).includes(needle))
+}
+
 describe('PostgresCaseLifecycleRepository', () => {
   it('deletes a case and rebuilds variant frequency in one transaction', async () => {
     const { client, pool } = makePool()
-    const repo = new PostgresCaseLifecycleRepository(pool as never, 'public')
+    const { summary } = makeSummary()
+    const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
 
     await repo.deleteCase(7)
 
@@ -34,18 +69,129 @@ describe('PostgresCaseLifecycleRepository', () => {
 
   it('preserves the original delete error when rollback fails', async () => {
     const { client, pool } = makePool()
+    const { summary } = makeSummary()
     const deleteError = new Error('delete failed')
     const rollbackError = new Error('rollback failed')
-    client.query.mockImplementation(async (sql: string) => {
-      if (sql.includes('DELETE FROM')) throw deleteError
+    client.query.mockImplementation(async (arg: unknown) => {
+      const sql = sqlText(arg)
+      if (sql.includes('DELETE FROM') && sql.includes('"cases"')) throw deleteError
       if (sql === 'ROLLBACK') throw rollbackError
+      if (sql.includes('SELECT genome_build')) return { rows: [{ genome_build: 'GRCh38' }] }
       return { rows: [] }
     })
-    const repo = new PostgresCaseLifecycleRepository(pool as never, 'public')
+    const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
 
     await expect(repo.deleteCase(7)).rejects.toBe(deleteError)
 
     expect(client.query).toHaveBeenCalledWith('ROLLBACK')
     expect(client.release).toHaveBeenCalledTimes(1)
+  })
+
+  describe('PostgresCaseLifecycleRepository.deleteCase — Sprint A C3', () => {
+    it('captures genome_build BEFORE delete (step 1)', async () => {
+      const { client, pool } = makePool('GRCh37')
+      const { summary } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await repo.deleteCase(7)
+
+      const selectIdx = firstIndex(client, 'SELECT genome_build')
+      const deleteCaseIdx = firstIndex(client, 'DELETE FROM "public"."cases"')
+      expect(selectIdx).toBeGreaterThanOrEqual(0)
+      expect(deleteCaseIdx).toBeGreaterThan(selectIdx)
+    })
+
+    it('runs _applyAnnotationFlagsOnCaseDelete BEFORE the case delete (Pass-5 HIGH #1)', async () => {
+      const { client, pool } = makePool()
+      const { summary } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await repo.deleteCase(7)
+
+      // The on-case-delete flag hook carries the ` AND v.case_id <> $1` predicate.
+      const flagIdx = firstIndex(client, 'v.case_id <> $1')
+      const deleteCaseIdx = firstIndex(client, 'DELETE FROM "public"."cases"')
+      expect(flagIdx).toBeGreaterThanOrEqual(0)
+      expect(deleteCaseIdx).toBeGreaterThan(flagIdx)
+    })
+
+    it('subtracts carrier_count, het_count, hom_count simultaneously (Pass-6 MED #3)', async () => {
+      const { client, pool } = makePool()
+      const { summary } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await repo.deleteCase(7)
+
+      const updateCall = client.query.mock.calls.find(
+        ([arg]) =>
+          sqlText(arg).includes('UPDATE') &&
+          sqlText(arg).includes('"cohort_variant_summary"') &&
+          sqlText(arg).includes('carrier_count = cvs.carrier_count - per_case.carrier_delta')
+      )
+      expect(updateCall).toBeDefined()
+      const sql = sqlText(updateCall?.[0])
+      expect(sql).toContain('het_count = cvs.het_count - per_case.het_delta')
+      expect(sql).toContain('hom_count = cvs.hom_count - per_case.hom_delta')
+      // Zero-carrier cleanup is a sibling DELETE (Pass-2 verdict #1).
+      expect(firstIndex(client, 'WHERE carrier_count <= 0')).toBeGreaterThanOrEqual(0)
+    })
+
+    it('rebuilds variant_frequency after the case delete (Pass-6 HIGH #1)', async () => {
+      const { client, pool } = makePool()
+      const { summary } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await repo.deleteCase(7)
+
+      const deleteCaseIdx = firstIndex(client, 'DELETE FROM "public"."cases"')
+      const rebuildIdx = firstIndex(client, 'INSERT INTO "public"."variant_frequency"')
+      expect(rebuildIdx).toBeGreaterThan(deleteCaseIdx)
+    })
+
+    it('recomputes cohort_frequency narrowed to captured genome_build (Pass-4 HIGH #1)', async () => {
+      const { pool } = makePool('GRCh37')
+      const { summary } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await repo.deleteCase(7)
+
+      expect(summary.recomputeCohortFrequency).toHaveBeenCalledWith(
+        expect.objectContaining({ schema: 'public', affectedBuilds: ['GRCh37'] })
+      )
+    })
+
+    it('removeColumnMetas runs after the cascade (step 8)', async () => {
+      const { pool } = makePool()
+      const { summary, calls } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await repo.deleteCase(7)
+
+      expect(summary.removeColumnMetas).toHaveBeenCalledWith(
+        expect.objectContaining({ schema: 'public', caseId: 7 })
+      )
+      // recompute (step 7) runs before removeColumnMetas (step 8).
+      expect(calls).toEqual(['recompute:["GRCh38"]', 'removeColumnMetas'])
+    })
+
+    it('handles zero-variant cases (steps still run cleanly, no rows updated)', async () => {
+      // No matching case row → SELECT returns no genome_build → recompute falls
+      // back to all builds (undefined affectedBuilds) and everything else runs.
+      const { client, pool } = makePool()
+      client.query.mockImplementation(async () => ({ rows: [] }))
+      const { summary } = makeSummary()
+      const repo = new PostgresCaseLifecycleRepository(pool as never, 'public', summary as never)
+
+      await expect(repo.deleteCase(999)).resolves.toBeUndefined()
+
+      expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+      expect(client.query).toHaveBeenLastCalledWith('COMMIT')
+      expect(summary.recomputeCohortFrequency).toHaveBeenCalledWith(
+        expect.objectContaining({ schema: 'public', affectedBuilds: undefined })
+      )
+      expect(summary.removeColumnMetas).toHaveBeenCalledWith(
+        expect.objectContaining({ caseId: 999 })
+      )
+    })
   })
 })

--- a/tests/main/storage/postgres-cohort-read-freshness.test.ts
+++ b/tests/main/storage/postgres-cohort-read-freshness.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Sprint A PR-3 C5 — cohort-read freshness / staleness orchestration against a
+ * real Postgres.
+ *
+ * Covers the read-path behaviour wired in PR3-17:
+ *
+ *   - readCohortSummaryStatus reads the cohort_summary_state singleton in the
+ *     existing IPC shape { is_stale, last_rebuilt_at:number } (Pass-9 #6).
+ *   - prepareCohortRead force-rebuilds on the bootstrap-on-existing-data case
+ *     (last_rebuilt_at IS NULL, or variants present but summary empty) regardless
+ *     of the 50-case sync threshold (Pass-9 #5), and clears staleness.
+ *   - prepareCohortRead surfaces warnings.staleSummary=true only while it serves
+ *     a stale summary it could not synchronously refresh (Pass-8 #6).
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import {
+  prepareCohortRead,
+  readCohortSummaryStatus
+} from '../../../src/main/storage/postgres/cohort-read-freshness'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+describe.skipIf(!RUN)('cohort-read freshness — Sprint A C5 (PR3-17)', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_cohort_fresh_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(caseId: number, chr: string, pos: number): Promise<void> {
+    await probe.query(
+      `INSERT INTO "${schema}".variants
+         (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gt_num)
+         VALUES ($1, $2, $3, 'A', 'T', 'snv', 'GENE1', '0/1')`,
+      [caseId, chr, pos]
+    )
+  }
+
+  async function summaryRowCount(): Promise<number> {
+    const res = await probe.query<{ n: string }>(
+      `SELECT COUNT(*)::bigint AS n FROM "${schema}".cohort_variant_summary`
+    )
+    return Number(res.rows[0].n)
+  }
+
+  async function isStale(): Promise<boolean> {
+    const res = await probe.query<{ is_stale: boolean }>(
+      `SELECT is_stale FROM "${schema}".cohort_summary_state WHERE id = 1`
+    )
+    return res.rows[0].is_stale
+  }
+
+  it('readCohortSummaryStatus returns the existing IPC shape', async () => {
+    const status = await readCohortSummaryStatus({ pool, schema })
+    expect(status).toEqual({ is_stale: false, last_rebuilt_at: 0 })
+    expect(typeof status.last_rebuilt_at).toBe('number')
+  }, 60_000)
+
+  it('bootstrap: never_rebuilt + variants present forces a synchronous rebuild', async () => {
+    const caseA = await seedCase('boot-a')
+    await seedVariant(caseA, '1', 100)
+    expect(await summaryRowCount()).toBe(0)
+
+    const result = await prepareCohortRead({ pool, schema })
+
+    // Summary materialised and staleness cleared by the forced rebuild.
+    expect(await summaryRowCount()).toBe(1)
+    expect(await isStale()).toBe(false)
+    // A successful synchronous rebuild serves fresh data → no warning.
+    expect(result.warnings).toBeUndefined()
+  }, 60_000)
+
+  it('variants present but summary empty forces a synchronous rebuild', async () => {
+    const caseA = await seedCase('boot-empty-a')
+    await seedVariant(caseA, '2', 200)
+    // Record a rebuild time so never_rebuilt is false, but leave summary empty.
+    await probe.query(
+      `UPDATE "${schema}".cohort_summary_state
+         SET last_rebuilt_at = now(), is_stale = false WHERE id = 1`
+    )
+    expect(await summaryRowCount()).toBe(0)
+
+    await prepareCohortRead({ pool, schema })
+
+    expect(await summaryRowCount()).toBe(1)
+  }, 60_000)
+
+  it('fresh empty schema does NOT rebuild and reports no warning', async () => {
+    const result = await prepareCohortRead({ pool, schema })
+    expect(await summaryRowCount()).toBe(0)
+    expect(result.warnings).toBeUndefined()
+  }, 60_000)
+
+  it('stale below the sync threshold rebuilds synchronously (no warning)', async () => {
+    const caseA = await seedCase('stale-sync-a')
+    await seedVariant(caseA, '3', 300)
+    // Establish a rebuilt baseline so the bootstrap override does not fire.
+    await prepareCohortRead({ pool, schema })
+    expect(await summaryRowCount()).toBe(1)
+
+    // Add a second variant and flag the summary stale.
+    await seedVariant(caseA, '3', 301)
+    await probe.query(
+      `UPDATE "${schema}".cohort_summary_state
+         SET is_stale = true, stale_reason = 'test', stale_at = now() WHERE id = 1`
+    )
+
+    const result = await prepareCohortRead({ pool, schema })
+    expect(await isStale()).toBe(false)
+    expect(await summaryRowCount()).toBe(2)
+    expect(result.warnings).toBeUndefined()
+  }, 60_000)
+
+  it('stale above the sync threshold serves stale + warns + schedules bg rebuild', async () => {
+    const caseA = await seedCase('stale-bg-a')
+    await seedVariant(caseA, '4', 400)
+    await prepareCohortRead({ pool, schema })
+
+    // Flag stale and force the sync threshold to 0 so this read serves stale.
+    await probe.query(
+      `UPDATE "${schema}".cohort_summary_state
+         SET is_stale = true, stale_reason = 'test', stale_at = now() WHERE id = 1`
+    )
+    const previous = process.env.VARLENS_PG_COHORT_SUMMARY_SYNC_MAX_CASES
+    process.env.VARLENS_PG_COHORT_SUMMARY_SYNC_MAX_CASES = '0'
+    try {
+      const result = await prepareCohortRead({ pool, schema })
+      expect(result.warnings).toEqual({ staleSummary: true })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.VARLENS_PG_COHORT_SUMMARY_SYNC_MAX_CASES
+      } else {
+        process.env.VARLENS_PG_COHORT_SUMMARY_SYNC_MAX_CASES = previous
+      }
+    }
+  }, 60_000)
+})

--- a/tests/main/storage/postgres-cohort-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-repository.test.ts
@@ -16,6 +16,21 @@ function normalizeSql(sql: string): string {
   return sql.replace(/\s+/g, ' ').trim()
 }
 
+// queryVariants / getColumnMeta route through runNamed / runNamedDynamic, which
+// call pool.query with a { name, text, values } spec object rather than
+// positional (text, values). These helpers read the SQL/params from either
+// shape so the assertions stay shape-agnostic.
+function callText(call: unknown[]): string {
+  const arg = call[0]
+  return typeof arg === 'string' ? arg : ((arg as { text?: string }).text ?? '')
+}
+
+function callParams(call: unknown[]): unknown[] {
+  const arg = call[0]
+  if (typeof arg === 'string') return (call[1] as unknown[]) ?? []
+  return ((arg as { values?: unknown[] }).values as unknown[]) ?? []
+}
+
 describe('PostgresCohortRepository', () => {
   it('queries total cases, grouped variant count, then rows and maps numeric strings', async () => {
     const query = vi
@@ -84,7 +99,9 @@ describe('PostgresCohortRepository', () => {
     })
   })
 
-  it('builds grouped cohort SQL with parameterized base filters', async () => {
+  it('builds summary-page cohort SQL with parameterized base filters (C4)', async () => {
+    // C4: materialisable predicates read from cohort_variant_summary (alias
+    // `cvs`) instead of the live variants GROUP BY.
     const query = vi
       .fn()
       .mockResolvedValueOnce({ rows: [{ total_cases: '10' }] })
@@ -105,25 +122,26 @@ describe('PostgresCohortRepository', () => {
       offset: 0
     })
 
-    const countSql = normalizeSql(query.mock.calls[1][0] as string)
-    const countParams = query.mock.calls[1][1] as unknown[]
-    const dataSql = normalizeSql(query.mock.calls[2][0] as string)
-    const dataParams = query.mock.calls[2][1] as unknown[]
+    const countSql = normalizeSql(callText(query.mock.calls[1]))
+    const countParams = callParams(query.mock.calls[1])
+    const dataSql = normalizeSql(callText(query.mock.calls[2]))
+    const dataParams = callParams(query.mock.calls[2])
 
-    expect(dataSql).toContain('FROM "tenant""schema"."variants" v')
-    expect(dataSql).toContain('GROUP BY v.chr, v.pos, v.ref, v.alt')
-    expect(dataSql).toContain('COUNT(DISTINCT v.case_id)::bigint AS carrier_count')
-    expect(dataSql).toContain('HAVING COUNT(DISTINCT v.case_id) >= $')
-    expect(countSql).toContain('SELECT COUNT(*)::bigint AS total_count FROM (')
-    expect(countSql).toContain('GROUP BY v.chr, v.pos, v.ref, v.alt')
-    expect(dataSql).toContain('(v.chr = $')
-    expect(dataSql).toContain('v.pos <= $')
-    expect(dataSql).toContain('COALESCE(v.end_pos, v.pos) >= $')
-    expect(dataSql).toContain('v.gene_symbol = $')
-    expect(dataSql).toContain('v.consequence IN ($')
-    expect(dataSql).toContain('v.clinvar IN ($')
-    expect(dataSql).toContain('(v.gnomad_af IS NULL OR v.gnomad_af <= $')
-    expect(dataSql).toContain('(v.cadd IS NULL OR v.cadd >= $')
+    expect(dataSql).toContain('FROM "tenant""schema"."cohort_variant_summary" cvs')
+    expect(dataSql).not.toContain('GROUP BY')
+    expect(dataSql).not.toContain('HAVING')
+    expect(dataSql).toContain('cvs.carrier_count')
+    expect(countSql).toContain('SELECT COUNT(*)::bigint AS total_count')
+    expect(countSql).toContain('FROM "tenant""schema"."cohort_variant_summary" cvs')
+    expect(dataSql).toContain('(cvs.chr = $')
+    expect(dataSql).toContain('cvs.pos <= $')
+    expect(dataSql).toContain('COALESCE(cvs.end_pos, cvs.pos) >= $')
+    expect(dataSql).toContain('cvs.gene_symbol = $')
+    expect(dataSql).toContain('cvs.consequence IN ($')
+    expect(dataSql).toContain('cvs.clinvar IN ($')
+    expect(dataSql).toContain('(cvs.gnomad_af IS NULL OR cvs.gnomad_af <= $')
+    expect(dataSql).toContain('(cvs.cadd IS NULL OR cvs.cadd >= $')
+    expect(dataSql).toContain('cvs.carrier_count >= $')
     expect(dataSql).toContain('ILIKE $')
     expect(dataSql).not.toContain('DROP TABLE')
     expect(dataSql).not.toContain('OR TRUE')
@@ -164,13 +182,13 @@ describe('PostgresCohortRepository', () => {
       offset: 0
     })
 
-    const dataSql = normalizeSql(query.mock.calls[3][0] as string)
-    const dataParams = query.mock.calls[3][1] as unknown[]
+    const dataSql = normalizeSql(callText(query.mock.calls[3]))
+    const dataParams = callParams(query.mock.calls[3])
 
     expect(resolveIntervals).toHaveBeenCalledWith([3, 4], 'GRCh37', 7500, false)
-    expect(dataSql).toContain('(v.chr = $')
-    expect(dataSql).toContain('v.pos <= $')
-    expect(dataSql).toContain('COALESCE(v.end_pos, v.pos) >= $')
+    expect(dataSql).toContain('(cvs.chr = $')
+    expect(dataSql).toContain('cvs.pos <= $')
+    expect(dataSql).toContain('COALESCE(cvs.end_pos, cvs.pos) >= $')
     expect(dataSql).not.toContain('panel_genes')
     expect(dataSql).not.toContain('case_active_panels')
     expect(dataParams).toEqual(['1', 200, 100, 'GRCh37', 10, 0])
@@ -207,15 +225,15 @@ describe('PostgresCohortRepository', () => {
       offset: 0
     })
 
-    const panelSql = normalizeSql(query.mock.calls[1][0] as string)
-    const panelParams = query.mock.calls[1][1] as unknown[]
-    const dataSql = normalizeSql(query.mock.calls[4][0] as string)
-    const dataParams = query.mock.calls[4][1] as unknown[]
+    const panelSql = normalizeSql(callText(query.mock.calls[1]))
+    const panelParams = callParams(query.mock.calls[1])
+    const dataSql = normalizeSql(callText(query.mock.calls[4]))
+    const dataParams = callParams(query.mock.calls[4])
 
     expect(panelSql).toContain('FROM "public"."panel_genes"')
     expect(panelParams).toEqual([[3]])
     expect(geneReferenceMocks.getCoordinatesForGenes).toHaveBeenCalledWith(['HGNC:1100'], 'GRCh38')
-    expect(dataSql).toContain('(v.chr = $')
+    expect(dataSql).toContain('(cvs.chr = $')
     expect(dataSql).not.toContain('panel_genes')
     expect(dataSql).not.toContain('case_active_panels')
     expect(dataParams).toEqual(['chr1', 7000, 1, 10, 0])
@@ -237,13 +255,13 @@ describe('PostgresCohortRepository', () => {
       offset: 0
     })
 
-    const dataSql = normalizeSql(query.mock.calls[2][0] as string)
-    const dataParams = query.mock.calls[2][1] as unknown[]
+    const dataSql = normalizeSql(callText(query.mock.calls[2]))
+    const dataParams = callParams(query.mock.calls[2])
 
     expect(resolveIntervals).not.toHaveBeenCalled()
-    expect(dataSql).toContain('(v.chr = $')
-    expect(dataSql).toContain('v.pos <= $')
-    expect(dataSql).toContain('COALESCE(v.end_pos, v.pos) >= $')
+    expect(dataSql).toContain('(cvs.chr = $')
+    expect(dataSql).toContain('cvs.pos <= $')
+    expect(dataSql).toContain('COALESCE(cvs.end_pos, cvs.pos) >= $')
     expect(dataSql).not.toContain('panel_genes')
     expect(dataSql).not.toContain('case_active_panels')
     expect(dataParams).toEqual(['1', 200, 100, 10, 0])
@@ -268,24 +286,27 @@ describe('PostgresCohortRepository', () => {
       }
     })
 
-    const dataSql = normalizeSql(query.mock.calls[2][0] as string)
-    const dataParams = query.mock.calls[2][1] as unknown[]
+    const dataSql = normalizeSql(callText(query.mock.calls[2]))
+    const dataParams = callParams(query.mock.calls[2])
 
-    expect(dataSql).toContain('v.gene_symbol ILIKE $')
-    expect(dataSql).toContain('COUNT(DISTINCT v.case_id) >= $')
-    expect(dataSql).toContain('COUNT(DISTINCT v.case_id)::double precision / NULLIF(10, 0) <= $')
-    expect(dataSql).toContain('(v.cadd IS NULL OR v.cadd > $')
-    expect(dataSql).toContain('v.gnomad_af <= $')
-    expect(dataSql).toContain('v.clinvar IN ($')
+    expect(dataSql).toContain('cvs.gene_symbol ILIKE $')
+    // Aggregate columns are stored columns on the summary table — plain
+    // comparisons, no COUNT(DISTINCT)/HAVING.
+    expect(dataSql).toContain('cvs.carrier_count >= $')
+    expect(dataSql).toContain('cvs.cohort_frequency <= $')
+    expect(dataSql).toContain('cvs.cadd > $')
+    expect(dataSql).toContain('cvs.gnomad_af <= $')
+    expect(dataSql).toContain('cvs.clinvar IN ($')
+    expect(dataSql).not.toContain('COUNT(DISTINCT')
     expect(dataSql).not.toContain('OR TRUE')
     expect(dataParams).toEqual([
       `%BRCA%' OR TRUE --%`,
-      'Pathogenic',
-      'Likely pathogenic',
-      0.01,
-      20,
       2,
       0.5,
+      20,
+      0.01,
+      'Pathogenic',
+      'Likely pathogenic',
       50,
       0
     ])
@@ -391,11 +412,15 @@ describe('PostgresCohortRepository', () => {
 
     expect(normalizeSql(query.mock.calls[0][0] as string)).toContain('WHERE genome_build = $1')
     expect(query.mock.calls[0][1]).toEqual(['GRCh38'])
-    const dataSql = normalizeSql(query.mock.calls[2][0] as string)
-    expect(dataSql).toContain('COUNT(DISTINCT v.case_id)::double precision / NULLIF(6, 0) <= $')
+    const dataSql = normalizeSql(callText(query.mock.calls[2]))
+    // cohort_frequency is a stored column on the summary table.
+    expect(dataSql).toContain('cvs.genome_build = $')
+    expect(dataSql).toContain('cvs.cohort_frequency <= $')
   })
 
-  it('checks global and per-case annotations for cohort annotation filters', async () => {
+  it('reads C5a-maintained annotation flags from the summary table', async () => {
+    // C4: annotation filters read the stored cvs.has_star / has_comment /
+    // acmg_best columns (kept current by C5a) — no live annotation joins.
     const query = vi
       .fn()
       .mockResolvedValueOnce({ rows: [{ total_cases: '10' }] })
@@ -409,15 +434,12 @@ describe('PostgresCohortRepository', () => {
       acmg_classifications: ['Pathogenic']
     })
 
-    const dataSql = normalizeSql(query.mock.calls[2][0] as string)
-    expect(dataSql).toContain('case_variant_annotations')
-    expect(dataSql).toContain('variant_annotations')
-    expect(dataSql).toContain('cva.starred')
-    expect(dataSql).toContain('va.starred')
-    expect(dataSql).toContain('cva.per_case_comment')
-    expect(dataSql).toContain('va.global_comment')
-    expect(dataSql).toContain('cva.acmg_classification IN')
-    expect(dataSql).toContain('va.acmg_classification IN')
+    const dataSql = normalizeSql(callText(query.mock.calls[2]))
+    expect(dataSql).toContain('cvs.has_star = true')
+    expect(dataSql).toContain('cvs.has_comment = true')
+    expect(dataSql).toContain('cvs.acmg_best IN ($')
+    expect(dataSql).not.toContain('case_variant_annotations')
+    expect(dataSql).not.toContain('variant_annotations')
   })
 
   it("treats variant_type 'snv' as snv plus indel", async () => {
@@ -430,9 +452,9 @@ describe('PostgresCohortRepository', () => {
 
     await repository.queryVariants({ variant_type: 'snv' })
 
-    const dataSql = normalizeSql(query.mock.calls[2][0] as string)
-    expect(dataSql).toContain("v.variant_type IN ('snv', 'indel')")
-    expect(query.mock.calls[2][1]).toEqual([50, 0])
+    const dataSql = normalizeSql(callText(query.mock.calls[2]))
+    expect(dataSql).toContain("cvs.variant_type IN ('snv', 'indel')")
+    expect(callParams(query.mock.calls[2])).toEqual([50, 0])
   })
 
   it('maps cohort summary statistics and ACMG counts from numeric strings', async () => {
@@ -550,7 +572,6 @@ describe('PostgresCohortRepository', () => {
     }
     const query = vi
       .fn()
-      .mockResolvedValueOnce({ rows: [{ total_cases: '10' }] })
       .mockResolvedValueOnce({ rows: [aggregateRow] })
       .mockResolvedValueOnce({
         rows: [
@@ -586,14 +607,17 @@ describe('PostgresCohortRepository', () => {
     expect(byKey.get('pos')?.max).toBe(10)
     expect(byKey.get('gene_symbol')?.dataType).toBe('text')
     expect(byKey.get('chr')?.distinctValues).toEqual(['1'])
-    expect(query).toHaveBeenCalledTimes(3)
-    expect(normalizeSql(query.mock.calls[1][0] as string)).toContain('COUNT(DISTINCT chr)')
-    expect(normalizeSql(query.mock.calls[1][0] as string)).not.toContain('ARRAY_AGG')
-    expect(normalizeSql(query.mock.calls[2][0] as string)).toContain(
-      'WITH cohort_columns AS MATERIALIZED'
-    )
-    expect(normalizeSql(query.mock.calls[2][0] as string)).toContain('UNION ALL')
-    expect(normalizeSql(query.mock.calls[2][0] as string)).not.toContain('FROM (SELECT')
+    // C4 Step 2: read directly from the deduped summary table — no total_cases
+    // query, no live GROUP BY subquery.
+    expect(query).toHaveBeenCalledTimes(2)
+    const aggSql = normalizeSql(callText(query.mock.calls[0]))
+    expect(aggSql).toContain('COUNT(DISTINCT chr)')
+    expect(aggSql).toContain('FROM "public"."cohort_variant_summary"')
+    expect(aggSql).not.toContain('ARRAY_AGG')
+    const valuesSql = normalizeSql(callText(query.mock.calls[1]))
+    expect(valuesSql).toContain('UNION ALL')
+    expect(valuesSql).toContain('FROM "public"."cohort_variant_summary"')
+    expect(valuesSql).not.toContain('GROUP BY v.chr')
   })
 
   it('streams cohort rows through pg-query-stream and releases the client', async () => {

--- a/tests/main/storage/postgres-cohort-summary-migration.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-migration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Sprint A PR-3 C1 — cohort_summary migration (0010) against a real Postgres.
+ *
+ * Verifies the three tables (cohort_variant_summary, cohort_column_meta,
+ * cohort_summary_state), the six-index set mirroring SQLite v25 (Pass-3 LOW #7),
+ * the composite PK including (variant_type, genome_build) (Codex finding 1),
+ * and the conditional seed semantics (Pass-9 #5): fresh schemas seed
+ * is_stale=false; existing-data schemas seed is_stale=true with reason
+ * 'migration_initial_existing_data'.
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+const MIGRATIONS_THROUGH_0009 = POSTGRES_MIGRATIONS.filter((m) => m.version < '0010')
+
+describe.skipIf(!RUN)('cohort_summary migration — Sprint A C1', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+
+  beforeEach(async () => {
+    schema = `varlens_test_cvs_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  it('creates cohort_variant_summary with the v25-mirroring index set', async () => {
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    const tablesRes = await probe.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = $1`,
+      [schema]
+    )
+    const tableNames = tablesRes.rows.map((r) => r.table_name)
+    expect(tableNames).toContain('cohort_variant_summary')
+    expect(tableNames).toContain('cohort_column_meta')
+    expect(tableNames).toContain('cohort_summary_state')
+
+    const indexRes = await probe.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes WHERE schemaname = $1 AND tablename = 'cohort_variant_summary'`,
+      [schema]
+    )
+    const indexNames = indexRes.rows.map((r) => r.indexname)
+    for (const expected of [
+      'idx_cvs_carrier',
+      'idx_cvs_filters',
+      'idx_cvs_cohort_freq',
+      'idx_cvs_covering_common',
+      'idx_cvs_gene_covering',
+      'idx_cvs_type_build'
+    ]) {
+      expect(indexNames, `index ${expected} must exist`).toContain(expected)
+    }
+  }, 60_000)
+
+  it('seeds cohort_summary_state with is_stale=false on a fresh schema (no variants)', async () => {
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    const res = await probe.query<{ is_stale: boolean; stale_reason: string | null }>(
+      `SELECT is_stale, stale_reason FROM "${schema}".cohort_summary_state WHERE id = 1`
+    )
+    expect(res.rows).toHaveLength(1)
+    expect(res.rows[0].is_stale).toBe(false)
+    expect(res.rows[0].stale_reason).toBeNull()
+  }, 60_000)
+
+  it('seeds cohort_summary_state with is_stale=true on an existing-data schema (Pass-9 #5)', async () => {
+    // Apply 0001-0009 first, insert a case + one variant, THEN apply 0010.
+    await new PostgresMigrationRunner(pool, schema, MIGRATIONS_THROUGH_0009).migrate()
+
+    const caseRes = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at)
+         VALUES ('seed-case', '/tmp/seed.json', 0, $1) RETURNING id`,
+      [Date.now()]
+    )
+    const caseId = caseRes.rows[0].id
+    await probe.query(
+      `INSERT INTO "${schema}".variants (case_id, chr, pos, ref, alt)
+         VALUES ($1, '1', 100, 'A', 'T')`,
+      [caseId]
+    )
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    const res = await probe.query<{ is_stale: boolean; stale_reason: string | null }>(
+      `SELECT is_stale, stale_reason FROM "${schema}".cohort_summary_state WHERE id = 1`
+    )
+    expect(res.rows).toHaveLength(1)
+    expect(res.rows[0].is_stale).toBe(true)
+    expect(res.rows[0].stale_reason).toBe('migration_initial_existing_data')
+  }, 60_000)
+
+  it('PK includes variant_type AND genome_build (Codex finding 1)', async () => {
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    const pkRes = await probe.query<{ column_name: string }>(
+      `SELECT kcu.column_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+           USING (constraint_schema, constraint_name)
+        WHERE tc.table_schema = $1
+          AND tc.table_name = 'cohort_variant_summary'
+          AND tc.constraint_type = 'PRIMARY KEY'`,
+      [schema]
+    )
+    const pkCols = pkRes.rows.map((r) => r.column_name)
+    expect(pkCols).toEqual(
+      expect.arrayContaining(['chr', 'pos', 'ref', 'alt', 'variant_type', 'genome_build'])
+    )
+    expect(pkCols).toHaveLength(6)
+  }, 60_000)
+})
+
+describe.skipIf(RUN)('cohort_summary migration — Sprint A C1 (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/postgres-cohort-summary-query.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-query.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CohortSearchParams } from '../../../src/shared/types/cohort'
+import { buildSummaryQueryParts } from '../../../src/main/storage/postgres/postgres-cohort-summary-query'
+
+const TOTAL_CASES = 10
+
+describe('buildSummaryQueryParts', () => {
+  it('returns no predicates and an empty join for an empty query', () => {
+    const result = buildSummaryQueryParts({}, TOTAL_CASES)
+
+    expect(result.unavailable).toBe(false)
+    expect(result.parts.joins).toBe('')
+    expect(result.parts.whereParts).toEqual([])
+    expect(result.parts.values).toEqual([])
+  })
+
+  it('maps direct columns to alias cvs', () => {
+    const params: CohortSearchParams = {
+      gene_symbol: 'BRCA1',
+      consequences: ['HIGH', 'MODERATE'],
+      funcs: ['missense_variant'],
+      clinvars: ['Pathogenic'],
+      gnomad_af_max: 0.01,
+      cadd_min: 20,
+      variant_type: 'sv'
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(result.unavailable).toBe(false)
+    expect(where).toContain('cvs.gene_symbol =')
+    expect(where).toContain('cvs.consequence IN (')
+    expect(where).toContain('cvs.func IN (')
+    expect(where).toContain('cvs.clinvar IN (')
+    expect(where).toContain('cvs.gnomad_af IS NULL OR cvs.gnomad_af <=')
+    expect(where).toContain('cvs.cadd IS NULL OR cvs.cadd >=')
+    expect(where).toContain('cvs.variant_type =')
+    // No alias `v.` leaks into the summary predicates.
+    expect(where).not.toMatch(/\bv\./)
+    expect(result.parts.values).toEqual([
+      'BRCA1',
+      'HIGH',
+      'MODERATE',
+      'missense_variant',
+      'Pathogenic',
+      0.01,
+      20,
+      'sv'
+    ])
+  })
+
+  it('expands variant_type snv to the snv/indel pair', () => {
+    const result = buildSummaryQueryParts({ variant_type: 'snv' }, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(where).toContain("cvs.variant_type IN ('snv', 'indel')")
+  })
+
+  it('scopes by genome_build directly on cvs (no cases join)', () => {
+    const result = buildSummaryQueryParts({ genome_build: 'GRCh37' }, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(where).toContain('cvs.genome_build =')
+    expect(where).not.toContain('cases')
+    expect(result.parts.joins).toBe('')
+    expect(result.parts.values).toContain('GRCh37')
+  })
+
+  it('moves aggregate predicates from HAVING to WHERE on stored columns', () => {
+    const params: CohortSearchParams = {
+      carrier_count_min: 3,
+      max_internal_af: 0.2
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(result.unavailable).toBe(false)
+    expect(where).toContain('cvs.carrier_count >=')
+    expect(where).toContain('cvs.cohort_frequency <=')
+    // No GROUP BY / HAVING aggregate expression leaks through.
+    expect(where).not.toContain('COUNT(')
+    // Mirrors live builder ordering: max_internal_af before carrier_count_min.
+    expect(result.parts.values).toEqual([0.2, 3])
+  })
+
+  it('maps aggregate column filters (carrier_count, cohort_frequency, het/hom) to cvs columns', () => {
+    const params: CohortSearchParams = {
+      column_filters: {
+        carrier_count: { operator: '>=', value: 2 },
+        cohort_frequency: { operator: '<', value: 0.5 },
+        het_count: { operator: '>', value: 1 },
+        hom_count: { operator: '=', value: 0 }
+      }
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(result.unavailable).toBe(false)
+    expect(where).toContain('cvs.carrier_count')
+    expect(where).toContain('cvs.cohort_frequency')
+    expect(where).toContain('cvs.het_count')
+    expect(where).toContain('cvs.hom_count')
+    expect(where).not.toContain('COUNT(')
+  })
+
+  it('maps annotation flags to stored boolean/text columns', () => {
+    const params: CohortSearchParams = {
+      starred_only: true,
+      has_comment: true,
+      acmg_classifications: ['pathogenic', 'likely_pathogenic']
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(result.unavailable).toBe(false)
+    expect(where).toContain('cvs.has_star')
+    expect(where).toContain('cvs.has_comment')
+    expect(where).toContain('cvs.acmg_best IN (')
+    expect(result.parts.values).toEqual(['pathogenic', 'likely_pathogenic'])
+  })
+
+  it('builds the genomic-coordinate search match on cvs', () => {
+    const result = buildSummaryQueryParts({ search_term: 'chr17:43044295' }, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(where).toContain('cvs.chr =')
+    expect(where).toContain('cvs.pos =')
+    expect(result.parts.values).toEqual(['17', 43044295])
+  })
+
+  it('builds the gene/consequence/OMIM ILIKE search on cvs', () => {
+    const result = buildSummaryQueryParts({ search_term: 'BRCA' }, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(where).toContain('cvs.gene_symbol ILIKE')
+    expect(where).toContain('cvs.consequence ILIKE')
+    expect(where).toContain('cvs.omim_mim_number ILIKE')
+    // Mirrors the live builder: one bound param per ILIKE branch.
+    expect(result.parts.values).toEqual(['%BRCA%', '%BRCA%', '%BRCA%'])
+  })
+
+  it('uses the exact panel-interval predicate that overlaps spanning variants', () => {
+    const params: CohortSearchParams = {
+      panel_intervals: [
+        { chr: '17', start: 43000000, end: 43100000 },
+        { chr: '13', start: 32000000, end: 32400000 }
+      ]
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    // Pass-9 #7: must mirror the live predicate verbatim against cvs.
+    expect(where).toContain(
+      'cvs.chr = $1 AND cvs.pos <= $2 AND COALESCE(cvs.end_pos, cvs.pos) >= $3'
+    )
+    expect(where).toContain(
+      'cvs.chr = $4 AND cvs.pos <= $5 AND COALESCE(cvs.end_pos, cvs.pos) >= $6'
+    )
+    expect(result.parts.values).toEqual(['17', 43100000, 43000000, '13', 32400000, 32000000])
+  })
+
+  it('falls back (unavailable) when an extension-table predicate is present', () => {
+    const params: CohortSearchParams = {
+      gene_symbol: 'BRCA1',
+      column_filters: {
+        'sv.support': { operator: '>=', value: 5 }
+      }
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+
+    expect(result.unavailable).toBe(true)
+    expect(result.unavailableReason).toBe('extension_predicate')
+  })
+
+  it('detects cnv and str extension predicates as well', () => {
+    expect(
+      buildSummaryQueryParts(
+        { column_filters: { 'cnv.copy_number': { operator: '>', value: 2 } } },
+        TOTAL_CASES
+      ).unavailable
+    ).toBe(true)
+    expect(
+      buildSummaryQueryParts(
+        { column_filters: { 'str.repeat_length': { operator: '>', value: 30 } } },
+        TOTAL_CASES
+      ).unavailable
+    ).toBe(true)
+  })
+
+  it('does not treat base column filters as extension predicates', () => {
+    const result = buildSummaryQueryParts(
+      { column_filters: { gnomad_af: { operator: '<', value: 0.01 } } },
+      TOTAL_CASES
+    )
+
+    expect(result.unavailable).toBe(false)
+    expect(result.parts.whereParts.join(' ')).toContain('cvs.gnomad_af')
+  })
+
+  it('builds aggregate-aware ORDER BY against direct cvs columns', () => {
+    const carrier = buildSummaryQueryParts(
+      { sort_by: 'carrier_count', sort_order: 'asc' },
+      TOTAL_CASES
+    )
+    expect(carrier.parts.orderBy).toContain('cvs.carrier_count ASC')
+    expect(carrier.parts.orderBy).not.toContain('COUNT(')
+
+    const freq = buildSummaryQueryParts(
+      { sort_by: 'cohort_frequency', sort_order: 'desc' },
+      TOTAL_CASES
+    )
+    expect(freq.parts.orderBy).toContain('cvs.cohort_frequency DESC')
+
+    const cadd = buildSummaryQueryParts({ sort_by: 'cadd_phred' }, TOTAL_CASES)
+    expect(cadd.parts.orderBy).toContain('cvs.cadd DESC')
+  })
+
+  it('defaults ORDER BY to carrier_count when sort_by is unknown', () => {
+    const result = buildSummaryQueryParts({ sort_by: 'nonexistent_column' }, TOTAL_CASES)
+    expect(result.parts.orderBy).toContain('cvs.carrier_count DESC')
+  })
+
+  it('produces sequential positional placeholders across mixed predicates', () => {
+    const params: CohortSearchParams = {
+      gene_symbol: 'TP53',
+      carrier_count_min: 2
+    }
+
+    const result = buildSummaryQueryParts(params, TOTAL_CASES)
+    const where = result.parts.whereParts.join(' ')
+
+    expect(where).toContain('$1')
+    expect(where).toContain('$2')
+    expect(result.parts.values).toEqual(['TP53', 2])
+  })
+})

--- a/tests/main/storage/postgres-cohort-summary-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-repository.test.ts
@@ -246,6 +246,224 @@ describe.skipIf(!RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2',
   }, 60_000)
 })
 
+describe.skipIf(!RUN)('PostgresCohortSummaryRepository.incrementalAdd/Remove — Sprint A C2', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_cvs_incr_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+           VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: SeedVariant): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+           (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gt_num)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+      [
+        v.caseId,
+        v.chr,
+        v.pos,
+        v.ref,
+        v.alt,
+        v.variantType ?? 'snv',
+        v.geneSymbol ?? null,
+        v.gtNum ?? null
+      ]
+    )
+    return res.rows[0].id
+  }
+
+  async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      return await fn(client as unknown as Client)
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  async function summaryRow(chr: string): Promise<{
+    carrier_count: number
+    het_count: number
+    hom_count: number
+    has_star: boolean
+    has_comment: boolean
+    acmg_best: string | null
+  } | null> {
+    const res = await probe.query<{
+      carrier_count: string
+      het_count: string
+      hom_count: string
+      has_star: boolean
+      has_comment: boolean
+      acmg_best: string | null
+    }>(
+      `SELECT carrier_count, het_count, hom_count, has_star, has_comment, acmg_best
+           FROM "${schema}".cohort_variant_summary WHERE chr = $1`,
+      [chr]
+    )
+    if (res.rows.length === 0) return null
+    const r = res.rows[0]
+    return {
+      carrier_count: Number(r.carrier_count),
+      het_count: Number(r.het_count),
+      hom_count: Number(r.hom_count),
+      has_star: r.has_star,
+      has_comment: r.has_comment,
+      acmg_best: r.acmg_best
+    }
+  }
+
+  const repo = new PostgresCohortSummaryRepository()
+
+  it('incrementalAdd inserts a brand-new row from the deduped CTE', async () => {
+    const caseA = await seedCase('add-new-a')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseA, chr: '2', pos: 200, ref: 'C', alt: 'G', gtNum: '1/1' })
+
+    await withClient((client) =>
+      repo.incrementalAdd({ schema, client: client as never, caseId: caseA })
+    )
+
+    const het = await summaryRow('1')
+    expect(het).not.toBeNull()
+    expect(het!.carrier_count).toBe(1)
+    expect(het!.het_count).toBe(1)
+    expect(het!.hom_count).toBe(0)
+
+    const hom = await summaryRow('2')
+    expect(hom!.carrier_count).toBe(1)
+    expect(hom!.het_count).toBe(0)
+    expect(hom!.hom_count).toBe(1)
+  }, 60_000)
+
+  it('incrementalAdd bumps all three counters on conflict', async () => {
+    const caseA = await seedCase('add-bump-a')
+    const caseB = await seedCase('add-bump-b')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseB, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '1/1' })
+
+    await withClient(async (client) => {
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseA })
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseB })
+    })
+
+    const row = await summaryRow('1')
+    expect(row!.carrier_count).toBe(2)
+    expect(row!.het_count).toBe(1)
+    expect(row!.hom_count).toBe(1)
+  }, 60_000)
+
+  it('incrementalAdd dedups duplicate per-case rows (counts once)', async () => {
+    const caseA = await seedCase('add-dedup-a')
+    await seedVariant({ caseId: caseA, chr: '3', pos: 300, ref: 'G', alt: 'A', gtNum: '0/1' })
+    await seedVariant({ caseId: caseA, chr: '3', pos: 300, ref: 'G', alt: 'A', gtNum: '0/1' })
+
+    await withClient((client) =>
+      repo.incrementalAdd({ schema, client: client as never, caseId: caseA })
+    )
+
+    const row = await summaryRow('3')
+    expect(row!.carrier_count).toBe(1)
+  }, 60_000)
+
+  it('incrementalAdd preserves existing flags (OR semantics, no clear)', async () => {
+    const caseA = await seedCase('add-flag-a')
+    const caseB = await seedCase('add-flag-b')
+    const vA = await seedVariant({
+      caseId: caseA,
+      chr: '4',
+      pos: 400,
+      ref: 'T',
+      alt: 'C',
+      gtNum: '0/1'
+    })
+    void vA
+    // Global star + comment annotation so caseA's add sets the flags true.
+    await probe.query(
+      `INSERT INTO "${schema}".variant_annotations
+           (chr, pos, ref, alt, global_comment, starred, acmg_classification, created_at, updated_at)
+           VALUES ('4', 400, 'T', 'C', 'noted', 1, 'Pathogenic', $1, $1)`,
+      [now]
+    )
+    await seedVariant({ caseId: caseB, chr: '4', pos: 400, ref: 'T', alt: 'C', gtNum: '0/1' })
+
+    await withClient(async (client) => {
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseA })
+      // caseB add must not clear the flags set by caseA's add.
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseB })
+    })
+
+    const row = await summaryRow('4')
+    expect(row!.carrier_count).toBe(2)
+    expect(row!.has_star).toBe(true)
+    expect(row!.has_comment).toBe(true)
+    expect(row!.acmg_best).toBe('Pathogenic')
+  }, 60_000)
+
+  it('incrementalRemove subtracts all three counters simultaneously', async () => {
+    const caseA = await seedCase('rm-a')
+    const caseB = await seedCase('rm-b')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseB, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '1/1' })
+
+    await withClient(async (client) => {
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseA })
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseB })
+      // Remove caseB (the hom carrier).
+      await repo.incrementalRemove({ schema, client: client as never, caseId: caseB })
+    })
+
+    const row = await summaryRow('1')
+    expect(row!.carrier_count).toBe(1)
+    expect(row!.het_count).toBe(1)
+    expect(row!.hom_count).toBe(0)
+  }, 60_000)
+
+  it('incrementalRemove deletes rows that drop to zero carriers', async () => {
+    const caseA = await seedCase('rm-zero-a')
+    await seedVariant({ caseId: caseA, chr: '5', pos: 500, ref: 'A', alt: 'G', gtNum: '0/1' })
+
+    await withClient(async (client) => {
+      await repo.incrementalAdd({ schema, client: client as never, caseId: caseA })
+      await repo.incrementalRemove({ schema, client: client as never, caseId: caseA })
+    })
+
+    const row = await summaryRow('5')
+    expect(row).toBeNull()
+  }, 60_000)
+})
+
 describe.skipIf(RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2 (skipped)', () => {
   it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
     expect(RUN).toBe(false)

--- a/tests/main/storage/postgres-cohort-summary-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-repository.test.ts
@@ -5,9 +5,9 @@
  * Verifies the deduped CTE rebuild (Pass-2 #4 — duplicate per-case rows count
  * once) and that has_star/has_comment/acmg_best are derived from the existing
  * variant_annotations + case_variant_annotations tables at rebuild time
- * (Pass-9 #8 — without this, every rebuild resets flags to false). The
- * cohort_frequency column is left NULL by rebuild() and populated by the C2a
- * recompute called by the caller next.
+ * (Pass-9 #8 — without this, every rebuild resets flags to false). Since
+ * Sprint A C2a, rebuild() recomputes cohort_frequency as its final step (per
+ * genome_build), so the column is populated, not NULL, when rebuild() returns.
  *
  * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
  */
@@ -143,11 +143,14 @@ describe.skipIf(!RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2',
     expect(Number(first.het_count)).toBe(1)
     expect(Number(first.hom_count)).toBe(1)
     expect(first.variant_key).toBe('1:100:A:T')
-    // cohort_frequency is populated by the C2a recompute, not rebuild().
-    expect(first.cohort_frequency).toBeNull()
+    // Since C2a, rebuild() recomputes cohort_frequency as its final step:
+    // 2 carriers / 2 GRCh38 cases = 1.0.
+    expect(Number(first.cohort_frequency)).toBeCloseTo(1.0)
 
     const second = rows.rows.find((r) => r.chr === '2')!
     expect(Number(second.carrier_count)).toBe(1)
+    // 1 carrier / 2 GRCh38 cases = 0.5.
+    expect(Number(second.cohort_frequency)).toBeCloseTo(0.5)
   }, 60_000)
 
   it('mirrors SQLite deduplication — duplicate per-case rows count once (Pass-2 #4)', async () => {
@@ -667,6 +670,163 @@ describe.skipIf(!RUN)('refreshColumnMetas + removeColumnMetas — C2', () => {
     expect(Number(bCount.rows[0].count)).toBe(21)
   }, 60_000)
 })
+
+describe.skipIf(!RUN)(
+  'PostgresCohortSummaryRepository.recomputeCohortFrequency — Sprint A C2a',
+  () => {
+    let schema: string
+    let pool: Pool
+    let probe: Client
+    const now = Date.now()
+
+    beforeEach(async () => {
+      schema = `varlens_test_cvs_freq_${Date.now()}_${randomBytes(4).toString('hex')}`
+      const provisioner = new Client({ connectionString: PG_URL })
+      await provisioner.connect()
+      await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+      await provisioner.end()
+
+      pool = new Pool({ connectionString: PG_URL, max: 2 })
+      probe = new Client({ connectionString: PG_URL })
+      await probe.connect()
+
+      await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+    }, 60_000)
+
+    afterEach(async () => {
+      if (probe) await probe.end()
+      if (pool) await pool.end()
+      const cleaner = new Client({ connectionString: PG_URL })
+      await cleaner.connect()
+      await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+      await cleaner.end()
+    }, 60_000)
+
+    async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+      const res = await probe.query<{ id: number }>(
+        `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+           VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+        [name, `/tmp/${name}.json`, now, genomeBuild]
+      )
+      return res.rows[0].id
+    }
+
+    async function seedVariant(v: SeedVariant): Promise<number> {
+      const res = await probe.query<{ id: number }>(
+        `INSERT INTO "${schema}".variants
+           (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gt_num)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+        [
+          v.caseId,
+          v.chr,
+          v.pos,
+          v.ref,
+          v.alt,
+          v.variantType ?? 'snv',
+          v.geneSymbol ?? null,
+          v.gtNum ?? null
+        ]
+      )
+      return res.rows[0].id
+    }
+
+    async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+      const client = await pool.connect()
+      try {
+        return await fn(client as unknown as Client)
+      } finally {
+        ;(client as { release: () => void }).release()
+      }
+    }
+
+    async function freqByChr(chr: string, genomeBuild: string): Promise<number | null> {
+      const res = await probe.query<{ cohort_frequency: number | null }>(
+        `SELECT cohort_frequency FROM "${schema}".cohort_variant_summary
+           WHERE chr = $1 AND genome_build = $2`,
+        [chr, genomeBuild]
+      )
+      return res.rows.length === 0 ? null : res.rows[0].cohort_frequency
+    }
+
+    const repo = new PostgresCohortSummaryRepository()
+
+    it('recomputeCohortFrequency narrowed to one genome_build does not touch others', async () => {
+      // One case + carrier per build. 1 carrier / 1 case = frequency 1.0.
+      const case38 = await seedCase('freq-38', 'GRCh38')
+      const case37 = await seedCase('freq-37', 'GRCh37')
+      await seedVariant({ caseId: case38, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+      await seedVariant({ caseId: case37, chr: '2', pos: 200, ref: 'C', alt: 'G', gtNum: '0/1' })
+
+      await withClient(async (client) => {
+        await repo.rebuild({ schema, client: client as never })
+        // Pin the GRCh37 row to a sentinel; a GRCh38-scoped recompute must leave
+        // it exactly as-is.
+        await probe.query(
+          `UPDATE "${schema}".cohort_variant_summary SET cohort_frequency = 0.123
+           WHERE genome_build = 'GRCh37'`
+        )
+        // Recompute only the GRCh38 build.
+        await repo.recomputeCohortFrequency({
+          schema,
+          client: client as never,
+          affectedBuilds: ['GRCh38']
+        })
+      })
+
+      // GRCh38 row recomputed: 1 carrier / 1 GRCh38 case = 1.0.
+      expect(await freqByChr('1', 'GRCh38')).toBeCloseTo(1.0)
+      // GRCh37 row untouched — the narrowed recompute must not reach it.
+      expect(await freqByChr('2', 'GRCh37')).toBeCloseTo(0.123)
+    }, 60_000)
+
+    it('rebuild() leaves cohort_frequency populated (not NULL)', async () => {
+      const caseA = await seedCase('freq-rebuild-a', 'GRCh38')
+      const caseB = await seedCase('freq-rebuild-b', 'GRCh38')
+      // One carrier across two cases → frequency 1/2 = 0.5.
+      await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+
+      await withClient((client) => repo.rebuild({ schema, client: client as never }))
+      void caseB
+
+      expect(await freqByChr('1', 'GRCh38')).toBeCloseTo(0.5)
+    }, 60_000)
+
+    it("incrementalAdd() updates cohort_frequency for the case's build only", async () => {
+      const case38 = await seedCase('iadd-38', 'GRCh38')
+      const case37 = await seedCase('iadd-37', 'GRCh37')
+      await seedVariant({ caseId: case38, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+      await seedVariant({ caseId: case37, chr: '2', pos: 200, ref: 'C', alt: 'G', gtNum: '0/1' })
+
+      await withClient(async (client) => {
+        // Add the GRCh37 case scoped to its own build first → its frequency is 1.0.
+        await repo.incrementalAdd({
+          schema,
+          client: client as never,
+          caseId: case37,
+          genomeBuild: 'GRCh37'
+        })
+        // Pin the GRCh37 row to a sentinel so we can prove the next GRCh38-scoped
+        // add does not touch it.
+        await probe.query(
+          `UPDATE "${schema}".cohort_variant_summary SET cohort_frequency = 0.123
+           WHERE genome_build = 'GRCh37'`
+        )
+        // Now add the GRCh38 case scoped to GRCh38.
+        await repo.incrementalAdd({
+          schema,
+          client: client as never,
+          caseId: case38,
+          genomeBuild: 'GRCh38'
+        })
+      })
+
+      // GRCh38 row recomputed: 1 carrier / 1 GRCh38 case = 1.0.
+      expect(await freqByChr('1', 'GRCh38')).toBeCloseTo(1.0)
+      // GRCh37 row untouched by the GRCh38-scoped recompute — sentinel preserved.
+      expect(await freqByChr('2', 'GRCh37')).toBeCloseTo(0.123)
+    }, 60_000)
+  }
+)
 
 describe.skipIf(RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2 (skipped)', () => {
   it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {

--- a/tests/main/storage/postgres-cohort-summary-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-repository.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Sprint A PR-3 C2 — PostgresCohortSummaryRepository.rebuild against a real
+ * Postgres.
+ *
+ * Verifies the deduped CTE rebuild (Pass-2 #4 — duplicate per-case rows count
+ * once) and that has_star/has_comment/acmg_best are derived from the existing
+ * variant_annotations + case_variant_annotations tables at rebuild time
+ * (Pass-9 #8 — without this, every rebuild resets flags to false). The
+ * cohort_frequency column is left NULL by rebuild() and populated by the C2a
+ * recompute called by the caller next.
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { PostgresCohortSummaryRepository } from '../../../src/main/storage/postgres/PostgresCohortSummaryRepository'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+interface SeedVariant {
+  caseId: number
+  chr: string
+  pos: number
+  ref: string
+  alt: string
+  variantType?: string
+  geneSymbol?: string | null
+  gtNum?: string | null
+}
+
+describe.skipIf(!RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_cvs_rebuild_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+         VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: SeedVariant): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+         (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gt_num)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+      [
+        v.caseId,
+        v.chr,
+        v.pos,
+        v.ref,
+        v.alt,
+        v.variantType ?? 'snv',
+        v.geneSymbol ?? null,
+        v.gtNum ?? null
+      ]
+    )
+    return res.rows[0].id
+  }
+
+  async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      return await fn(client as unknown as Client)
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  it('TRUNCATEs and reinserts from the deduped CTE', async () => {
+    const caseA = await seedCase('case-a')
+    const caseB = await seedCase('case-b')
+    // Two carriers (het + hom) of the same coordinate, one carrier elsewhere.
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+    await seedVariant({ caseId: caseB, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '1/1' })
+    await seedVariant({ caseId: caseA, chr: '2', pos: 200, ref: 'C', alt: 'G', gtNum: '0/1' })
+
+    // Pre-populate with stale data that must be wiped by TRUNCATE.
+    await probe.query(
+      `INSERT INTO "${schema}".cohort_variant_summary
+         (chr, pos, ref, alt, variant_type, genome_build, carrier_count)
+         VALUES ('99', 1, 'X', 'Y', 'snv', 'GRCh38', 42)`
+    )
+
+    const repo = new PostgresCohortSummaryRepository()
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+
+    const rows = await probe.query<{
+      chr: string
+      pos: string
+      ref: string
+      alt: string
+      carrier_count: string
+      het_count: string
+      hom_count: string
+      variant_key: string
+      cohort_frequency: number | null
+    }>(
+      `SELECT chr, pos, ref, alt, carrier_count, het_count, hom_count, variant_key, cohort_frequency
+         FROM "${schema}".cohort_variant_summary ORDER BY chr, pos`
+    )
+
+    expect(rows.rows).toHaveLength(2)
+    expect(rows.rows.some((r) => r.chr === '99')).toBe(false)
+
+    const first = rows.rows.find((r) => r.chr === '1')!
+    expect(Number(first.carrier_count)).toBe(2)
+    expect(Number(first.het_count)).toBe(1)
+    expect(Number(first.hom_count)).toBe(1)
+    expect(first.variant_key).toBe('1:100:A:T')
+    // cohort_frequency is populated by the C2a recompute, not rebuild().
+    expect(first.cohort_frequency).toBeNull()
+
+    const second = rows.rows.find((r) => r.chr === '2')!
+    expect(Number(second.carrier_count)).toBe(1)
+  }, 60_000)
+
+  it('mirrors SQLite deduplication — duplicate per-case rows count once (Pass-2 #4)', async () => {
+    const caseA = await seedCase('case-dedup')
+    // Same case_id has two rows with identical (chr, pos, ref, alt).
+    await seedVariant({ caseId: caseA, chr: '3', pos: 300, ref: 'G', alt: 'A', gtNum: '0/1' })
+    await seedVariant({ caseId: caseA, chr: '3', pos: 300, ref: 'G', alt: 'A', gtNum: '0/1' })
+
+    const repo = new PostgresCohortSummaryRepository()
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+
+    const res = await probe.query<{ carrier_count: string }>(
+      `SELECT carrier_count FROM "${schema}".cohort_variant_summary
+         WHERE chr = '3' AND pos = 300 AND ref = 'G' AND alt = 'A'`
+    )
+    expect(res.rows).toHaveLength(1)
+    expect(Number(res.rows[0].carrier_count)).toBe(1)
+  }, 60_000)
+
+  it('populates has_star/has_comment/acmg_best from existing annotations (Pass-9 #8)', async () => {
+    const caseA = await seedCase('case-anno')
+
+    // Global star + comment annotation (variant_annotations).
+    const starred = await seedVariant({
+      caseId: caseA,
+      chr: '4',
+      pos: 400,
+      ref: 'T',
+      alt: 'C',
+      gtNum: '0/1'
+    })
+    void starred
+    await probe.query(
+      `INSERT INTO "${schema}".variant_annotations
+         (chr, pos, ref, alt, global_comment, starred, acmg_classification, created_at, updated_at)
+         VALUES ('4', 400, 'T', 'C', NULL, 1, NULL, $1, $1)`,
+      [now]
+    )
+
+    // Per-case comment + ACMG (case_variant_annotations) on a second coord.
+    const commented = await seedVariant({
+      caseId: caseA,
+      chr: '5',
+      pos: 500,
+      ref: 'A',
+      alt: 'G',
+      gtNum: '0/1'
+    })
+    await probe.query(
+      `INSERT INTO "${schema}".case_variant_annotations
+         (case_id, variant_id, per_case_comment, starred, acmg_classification, created_at, updated_at)
+         VALUES ($1, $2, 'looks pathogenic', 0, 'Pathogenic', $3, $3)`,
+      [caseA, commented, now]
+    )
+
+    // A plain variant with no annotations.
+    await seedVariant({ caseId: caseA, chr: '6', pos: 600, ref: 'C', alt: 'T', gtNum: '0/1' })
+
+    const repo = new PostgresCohortSummaryRepository()
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+
+    const rows = await probe.query<{
+      chr: string
+      has_star: boolean
+      has_comment: boolean
+      acmg_best: string | null
+    }>(
+      `SELECT chr, has_star, has_comment, acmg_best
+         FROM "${schema}".cohort_variant_summary ORDER BY chr`
+    )
+
+    const star = rows.rows.find((r) => r.chr === '4')!
+    expect(star.has_star).toBe(true)
+    expect(star.has_comment).toBe(false)
+    expect(star.acmg_best).toBeNull()
+
+    const comment = rows.rows.find((r) => r.chr === '5')!
+    expect(comment.has_comment).toBe(true)
+    expect(comment.has_star).toBe(false)
+    expect(comment.acmg_best).toBe('Pathogenic')
+
+    const plain = rows.rows.find((r) => r.chr === '6')!
+    expect(plain.has_star).toBe(false)
+    expect(plain.has_comment).toBe(false)
+    expect(plain.acmg_best).toBeNull()
+  }, 60_000)
+
+  it('survives an empty variants table (no rows inserted)', async () => {
+    const repo = new PostgresCohortSummaryRepository()
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+
+    const res = await probe.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "${schema}".cohort_variant_summary`
+    )
+    expect(Number(res.rows[0].count)).toBe(0)
+  }, 60_000)
+})
+
+describe.skipIf(RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2 (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/postgres-cohort-summary-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-repository.test.ts
@@ -828,6 +828,180 @@ describe.skipIf(!RUN)(
   }
 )
 
+describe.skipIf(!RUN)('cohort_summary_state lifecycle — C2 + C1', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_cvs_state_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+           VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: SeedVariant): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+           (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gt_num)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+      [
+        v.caseId,
+        v.chr,
+        v.pos,
+        v.ref,
+        v.alt,
+        v.variantType ?? 'snv',
+        v.geneSymbol ?? null,
+        v.gtNum ?? null
+      ]
+    )
+    return res.rows[0].id
+  }
+
+  async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      return await fn(client as unknown as Client)
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  async function stateRow(): Promise<{
+    is_stale: boolean
+    stale_reason: string | null
+    stale_at: Date | null
+    last_rebuilt_at: Date | null
+    last_incremental_at: Date | null
+  }> {
+    const res = await probe.query<{
+      is_stale: boolean
+      stale_reason: string | null
+      stale_at: Date | null
+      last_rebuilt_at: Date | null
+      last_incremental_at: Date | null
+    }>(
+      `SELECT is_stale, stale_reason, stale_at, last_rebuilt_at, last_incremental_at
+         FROM "${schema}".cohort_summary_state WHERE id = 1`
+    )
+    return res.rows[0]
+  }
+
+  const repo = new PostgresCohortSummaryRepository()
+
+  it('rebuild() sets is_stale=false, last_rebuilt_at=now()', async () => {
+    // Pre-flag stale so the rebuild has something to clear.
+    await withClient((client) =>
+      repo.markStale({ schema, client: client as never, reason: 'before-rebuild' })
+    )
+    const before = await stateRow()
+    expect(before.is_stale).toBe(true)
+    expect(before.last_rebuilt_at).toBeNull()
+
+    const caseA = await seedCase('state-rebuild-a')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+
+    const after = await stateRow()
+    expect(after.is_stale).toBe(false)
+    expect(after.stale_reason).toBeNull()
+    expect(after.stale_at).toBeNull()
+    expect(after.last_rebuilt_at).not.toBeNull()
+  }, 60_000)
+
+  it('markStale(reason) sets is_stale=true, stale_reason=<reason>, stale_at=now()', async () => {
+    // Establish a non-stale baseline with a recorded rebuild time first.
+    await withClient((client) => repo.rebuild({ schema, client: client as never }))
+    const baseline = await stateRow()
+    expect(baseline.is_stale).toBe(false)
+    expect(baseline.last_rebuilt_at).not.toBeNull()
+
+    await withClient((client) =>
+      repo.markStale({ schema, client: client as never, reason: 'case_deleted' })
+    )
+
+    const after = await stateRow()
+    expect(after.is_stale).toBe(true)
+    expect(after.stale_reason).toBe('case_deleted')
+    expect(after.stale_at).not.toBeNull()
+    // markStale must preserve rebuild history (last_rebuilt_at untouched).
+    // node-pg deserialises TIMESTAMPTZ to Date, so compare by epoch value.
+    expect(new Date(after.last_rebuilt_at!).getTime()).toBe(
+      new Date(baseline.last_rebuilt_at!).getTime()
+    )
+  }, 60_000)
+
+  it('incrementalAdd does NOT touch is_stale', async () => {
+    // Force is_stale=true, then add a case incrementally; the flag must remain.
+    await withClient((client) =>
+      repo.markStale({ schema, client: client as never, reason: 'pending' })
+    )
+    const caseA = await seedCase('state-incr-a')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', gtNum: '0/1' })
+
+    await withClient((client) =>
+      repo.incrementalAdd({ schema, client: client as never, caseId: caseA, genomeBuild: 'GRCh38' })
+    )
+
+    const after = await stateRow()
+    expect(after.is_stale).toBe(true)
+    expect(after.stale_reason).toBe('pending')
+    // Incremental maintenance is recorded but does not clear staleness.
+    expect(after.last_incremental_at).not.toBeNull()
+  }, 60_000)
+
+  it('getState maps TIMESTAMPTZ → epoch ms via EXTRACT(EPOCH)*1000 (Pass-9 #6)', async () => {
+    // Pin last_rebuilt_at to a known instant and assert the epoch-ms mapping.
+    const fixedIso = '2026-05-01T12:00:00.000Z'
+    const fixedMs = Date.parse(fixedIso)
+    await probe.query(
+      `UPDATE "${schema}".cohort_summary_state
+         SET is_stale = false, last_rebuilt_at = $1::timestamptz WHERE id = 1`,
+      [fixedIso]
+    )
+
+    const state = await withClient((client) => repo.getState({ schema, client: client as never }))
+    expect(state.is_stale).toBe(false)
+    expect(typeof state.last_rebuilt_at).toBe('number')
+    expect(state.last_rebuilt_at).toBe(fixedMs)
+  }, 60_000)
+
+  it('getState returns last_rebuilt_at=0 when never rebuilt (NULL coalesce)', async () => {
+    // Fresh schema with no variants seeds is_stale=false, last_rebuilt_at NULL.
+    const state = await withClient((client) => repo.getState({ schema, client: client as never }))
+    expect(state.is_stale).toBe(false)
+    expect(state.last_rebuilt_at).toBe(0)
+  }, 60_000)
+})
+
 describe.skipIf(RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2 (skipped)', () => {
   it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
     expect(RUN).toBe(false)

--- a/tests/main/storage/postgres-cohort-summary-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-summary-repository.test.ts
@@ -464,6 +464,210 @@ describe.skipIf(!RUN)('PostgresCohortSummaryRepository.incrementalAdd/Remove —
   }, 60_000)
 })
 
+describe.skipIf(!RUN)('refreshColumnMetas + removeColumnMetas — C2', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+  const now = Date.now()
+
+  beforeEach(async () => {
+    schema = `varlens_test_cvs_meta_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  async function seedCase(name: string, genomeBuild = 'GRCh38'): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+           VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+      [name, `/tmp/${name}.json`, now, genomeBuild]
+    )
+    return res.rows[0].id
+  }
+
+  async function seedVariant(v: {
+    caseId: number
+    chr: string
+    pos: number
+    ref: string
+    alt: string
+    geneSymbol?: string | null
+    gnomadAf?: number | null
+    cadd?: number | null
+    consequence?: string | null
+  }): Promise<number> {
+    const res = await probe.query<{ id: number }>(
+      `INSERT INTO "${schema}".variants
+           (case_id, chr, pos, ref, alt, variant_type, gene_symbol, gnomad_af, cadd, consequence)
+           VALUES ($1, $2, $3, $4, $5, 'snv', $6, $7, $8, $9) RETURNING id`,
+      [
+        v.caseId,
+        v.chr,
+        v.pos,
+        v.ref,
+        v.alt,
+        v.geneSymbol ?? null,
+        v.gnomadAf ?? null,
+        v.cadd ?? null,
+        v.consequence ?? null
+      ]
+    )
+    return res.rows[0].id
+  }
+
+  async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      return await fn(client as unknown as Client)
+    } finally {
+      ;(client as { release: () => void }).release()
+    }
+  }
+
+  const repo = new PostgresCohortSummaryRepository()
+
+  it('refreshColumnMetas writes one row per (case_id, column_name) tuple', async () => {
+    const caseA = await seedCase('meta-a')
+    await seedVariant({
+      caseId: caseA,
+      chr: '1',
+      pos: 100,
+      ref: 'A',
+      alt: 'T',
+      geneSymbol: 'BRCA1',
+      gnomadAf: 0.01,
+      cadd: 12.5,
+      consequence: 'HIGH'
+    })
+    await seedVariant({
+      caseId: caseA,
+      chr: '2',
+      pos: 200,
+      ref: 'C',
+      alt: 'G',
+      geneSymbol: 'TP53',
+      gnomadAf: 0.5,
+      cadd: 30,
+      consequence: 'MODERATE'
+    })
+
+    await withClient((client) =>
+      repo.refreshColumnMetas({ schema, client: client as never, caseId: caseA })
+    )
+
+    const rows = await probe.query<{
+      column_name: string
+      min_value: unknown
+      max_value: unknown
+      distinct_count: number
+      distinct_values: unknown
+    }>(
+      `SELECT column_name, min_value, max_value, distinct_count, distinct_values
+         FROM "${schema}".cohort_column_meta WHERE case_id = $1`,
+      [caseA]
+    )
+
+    // One row per BASE_SORTABLE_COLUMNS key (21 columns).
+    expect(rows.rows.length).toBe(21)
+    const byName = new Map(rows.rows.map((r) => [r.column_name, r]))
+
+    // Numeric column: min/max populated, distinct_count = 2.
+    const gnomad = byName.get('gnomad_af')!
+    expect(Number(gnomad.min_value)).toBeCloseTo(0.01)
+    expect(Number(gnomad.max_value)).toBeCloseTo(0.5)
+    expect(Number(gnomad.distinct_count)).toBe(2)
+
+    const cadd = byName.get('cadd')!
+    expect(Number(cadd.min_value)).toBeCloseTo(12.5)
+    expect(Number(cadd.max_value)).toBeCloseTo(30)
+
+    // `pos` is BIGINT in the variants table — node-pg returns BIGINT as a JS
+    // string, so min/max must be coerced to JSON numbers before storage,
+    // matching SQLite's raw-number shape (not a JSON string).
+    const pos = byName.get('pos')!
+    expect(typeof pos.min_value).toBe('number')
+    expect(typeof pos.max_value).toBe('number')
+    expect(pos.min_value).toBe(100)
+    expect(pos.max_value).toBe(200)
+
+    // Text column: low cardinality → distinct_values populated, no min/max.
+    const consequence = byName.get('consequence')!
+    expect(Number(consequence.distinct_count)).toBe(2)
+    expect(consequence.min_value).toBeNull()
+    expect(consequence.max_value).toBeNull()
+    expect(consequence.distinct_values).toEqual(['HIGH', 'MODERATE'])
+
+    const gene = byName.get('gene_symbol')!
+    expect(Number(gene.distinct_count)).toBe(2)
+    expect(gene.distinct_values).toEqual(['BRCA1', 'TP53'])
+  }, 60_000)
+
+  it('refreshColumnMetas deletes existing rows before reinserting', async () => {
+    const caseA = await seedCase('meta-refresh-a')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', geneSymbol: 'AAA' })
+
+    // Pre-populate a stale row that must be wiped.
+    await probe.query(
+      `INSERT INTO "${schema}".cohort_column_meta (case_id, column_name, distinct_count)
+         VALUES ($1, 'gene_symbol', 999)`,
+      [caseA]
+    )
+
+    await withClient((client) =>
+      repo.refreshColumnMetas({ schema, client: client as never, caseId: caseA })
+    )
+
+    const res = await probe.query<{ distinct_count: number }>(
+      `SELECT distinct_count FROM "${schema}".cohort_column_meta
+         WHERE case_id = $1 AND column_name = 'gene_symbol'`,
+      [caseA]
+    )
+    expect(res.rows).toHaveLength(1)
+    expect(Number(res.rows[0].distinct_count)).toBe(1)
+  }, 60_000)
+
+  it('removeColumnMetas deletes only the target case rows', async () => {
+    const caseA = await seedCase('meta-rm-a')
+    const caseB = await seedCase('meta-rm-b')
+    await seedVariant({ caseId: caseA, chr: '1', pos: 100, ref: 'A', alt: 'T', geneSymbol: 'AAA' })
+    await seedVariant({ caseId: caseB, chr: '2', pos: 200, ref: 'C', alt: 'G', geneSymbol: 'BBB' })
+
+    await withClient(async (client) => {
+      await repo.refreshColumnMetas({ schema, client: client as never, caseId: caseA })
+      await repo.refreshColumnMetas({ schema, client: client as never, caseId: caseB })
+      await repo.removeColumnMetas({ schema, client: client as never, caseId: caseA })
+    })
+
+    const aCount = await probe.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "${schema}".cohort_column_meta WHERE case_id = $1`,
+      [caseA]
+    )
+    const bCount = await probe.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "${schema}".cohort_column_meta WHERE case_id = $1`,
+      [caseB]
+    )
+    expect(Number(aCount.rows[0].count)).toBe(0)
+    expect(Number(bCount.rows[0].count)).toBe(21)
+  }, 60_000)
+})
+
 describe.skipIf(RUN)('PostgresCohortSummaryRepository.rebuild — Sprint A C2 (skipped)', () => {
   it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
     expect(RUN).toBe(false)

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -4,7 +4,7 @@ import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migratio
 
 describe('Postgres migration definitions', () => {
   it('loads the PostgreSQL migrations with SQL and sha256 checksums', () => {
-    expect(POSTGRES_MIGRATIONS).toHaveLength(9)
+    expect(POSTGRES_MIGRATIONS).toHaveLength(10)
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.version)).toEqual([
       '0001',
       '0002',
@@ -14,7 +14,8 @@ describe('Postgres migration definitions', () => {
       '0006',
       '0007',
       '0008',
-      '0009'
+      '0009',
+      '0010'
     ])
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.name)).toEqual([
       'create_cases',
@@ -25,7 +26,8 @@ describe('Postgres migration definitions', () => {
       'create_audit_log',
       'perf_indexes',
       'create_users_and_settings',
-      'idx_variants_coords'
+      'idx_variants_coords',
+      'cohort_summary'
     ])
 
     for (const migration of POSTGRES_MIGRATIONS) {

--- a/tests/main/storage/postgres-read-executor.test.ts
+++ b/tests/main/storage/postgres-read-executor.test.ts
@@ -303,7 +303,9 @@ describe('PostgresReadExecutor', () => {
     })()
     const cohort = {
       queryVariants: vi.fn().mockResolvedValue({ data: [], total_count: 0 }),
+      queryVariantsWithStaleness: vi.fn().mockResolvedValue({ data: [], total_count: 0 }),
       getSummary: vi.fn().mockResolvedValue({ total_cases: 1 }),
+      getSummaryStatus: vi.fn().mockResolvedValue({ is_stale: false, last_rebuilt_at: 0 }),
       getColumnMeta: vi.fn().mockResolvedValue([{ key: 'gene_symbol' }]),
       getCarriers: vi.fn().mockResolvedValue([{ case_id: 1 }]),
       getGeneBurden: vi.fn().mockResolvedValue([{ gene_symbol: 'BRCA1' }]),
@@ -329,6 +331,9 @@ describe('PostgresReadExecutor', () => {
       total_cases: 1
     })
     await expect(
+      executor.execute({ type: 'cohort:summaryStatus', params: [] })
+    ).resolves.toStrictEqual({ is_stale: false, last_rebuilt_at: 0 })
+    await expect(
       executor.execute({ type: 'cohort:columnMeta', params: [] })
     ).resolves.toStrictEqual([{ key: 'gene_symbol' }])
     await expect(
@@ -341,8 +346,9 @@ describe('PostgresReadExecutor', () => {
       cohortRows
     )
 
-    expect(cohort.queryVariants).toHaveBeenCalledWith(cohortParams)
+    expect(cohort.queryVariantsWithStaleness).toHaveBeenCalledWith(cohortParams)
     expect(cohort.getSummary).toHaveBeenCalledWith()
+    expect(cohort.getSummaryStatus).toHaveBeenCalledWith()
     expect(cohort.getColumnMeta).toHaveBeenCalledWith()
     expect(cohort.getCarriers).toHaveBeenCalledWith('chr1', 100, 'A', 'T')
     expect(cohort.getGeneBurden).toHaveBeenCalledWith()

--- a/tests/main/storage/postgres-variant-filter-options.test.ts
+++ b/tests/main/storage/postgres-variant-filter-options.test.ts
@@ -2,44 +2,73 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { PostgresVariantReadRepository } from '../../../src/main/storage/postgres/PostgresVariantReadRepository'
 
-// getColumnMeta now routes through runNamedDynamic, which calls pool.query with a
-// { name, text, values } spec object rather than positional (text, values). Extract
-// the SQL text regardless of call shape so these branches keep matching.
+// getColumnMeta / getFilterOptions route through runNamed / runNamedDynamic,
+// which call pool.query with a { name, text, values } spec object rather than
+// positional (text, values). Extract the SQL text regardless of call shape.
 function sqlTextOf(arg: unknown): string {
   if (typeof arg === 'string') return arg
   return (arg as { text?: string }).text ?? ''
 }
 
 describe('PostgresVariantReadRepository filter metadata', () => {
-  it('returns SQLite-compatible filter options for a case', async () => {
-    const query = vi.fn(async (arg: unknown) => {
-      const sql = sqlTextOf(arg)
-      if (sql.includes('COUNT(DISTINCT v.cadd)')) {
-        return { rows: [{ distinct_count: '2', min: '10', max: '35' }] }
-      }
-      if (sql.includes('COUNT(DISTINCT v.gnomad_af)')) {
-        return { rows: [{ distinct_count: '2', min: '0.01', max: '0.2' }] }
-      }
-      if (sql.includes('COUNT(DISTINCT')) {
-        return { rows: [{ distinct_count: '1' }] }
-      }
-      if (sql.includes('DISTINCT v.consequence')) {
-        return { rows: [{ value: 'HIGH' }] }
-      }
-      if (sql.includes('DISTINCT v.func')) {
-        return { rows: [{ value: 'stop_gained' }] }
-      }
-      if (sql.includes('DISTINCT v.clinvar')) {
-        return { rows: [{ value: 'Pathogenic' }] }
-      }
-      if (sql.includes('SELECT DISTINCT')) {
-        return { rows: [{ value: 'HIGH' }] }
-      }
-      return { rows: [] }
-    })
+  it('reads per-case filter options from cohort_column_meta and reshapes to SQLite shape', async () => {
+    // C4 Step 3: getFilterOptions(caseId) issues a single cohort_column_meta
+    // read. JSONB columns come back from node-pg already parsed.
+    const query = vi.fn(async () => ({
+      rows: [
+        {
+          column_name: 'chr',
+          min_value: null,
+          max_value: null,
+          distinct_count: 2,
+          distinct_values: ['1', '2']
+        },
+        {
+          column_name: 'cadd',
+          min_value: 10,
+          max_value: 35,
+          distinct_count: 2,
+          distinct_values: null
+        },
+        {
+          column_name: 'gnomad_af',
+          min_value: 0.01,
+          max_value: 0.2,
+          distinct_count: 2,
+          distinct_values: null
+        },
+        {
+          column_name: 'consequence',
+          min_value: null,
+          max_value: null,
+          distinct_count: 1,
+          distinct_values: ['HIGH']
+        },
+        {
+          column_name: 'func',
+          min_value: null,
+          max_value: null,
+          distinct_count: 1,
+          distinct_values: ['stop_gained']
+        },
+        {
+          column_name: 'clinvar',
+          min_value: null,
+          max_value: null,
+          distinct_count: 1,
+          distinct_values: ['Pathogenic']
+        }
+      ]
+    }))
     const repo = new PostgresVariantReadRepository({ query } as never, 'public')
 
     const options = await repo.getFilterOptions(1)
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const sql = sqlTextOf(query.mock.calls[0][0])
+    expect(sql).toContain('"public"."cohort_column_meta"')
+    expect(sql).toContain('WHERE case_id = $1')
+    expect((query.mock.calls[0][0] as { values: unknown[] }).values).toEqual([1])
 
     expect(options.consequences).toStrictEqual(['HIGH'])
     expect(options.funcs).toStrictEqual(['stop_gained'])
@@ -48,6 +77,8 @@ describe('PostgresVariantReadRepository filter metadata', () => {
     expect(options.maxCadd).toBe(35)
     expect(options.minGnomadAf).toBe(0.01)
     expect(options.maxGnomadAf).toBe(0.2)
+    // columnMeta mirrors SQLite getAllColumnMetas — base columns only, in the
+    // canonical order; extension columns are not part of the per-case cache.
     expect(options.columnMeta.map((meta) => meta.key)).toStrictEqual([
       'chr',
       'pos',
@@ -69,47 +100,7 @@ describe('PostgresVariantReadRepository filter metadata', () => {
       'end_pos',
       'sv_type',
       'sv_length',
-      'caller',
-      'sv.sv_is_precise',
-      'sv.support',
-      'sv.pe_support',
-      'sv.sr_support',
-      'sv.dr',
-      'sv.dv',
-      'sv.vaf',
-      'sv.strand',
-      'sv.coverage',
-      'sv.cipos_left',
-      'sv.cipos_right',
-      'sv.ciend_left',
-      'sv.ciend_right',
-      'sv.stdev_len',
-      'sv.stdev_pos',
-      'sv.event_id',
-      'sv.mate_id',
-      'cnv.copy_number',
-      'cnv.copy_number_quality',
-      'cnv.homozygosity_ref',
-      'cnv.homozygosity_alt',
-      'cnv.sm',
-      'cnv.bin_count',
-      'str.repeat_id',
-      'str.variant_catalog_id',
-      'str.repeat_unit',
-      'str.display_repeat_unit',
-      'str.repeat_length',
-      'str.ref_copies',
-      'str.alt_copies',
-      'str.str_status',
-      'str.disease',
-      'str.inheritance_mode',
-      'str.source_display',
-      'str.support_type',
-      'str.normal_max',
-      'str.pathologic_min',
-      'str.locus_coverage',
-      'str.rank_score',
-      'str.confidence_interval'
+      'caller'
     ])
     expect(options.columnMeta).toContainEqual({
       key: 'cadd',
@@ -124,11 +115,32 @@ describe('PostgresVariantReadRepository filter metadata', () => {
       distinctCount: 1,
       distinctValues: ['HIGH']
     })
+    // A column with no stored row degrades to an empty-distinct entry.
+    expect(options.columnMeta).toContainEqual({
+      key: 'moi',
+      dataType: 'text',
+      distinctCount: 0
+    })
+    // SQLite output-shape parity: end_pos and sv_length are categorical on the
+    // write side (PostgresCohortSummaryRepository.META_NUMERIC_COLUMNS /
+    // VariantRepository.NUMERIC_COLUMNS define only 5 numeric columns), so the
+    // per-case reshape MUST report dataType 'text' for them — never 'numeric'.
+    const metaByKey = new Map(options.columnMeta.map((meta) => [meta.key, meta]))
+    expect(metaByKey.get('end_pos')?.dataType).toBe('text')
+    expect(metaByKey.get('sv_length')?.dataType).toBe('text')
   })
 
-  it('returns SQLite-compatible numeric column metadata', async () => {
+  it('reads single-case numeric column metadata from cohort_column_meta', async () => {
     const query = vi.fn(async () => ({
-      rows: [{ distinct_count: '3', min: '1', max: '99' }]
+      rows: [
+        {
+          column_name: 'cadd',
+          min_value: 1,
+          max_value: 99,
+          distinct_count: 3,
+          distinct_values: null
+        }
+      ]
     }))
     const repo = new PostgresVariantReadRepository({ query } as never, 'public')
 
@@ -139,14 +151,24 @@ describe('PostgresVariantReadRepository filter metadata', () => {
       min: 1,
       max: 99
     })
+    const sql = sqlTextOf(query.mock.calls[0][0])
+    expect(sql).toContain('"public"."cohort_column_meta"')
+    expect(sql).toContain('column_name = $2')
+    expect((query.mock.calls[0][0] as { values: unknown[] }).values).toEqual([1, 'cadd'])
   })
 
-  it('returns SQLite-compatible categorical column metadata', async () => {
-    const query = vi.fn(async (arg: unknown) => {
-      const sql = sqlTextOf(arg)
-      if (sql.includes('COUNT(DISTINCT')) return { rows: [{ distinct_count: '1' }] }
-      return { rows: [{ value: 'HIGH' }] }
-    })
+  it('reads single-case categorical column metadata from cohort_column_meta', async () => {
+    const query = vi.fn(async () => ({
+      rows: [
+        {
+          column_name: 'consequence',
+          min_value: null,
+          max_value: null,
+          distinct_count: 1,
+          distinct_values: ['HIGH']
+        }
+      ]
+    }))
     const repo = new PostgresVariantReadRepository({ query } as never, 'public')
 
     await expect(repo.getColumnMeta({ caseId: 1 }, 'consequence')).resolves.toStrictEqual({
@@ -155,6 +177,55 @@ describe('PostgresVariantReadRepository filter metadata', () => {
       distinctCount: 1,
       distinctValues: ['HIGH']
     })
+  })
+
+  it('returns an empty entry when no cohort_column_meta row exists for the case column', async () => {
+    const query = vi.fn(async () => ({ rows: [] }))
+    const repo = new PostgresVariantReadRepository({ query } as never, 'public')
+
+    await expect(repo.getColumnMeta({ caseId: 9 }, 'consequence')).resolves.toStrictEqual({
+      key: 'consequence',
+      dataType: 'text',
+      distinctCount: 0
+    })
+  })
+
+  it('keeps single-case extension column metadata live-aggregating', async () => {
+    const query = vi.fn(async () => ({
+      rows: [{ distinct_count: '2', min: '4', max: '12' }]
+    }))
+    const repo = new PostgresVariantReadRepository({ query } as never, 'public')
+
+    await expect(repo.getColumnMeta({ caseId: 1 }, 'sv.support')).resolves.toMatchObject({
+      key: 'sv.support',
+      dataType: 'numeric',
+      distinctCount: 2,
+      min: 4,
+      max: 12
+    })
+
+    const sql = sqlTextOf(query.mock.calls[0][0])
+    expect(sql).toContain('"variant_sv" sv')
+    expect(sql).not.toContain('cohort_column_meta')
+  })
+
+  it('keeps multi-case base column metadata live-aggregating', async () => {
+    const query = vi.fn(async (arg: unknown) => {
+      const sql = sqlTextOf(arg)
+      if (sql.includes('COUNT(DISTINCT')) return { rows: [{ distinct_count: '1' }] }
+      return { rows: [{ value: 'HIGH' }] }
+    })
+    const repo = new PostgresVariantReadRepository({ query } as never, 'public')
+
+    await expect(repo.getColumnMeta({ caseIds: [1, 2] }, 'consequence')).resolves.toStrictEqual({
+      key: 'consequence',
+      dataType: 'text',
+      distinctCount: 1,
+      distinctValues: ['HIGH']
+    })
+    const sql = sqlTextOf(query.mock.calls[0][0])
+    expect(sql).toContain('ANY($1::bigint[])')
+    expect(sql).not.toContain('cohort_column_meta')
   })
 
   it('uses extension joins for extension column metadata', async () => {

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Phase 16+: VCF imports write via runBulkCopy (pg-copy-streams). The mock
 // here drains the rows iterator so the worker's per-batch contract still
@@ -16,6 +16,23 @@ vi.mock('../../../src/main/storage/postgres/postgres-bulk-write', () => ({
       }
     }
   )
+}))
+
+// C3: spy on the cohort summary repo so the import-wiring tests can assert the
+// post-loop SAVEPOINT block calls incrementalAdd / recomputeCohortFrequency /
+// refreshColumnMetas without standing up a real Postgres. Each test overrides
+// the mock implementations via the exported spies below.
+const incrementalAddSpy = vi.fn(async () => undefined)
+const recomputeCohortFrequencySpy = vi.fn(async () => undefined)
+const refreshColumnMetasSpy = vi.fn(async () => undefined)
+const markStaleSpy = vi.fn(async () => undefined)
+vi.mock('../../../src/main/storage/postgres/PostgresCohortSummaryRepository', () => ({
+  PostgresCohortSummaryRepository: class {
+    incrementalAdd = incrementalAddSpy
+    recomputeCohortFrequency = recomputeCohortFrequencySpy
+    refreshColumnMetas = refreshColumnMetasSpy
+    markStale = markStaleSpy
+  }
 }))
 
 import { runImport } from '../../../src/main/workers/postgres-import-worker'
@@ -439,5 +456,185 @@ describe('postgres-import-worker runImport', () => {
       passOnly: true,
       minQual: 30
     })
+  })
+})
+
+describe('postgres-import-worker — C3 import wiring', () => {
+  beforeEach(() => {
+    incrementalAddSpy.mockReset().mockResolvedValue(undefined)
+    recomputeCohortFrequencySpy.mockReset().mockResolvedValue(undefined)
+    refreshColumnMetasSpy.mockReset().mockResolvedValue(undefined)
+    markStaleSpy.mockReset().mockResolvedValue(undefined)
+  })
+
+  const fakeVariant = {
+    chr: '1',
+    pos: 100,
+    ref: 'A',
+    alt: 'T',
+    gene_symbol: 'BRCA1',
+    omim_mim_number: null,
+    consequence: 'HIGH',
+    gnomad_af: null,
+    cadd: null,
+    clinvar: null,
+    gt_num: '0/1',
+    func: 'missense_variant',
+    qual: 50,
+    hpo_sim_score: null,
+    transcript: 'ENST1',
+    cdna: 'c.1A>T',
+    aa_change: 'p.M1I',
+    hpo_match: null,
+    moi: null,
+    gq: 99,
+    dp: 30,
+    ad_ref: 15,
+    ad_alt: 15,
+    ab: 0.5,
+    filter: 'PASS',
+    info_json: null,
+    source_format: 'vcf',
+    variant_type: 'snv',
+    end_pos: null,
+    sv_type: null,
+    sv_length: null,
+    caller: null
+  }
+
+  const makeClient = (
+    queries: string[]
+  ): {
+    connect: ReturnType<typeof vi.fn>
+    query: ReturnType<typeof vi.fn>
+    end: ReturnType<typeof vi.fn>
+  } => ({
+    connect: vi.fn(async () => undefined),
+    query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
+      const text = typeof sql === 'string' ? sql : sql.text
+      queries.push(text)
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
+      if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) return { rows: [] }
+      if (text.startsWith('INSERT INTO') && text.includes('"cases"')) return { rows: [{ id: 13 }] }
+      if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
+        const n = (params?.[1] as number) ?? 0
+        return {
+          rows: Array.from({ length: n }, (_, i) => ({ ordinal: String(i), id: String(5000 + i) }))
+        }
+      }
+      return { rows: [] }
+    }),
+    end: vi.fn(async () => undefined)
+  })
+
+  const runVcfSingleFile = async (
+    client: ReturnType<typeof makeClient>,
+    messages: unknown[]
+  ): Promise<void> => {
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
+        createVcfMappedStream: async () => Readable.from([fakeVariant]) as never,
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'single-file',
+        caseName: 'VCF case',
+        filePath: '/tmp/a.vcf.gz',
+        format: 'vcf',
+        vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' }
+      },
+      (m) => messages.push(m)
+    )
+  }
+
+  it('updates cohort_variant_summary after a successful import', async () => {
+    const queries: string[] = []
+    const client = makeClient(queries)
+    const messages: unknown[] = []
+    await runVcfSingleFile(client, messages)
+
+    // The summary update is wrapped in a SAVEPOINT inside the post-loop txn.
+    expect(queries).toContain('SAVEPOINT cohort_summary')
+    expect(queries).toContain('RELEASE SAVEPOINT cohort_summary')
+    expect(queries).not.toContain('ROLLBACK TO SAVEPOINT cohort_summary')
+
+    expect(incrementalAddSpy).toHaveBeenCalledTimes(1)
+    expect(incrementalAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ schema: 'public', caseId: 13, genomeBuild: 'GRCh38' })
+    )
+    expect(recomputeCohortFrequencySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ schema: 'public', affectedBuilds: ['GRCh38'] })
+    )
+    expect(refreshColumnMetasSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ schema: 'public', caseId: 13 })
+    )
+
+    // SAVEPOINT must come AFTER the variant_count bookkeeping and BEFORE the
+    // final COMMIT (Pass-3 HIGH #1 + Pass-4 HIGH #2).
+    const savepointIdx = queries.indexOf('SAVEPOINT cohort_summary')
+    const bookkeepingIdx = queries.findIndex(
+      (q) => q.startsWith('UPDATE') && q.includes('variant_count')
+    )
+    expect(bookkeepingIdx).toBeGreaterThanOrEqual(0)
+    expect(savepointIdx).toBeGreaterThan(bookkeepingIdx)
+    expect(queries.at(-1)).toBe('COMMIT')
+
+    expect(markStaleSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves variant_count + rebuildVariantFrequencyForCase on summary failure', async () => {
+    incrementalAddSpy.mockRejectedValueOnce(new Error('boom in incrementalAdd'))
+    const queries: string[] = []
+    const client = makeClient(queries)
+    const messages: unknown[] = []
+    await runVcfSingleFile(client, messages)
+
+    // Bookkeeping committed: the variant_count UPDATE and the variant_frequency
+    // rebuild ran before the savepoint and survive the savepoint rollback.
+    expect(queries.find((q) => q.startsWith('UPDATE') && q.includes('variant_count'))).toBeDefined()
+    expect(queries.find((q) => q.includes('"variant_frequency"'))).toBeDefined()
+
+    // Savepoint opened, then rolled back; the outer transaction still committed.
+    expect(queries).toContain('SAVEPOINT cohort_summary')
+    expect(queries).toContain('ROLLBACK TO SAVEPOINT cohort_summary')
+    expect(queries).not.toContain('RELEASE SAVEPOINT cohort_summary')
+    expect(queries).toContain('COMMIT')
+
+    // markStale runs in a separate tiny transaction (BEGIN/COMMIT after the
+    // outer COMMIT) so the bookkeeping commit survives regardless.
+    expect(markStaleSpy).toHaveBeenCalledTimes(1)
+    expect(markStaleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'post_import_summary_failed_case_13' })
+    )
+
+    // Import still reports success — staleness lives in cohort_summary_state.
+    const complete = messages.find(
+      (m): m is { type: 'complete' } => (m as { type: string }).type === 'complete'
+    )
+    expect(complete).toBeDefined()
+  })
+
+  it('ImportResult shape carries NO warnings field (Pass-4 HIGH #3)', async () => {
+    incrementalAddSpy.mockRejectedValueOnce(new Error('boom'))
+    const queries: string[] = []
+    const client = makeClient(queries)
+    const messages: unknown[] = []
+    await runVcfSingleFile(client, messages)
+
+    const complete = messages.find(
+      (m): m is { type: 'complete'; result: Record<string, unknown> } =>
+        (m as { type: string }).type === 'complete'
+    )
+    expect(complete).toBeDefined()
+    expect(complete!.result).not.toHaveProperty('warnings')
+    expect(Object.keys(complete!.result).sort()).toEqual(
+      ['caseId', 'elapsed', 'errors', 'skipped', 'variantCount'].sort()
+    )
   })
 })

--- a/tests/perf/postgres-cohort-warm.perf.test.ts
+++ b/tests/perf/postgres-cohort-warm.perf.test.ts
@@ -1,0 +1,298 @@
+/**
+ * PostgreSQL cohort warm-perf gate — Sprint A PR-3 (C6 + Gate 8).
+ *
+ * Opens the 100-case fixture (tests/.cache/perf-100case/, built by
+ * scripts/perf/build-100-case-fixture.mjs) into a fresh PG schema, bulk-loads
+ * all cases via COPY, rebuilds the cohort summary once (cold), then runs the
+ * cohort page-load 5× warm (after 1 cold) and asserts the warm p95 < 500 ms.
+ *
+ * Reads the materialised cohort_variant_summary page exactly as the renderer
+ * does (PostgresCohortRepository.queryVariants, default page: limit 50,
+ * offset 0). The timing artifact lands under
+ * .planning/artifacts/perf/postgres-cohort/.
+ *
+ * Gated two ways:
+ *   - describe.skipIf when the 100-case fixture manifest is absent, so CI stays
+ *     green without the (gitignored) fixture.
+ *   - VARLENS_RUN_POSTGRES_E2E=1 + a reachable VARLENS_PG_URL are required for
+ *     the body to do real work; without them the schema setup would fail, so
+ *     the run is skipped unless both the fixture and a live PG are present.
+ *
+ * Setup:
+ *   node scripts/perf/build-100-case-fixture.mjs   # if the fixture is missing
+ *   make pg-reset && make pg-up && make rebuild-node
+ *   VARLENS_RUN_POSTGRES_E2E=1 npx vitest run tests/perf/postgres-cohort-warm.perf.test.ts
+ *   make pg-down
+ */
+import { randomBytes } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { gunzipSync } from 'node:zlib'
+
+import { Client, Pool } from 'pg'
+import { describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { PostgresCohortRepository } from '../../src/main/storage/postgres/PostgresCohortRepository'
+import { PostgresCohortSummaryRepository } from '../../src/main/storage/postgres/PostgresCohortSummaryRepository'
+import {
+  encodeFloat,
+  encodeInteger,
+  encodeText,
+  type CopyColumn
+} from '../../src/main/storage/postgres/copy-text-encoder'
+import { runBulkCopy } from '../../src/main/storage/postgres/postgres-bulk-write'
+
+const FIXTURE_DIR = resolve(process.cwd(), 'tests/.cache/perf-100case')
+const MANIFEST_PATH = join(FIXTURE_DIR, 'manifest.json')
+const ARTIFACT_DIR = resolve(process.cwd(), '.planning/artifacts/perf/postgres-cohort')
+
+const RUN_PG = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+/** Warm page-load p95 budget (Gate 8). */
+const P95_BUDGET_MS = Number(process.env.VARLENS_PG_COHORT_P95_MS ?? '500')
+const WARM_RUNS = 5
+const GENOME_BUILD = 'GRCh38'
+
+interface ManifestCase {
+  id: string
+  filePath: string
+  variantCount: number
+}
+
+interface Manifest {
+  totalCases: number
+  totalVariants: number
+  cases: ManifestCase[]
+}
+
+/**
+ * COPY columns for the variants table. coord_hash is a GENERATED column and is
+ * deliberately omitted; variant_type defaults to 'snv'. The encoders mirror the
+ * production bulk-write path.
+ */
+const VARIANT_COPY_COLUMNS: ReadonlyArray<CopyColumn> = [
+  { name: 'case_id', encoder: encodeInteger },
+  { name: 'chr', encoder: encodeText },
+  { name: 'pos', encoder: encodeInteger },
+  { name: 'ref', encoder: encodeText },
+  { name: 'alt', encoder: encodeText },
+  { name: 'gene_symbol', encoder: encodeText },
+  { name: 'consequence', encoder: encodeText },
+  { name: 'func', encoder: encodeText },
+  { name: 'gnomad_af', encoder: encodeFloat },
+  { name: 'cadd', encoder: encodeFloat },
+  { name: 'clinvar', encoder: encodeText },
+  { name: 'gt_num', encoder: encodeText },
+  { name: 'transcript', encoder: encodeText },
+  { name: 'cdna', encoder: encodeText },
+  { name: 'aa_change', encoder: encodeText },
+  { name: 'variant_type', encoder: encodeText }
+]
+
+function readManifest(): Manifest {
+  return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as Manifest
+}
+
+/** Decompress one wrapped-columnar .json.gz fixture case into header + rows. */
+function readCaseFile(filePath: string): {
+  header: Array<{ id: string }>
+  data: unknown[][]
+} {
+  const raw = JSON.parse(
+    gunzipSync(readFileSync(resolve(process.cwd(), filePath))).toString('utf8')
+  ) as Record<string, { header: Array<{ id: string }>; data: unknown[][] }>
+  const caseKey = Object.keys(raw)[0]
+  return raw[caseKey]
+}
+
+function colIndexer(header: Array<{ id: string }>): (id: string) => number {
+  const map = new Map(header.map((c, i) => [c.id, i]))
+  return (id) => map.get(id) ?? -1
+}
+
+function toNum(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function p95(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const rank = Math.ceil(0.95 * sorted.length)
+  return sorted[Math.min(rank, sorted.length) - 1]
+}
+
+function writeArtifact(args: {
+  manifest: Manifest
+  loadSec: number
+  rebuildSec: number
+  coldMs: number
+  warmMs: number[]
+  warmP95Ms: number
+}): string {
+  mkdirSync(ARTIFACT_DIR, { recursive: true })
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const path = resolve(ARTIFACT_DIR, `${ts}-postgres-cohort-warm.md`)
+  writeFileSync(
+    path,
+    [
+      `# Postgres cohort warm-perf — Sprint A C6 / Gate 8`,
+      ``,
+      `- timestamp: ${ts}`,
+      `- fixture: ${FIXTURE_DIR}`,
+      `- cases: ${args.manifest.totalCases}`,
+      `- variants: ${args.manifest.totalVariants}`,
+      `- bulk-load: ${args.loadSec.toFixed(2)}s`,
+      `- summary rebuild (cold): ${args.rebuildSec.toFixed(2)}s`,
+      `- page-load cold: ${args.coldMs.toFixed(1)}ms`,
+      `- page-load warm samples (ms): ${args.warmMs.map((m) => m.toFixed(1)).join(', ')}`,
+      `- page-load warm p95: ${args.warmP95Ms.toFixed(1)}ms`,
+      `- budget: ${P95_BUDGET_MS.toFixed(1)}ms (override via VARLENS_PG_COHORT_P95_MS)`,
+      ``
+    ].join('\n')
+  )
+  return path
+}
+
+describe.skipIf(!existsSync(MANIFEST_PATH) || !RUN_PG)(
+  'postgres cohort warm-perf — Sprint A C6 / Gate 8',
+  () => {
+    it(`cohort page-load p95 < ${P95_BUDGET_MS}ms warm on the 100-case fixture`, async () => {
+      const manifest = readManifest()
+      expect(manifest.cases.length).toBeGreaterThan(0)
+
+      const schema = `varlens_perf_cohort_${Date.now()}_${randomBytes(4).toString('hex')}`
+
+      const provisioner = new Client({ connectionString: PG_URL })
+      await provisioner.connect()
+      await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+      await provisioner.end()
+
+      const pool = new Pool({ connectionString: PG_URL, max: 4 })
+
+      try {
+        // 1. Fresh schema + migrations.
+        await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+        // 2. Bulk-load all cases via COPY (fast path).
+        const loadT0 = performance.now()
+        const loadClient = await pool.connect()
+        try {
+          for (const entry of manifest.cases) {
+            const { header, data } = readCaseFile(entry.filePath)
+            const idx = colIndexer(header)
+            const iChr = idx('Chr')
+            const iPos = idx('Pos')
+            const iRef = idx('Ref')
+            const iAlt = idx('Alt')
+            const iGene = idx('Gene')
+            const iConsequence = idx('Consequence')
+            const iFunc = idx('Func')
+            const iTranscript = idx('Transcript')
+            const iCdna = idx('cDNA')
+            const iAa = idx('AAChange')
+            const iGnomad = idx('GnomadAF')
+            const iCadd = idx('CADDPhredScore')
+            const iClinvar = idx('ClinVSig')
+            const iGt = idx('GTNum-Index')
+
+            const inserted = await loadClient.query<{ id: number }>(
+              `INSERT INTO "${schema}".cases (name, file_path, file_size, created_at, genome_build)
+                   VALUES ($1, $2, 0, $3, $4) RETURNING id`,
+              [entry.id, entry.filePath, Date.now(), GENOME_BUILD]
+            )
+            const caseId = inserted.rows[0].id
+
+            const rows = data.map((row) => ({
+              case_id: caseId,
+              chr: String(row[iChr]),
+              pos: Number(row[iPos]),
+              ref: String(row[iRef]),
+              alt: String(row[iAlt]),
+              gene_symbol: iGene >= 0 ? (row[iGene] ?? null) : null,
+              consequence: iConsequence >= 0 ? (row[iConsequence] ?? null) : null,
+              func: iFunc >= 0 ? (row[iFunc] ?? null) : null,
+              gnomad_af: toNum(row[iGnomad]),
+              cadd: toNum(row[iCadd]),
+              clinvar: iClinvar >= 0 ? (row[iClinvar] ?? null) : null,
+              gt_num: iGt >= 0 ? (row[iGt] === null ? null : String(row[iGt])) : null,
+              transcript: iTranscript >= 0 ? (row[iTranscript] ?? null) : null,
+              cdna: iCdna >= 0 ? (row[iCdna] ?? null) : null,
+              aa_change: iAa >= 0 ? (row[iAa] ?? null) : null,
+              variant_type: 'snv'
+            }))
+
+            await runBulkCopy({
+              client: loadClient,
+              sql: `COPY "${schema}".variants (${VARIANT_COPY_COLUMNS.map((c) => c.name).join(', ')}) FROM STDIN`,
+              columns: VARIANT_COPY_COLUMNS,
+              rows
+            })
+          }
+        } finally {
+          loadClient.release()
+        }
+        const loadSec = (performance.now() - loadT0) / 1000
+
+        // 3. Rebuild the cohort summary once (cold).
+        const summaryRepo = new PostgresCohortSummaryRepository()
+        const rebuildT0 = performance.now()
+        const rebuildClient = await pool.connect()
+        try {
+          await summaryRepo.rebuild({ schema, client: rebuildClient as never })
+        } finally {
+          rebuildClient.release()
+        }
+        const rebuildSec = (performance.now() - rebuildT0) / 1000
+
+        // 4. Cohort page-load: 1 cold, then WARM_RUNS warm.
+        const cohortRepo = new PostgresCohortRepository(pool, schema)
+        const pageParams = { limit: 50, offset: 0 }
+
+        const coldT0 = performance.now()
+        const coldResult = await cohortRepo.queryVariants(pageParams)
+        const coldMs = performance.now() - coldT0
+        expect(coldResult.data.length).toBeGreaterThan(0)
+
+        const warmMs: number[] = []
+        for (let i = 0; i < WARM_RUNS; i++) {
+          const t0 = performance.now()
+          const result = await cohortRepo.queryVariants(pageParams)
+          warmMs.push(performance.now() - t0)
+          expect(result.data.length).toBeGreaterThan(0)
+        }
+
+        const warmP95Ms = p95(warmMs)
+        const artifactPath = writeArtifact({
+          manifest,
+          loadSec,
+          rebuildSec,
+          coldMs,
+          warmMs,
+          warmP95Ms
+        })
+
+        // Surface the numbers for the run log without console.* in app code —
+        // this is test code, where reporters expect stdout.
+        process.stdout.write(
+          `[cohort-warm-perf] cold=${coldMs.toFixed(1)}ms warm-p95=${warmP95Ms.toFixed(1)}ms ` +
+            `budget=${P95_BUDGET_MS}ms artifact=${artifactPath}\n`
+        )
+
+        expect(warmP95Ms).toBeLessThan(P95_BUDGET_MS)
+      } finally {
+        await pool.end()
+        const cleaner = new Client({ connectionString: PG_URL })
+        await cleaner.connect()
+        await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+        await cleaner.end()
+      }
+    }, 600_000)
+  }
+)

--- a/tests/refactor-checkpoint/__snapshots__/pool-vs-main-routing.json
+++ b/tests/refactor-checkpoint/__snapshots__/pool-vs-main-routing.json
@@ -110,6 +110,11 @@
     {
       "file": "src/main/storage/sqlite/SqliteReadExecutor.ts",
       "callerFunction": "execute",
+      "type": "cohort:summaryStatus"
+    },
+    {
+      "file": "src/main/storage/sqlite/SqliteReadExecutor.ts",
+      "callerFunction": "execute",
       "type": "cohort:variants"
     },
     {

--- a/tests/shared/types/preload-contract.test.ts
+++ b/tests/shared/types/preload-contract.test.ts
@@ -16,6 +16,7 @@ import { resolve } from 'path'
 import { ErrorCode } from '../../../src/shared/types/errors'
 import type { WindowAPI, Case, BatchAnnotationKey } from '../../../src/shared/types/api'
 import type { IpcResult } from '../../../src/shared/types/errors'
+import type { ImportResult } from '../../../src/shared/types/import'
 import { DEBUG_CHANNELS } from '../../../src/shared/ipc/domains/debug'
 
 const ROOT = resolve(__dirname, '..', '..', '..')
@@ -579,6 +580,89 @@ describe('debug domain — Sprint A PR-2 Gate 10c', () => {
     expectTypeOf<Awaited<ReturnType<WindowAPI['debug']['queryCountersReset']>>>().toEqualTypeOf<
       IpcResult<{ enabled: boolean }>
     >()
+  })
+})
+
+/**
+ * Return the brace-balanced body of `export interface <name> { ... }` from a
+ * source string (used by Gate 10b to assert import-result types stay
+ * warnings-free without importing main-process modules).
+ */
+function extractInterfaceBlock(source: string, interfaceName: string): string {
+  const startIdx = source.indexOf(`export interface ${interfaceName}`)
+  if (startIdx === -1) throw new Error(`interface ${interfaceName} not found`)
+  const braceStart = source.indexOf('{', startIdx)
+  let depth = 0
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(braceStart, i + 1)
+    }
+  }
+  throw new Error(`unbalanced braces for interface ${interfaceName}`)
+}
+
+describe('cohort domain — Sprint A PR-3 Gate 10b', () => {
+  it('cohort getVariants response carries an optional warnings field', () => {
+    type CohortGetVariantsReturn = Awaited<ReturnType<WindowAPI['cohort']['getVariants']>>
+
+    // A response without warnings still satisfies the type (warnings optional).
+    const withoutWarnings: CohortGetVariantsReturn = {
+      data: [],
+      total_count: 0
+    }
+    // A response carrying warnings.staleSummary also type-checks.
+    const withWarnings: CohortGetVariantsReturn = {
+      data: [],
+      total_count: 0,
+      warnings: { staleSummary: true }
+    }
+
+    expect(withoutWarnings.warnings).toBeUndefined()
+    expect(withWarnings.warnings?.staleSummary).toBe(true)
+  })
+
+  it('getSummaryStatus contract shape is unchanged ({ is_stale, last_rebuilt_at:number })', () => {
+    expectTypeOf<Awaited<ReturnType<WindowAPI['cohort']['getSummaryStatus']>>>().toEqualTypeOf<
+      IpcResult<{ is_stale: boolean; last_rebuilt_at: number }>
+    >()
+  })
+
+  it('ImportResult shape unchanged — no warnings field (Pass-4 HIGH #3)', () => {
+    const result: ImportResult = {
+      caseId: 1,
+      variantCount: 0,
+      skipped: 0,
+      errors: [],
+      elapsed: 0
+    }
+    // @ts-expect-error — warnings is intentionally NOT on ImportResult
+    void result.warnings
+    expect(result.caseId).toBe(1)
+  })
+
+  it('StorageImportSingleFileResult + PostgresImportWorkerCompleteMessage stay warnings-free', () => {
+    const importExecutorSource = readFileSync(
+      resolve(ROOT, 'src/main/storage/import-executor.ts'),
+      'utf-8'
+    )
+    const postgresWorkerSource = readFileSync(
+      resolve(ROOT, 'src/shared/types/postgres-import-worker.ts'),
+      'utf-8'
+    )
+
+    const singleFileBlock = extractInterfaceBlock(
+      importExecutorSource,
+      'StorageImportSingleFileResult'
+    )
+    const completeBlock = extractInterfaceBlock(
+      postgresWorkerSource,
+      'PostgresImportWorkerCompleteMessage'
+    )
+
+    expect(singleFileBlock).not.toContain('warnings')
+    expect(completeBlock).not.toContain('warnings')
   })
 })
 


### PR DESCRIPTION
## Summary

Sprint A **PR-3** (foundations). Materialised PG cohort summary with incremental maintenance, toward 1000-genome-scale cohort queries.

Spec: `.planning/specs/2026-05-28-sprint-a-foundations.md`

### What landed (C1–C8)
- **C1** — migration `0010_cohort_summary` (cohort_variant_summary + cohort_column_meta + cohort_summary_state, composite PK incl. variant_type+genome_build, end_pos).
- **C2 / C2a** — `PostgresCohortSummaryRepository` (rebuild, incrementalAdd/Remove, refresh/removeColumnMetas, cohort_frequency recompute, getState/markStale).
- **C5a** — annotation-flag write-hooks (client-passed helpers).
- **C3** — incremental maintenance wired into the import worker (inside the worker txn, SAVEPOINT) + 8-step delete sequence.
- **C4** — `buildSummaryQueryParts` + scoped read sites switched to the materialised summary with live-aggregation fallback.
- **C6** — 100-case perf fixture builder + warm-perf gate.
- **C5** — cohort staleness state + cohort-read `warnings.staleSummary` (Gate 10b), with synchronous/background rebuild bootstrap at the read seam.

### Backend parity gap-fill (C7 / Gate 9)
The parity gate caught a real divergence: PG gained spanning-SV interval-overlap but SQLite's `cohort_variant_summary` lacked `end_pos` (point-in-interval only). Closed the gap rather than weakening the gate — SQLite migration **v30** adds `end_pos` + index, the rebuild/incremental SQL populate it, and `cohort.ts` panel-interval now does true overlap (`pos <= end AND COALESCE(end_pos,pos) >= start`; SNVs unchanged). All 6 parity sub-checks pass.

### Verification
- [x] Gate 1 — `make ci` green (3806 pass)
- [x] Gate 2 — `VARLENS_WEB=1 make ci` green (3937 pass)
- [x] Gate 8 — cohort warm-perf gate (100-case fixture)
- [x] Gate 9 — backend-parity (a–e + spanning-SV), validated against live PG
- [x] Gate 10 — cohort-summary drift detection
- [x] Gate 10b — cohort staleness warnings locked in preload contract

Migration note: SQLite **v30** consumed here (cohort end_pos); PG head **0010**. PR-4's projects registry therefore becomes SQLite v31 / PG 0011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)