### PR TITLE
feat(jobs): JobRunner skeleton + jobs IPC + multi-project design doc

### DIFF
--- a/.planning/specs/2026-05-28-multi-project-architecture.md
+++ b/.planning/specs/2026-05-28-multi-project-architecture.md
@@ -1,0 +1,179 @@
+# Sprint E — Multi-Project Architecture — Design Doc
+
+**Status:** Locked 2026-05-28
+**Spec for Sprint E** (plan in Sprint E itself)
+**Predecessor:** Sprint A PR-4 D5 — this doc + the projects-registry migration land in PR-4; no code references it in Sprint A.
+
+## Goal
+
+Allow VarLens to manage multiple isolated projects (each a PG schema or SQLite database) from one running instance, with a project picker, hot session pool, and cross-project queries (PG only).
+
+## In scope (Sprint E)
+
+- Data model: `projects` table — see migrations 0011 (PG) and v30 (SQLite) from PR-4 D5.
+- Session model — where the implicit single-project assumption lives today (StorageSession.constructor), what to refactor.
+- Hot session pool — SessionPool + pickProject(projectId) API.
+- Cross-project query story (PG only) — UNION ALL over schemas; SQLite stays single-project.
+- Existing-user migration — default project row backfilled on first launch (already shipped in PR-4 D5's seed).
+
+## Out of scope (Sprint F+)
+
+- Multi-tenant authentication / authorisation.
+- Per-project encryption keys.
+- Cross-project annotations.
+
+## Data model (already shipped in PR-4)
+
+PG migration 0011_projects_registry.sql + SQLite v30 created the `projects`
+table with a single 'default' row.
+
+> **Migration-number note (verified 2026-05-28 against `feat/job-runner`):**
+> at the time this doc was locked the highest shipped PG migration was
+> `0010_cohort_summary.sql` and the highest SQLite `user_version` was `30`
+> (`end_pos` on `cohort_variant_summary`, Sprint A PR-3). The PR-4 D5
+> migration task MUST therefore re-verify the next free number for **each**
+> backend immediately before writing — the projects registry lands as PG
+> `0011` and SQLite **`v31`** (one greater than the SQLite head, not `v30`,
+> which is already taken). This doc keeps the plan's nominal `0011 / v30`
+> labels for traceability; the executing task uses the re-verified numbers.
+
+```sql
+CREATE TABLE projects (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  schema_name TEXT NOT NULL,           -- PG schema OR SQLite path
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+INSERT INTO projects (id, name, schema_name) VALUES (1, 'default', 'public');
+```
+
+The `schema_name` column is intentionally backend-overloaded: on PostgreSQL it
+is the SQL schema (`public`, `project_2`, …) that already threads through every
+repository as the `schema: string` argument; on SQLite it is the absolute
+database-file path. This keeps one registry shape across both backends without a
+backend-discriminated union at the row level — the consuming code branches on
+`StorageCapabilities.backend`, not on the row.
+
+## Session model
+
+Today VarLens runs exactly one `StorageSession` at a time, and the
+single-project assumption is structural rather than explicit. The relevant
+seams:
+
+- **`StorageSession` (`src/main/storage/session.ts`)** carries a single
+  `readonly workspace: WorkspaceRef`. There is no notion of "which project"
+  beyond "which workspace is open right now".
+- **`WorkspaceRef` (`src/main/storage/types.ts`)** is a union of
+  `{ kind: 'sqlite', path, name, encrypted }` and
+  `{ kind: 'postgres', connectionLabel, connectionUrlRedacted, schema }`. The
+  `schema` (PG) and `path` (SQLite) fields ARE the per-project discriminators —
+  they map one-to-one onto `projects.schema_name`. A project is therefore not a
+  new concept at the storage layer; it is a named, registry-backed
+  `WorkspaceRef`.
+- **`PostgresStorageSession` (`src/main/storage/postgres/PostgresStorageSession.ts`)**
+  is constructed for one `schema` and threads that schema into every repository
+  (`createCaseListRepository(pool, schema)` and the per-call `args.schema`
+  pattern seen across `cohort-annotation-flags-sql.ts`,
+  `PostgresCaseLifecycleRepository`, etc.). The PG plumbing is already
+  schema-parameterised; what is missing is a registry that maps a project id to
+  a schema and a factory that opens a session for an arbitrary registered
+  schema.
+- **`SqliteStorageSession` (`src/main/storage/sqlite/SqliteStorageSession.ts`)**
+  is constructed for one database file (one `path`). SQLite multi-project means
+  one file per project; there is no cross-file query path (see below).
+- **Single-flight guards** (`PostgresImportExecutor` "An import is already in
+  progress"; cohort association guard in cohort-logic; batch-import-logic
+  "A batch import is already in progress") are today implicitly per-instance.
+  Once multiple sessions can be live in the pool, these guards MUST become
+  **per-project** (keyed by project id / schema) rather than per-process, or
+  importing into project A would wrongly block an import into project B. Sprint E
+  MUST audit each guard and re-key it; this is called out explicitly so the
+  refactor does not silently re-scope or weaken an existing guard.
+
+**Refactor target:** introduce a `ProjectRegistry` (reads the `projects` table
+through the active connection / a control session) and make session creation
+take a `projectId`. The existing factories
+(`createPostgresStorageSession` / `createSqliteStorageSession`) already accept
+the workspace shape; Sprint E wraps them so a `projectId` resolves to a
+`schema_name` and then to a `WorkspaceRef`.
+
+## Hot session pool
+
+A `SessionPool` holds up to N open `StorageSession` instances keyed by
+`projectId`, so switching projects in the UI does not pay full
+connect + migrate cost every time.
+
+```ts
+interface SessionPool {
+  // Resolve projectId -> schema_name via ProjectRegistry, open or reuse a
+  // StorageSession, mark it most-recently-used. Opens lazily.
+  pickProject(projectId: number): Promise<StorageSession>
+
+  // The currently active session, if any (drives the renderer's data views).
+  active(): StorageSession | undefined
+
+  // Pool sizing. When size would exceed max, evict the least-recently-used
+  // session whose close() is safe (no in-flight import / single-flight guard
+  // held). Eviction MUST respect per-project single-flight state.
+  readonly maxOpen: number
+
+  closeAll(): Promise<void>
+}
+```
+
+- **LRU eviction**: when `pickProject` would exceed `maxOpen`, evict the
+  least-recently-used idle session and `close()` it. A session holding a
+  per-project single-flight guard (active import / cohort association /
+  batch import) is **not** evictable until that operation completes.
+- **PG vs SQLite**: PG sessions share one `Pool` connection pool and differ
+  only by `schema` / `search_path`, so they are cheap to keep hot. SQLite
+  sessions each own a file handle (and possibly an encryption key), so `maxOpen`
+  may be smaller for SQLite.
+- **Encryption**: per-project encryption keys are out of scope (Sprint F+); for
+  Sprint E a SQLite project reuses the existing single-key model via
+  `getEncryptionKey()`.
+
+## Cross-project queries (PG)
+
+PostgreSQL only. Because each project is a schema in the same database, a
+cross-project cohort query is a `UNION ALL` over the per-project schemas with a
+synthetic `project_id` column so results stay attributable:
+
+```sql
+SELECT 1 AS project_id, /* cohort cols */ FROM project_1.variants v /* ... */
+UNION ALL
+SELECT 2 AS project_id, /* cohort cols */ FROM project_2.variants v /* ... */
+-- one branch per selected project's schema_name, generated from ProjectRegistry
+```
+
+- The branch list is generated from the `projects` registry (filtered to the
+  user's selected projects), reusing the existing schema-parameterised SQL
+  builders — each builder already takes `schema: string`, so the cross-project
+  builder composes N single-schema fragments rather than introducing new SQL.
+- **Set-equality guarantee** (Gate, below): the `UNION ALL` result MUST be
+  set-equal to running the same single-schema query against each schema
+  separately and unioning client-side. This is the correctness contract the
+  Sprint E plan tests.
+- **SQLite stays single-project.** SQLite has no cross-database schema-union
+  equivalent that matches the PG semantics cheaply (ATTACH-based unions are
+  out of scope), so the cross-project feature is PG-only by design. The
+  renderer disables the cross-project affordance when
+  `capabilities.backend === 'sqlite'`.
+
+## Migration story
+
+Existing users get the default project row backfilled in PR-4 D5; the migration
+inserts `(1, 'default', 'public')` (PG) / `(1, 'default', <existing db path>)`
+(SQLite) so every already-open workspace becomes "the default project" with no
+data movement. Sprint E's renderer picks `'default'` (project id 1) when no
+explicit project is selected, so a user who never opens the project picker sees
+identical behaviour to today. No backfill re-keys data or moves it between
+schemas; the default project simply names the schema/file that already exists.
+
+## Acceptance gates (for Sprint E plan)
+
+1. SessionPool can hold N open StorageSessions; LRU eviction.
+2. Project picker UI in renderer.
+3. Cross-project cohort query (PG only) returns set-equal results to
+   running the query against each schema separately and UNION-ing.
+4. Existing single-project users see no behaviour change.

--- a/scripts/agent-health-baseline.json
+++ b/scripts/agent-health-baseline.json
@@ -136,10 +136,10 @@
     },
     {
       "path": "src/shared/types/api.ts",
-      "lines": 927,
+      "lines": 929,
       "threshold": 600,
       "category": "source",
-      "reason": "existing shared contract surface; must not grow before contract split. Sprint A additions to this central interface are structurally unavoidable: PR-1 A1 added the `BatchAnnotationKey` type (Pass-8 #1) used across the annotations IPC contract; PR-2 added a new top-level WindowAPI domain key (`debug: DebugAPI`) plus its import and the `DebugAPI` alias that resolves the Gate 10c preload-contract test back to the domain contract. PR-3 PR3-17 (C5/Gate 10b) widened the existing `CohortAPI.getVariants` return shape with an optional `warnings?: { staleSummary?: boolean }` field — a same-method contract extension that must live on the central interface and cannot be split out. Neither can be split out without breaking the contract or its tests."
+      "reason": "existing shared contract surface; must not grow before contract split. Sprint A additions to this central interface are structurally unavoidable: PR-1 A1 added the `BatchAnnotationKey` type (Pass-8 #1) used across the annotations IPC contract; PR-2 added a new top-level WindowAPI domain key (`debug: DebugAPI`) plus its import and the `DebugAPI` alias that resolves the Gate 10c preload-contract test back to the domain contract. PR-3 PR3-17 (C5/Gate 10b) widened the existing `CohortAPI.getVariants` return shape with an optional `warnings?: { staleSummary?: boolean }` field — a same-method contract extension that must live on the central interface and cannot be split out. PR-4 PR4-8 (D4/Gate 11) added a new top-level WindowAPI domain key (`jobs: JobsAPI`) plus its `import type { JobsApi }` import and the `JobsAPI` alias, following the existing DebugAPI alias pattern (+2 lines, 927->929) — the jobs-domain WindowAPI wiring cannot be split out without diverging from the contract. None can be split out without breaking the contract or its tests."
     },
     {
       "path": "src/shared/types/database.ts",

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -1755,4 +1755,23 @@ export function runMigrations(db: Database.Database): void {
     )
     db.exec('PRAGMA user_version = 30')
   }
+
+  // Migration v31: projects registry
+  // Sprint A PR-4 D5. Mirrors PG 0011. Single-row default backfill so Sprint E
+  // doesn't have to handle projectless databases. No code references this table
+  // in Sprint A. (Plan named this v30; v30 was already taken by PR-3's
+  // cohort_variant_summary.end_pos migration, so this lands as v31.)
+  if (currentVersion < 31) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS projects (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        schema_name TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT OR IGNORE INTO projects (id, name, schema_name)
+        VALUES (1, 'default', 'main');
+    `)
+    db.exec('PRAGMA user_version = 31')
+  }
 }

--- a/src/main/ipc/domains/jobs.ts
+++ b/src/main/ipc/domains/jobs.ts
@@ -1,0 +1,26 @@
+import { ipcMain } from 'electron'
+import { JOBS_CHANNELS } from '../../../shared/ipc/domains/jobs'
+import type { JobKind, JobStatus } from '../../../shared/types/jobs'
+import { jobRunner } from '../../services/jobs/runner'
+import { wrapHandler } from '../errorHandler'
+
+/**
+ * Registers the read-only `jobs:` channels against the process-wide
+ * {@link jobRunner}. No renderer consumes these in PR-4; the contract exists so
+ * Sprint D's jobs drawer can wire up without further IPC plumbing.
+ */
+export function registerJobsHandlers(): void {
+  ipcMain.handle(
+    JOBS_CHANNELS.list,
+    async (_event, filter?: { kind?: JobKind; status?: JobStatus }) =>
+      wrapHandler(async () => jobRunner.list(filter))
+  )
+
+  ipcMain.handle(JOBS_CHANNELS.get, async (_event, jobId: string) =>
+    wrapHandler(async () => jobRunner.get(jobId) ?? null)
+  )
+
+  ipcMain.handle(JOBS_CHANNELS.progress, async (_event, jobId: string) =>
+    wrapHandler(async () => jobRunner.get(jobId)?.progress ?? null)
+  )
+}

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -7,10 +7,12 @@
  */
 import { basename } from 'path'
 import { mainLogger } from '../../services/MainLogger'
+import { jobRunner } from '../../services/jobs/runner'
 import { checkDuplicates } from '../../import/batch-utils'
 import { ZipExtractor, TempDirectoryManager } from '../../import'
 import { ImportWorkerClient } from '../../workers/import-worker-client'
 import { API_CONFIG } from '../../../shared/config'
+import type { FileImportRequest } from '../../../shared/types/import-worker'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DuplicateChoice } from '../../../shared/types/api'
 
@@ -58,17 +60,8 @@ export function checkDuplicateFiles(
   }
 }
 
-/**
- * Start batch import with a pre-determined duplicate strategy.
- * Delegates to import worker thread.
- */
-export async function startBatchImport(
-  getDb: () => DatabaseService,
-  filePaths: string[],
-  duplicateStrategy: DuplicateChoice,
-  stripText: string | undefined,
-  callbacks: BatchImportCallbacks
-): Promise<{
+/** Result payload returned by {@link startBatchImport}. */
+export interface BatchImportResult {
   succeeded: number
   failed: number
   skipped: number
@@ -81,13 +74,31 @@ export async function startBatchImport(
     variantCount?: number
     error?: string
   }>
-}> {
+}
+
+/** Params tracked on the `import_batch` job (see {@link JobRunner}). */
+interface BatchImportParams {
+  files: FileImportRequest[]
+}
+
+/**
+ * Start batch import with a pre-determined duplicate strategy.
+ * Delegates to import worker thread.
+ *
+ * The actual worker run is enqueued on the shared {@link jobRunner} under the
+ * `import_batch` kind, which enforces single-flight (message "A batch import is
+ * already in progress") and routes cancellation to {@link ImportWorkerClient.cancel}.
+ * `callbacks.onCohortStale` and the per-file IPC emissions are unchanged.
+ */
+export async function startBatchImport(
+  getDb: () => DatabaseService,
+  filePaths: string[],
+  duplicateStrategy: DuplicateChoice,
+  stripText: string | undefined,
+  callbacks: BatchImportCallbacks
+): Promise<BatchImportResult> {
   try {
     const db = getDb()
-
-    if (workerClient?.isRunning === true) {
-      throw new Error('A batch import is already in progress')
-    }
 
     callbacks.onCohortStale?.({ is_stale: true })
 
@@ -101,89 +112,15 @@ export async function startBatchImport(
       duplicateStrategy
     }))
 
-    workerClient = new ImportWorkerClient()
-
-    return await new Promise((resolve, reject) => {
-      workerClient!.start({
-        files,
-        dbPath: db.getPath(),
-        encryptionKey: db.getEncryptionKey(),
-        throttleMs: API_CONFIG.PROGRESS_THROTTLE_MS,
-        onProgress: (msg) => {
-          callbacks.onProgress?.({
-            currentIndex: msg.fileIndex,
-            totalFiles: msg.totalFiles,
-            currentFileName: msg.fileName,
-            overallPercent: msg.overallPercent,
-            fileProgress: {
-              phase: msg.phase,
-              count: msg.variantCount,
-              elapsed: 0,
-              skipped: msg.skipped
-            }
-          })
-        },
-        onFileComplete: () => {
-          // File complete -- progress already sent via onProgress
-        },
-        onComplete: (msg) => {
-          workerClient = null
-
-          // Update internal variant frequency counts for successful imports
-          try {
-            for (const detail of msg.results.details) {
-              if (detail.status === 'success' && detail.caseName) {
-                const c = db.cases.getCaseByName(detail.caseName)
-                db.variants.updateFrequencies(c.id)
-              }
-            }
-          } catch (freqError) {
-            mainLogger.warn(`Failed to update variant frequencies: ${freqError}`, 'batch-import')
-          }
-
-          // Send final progress
-          callbacks.onProgress?.({
-            currentIndex: msg.results.details.length,
-            totalFiles: msg.results.details.length,
-            currentFileName: '',
-            overallPercent: 100
-          })
-
-          callbacks.onCohortStale?.({ is_stale: false })
-
-          // Build a plain-data result object. Use JSON round-trip to
-          // guarantee structured-clone compatibility.
-          const batchResult = JSON.parse(
-            JSON.stringify({
-              succeeded: msg.results.succeeded,
-              failed: msg.results.failed,
-              skipped: msg.results.skipped,
-              cancelled: msg.results.cancelled,
-              details: msg.results.details.map((d) => ({
-                filePath: d.filePath,
-                fileName: d.fileName,
-                status: d.status,
-                caseName: d.caseName,
-                variantCount: d.variantCount,
-                error: d.error
-              }))
-            })
-          )
-
-          // Notify renderer globally that import completed
-          callbacks.onComplete?.(batchResult)
-
-          resolve(batchResult)
-        },
-        onError: (msg) => {
-          if (msg.fileIndex === -1) {
-            // Fatal error
-            workerClient = null
-            reject(new Error(msg.error))
-          }
-        }
-      })
-    })
+    const handle = jobRunner.enqueue<BatchImportParams, BatchImportResult>(
+      'import_batch',
+      { files },
+      async (ctx, p) => {
+        ctx.registerCancel(() => workerClient?.cancel())
+        return await runBatchWorker(db, p.files, callbacks)
+      }
+    )
+    return await handle.result
   } catch (error) {
     workerClient = null
     mainLogger.error(`batch-import:start error: ${error}`, 'import')
@@ -200,6 +137,102 @@ export async function startBatchImport(
       }))
     }
   }
+}
+
+/**
+ * Run the import worker for a prepared batch and resolve to the aggregated
+ * result. The progress / completion / cohort-stale emissions are identical to
+ * the pre-JobRunner path; only the single-flight gate and cancellation hook
+ * moved up into {@link startBatchImport}.
+ */
+function runBatchWorker(
+  db: DatabaseService,
+  files: FileImportRequest[],
+  callbacks: BatchImportCallbacks
+): Promise<BatchImportResult> {
+  workerClient = new ImportWorkerClient()
+
+  return new Promise((resolve, reject) => {
+    workerClient!.start({
+      files,
+      dbPath: db.getPath(),
+      encryptionKey: db.getEncryptionKey(),
+      throttleMs: API_CONFIG.PROGRESS_THROTTLE_MS,
+      onProgress: (msg) => {
+        callbacks.onProgress?.({
+          currentIndex: msg.fileIndex,
+          totalFiles: msg.totalFiles,
+          currentFileName: msg.fileName,
+          overallPercent: msg.overallPercent,
+          fileProgress: {
+            phase: msg.phase,
+            count: msg.variantCount,
+            elapsed: 0,
+            skipped: msg.skipped
+          }
+        })
+      },
+      onFileComplete: () => {
+        // File complete -- progress already sent via onProgress
+      },
+      onComplete: (msg) => {
+        workerClient = null
+
+        // Update internal variant frequency counts for successful imports
+        try {
+          for (const detail of msg.results.details) {
+            if (detail.status === 'success' && detail.caseName) {
+              const c = db.cases.getCaseByName(detail.caseName)
+              db.variants.updateFrequencies(c.id)
+            }
+          }
+        } catch (freqError) {
+          mainLogger.warn(`Failed to update variant frequencies: ${freqError}`, 'batch-import')
+        }
+
+        // Send final progress
+        callbacks.onProgress?.({
+          currentIndex: msg.results.details.length,
+          totalFiles: msg.results.details.length,
+          currentFileName: '',
+          overallPercent: 100
+        })
+
+        callbacks.onCohortStale?.({ is_stale: false })
+
+        // Build a plain-data result object. Use JSON round-trip to
+        // guarantee structured-clone compatibility.
+        const batchResult = JSON.parse(
+          JSON.stringify({
+            succeeded: msg.results.succeeded,
+            failed: msg.results.failed,
+            skipped: msg.results.skipped,
+            cancelled: msg.results.cancelled,
+            details: msg.results.details.map((d) => ({
+              filePath: d.filePath,
+              fileName: d.fileName,
+              status: d.status,
+              caseName: d.caseName,
+              variantCount: d.variantCount,
+              error: d.error
+            }))
+          })
+        )
+
+        // Notify renderer globally that import completed
+        callbacks.onComplete?.(batchResult)
+
+        resolve(batchResult)
+      },
+      onError: (msg) => {
+        if (msg.fileIndex === -1) {
+          // Fatal error
+          workerClient = null
+          reject(new Error(msg.error))
+        }
+      }
+    })
+  })
 }
 
 /**

--- a/src/main/ipc/handlers/cohort-logic.ts
+++ b/src/main/ipc/handlers/cohort-logic.ts
@@ -14,6 +14,7 @@ import type { DbPool } from '../../database/DbPool'
 import type { RebuildWorkerResponse, RebuildPhase } from '../../workers/rebuild-summary-worker'
 import type { StorageSession } from '../../storage/session'
 import { AssociationEngine } from '../../statistics/AssociationEngine'
+import { jobRunner } from '../../services/jobs/runner'
 import { computePanelIntervals } from './panelIntervalHelper'
 import { convertBigInts } from '../../utils/convertBigInts'
 import type { ValidatedCohortSearchParams } from '../../../shared/types/ipc-schemas'
@@ -311,36 +312,50 @@ export async function runGeneBurdenCompare(
   getDbPool?: () => DbPool | null,
   onProgress?: (data: { completed: number; total: number }) => void
 ): Promise<unknown> {
-  // Prevent concurrent runs
-  if (activeEngine !== null) {
-    throw new Error('An association analysis is already running')
-  }
-
-  // Validate no overlap between groups
+  // Validate no overlap between groups (preserved from pre-PR-4; runs before the
+  // engine is constructed so a bad request never occupies the single-flight slot).
   const groupASet = new Set(config.groupA_ids)
   const overlap = config.groupB_ids.filter((id) => groupASet.has(id))
   if (overlap.length > 0) {
     throw new Error(`Groups overlap: case IDs ${overlap.join(', ')} appear in both groups`)
   }
 
-  const db = getDb()
-  const pool = getDbPool?.() ?? null
+  // Single-flight gating moves to the shared JobRunner (kind 'association').
+  // The 'association' single-flight message in JobRunner is identical to the
+  // pre-PR-4 guard text ('An association analysis is already running').
+  const handle = jobRunner.enqueue<AssociationConfig, unknown>(
+    'association',
+    config,
+    async (ctx) => {
+      let engineRef: AssociationEngine | null = null
+      // Cancellation chains to engine.abort() (Pass-9 #9 — NOT terminate()).
+      ctx.registerCancel(() => engineRef?.abort())
 
-  activeEngine = new AssociationEngine(
-    db.database,
-    (completed, total) => {
-      onProgress?.({ completed, total })
-    },
-    pool
+      const db = getDb()
+      const pool = getDbPool?.() ?? null
+
+      engineRef = new AssociationEngine(
+        db.database,
+        (completed, total) => {
+          onProgress?.({ completed, total })
+        },
+        pool
+      )
+      // Preserve the module-level reference so the existing
+      // cohort:cancelAssociation IPC path keeps calling activeEngine.abort().
+      activeEngine = engineRef
+
+      try {
+        const results = await engineRef.run(config)
+        // Deep clone for IPC serialization
+        return JSON.parse(JSON.stringify(results))
+      } finally {
+        activeEngine = null
+      }
+    }
   )
 
-  try {
-    const results = await activeEngine.run(config)
-    // Deep clone for IPC serialization
-    return JSON.parse(JSON.stringify(results))
-  } finally {
-    activeEngine = null
-  }
+  return handle.result
 }
 
 /**

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -24,6 +24,7 @@ import { registerGeneRefDomain } from './domains/gene-ref'
 import { registerGnomadDomain } from './domains/gnomad'
 import { registerHpoDomain } from './domains/hpo'
 import { registerImportDomain } from './domains/import'
+import { registerJobsHandlers } from './domains/jobs'
 import { registerMyvariantDomain } from './domains/myvariant'
 import { registerPanelsDomain } from './domains/panels'
 import { registerProteinDomain } from './domains/protein'
@@ -89,6 +90,7 @@ export function registerIpcHandlers(): void {
   registerGnomadDomain(ipcMain)
   registerHpoDomain(ipcMain)
   registerImportDomain(ipcMain)
+  registerJobsHandlers()
   registerMyvariantDomain(ipcMain)
   registerPanelsDomain(ipcMain)
   registerProteinDomain(ipcMain)

--- a/src/main/services/jobs/JobRunner.ts
+++ b/src/main/services/jobs/JobRunner.ts
@@ -1,0 +1,211 @@
+import { toSerializableError } from '../../ipc/errorHandler'
+import type { SerializableError } from '../../../shared/types/errors'
+import type { Job, JobKind } from './types'
+
+/**
+ * Context handed to every job handler. The {@link AbortController} is owned by
+ * {@link JobRunner}; handlers receive only the read-only signal plus a hook to
+ * register teardown callbacks that fire on cancellation.
+ */
+export interface JobContext {
+  signal: AbortSignal
+  registerCancel(fn: () => void | Promise<void>): void
+}
+
+/**
+ * Synchronously-returned handle for an enqueued job. `result` is the only async
+ * surface, so call sites preserve their existing return types via
+ * `(await handle.result)`.
+ */
+export interface JobHandle<R> {
+  id: string
+  kind: JobKind
+  result: Promise<R>
+}
+
+/**
+ * Per-kind single-flight error messages. These are copied verbatim from the
+ * existing wire-site guards so behaviour is identical when the JobRunner is
+ * wired into the import/cohort/export paths.
+ */
+const SINGLE_FLIGHT_MESSAGES: Record<JobKind, string> = {
+  import_single: 'An import is already in progress',
+  import_batch: 'A batch import is already in progress',
+  cohort_rebuild: 'A cohort rebuild is already running',
+  association: 'An association analysis is already running',
+  export: 'An export is already in progress'
+}
+
+type Listener = (job: Job) => void
+
+// Crockford base32 alphabet (ULID spec) — chronologically sortable.
+const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+let lastIdTime = 0
+let lastIdSeq = 0
+
+/**
+ * Minimal monotonic, chronologically-sortable id generator. Avoids adding a
+ * runtime dependency while preserving the ULID-style sort guarantee documented
+ * on {@link Job.id}: the time prefix increases monotonically and a per-ms
+ * sequence counter breaks ties within the same millisecond.
+ */
+function generateId(): string {
+  let now = Date.now()
+  if (now > lastIdTime) {
+    lastIdTime = now
+    lastIdSeq = 0
+  } else {
+    // Same (or clock-skewed-back) ms: keep time monotonic, bump the sequence.
+    now = lastIdTime
+    lastIdSeq += 1
+  }
+  let timePart = ''
+  let t = now
+  for (let i = 0; i < 10; i++) {
+    timePart = ULID_ALPHABET[t % 32] + timePart
+    t = Math.floor(t / 32)
+  }
+  let seqPart = ''
+  let s = lastIdSeq
+  for (let i = 0; i < 6; i++) {
+    seqPart = ULID_ALPHABET[s % 32] + seqPart
+    s = Math.floor(s / 32)
+  }
+  return timePart + seqPart
+}
+
+/**
+ * Tracking wrapper around long-running main-process jobs (import, cohort
+ * rebuild, association, export). It owns lifecycle bookkeeping, per-kind
+ * single-flight gating, and AbortController-based cancellation. It does NOT
+ * intercept progress — existing emitters keep firing through their own paths.
+ *
+ * Sprint A scope (D2): tracking only. Normalised progress, concurrency cap and
+ * persistence are deferred to Sprint C.
+ */
+export class JobRunner {
+  private jobs = new Map<string, Job>()
+  private inFlight = new Map<JobKind, Promise<unknown>>()
+  private cancelHandlers = new Map<string, Array<() => void | Promise<void>>>()
+  private controllers = new Map<string, AbortController>()
+  private listeners: Listener[] = []
+
+  /**
+   * Enqueue a job. Returns SYNCHRONOUSLY: the single-flight check,
+   * AbortController creation and handler kickoff all run inline; only
+   * {@link JobHandle.result} is async.
+   */
+  enqueue<P, R>(
+    kind: JobKind,
+    params: P,
+    handler: (ctx: JobContext, params: P) => Promise<R>
+  ): JobHandle<R> {
+    if (this.inFlight.has(kind)) {
+      throw new Error(SINGLE_FLIGHT_MESSAGES[kind])
+    }
+    const id = generateId()
+    const controller = new AbortController()
+    const cancelFns: Array<() => void | Promise<void>> = []
+    this.controllers.set(id, controller)
+    this.cancelHandlers.set(id, cancelFns)
+    const ctx: JobContext = {
+      signal: controller.signal,
+      registerCancel: (fn) => {
+        cancelFns.push(fn)
+      }
+    }
+    const job: Job<P> = {
+      id,
+      kind,
+      status: 'queued',
+      params,
+      progress: null,
+      error: null,
+      createdAt: Date.now(),
+      startedAt: null,
+      finishedAt: null
+    }
+    this.jobs.set(id, job)
+    this.fireLifecycle(job)
+
+    job.status = 'running'
+    job.startedAt = Date.now()
+    this.fireLifecycle(job)
+
+    const resultPromise = handler(ctx, params)
+      .then((r) => {
+        job.status = 'completed'
+        job.finishedAt = Date.now()
+        this.fireLifecycle(job)
+        return r
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) {
+          job.status = 'cancelled'
+        } else {
+          job.status = 'failed'
+          job.error = toSerializableError(err)
+        }
+        job.finishedAt = Date.now()
+        this.fireLifecycle(job)
+        throw err
+      })
+      .finally(() => {
+        this.inFlight.delete(kind)
+        this.controllers.delete(id)
+        this.cancelHandlers.delete(id)
+      })
+
+    this.inFlight.set(kind, resultPromise)
+    return { id, kind, result: resultPromise }
+  }
+
+  /**
+   * Cancel a job: abort its signal, then await every registered cancel
+   * callback. Cancellation is best-effort — callback failures are swallowed.
+   */
+  async cancel(jobId: string): Promise<void> {
+    const controller = this.controllers.get(jobId)
+    if (!controller) return
+    controller.abort()
+    const fns = this.cancelHandlers.get(jobId) ?? []
+    for (const fn of fns) {
+      try {
+        await fn()
+      } catch {
+        /* swallow — cancellation is best-effort */
+      }
+    }
+  }
+
+  get(jobId: string): Job | undefined {
+    return this.jobs.get(jobId)
+  }
+
+  list(filter?: { kind?: JobKind; status?: Job['status'] }): Job[] {
+    let result = [...this.jobs.values()]
+    if (filter?.kind) result = result.filter((j) => j.kind === filter.kind)
+    if (filter?.status) result = result.filter((j) => j.status === filter.status)
+    return result
+  }
+
+  onLifecycle(listener: Listener): () => void {
+    this.listeners.push(listener)
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener)
+    }
+  }
+
+  private fireLifecycle(job: Job): void {
+    for (const l of this.listeners) {
+      try {
+        l(job)
+      } catch {
+        /* swallow — a misbehaving listener must not break job tracking */
+      }
+    }
+  }
+}
+
+// Re-exported for callers that need the serialized error shape alongside jobs.
+export type { SerializableError }

--- a/src/main/services/jobs/runner.ts
+++ b/src/main/services/jobs/runner.ts
@@ -1,0 +1,8 @@
+import { JobRunner } from './JobRunner'
+
+/**
+ * Process-wide single-flight {@link JobRunner}. Wire sites (import, cohort
+ * rebuild, association, export) share this instance so per-kind single-flight
+ * gating spans the whole main process. Sprint C makes the runner injectable.
+ */
+export const jobRunner = new JobRunner()

--- a/src/main/services/jobs/types.ts
+++ b/src/main/services/jobs/types.ts
@@ -1,0 +1,17 @@
+import type { SerializableError } from '../../../shared/types/errors'
+
+export type JobKind = 'import_single' | 'import_batch' | 'cohort_rebuild' | 'association' | 'export'
+
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+
+export interface Job<P = unknown> {
+  id: string // ULID, chronologically sortable
+  kind: JobKind
+  status: JobStatus
+  params: P
+  progress: { current: number; total: number; message?: string } | null
+  error: SerializableError | null
+  createdAt: number // epoch ms
+  startedAt: number | null
+  finishedAt: number | null
+}

--- a/src/main/services/jobs/types.ts
+++ b/src/main/services/jobs/types.ts
@@ -1,17 +1,6 @@
-import type { SerializableError } from '../../../shared/types/errors'
-
-export type JobKind = 'import_single' | 'import_batch' | 'cohort_rebuild' | 'association' | 'export'
-
-export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
-
-export interface Job<P = unknown> {
-  id: string // ULID, chronologically sortable
-  kind: JobKind
-  status: JobStatus
-  params: P
-  progress: { current: number; total: number; message?: string } | null
-  error: SerializableError | null
-  createdAt: number // epoch ms
-  startedAt: number | null
-  finishedAt: number | null
-}
+/**
+ * Job lifecycle types now live in `src/shared/types/jobs.ts` so the renderer can
+ * reference them through the `jobs:` IPC contract without importing from
+ * `src/main/…`. This module re-exports them for main-side call sites.
+ */
+export type { Job, JobKind, JobStatus } from '../../../shared/types/jobs'

--- a/src/main/storage/postgres/PostgresImportExecutor.ts
+++ b/src/main/storage/postgres/PostgresImportExecutor.ts
@@ -30,7 +30,6 @@ export interface PostgresImportExecutorOptions {
 
 export class PostgresImportExecutor implements StorageImportExecutor {
   private currentClient: PostgresImportWorkerClient | null = null
-  private inProgress = false
 
   constructor(private readonly options: PostgresImportExecutorOptions) {}
 
@@ -60,7 +59,6 @@ export class PostgresImportExecutor implements StorageImportExecutor {
   private async _performImport(
     params: StorageImportSingleFileParams
   ): Promise<StorageImportSingleFileResult> {
-    this.inProgress = true
     const startedAt = Date.now()
     try {
       const start: PostgresImportWorkerStartMessage = {
@@ -82,7 +80,6 @@ export class PostgresImportExecutor implements StorageImportExecutor {
         elapsed: result.elapsed
       }
     } finally {
-      this.inProgress = false
       this.currentClient = null
     }
   }
@@ -90,17 +87,27 @@ export class PostgresImportExecutor implements StorageImportExecutor {
   async importMultiFile(
     params: StorageImportMultiFileParams
   ): Promise<StorageImportMultiFileResult> {
-    // INTERIM (PR4-3 → PR4-4): importSingleFile now routes through
-    // jobRunner('import_single') while importMultiFile still guards on the
-    // local `inProgress` flag. This is an intentional, asymmetric intermediate
-    // state: cross-path mutual exclusion between single and multi imports is
-    // NOT enforced at this commit. PR4-4 wires importMultiFile through the same
-    // jobRunner 'import_single' kind and removes `inProgress` entirely,
-    // restoring the pre-PR-4 cross-path single-flight invariant. Do not ship a
-    // release/merge boundary between PR4-3 and PR4-4 — the guard is only
-    // correct once both paths share the runner.
-    if (this.inProgress) throw new Error('An import is already in progress')
-    this.inProgress = true
+    // Shares the 'import_single' JobKind with importSingleFile (Pass-9 #9): the
+    // pre-PR-4 `inProgress` flag gated BOTH paths, so cross-path mutual
+    // exclusion between single- and multi-file imports is preserved by routing
+    // both through the same runner kind. The flag is now gone — single-flight
+    // is enforced entirely by the runner's per-kind concurrency limit.
+    const handle = jobRunner.enqueue<StorageImportMultiFileParams, StorageImportMultiFileResult>(
+      'import_single',
+      params,
+      async (ctx, p) => {
+        // Cancellation posts { type: 'cancel' } to the worker via the client's
+        // cancel() method (PostgresImportWorkerClient.cancel), NOT terminate().
+        ctx.registerCancel(() => this.currentClient?.cancel())
+        return await this._performMultiImport(p)
+      }
+    )
+    return handle.result
+  }
+
+  private async _performMultiImport(
+    params: StorageImportMultiFileParams
+  ): Promise<StorageImportMultiFileResult> {
     const startedAt = Date.now()
     try {
       const start: PostgresImportWorkerStartMessage = {
@@ -138,7 +145,6 @@ export class PostgresImportExecutor implements StorageImportExecutor {
         elapsed: result.elapsed
       }
     } finally {
-      this.inProgress = false
       this.currentClient = null
     }
   }

--- a/src/main/storage/postgres/PostgresImportExecutor.ts
+++ b/src/main/storage/postgres/PostgresImportExecutor.ts
@@ -7,6 +7,7 @@
  * batching, and SQL writes happen in the postgres-import-worker.
  */
 import { mainLogger } from '../../services/MainLogger'
+import { jobRunner } from '../../services/jobs/runner'
 import type {
   StorageImportExecutor,
   StorageImportSingleFileParams,
@@ -43,9 +44,22 @@ export class PostgresImportExecutor implements StorageImportExecutor {
     if ('filters' in (params as object)) {
       throw new Error('Filters are only supported on import:startMultiFile')
     }
-    if (this.inProgress) {
-      throw new Error('An import is already in progress')
-    }
+    const handle = jobRunner.enqueue<StorageImportSingleFileParams, StorageImportSingleFileResult>(
+      'import_single',
+      params,
+      async (ctx, p) => {
+        // Cancellation posts { type: 'cancel' } to the worker via the client's
+        // cancel() method (PostgresImportWorkerClient.cancel), NOT terminate().
+        ctx.registerCancel(() => this.currentClient?.cancel())
+        return await this._performImport(p)
+      }
+    )
+    return handle.result
+  }
+
+  private async _performImport(
+    params: StorageImportSingleFileParams
+  ): Promise<StorageImportSingleFileResult> {
     this.inProgress = true
     const startedAt = Date.now()
     try {
@@ -76,6 +90,15 @@ export class PostgresImportExecutor implements StorageImportExecutor {
   async importMultiFile(
     params: StorageImportMultiFileParams
   ): Promise<StorageImportMultiFileResult> {
+    // INTERIM (PR4-3 → PR4-4): importSingleFile now routes through
+    // jobRunner('import_single') while importMultiFile still guards on the
+    // local `inProgress` flag. This is an intentional, asymmetric intermediate
+    // state: cross-path mutual exclusion between single and multi imports is
+    // NOT enforced at this commit. PR4-4 wires importMultiFile through the same
+    // jobRunner 'import_single' kind and removes `inProgress` entirely,
+    // restoring the pre-PR-4 cross-path single-flight invariant. Do not ship a
+    // release/merge boundary between PR4-3 and PR4-4 — the guard is only
+    // correct once both paths share the runner.
     if (this.inProgress) throw new Error('An import is already in progress')
     this.inProgress = true
     const startedAt = Date.now()

--- a/src/main/storage/postgres/migrations/definitions.ts
+++ b/src/main/storage/postgres/migrations/definitions.ts
@@ -53,6 +53,11 @@ const MIGRATION_FILES: readonly MigrationFile[] = [
     version: '0010',
     name: 'cohort_summary',
     fileName: '0010_cohort_summary.sql'
+  },
+  {
+    version: '0011',
+    name: 'projects_registry',
+    fileName: '0011_projects_registry.sql'
   }
 ]
 

--- a/src/main/storage/postgres/migrations/sql/0011_projects_registry.sql
+++ b/src/main/storage/postgres/migrations/sql/0011_projects_registry.sql
@@ -1,0 +1,24 @@
+-- Sprint A PR-4 D5 — projects registry. Single-row default backfill so
+-- Sprint E doesn't have to handle projectless databases (cheap-to-add-now
+-- /expensive-to-add-later). No code references this table in Sprint A.
+
+CREATE TABLE IF NOT EXISTS "__schema__"."projects" (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  schema_name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- schema_name reflects the actual (template-replaced) schema. The runner only
+-- interpolates the double-quoted "__schema__" token, so we resolve the real
+-- schema name from the table's own catalog entry rather than a string literal:
+-- '"__schema__"."projects"'::regclass becomes '"<schema>"."projects"'::regclass
+-- after interpolation, and its namespace is the actual schema.
+INSERT INTO "__schema__"."projects" (id, name, schema_name)
+SELECT 1, 'default', (
+  SELECT n.nspname
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.oid = '"__schema__"."projects"'::regclass
+)
+ON CONFLICT (id) DO NOTHING;

--- a/src/main/storage/sqlite/SqliteImportExecutor.ts
+++ b/src/main/storage/sqlite/SqliteImportExecutor.ts
@@ -17,6 +17,7 @@
  */
 import { ImportWorkerClient } from '../../workers/import-worker-client'
 import { mainLogger } from '../../services/MainLogger'
+import { jobRunner } from '../../services/jobs/runner'
 import { BedFilter } from '../../import/vcf/bed-filter'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { ImportFilters } from '../../import/vcf/import-filters'
@@ -107,11 +108,25 @@ export class SqliteImportExecutor implements StorageImportExecutor {
     }
   }
 
-  importSingleFile(params: StorageImportSingleFileParams): Promise<StorageImportSingleFileResult> {
-    if (this.workerClient !== null && this.workerClient.isRunning) {
-      return Promise.reject(new Error('An import is already in progress'))
-    }
+  async importSingleFile(
+    params: StorageImportSingleFileParams
+  ): Promise<StorageImportSingleFileResult> {
+    const handle = jobRunner.enqueue<StorageImportSingleFileParams, StorageImportSingleFileResult>(
+      'import_single',
+      params,
+      async (ctx, p) => {
+        // Cancellation posts { type: 'cancel' } to the worker via the client's
+        // cancel() method (ImportWorkerClient.cancel), NOT terminate().
+        ctx.registerCancel(() => this.workerClient?.cancel())
+        return await this._performImport(p)
+      }
+    )
+    return await handle.result
+  }
 
+  private _performImport(
+    params: StorageImportSingleFileParams
+  ): Promise<StorageImportSingleFileResult> {
     const db = this.getDatabaseService()
     const worker = this.createWorkerClient()
     this.workerClient = worker

--- a/src/main/storage/sqlite/SqliteImportExecutor.ts
+++ b/src/main/storage/sqlite/SqliteImportExecutor.ts
@@ -231,10 +231,28 @@ export class SqliteImportExecutor implements StorageImportExecutor {
   async importMultiFile(
     params: StorageImportMultiFileParams
   ): Promise<StorageImportMultiFileResult> {
-    if (this.workerClient !== null && this.workerClient.isRunning) {
-      throw new Error('An import is already in progress')
-    }
+    // Shares the 'import_single' JobKind with importSingleFile, mirroring
+    // PostgresImportExecutor.importMultiFile: routing both paths through the same
+    // runner kind gives a true cross-path single-flight (a running single-file
+    // import blocks a multi-file import and vice versa). The multi-file path
+    // goes through startMultiFileImport, which never sets `this.workerClient`,
+    // so the cancel registration is best-effort (no-op unless a sibling
+    // single-file worker happens to be referenced); the runner's per-kind
+    // concurrency limit is what enforces exclusion here.
+    const handle = jobRunner.enqueue<StorageImportMultiFileParams, StorageImportMultiFileResult>(
+      'import_single',
+      params,
+      async (ctx, p) => {
+        ctx.registerCancel(() => this.workerClient?.cancel())
+        return await this._performMultiImport(p)
+      }
+    )
+    return await handle.result
+  }
 
+  private async _performMultiImport(
+    params: StorageImportMultiFileParams
+  ): Promise<StorageImportMultiFileResult> {
     const startedAt = Date.now()
     const filters = this.translateFilters(params.filters)
 

--- a/src/preload/domains/jobs.ts
+++ b/src/preload/domains/jobs.ts
@@ -1,0 +1,10 @@
+import { ipcRenderer } from 'electron'
+import { JOBS_CHANNELS, type JobsApi } from '../../shared/ipc/domains/jobs'
+
+export function createJobsApi(): JobsApi {
+  return {
+    list: (filter) => ipcRenderer.invoke(JOBS_CHANNELS.list, filter),
+    get: (jobId) => ipcRenderer.invoke(JOBS_CHANNELS.get, jobId),
+    progress: (jobId) => ipcRenderer.invoke(JOBS_CHANNELS.progress, jobId)
+  }
+}

--- a/src/preload/window-api/create-window-api.ts
+++ b/src/preload/window-api/create-window-api.ts
@@ -2,6 +2,7 @@ import { createAppApi } from './app-api'
 import { createCoreApi } from './core-api'
 import { createPreloadDomainApis } from './domains'
 import { createDebugApi } from '../domains/debug'
+import { createJobsApi } from '../domains/jobs'
 import type { WindowAPI } from '../../shared/types/api'
 
 export function createWindowApi(): WindowAPI {
@@ -42,6 +43,7 @@ export function createWindowApi(): WindowAPI {
     gnomad: app.gnomad,
     perf: core.perf,
     presets: app.presets,
-    debug: createDebugApi()
+    debug: createDebugApi(),
+    jobs: createJobsApi()
   }
 }

--- a/src/shared/ipc/domains/jobs.ts
+++ b/src/shared/ipc/domains/jobs.ts
@@ -1,0 +1,22 @@
+import type { IpcResult } from '../../types/errors'
+import type { Job, JobKind, JobStatus } from '../../types/jobs'
+
+/**
+ * Read-only `jobs:` IPC surface. Registered in PR-4 against the process-wide
+ * {@link Job} tracker but NOT consumed by any renderer yet — Sprint D's global
+ * jobs drawer ships against this contract.
+ */
+export interface JobsApi {
+  /** `jobs:list` — all tracked jobs, optionally filtered by kind/status. */
+  list: (filter?: { kind?: JobKind; status?: JobStatus }) => Promise<IpcResult<Job[]>>
+  /** `jobs:get` — a single tracked job by id, or null when unknown. */
+  get: (jobId: string) => Promise<IpcResult<Job | null>>
+  /** `jobs:progress` — the current progress snapshot for a job (null if none). */
+  progress: (jobId: string) => Promise<IpcResult<Job['progress']>>
+}
+
+export const JOBS_CHANNELS = {
+  list: 'jobs:list',
+  get: 'jobs:get',
+  progress: 'jobs:progress'
+} as const

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -111,6 +111,7 @@ import type { PerfSnapshot } from './perf'
 import type { CasesDomainContract } from '../ipc/domains/cases'
 import type { DatabaseDomainContract } from '../ipc/domains/database'
 import type { DebugApi } from '../ipc/domains/debug'
+import type { JobsApi } from '../ipc/domains/jobs'
 export type { DatabaseInfo, DatabaseOpenResult, RecentDatabase } from '../ipc/domains/database'
 
 // Re-export for convenience
@@ -861,9 +862,12 @@ export interface WindowAPI {
   gnomad: GnomadAPI
   perf: PerfAPI
   debug: DebugAPI
+  jobs: JobsAPI
 }
 
 export type DebugAPI = DebugApi
+
+export type JobsAPI = JobsApi
 
 export interface PresetsAPI {
   list: () => Promise<IpcResult<FilterPreset[]>>

--- a/src/shared/types/jobs.ts
+++ b/src/shared/types/jobs.ts
@@ -1,0 +1,27 @@
+import type { SerializableError } from './errors'
+
+/**
+ * Cross-process job shape. Lives in `src/shared/` so both the main process
+ * (JobRunner) and the renderer (via the `jobs:` IPC contract) can reference it
+ * without the renderer importing from `src/main/…` — the two processes do not
+ * share a runtime, so the type must live on the shared layer.
+ *
+ * `src/main/services/jobs/types.ts` re-exports these names for main-side call
+ * sites that predate this split.
+ */
+
+export type JobKind = 'import_single' | 'import_batch' | 'cohort_rebuild' | 'association' | 'export'
+
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+
+export interface Job<P = unknown> {
+  id: string // ULID, chronologically sortable
+  kind: JobKind
+  status: JobStatus
+  params: P
+  progress: { current: number; total: number; message?: string } | null
+  error: SerializableError | null
+  createdAt: number // epoch ms
+  startedAt: number | null
+  finishedAt: number | null
+}

--- a/tests/main/database/FilterPresetRepository.test.ts
+++ b/tests/main/database/FilterPresetRepository.test.ts
@@ -30,7 +30,7 @@ describe('migration v15 - filter_presets', () => {
 
   it('sets user_version to latest', () => {
     const version = db.pragma('user_version', { simple: true })
-    expect(version).toBe(30)
+    expect(version).toBe(31)
   })
 
   it('creates unique index on name', () => {

--- a/tests/main/database/PanelRepository.test.ts
+++ b/tests/main/database/PanelRepository.test.ts
@@ -54,7 +54,7 @@ describe('PanelRepository', () => {
 
     it('sets user_version to latest', () => {
       const version = db.pragma('user_version', { simple: true })
-      expect(version).toBe(30)
+      expect(version).toBe(31)
     })
   })
 

--- a/tests/main/database/migration-v13.test.ts
+++ b/tests/main/database/migration-v13.test.ts
@@ -67,6 +67,6 @@ describe('Migration v13-v14: cohort summary tables', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const version = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(version.user_version).toBe(30)
+    expect(version.user_version).toBe(31)
   })
 })

--- a/tests/main/database/migration-v8.test.ts
+++ b/tests/main/database/migration-v8.test.ts
@@ -40,6 +40,6 @@ describe('Migration v8: age and date_of_birth', () => {
 
   it('sets schema version to latest after all migrations', () => {
     const result = db.pragma('user_version') as Array<{ user_version: number }>
-    expect(result[0].user_version).toBe(30)
+    expect(result[0].user_version).toBe(31)
   })
 })

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -131,7 +131,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(30)
+      expect(versionResult.user_version).toBe(31)
 
       service.close()
 
@@ -141,7 +141,7 @@ describe('Schema Migrations', () => {
       const versionAfterReopen = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionAfterReopen.user_version).toBe(30)
+      expect(versionAfterReopen.user_version).toBe(31)
 
       service.close()
     })
@@ -468,7 +468,7 @@ describe('Schema Migrations', () => {
       let versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(30)
+      expect(versionResult.user_version).toBe(31)
 
       service.close()
 
@@ -488,7 +488,7 @@ describe('Schema Migrations', () => {
       versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(30)
+      expect(versionResult.user_version).toBe(31)
 
       service.close()
     })
@@ -522,7 +522,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(30)
+      expect(versionResult.user_version).toBe(31)
 
       service.close()
     })
@@ -760,7 +760,7 @@ describe('Schema Migrations', () => {
       const version = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(version.user_version).toBe(30)
+      expect(version.user_version).toBe(31)
 
       service.close()
     })
@@ -801,7 +801,7 @@ describe('Schema Migrations', () => {
 
       // Verify user_version = latest (v15 + v16 + v17 + v18 + … + v28 + v29 all run)
       const version = db.pragma('user_version', { simple: true }) as number
-      expect(version).toBe(30)
+      expect(version).toBe(31)
 
       service.close()
     })
@@ -1257,9 +1257,9 @@ describe('migration v27 — filter_presets.kind + shortlist seeds', () => {
     expect(idx).toBeTruthy()
   })
 
-  it('PRAGMA user_version = 30 after migration', () => {
+  it('PRAGMA user_version = 31 after migration', () => {
     const v = db.pragma('user_version', { simple: true })
-    expect(v).toBe(30)
+    expect(v).toBe(31)
   })
 })
 
@@ -1287,5 +1287,44 @@ describe('migration v28 — variants case/type index', () => {
 
     expect(indexColumns('idx_variants_case_type')).toEqual(['case_id', 'variant_type'])
     expect(indexColumns('idx_variants_type_case')).toEqual(['variant_type', 'case_id'])
+  })
+})
+
+describe('migration v31 — projects registry (D5)', () => {
+  let db: Database.Database
+
+  afterEach(() => {
+    db.close()
+  })
+
+  it('SQLite v31: creates table + seeds default row', () => {
+    db = new Database(':memory:')
+    initializeSchema(db)
+    runMigrations(db)
+
+    const table = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='projects'`)
+      .get()
+    expect(table).toBeTruthy()
+
+    const row = db.prepare(`SELECT id, name, schema_name FROM projects WHERE id = 1`).get() as {
+      id: number
+      name: string
+      schema_name: string
+    }
+    expect(row).toEqual({ id: 1, name: 'default', schema_name: 'main' })
+
+    expect(db.pragma('user_version', { simple: true })).toBe(31)
+  })
+
+  it('SQLite v31: re-running migrations is idempotent (single default row)', () => {
+    db = new Database(':memory:')
+    initializeSchema(db)
+    runMigrations(db)
+    expect(() => runMigrations(db)).not.toThrow()
+
+    const count = db.prepare(`SELECT COUNT(*) AS c FROM projects`).get() as { c: number }
+    expect(count.c).toBe(1)
+    expect(db.pragma('user_version', { simple: true })).toBe(31)
   })
 })

--- a/tests/main/database/vcf-migration.test.ts
+++ b/tests/main/database/vcf-migration.test.ts
@@ -46,14 +46,14 @@ describe('Migration v23: VCF import columns', () => {
   it('sets user_version to latest', () => {
     runMigrations(db)
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(30)
+    expect(result.user_version).toBe(31)
   })
 
   it('is idempotent — running migrations twice does not fail', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(30)
+    expect(result.user_version).toBe(31)
   })
 
   it('new variant columns are nullable and default to NULL', () => {

--- a/tests/main/ipc/handlers/batch-import-logic.test.ts
+++ b/tests/main/ipc/handlers/batch-import-logic.test.ts
@@ -1,0 +1,368 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ImportWorkerCallbacks } from '../../../../src/main/workers/import-worker-client'
+import type { WorkerMessage } from '../../../../src/shared/types/import-worker'
+
+// ---------------------------------------------------------------------------
+// Gate 12 coverage for D3 wire site (iii):
+//   startBatchImport (batch-import-logic) routes the worker run through the
+//   shared module-singleton JobRunner under the `import_batch` kind. These
+//   tests assert the four invariants the wiring must preserve:
+//     (a) return payload (BatchImportResult) unchanged
+//     (b) single-flight conflict message preserved ("A batch import is already
+//         in progress") — surfaced through the existing catch-to-failure path
+//     (c) cancellation routed through workerClient.cancel() (posts
+//         {type:'cancel'} to the worker, NOT terminate())
+//     (d) onProgress mapping + onCohortStale + onComplete emissions unchanged
+//
+// The real ImportWorkerClient spawns a worker thread; it is mocked here so the
+// JobRunner wiring is exercised without touching worker_threads.
+// ---------------------------------------------------------------------------
+
+// A controllable fake ImportWorkerClient. `start` captures the callbacks so the
+// test can drive worker -> main messages; `cancel` is a spy and `isRunning`
+// tracks the worker lifecycle the way the real client does.
+class FakeImportWorkerClient {
+  static instances: FakeImportWorkerClient[] = []
+  captured: ImportWorkerCallbacks | null = null
+  cancel = vi.fn()
+  private running = false
+
+  constructor() {
+    FakeImportWorkerClient.instances.push(this)
+  }
+
+  get isRunning(): boolean {
+    return this.running
+  }
+
+  start(callbacks: ImportWorkerCallbacks): void {
+    this.captured = callbacks
+    this.running = true
+  }
+
+  emit(msg: WorkerMessage): void {
+    if (!this.captured) throw new Error('worker not started')
+    switch (msg.type) {
+      case 'progress':
+        this.captured.onProgress(msg)
+        break
+      case 'file-complete':
+        this.captured.onFileComplete(msg)
+        break
+      case 'complete':
+        this.running = false
+        this.captured.onComplete(msg)
+        break
+      case 'error':
+        this.captured.onError(msg)
+        if (msg.fileIndex === -1) this.running = false
+        break
+    }
+  }
+}
+
+vi.mock('../../../../src/main/workers/import-worker-client', () => ({
+  ImportWorkerClient: FakeImportWorkerClient
+}))
+
+// Imported after the mock is registered.
+let startBatchImport: typeof import('../../../../src/main/ipc/handlers/batch-import-logic').startBatchImport
+let jobRunner: typeof import('../../../../src/main/services/jobs/runner').jobRunner
+
+beforeEach(async () => {
+  FakeImportWorkerClient.instances = []
+  startBatchImport = (await import('../../../../src/main/ipc/handlers/batch-import-logic'))
+    .startBatchImport
+  jobRunner = (await import('../../../../src/main/services/jobs/runner')).jobRunner
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+/**
+ * Minimal DatabaseService stub covering the methods batch-import-logic touches:
+ * checkDuplicates -> cases.getExistingCaseNames, getPath/getEncryptionKey, and
+ * the onComplete frequency-update path (cases.getCaseByName, variants.updateFrequencies).
+ */
+function makeDb(overrides?: { existingNames?: Set<string> }) {
+  return {
+    getPath: () => '/tmp/test.db',
+    getEncryptionKey: () => undefined,
+    cases: {
+      getExistingCaseNames: vi.fn(() => overrides?.existingNames ?? new Set<string>()),
+      getCaseByName: vi.fn((name: string) => ({ id: 1, name }))
+    },
+    variants: {
+      updateFrequencies: vi.fn()
+    }
+  } as never
+}
+
+const COMPLETE_MSG: Extract<WorkerMessage, { type: 'complete' }> = {
+  type: 'complete',
+  results: {
+    succeeded: 2,
+    failed: 0,
+    skipped: 1,
+    cancelled: false,
+    details: [
+      {
+        filePath: '/data/a.json',
+        fileName: 'a.json',
+        caseName: 'a',
+        status: 'success',
+        variantCount: 100
+      },
+      {
+        filePath: '/data/b.json',
+        fileName: 'b.json',
+        caseName: 'b',
+        status: 'success',
+        variantCount: 50
+      }
+    ]
+  }
+}
+
+describe('startBatchImport — Sprint A D3 (iii) / Gate 12', () => {
+  it('(a) return payload: returns the aggregated BatchImportResult unchanged', async () => {
+    const db = makeDb()
+    const promise = startBatchImport(
+      () => db,
+      ['/data/a.json', '/data/b.json'],
+      'skip',
+      undefined,
+      {}
+    )
+    await new Promise((r) => queueMicrotask(r as () => void))
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+
+    const result = await promise
+    expect(result).toEqual({
+      succeeded: 2,
+      failed: 0,
+      skipped: 1,
+      cancelled: false,
+      details: [
+        {
+          filePath: '/data/a.json',
+          fileName: 'a.json',
+          caseName: 'a',
+          status: 'success',
+          variantCount: 100
+        },
+        {
+          filePath: '/data/b.json',
+          fileName: 'b.json',
+          caseName: 'b',
+          status: 'success',
+          variantCount: 50
+        }
+      ]
+    })
+  })
+
+  it('(a) frequency update: updateFrequencies is called per successful imported case', async () => {
+    const db = makeDb()
+    const promise = startBatchImport(
+      () => db,
+      ['/data/a.json', '/data/b.json'],
+      'skip',
+      undefined,
+      {}
+    )
+    await new Promise((r) => queueMicrotask(r as () => void))
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await promise
+
+    expect(db.variants.updateFrequencies).toHaveBeenCalledTimes(2)
+  })
+
+  it('(b) conflict: a second concurrent batch surfaces "A batch import is already in progress"', async () => {
+    const db = makeDb()
+    const first = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    // Second call while the first import_batch job is still running.
+    const conflict = await startBatchImport(() => db, ['/data/c.json'], 'skip', undefined, {})
+
+    // The conflict is surfaced through the existing catch-to-failure path.
+    expect(conflict.failed).toBe(1)
+    expect(conflict.details[0].error).toBe('A batch import is already in progress')
+
+    // Free the slot.
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await first
+  })
+
+  it('(b) single-flight uses the import_batch kind on the shared jobRunner', async () => {
+    const db = makeDb()
+    const first = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const running = jobRunner.list({ kind: 'import_batch', status: 'running' })
+    expect(running.length).toBe(1)
+
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await first
+  })
+
+  it('(c) cancellation: jobRunner.cancel triggers workerClient.cancel()', async () => {
+    const db = makeDb()
+    const promise = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const running = jobRunner.list({ kind: 'import_batch', status: 'running' })
+    expect(running.length).toBe(1)
+    await jobRunner.cancel(running[0].id)
+
+    expect(FakeImportWorkerClient.instances[0].cancel).toHaveBeenCalledTimes(1)
+
+    // Resolve so the slot frees.
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await promise
+  })
+
+  it('(d) onCohortStale: emits is_stale:true at start and is_stale:false on completion', async () => {
+    const db = makeDb()
+    const stale: boolean[] = []
+    const promise = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {
+      onCohortStale: (d) => stale.push(d.is_stale)
+    })
+    await new Promise((r) => queueMicrotask(r as () => void))
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await promise
+
+    expect(stale).toEqual([true, false])
+  })
+
+  it('(d) onProgress mapping: worker progress maps to the renderer progress shape unchanged', async () => {
+    const db = makeDb()
+    const recorded: Array<{ phase: string; count: number; skipped: number }> = []
+    const promise = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {
+      onProgress: (data) => {
+        const d = data as { fileProgress?: { phase: string; count: number; skipped: number } }
+        if (d.fileProgress) {
+          recorded.push({
+            phase: d.fileProgress.phase,
+            count: d.fileProgress.count,
+            skipped: d.fileProgress.skipped
+          })
+        }
+      }
+    })
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const w = FakeImportWorkerClient.instances[0]
+    w.emit({
+      type: 'progress',
+      fileIndex: 0,
+      totalFiles: 1,
+      fileName: 'a.json',
+      overallPercent: 10,
+      phase: 'parsing',
+      variantCount: 0,
+      skipped: 0
+    })
+    w.emit({
+      type: 'progress',
+      fileIndex: 0,
+      totalFiles: 1,
+      fileName: 'a.json',
+      overallPercent: 80,
+      phase: 'inserting',
+      variantCount: 100,
+      skipped: 3
+    })
+    w.emit(COMPLETE_MSG)
+    await promise
+
+    expect(recorded).toEqual([
+      { phase: 'parsing', count: 0, skipped: 0 },
+      { phase: 'inserting', count: 100, skipped: 3 }
+    ])
+  })
+
+  it('(d) onComplete: emits the final batch result to callbacks.onComplete', async () => {
+    const db = makeDb()
+    let completed: unknown = null
+    const promise = startBatchImport(
+      () => db,
+      ['/data/a.json', '/data/b.json'],
+      'skip',
+      undefined,
+      {
+        onComplete: (data) => {
+          completed = data
+        }
+      }
+    )
+    await new Promise((r) => queueMicrotask(r as () => void))
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await promise
+
+    expect(completed).toMatchObject({ succeeded: 2, failed: 0, skipped: 1, cancelled: false })
+  })
+
+  it('(d) fatal worker error: rejection is converted to a failure BatchImportResult', async () => {
+    const db = makeDb()
+    const promise = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    FakeImportWorkerClient.instances[0].emit({
+      type: 'error',
+      fileIndex: -1,
+      error: 'worker boom',
+      phase: 'worker'
+    })
+
+    const result = await promise
+    expect(result.failed).toBe(1)
+    expect(result.details[0].error).toBe('worker boom')
+  })
+
+  it('(a) duplicate strategy: isDuplicate flag is forwarded to the worker files', async () => {
+    const db = makeDb({ existingNames: new Set(['a']) })
+    const promise = startBatchImport(() => db, ['/data/a.json'], 'overwrite', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const w = FakeImportWorkerClient.instances[0]
+    expect(w.captured?.files).toEqual([
+      { filePath: '/data/a.json', caseName: 'a', isDuplicate: true, duplicateStrategy: 'overwrite' }
+    ])
+
+    w.emit(COMPLETE_MSG)
+    await promise
+  })
+
+  it('(a) start message: forwards dbPath and throttleMs to the worker', async () => {
+    const db = makeDb()
+    const promise = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const w = FakeImportWorkerClient.instances[0]
+    expect(w.captured?.dbPath).toBe('/tmp/test.db')
+    expect(typeof w.captured?.throttleMs).toBe('number')
+
+    w.emit(COMPLETE_MSG)
+    await promise
+  })
+
+  it('(b) slot frees after completion: a subsequent batch can start', async () => {
+    const db = makeDb()
+    const first = startBatchImport(() => db, ['/data/a.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+    FakeImportWorkerClient.instances[0].emit(COMPLETE_MSG)
+    await first
+
+    const second = startBatchImport(() => db, ['/data/b.json'], 'skip', undefined, {})
+    await new Promise((r) => queueMicrotask(r as () => void))
+    expect(FakeImportWorkerClient.instances.length).toBe(2)
+
+    FakeImportWorkerClient.instances[1].emit(COMPLETE_MSG)
+    const result = await second
+    expect(result.succeeded).toBe(2)
+  })
+})

--- a/tests/main/ipc/handlers/cohort-logic-job-runner.test.ts
+++ b/tests/main/ipc/handlers/cohort-logic-job-runner.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Gate 12 four-dimension coverage for D3 wire site (iv):
+//   runGeneBurdenCompare is routed through the shared module-singleton
+//   JobRunner (kind 'association'). These tests assert the four invariants the
+//   wiring must preserve:
+//     (a) return payload unchanged (deep-cloned AssociationResults)
+//     (b) single-flight conflict message preserved
+//         ('An association analysis is already running')
+//     (c) cancellation routed through engine.abort() (Pass-9 #9 — NOT
+//         terminate()), via both jobRunner.cancel() and the existing
+//         cohort:cancelAssociation IPC path (cancelGeneBurdenCompare)
+//     (d) onProgress { completed, total } mapping unchanged from pre-PR-4
+//
+// AssociationEngine is mocked so the wiring is exercised without a real DB.
+// Each fake engine's run() returns a deferred the test resolves explicitly,
+// matching the long-running nature of the real engine — this lets the handler
+// occupy the single-flight slot until the test drives completion/cancellation.
+// ---------------------------------------------------------------------------
+
+interface FakeEngine {
+  run: ReturnType<typeof vi.fn>
+  abort: ReturnType<typeof vi.fn>
+  onProgress?: (completed: number, total: number) => void
+  resolveRun: (value: unknown) => void
+  emitProgress: (completed: number, total: number) => void
+}
+
+const engines: FakeEngine[] = []
+
+vi.mock('../../../../src/main/statistics/AssociationEngine', () => ({
+  AssociationEngine: class {
+    abort = vi.fn()
+    onProgress?: (completed: number, total: number) => void
+    resolveRun!: (value: unknown) => void
+    run: ReturnType<typeof vi.fn>
+
+    constructor(_db: unknown, onProgress?: (completed: number, total: number) => void) {
+      this.onProgress = onProgress
+      const deferred = new Promise((resolve) => {
+        this.resolveRun = resolve
+      })
+      this.run = vi.fn(() => deferred)
+      engines.push(this as unknown as FakeEngine)
+    }
+
+    emitProgress(completed: number, total: number): void {
+      this.onProgress?.(completed, total)
+    }
+  }
+}))
+
+import {
+  runGeneBurdenCompare,
+  cancelGeneBurdenCompare
+} from '../../../../src/main/ipc/handlers/cohort-logic'
+import { jobRunner } from '../../../../src/main/services/jobs/runner'
+import type { AssociationConfig } from '../../../../src/main/statistics/types'
+
+const BASE_CONFIG = {
+  groupA_ids: [1, 2],
+  groupB_ids: [3, 4],
+  primary_test: 'fisher',
+  weight_scheme: 'uniform',
+  filters: {},
+  covariates: []
+} as unknown as AssociationConfig
+
+// getDb returns the minimal { database } surface the engine constructor reads.
+const getDb = () => ({ database: {} }) as never
+const getDbPool = () => null
+
+const RESULTS = {
+  results: [{ gene: 'BRCA1', p_value: 0.01 }],
+  primary_test: 'fisher',
+  config: BASE_CONFIG,
+  warnings: [],
+  elapsed_ms: 12
+}
+
+// Yield long enough for enqueue → handler kickoff → engine construction.
+async function flush(): Promise<void> {
+  await new Promise((r) => queueMicrotask(r as () => void))
+}
+
+afterEach(() => {
+  engines.length = 0
+  vi.clearAllMocks()
+})
+
+describe('runGeneBurdenCompare — Sprint A D3 (iv) / Gate 12', () => {
+  it('(a) return payload: returns the deep-cloned AssociationResults unchanged', async () => {
+    const promise = runGeneBurdenCompare(BASE_CONFIG, getDb, getDbPool)
+    await flush()
+
+    expect(engines.length).toBe(1)
+    engines[0].resolveRun(RESULTS)
+
+    const returned = await promise
+    expect(returned).toEqual(RESULTS)
+    // Deep clone — not the same reference.
+    expect(returned).not.toBe(RESULTS)
+  })
+
+  it('(b) conflict: a second concurrent call rejects with the preserved message', async () => {
+    const first = runGeneBurdenCompare(BASE_CONFIG, getDb, getDbPool)
+    await flush()
+
+    await expect(runGeneBurdenCompare(BASE_CONFIG, getDb, getDbPool)).rejects.toThrow(
+      'An association analysis is already running'
+    )
+
+    // Unblock the first run so the 'association' slot frees for later tests.
+    engines[0].resolveRun(RESULTS)
+    await first
+  })
+
+  it('(b) validation: overlapping groups reject before occupying the single-flight slot', async () => {
+    const overlapping = {
+      ...BASE_CONFIG,
+      groupA_ids: [1, 2],
+      groupB_ids: [2, 3]
+    } as unknown as AssociationConfig
+
+    await expect(runGeneBurdenCompare(overlapping, getDb, getDbPool)).rejects.toThrow(
+      'Groups overlap: case IDs 2 appear in both groups'
+    )
+    // No engine constructed, no slot occupied — a subsequent valid run starts.
+    expect(engines.length).toBe(0)
+    expect(jobRunner.list({ kind: 'association', status: 'running' }).length).toBe(0)
+  })
+
+  it('(c) cancellation: jobRunner.cancel triggers engine.abort() (NOT terminate)', async () => {
+    const promise = runGeneBurdenCompare(BASE_CONFIG, getDb, getDbPool)
+    await flush()
+
+    const running = jobRunner.list({ kind: 'association', status: 'running' })
+    expect(running.length).toBe(1)
+    await jobRunner.cancel(running[0].id)
+
+    expect(engines[0].abort).toHaveBeenCalledTimes(1)
+
+    // Settle the run so the slot frees.
+    engines[0].resolveRun(RESULTS)
+    await promise
+  })
+
+  it('(c) cancellation: cohort:cancelAssociation path still calls activeEngine.abort()', async () => {
+    const promise = runGeneBurdenCompare(BASE_CONFIG, getDb, getDbPool)
+    await flush()
+
+    // The existing IPC channel path — unchanged by PR-4.
+    cancelGeneBurdenCompare()
+    expect(engines[0].abort).toHaveBeenCalledTimes(1)
+
+    engines[0].resolveRun(RESULTS)
+    await promise
+  })
+
+  it('(d) progress mapping: onProgress { completed, total } is unchanged from pre-PR-4', async () => {
+    const recorded: Array<{ completed: number; total: number }> = []
+    const promise = runGeneBurdenCompare(BASE_CONFIG, getDb, getDbPool, (data) => {
+      recorded.push(data)
+    })
+    await flush()
+
+    // The engine reports progress via the constructor-supplied callback.
+    engines[0].emitProgress(1, 3)
+    engines[0].emitProgress(3, 3)
+    engines[0].resolveRun(RESULTS)
+    await promise
+
+    expect(recorded).toEqual([
+      { completed: 1, total: 3 },
+      { completed: 3, total: 3 }
+    ])
+  })
+})

--- a/tests/main/services/jobs/job-runner.test.ts
+++ b/tests/main/services/jobs/job-runner.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { JobRunner } from '../../../../src/main/services/jobs/JobRunner'
+
+describe('JobRunner — Sprint A D2', () => {
+  it('enqueue returns SYNCHRONOUSLY with id + kind + result (Pass-9 #9)', () => {
+    const runner = new JobRunner()
+    const handle = runner.enqueue('import_single', {}, async () => 42)
+    // No `await` — handle is already there.
+    expect(typeof handle.id).toBe('string')
+    expect(handle.kind).toBe('import_single')
+    expect(handle.result).toBeInstanceOf(Promise)
+  })
+
+  it('handle.result resolves to the handler return value', async () => {
+    const runner = new JobRunner()
+    const handle = runner.enqueue('import_single', { x: 1 }, async (_ctx, p: { x: number }) => ({
+      doubled: p.x * 2
+    }))
+    const r = await handle.result
+    expect(r).toEqual({ doubled: 2 })
+  })
+
+  it('per-kind single-flight gate preserves the three existing error messages (Pass-7 HIGH #2)', () => {
+    const runner = new JobRunner()
+    // First enqueue ok
+    runner.enqueue('import_single', {}, async () => new Promise(() => {})) // pending forever
+    // Second enqueue rejects with the preserved message
+    expect(() => runner.enqueue('import_single', {}, async () => 0)).toThrow(
+      'An import is already in progress'
+    )
+  })
+
+  it('cancel(jobId) aborts the signal AND invokes registered cancel callbacks (Pass-8 #9)', async () => {
+    const runner = new JobRunner()
+    const cancelFn = vi.fn()
+    const handle = runner.enqueue('import_single', {}, async (ctx) => {
+      ctx.registerCancel(cancelFn)
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return ctx.signal.aborted ? 'cancelled' : 'completed'
+    })
+    runner.cancel(handle.id)
+    const r = await handle.result
+    expect(r).toBe('cancelled')
+    expect(cancelFn).toHaveBeenCalled()
+  })
+
+  it('onLifecycle fires for queued → running → completed', async () => {
+    const runner = new JobRunner()
+    const events: string[] = []
+    runner.onLifecycle((j) => events.push(j.status))
+    const handle = runner.enqueue('export', {}, async () => 'ok')
+    await handle.result
+    expect(events).toEqual(['queued', 'running', 'completed'])
+  })
+})

--- a/tests/main/storage/postgres-import-executor-job-runner.test.ts
+++ b/tests/main/storage/postgres-import-executor-job-runner.test.ts
@@ -193,3 +193,451 @@ describe('PostgresImportExecutor.importSingleFile — Sprint A D3 (i) / Gate 12'
     ])
   })
 })
+
+// ---------------------------------------------------------------------------
+// Gate 12 four-dimension coverage for D3 wire site (ii):
+//   PostgresImportExecutor.importMultiFile is routed through the SAME
+//   module-singleton JobRunner kind ('import_single') as importSingleFile
+//   (Pass-9 #9 — the pre-PR-4 `inProgress` flag gated BOTH paths). These tests
+//   assert the four invariants the wiring must preserve:
+//     (a) return payload (StorageImportMultiFileResult) unchanged
+//     (b) single-flight conflict message preserved — including the cross-path
+//         case where a single-file import blocks a multi-file import (and vice
+//         versa) because both share the 'import_single' kind
+//     (c) cancellation routed through worker client.cancel() (posts
+//         {type:'cancel'}, NOT terminate())
+//     (d) import:progress phase/count/skipped + onFileComplete mapping unchanged
+// ---------------------------------------------------------------------------
+
+const MULTI_FILES = [
+  { filePath: '/tmp/a.vcf', variantType: 'small', caller: null, annotationFormat: null }
+]
+
+describe('PostgresImportExecutor.importMultiFile — Sprint A D3 (ii) / Gate 12', () => {
+  it('(a) return payload: returns StorageImportMultiFileResult unchanged', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: {
+                caseId: 7,
+                variantCount: 500,
+                files: [{ filePath: '/tmp/a.vcf', variantType: 'small', variantCount: 500 }],
+                skipped: 3,
+                errors: ['warnM'],
+                elapsed: 99
+              }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const result = await executor.importMultiFile({
+      caseName: 'MultiA',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    expect(result).toEqual({
+      caseId: 7,
+      variantCount: 500,
+      files: [{ filePath: '/tmp/a.vcf', variantType: 'small', variantCount: 500 }],
+      skipped: 3,
+      errors: ['warnM'],
+      elapsed: 99
+    })
+  })
+
+  it('(a) return payload: missing worker files coerce to empty array', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: { caseId: 8, variantCount: 0, skipped: 0, errors: [], elapsed: 1 }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const result = await executor.importMultiFile({
+      caseName: 'MultiEmpty',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    expect(result.files).toEqual([])
+  })
+
+  it('(b) conflict: second concurrent multi-file call rejects with "An import is already in progress"', async () => {
+    let capturedCallbacks!: PostgresImportWorkerCallbacks
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          capturedCallbacks = callbacks
+          // Do not complete — keep the import_single slot occupied.
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+
+    const first = executor.importMultiFile({
+      caseName: 'M1',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    await expect(
+      executor.importMultiFile({ caseName: 'M2', files: MULTI_FILES, throttleMs: 0 })
+    ).rejects.toThrow('An import is already in progress')
+
+    capturedCallbacks.onComplete({
+      type: 'complete',
+      mode: 'multi-file',
+      result: { caseId: 1, variantCount: 1, files: [], skipped: 0, errors: [], elapsed: 1 }
+    })
+    const result = await first
+    expect(result.errors).toEqual([])
+  })
+
+  it('(b) conflict cross-path: an in-flight single-file import blocks importMultiFile (shared import_single kind)', async () => {
+    let capturedCallbacks!: PostgresImportWorkerCallbacks
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          capturedCallbacks = callbacks
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+
+    const single = executor.importSingleFile({
+      filePath: '/tmp/single.json',
+      caseName: 'S1',
+      throttleMs: 0
+    })
+
+    await expect(
+      executor.importMultiFile({ caseName: 'MX', files: MULTI_FILES, throttleMs: 0 })
+    ).rejects.toThrow('An import is already in progress')
+
+    capturedCallbacks.onComplete({
+      type: 'complete',
+      mode: 'single-file',
+      result: { caseId: 1, variantCount: 1, skipped: 0, errors: [], elapsed: 1 }
+    })
+    await single
+  })
+
+  it('(b) conflict cross-path: an in-flight multi-file import blocks importSingleFile (shared import_single kind)', async () => {
+    let capturedCallbacks!: PostgresImportWorkerCallbacks
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          capturedCallbacks = callbacks
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+
+    const multi = executor.importMultiFile({
+      caseName: 'MB',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    await expect(
+      executor.importSingleFile({ filePath: '/tmp/blocked.json', caseName: 'SB', throttleMs: 0 })
+    ).rejects.toThrow('An import is already in progress')
+
+    capturedCallbacks.onComplete({
+      type: 'complete',
+      mode: 'multi-file',
+      result: { caseId: 1, variantCount: 1, files: [], skipped: 0, errors: [], elapsed: 1 }
+    })
+    await multi
+  })
+
+  it('(c) cancellation: jobRunner.cancel triggers worker client.cancel() (posts {type:"cancel"})', async () => {
+    let capturedCallbacks!: PostgresImportWorkerCallbacks
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          capturedCallbacks = callbacks
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+
+    const importPromise = executor.importMultiFile({
+      caseName: 'MZ',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const running = jobRunner.list({ kind: 'import_single', status: 'running' })
+    expect(running.length).toBe(1)
+    await jobRunner.cancel(running[0].id)
+
+    expect(fakeClient.cancel).toHaveBeenCalledTimes(1)
+
+    capturedCallbacks.onComplete({
+      type: 'complete',
+      mode: 'multi-file',
+      result: {
+        caseId: 0,
+        variantCount: 0,
+        files: [],
+        skipped: 0,
+        errors: ['Import cancelled by user'],
+        elapsed: 0
+      }
+    })
+    await importPromise
+  })
+
+  it('(d) progress mapping: phase/count/skipped emissions are unchanged from pre-PR-4', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onProgress({ type: 'progress', phase: 'parsing', rowsProcessed: 0 })
+            callbacks.onProgress({ type: 'progress', phase: 'inserting', rowsProcessed: 250 })
+            callbacks.onProgress({ type: 'progress', phase: 'inserting', rowsProcessed: 500 })
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: {
+                caseId: 1,
+                variantCount: 500,
+                files: [],
+                skipped: 0,
+                errors: [],
+                elapsed: 10
+              }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const recorded: Array<{ phase: string; count: number; skipped: number }> = []
+    await executor.importMultiFile({
+      caseName: 'MP',
+      files: MULTI_FILES,
+      throttleMs: 0,
+      onProgress: (data) => {
+        recorded.push({ phase: data.phase, count: data.count, skipped: data.skipped })
+      }
+    })
+
+    expect(recorded).toEqual([
+      { phase: 'parsing', count: 0, skipped: 0 },
+      { phase: 'inserting', count: 250, skipped: 0 },
+      { phase: 'inserting', count: 500, skipped: 0 }
+    ])
+  })
+
+  it('(d) onFileComplete mapping: per-file completion events forwarded unchanged', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onFileComplete({
+              type: 'file-complete',
+              filePath: '/tmp/a.vcf',
+              caseId: 11,
+              variantCount: 120
+            })
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: {
+                caseId: 11,
+                variantCount: 120,
+                files: [{ filePath: '/tmp/a.vcf', variantType: 'small', variantCount: 120 }],
+                skipped: 0,
+                errors: [],
+                elapsed: 5
+              }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const files: Array<{ filePath: string; caseId: number; variantCount: number }> = []
+    await executor.importMultiFile({
+      caseName: 'MFC',
+      files: MULTI_FILES,
+      throttleMs: 0,
+      onFileComplete: (event) => {
+        files.push({
+          filePath: event.filePath,
+          caseId: event.caseId,
+          variantCount: event.variantCount
+        })
+      }
+    })
+
+    expect(files).toEqual([{ filePath: '/tmp/a.vcf', caseId: 11, variantCount: 120 }])
+  })
+
+  it('(d) error propagation: worker onError rejects with the worker message', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onError({ type: 'error', message: 'multi import boom' })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    await expect(
+      executor.importMultiFile({ caseName: 'ME', files: MULTI_FILES, throttleMs: 0 })
+    ).rejects.toThrow('multi import boom')
+  })
+
+  it('(d) start message: forwards multi-file mode, files and filters to the worker', async () => {
+    let captured!: PostgresImportWorkerStartMessage
+    const fakeClient = {
+      start: vi.fn(
+        (msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          captured = msg
+          queueMicrotask(() => {
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: { caseId: 1, variantCount: 0, files: [], skipped: 0, errors: [], elapsed: 1 }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    await executor.importMultiFile({
+      caseName: 'MStart',
+      files: MULTI_FILES,
+      throttleMs: 0,
+      filters: {
+        bedFilePath: '/tmp/regions.bed',
+        bedPadding: 10,
+        passOnly: true,
+        minQual: 20,
+        minGq: 30,
+        minDp: 8
+      }
+    })
+
+    expect(captured.mode).toBe('multi-file')
+    expect(captured.caseName).toBe('MStart')
+    expect(captured.files).toEqual(MULTI_FILES)
+    expect(captured.filters).toEqual({
+      bedFilePath: '/tmp/regions.bed',
+      bedPadding: 10,
+      passOnly: true,
+      minQual: 20,
+      minGq: 30,
+      minDp: 8
+    })
+  })
+
+  it('(d) start message: omits filters when none provided', async () => {
+    let captured!: PostgresImportWorkerStartMessage
+    const fakeClient = {
+      start: vi.fn(
+        (msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          captured = msg
+          queueMicrotask(() => {
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: { caseId: 1, variantCount: 0, files: [], skipped: 0, errors: [], elapsed: 1 }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    await executor.importMultiFile({
+      caseName: 'MNoFilter',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    expect(captured.filters).toBeUndefined()
+  })
+
+  it('(a) return payload: top-level worker errors surface in StorageImportMultiFileResult.errors', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'multi-file',
+              result: {
+                caseId: 0,
+                variantCount: 0,
+                files: [
+                  {
+                    filePath: '/tmp/a.vcf',
+                    variantType: 'small',
+                    variantCount: 0,
+                    error: 'bad row'
+                  }
+                ],
+                skipped: 0,
+                errors: ['session failed'],
+                elapsed: 2
+              }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const result = await executor.importMultiFile({
+      caseName: 'MErr',
+      files: MULTI_FILES,
+      throttleMs: 0
+    })
+
+    expect(result.errors).toEqual(['session failed'])
+    expect(result.files[0].error).toBe('bad row')
+  })
+})

--- a/tests/main/storage/postgres-import-executor-job-runner.test.ts
+++ b/tests/main/storage/postgres-import-executor-job-runner.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PostgresImportExecutor } from '../../../src/main/storage/postgres/PostgresImportExecutor'
+import { jobRunner } from '../../../src/main/services/jobs/runner'
+import type { PostgresImportWorkerCallbacks } from '../../../src/main/storage/postgres/PostgresImportWorkerClient'
+import type {
+  PostgresImportWorkerStartMessage,
+  PostgresClientConfig
+} from '../../../src/shared/types/postgres-import-worker'
+
+// ---------------------------------------------------------------------------
+// Gate 12 four-dimension coverage for D3 wire site (i):
+//   PostgresImportExecutor.importSingleFile is routed through the shared
+//   module-singleton JobRunner (`import_single` kind). These tests assert the
+//   four invariants the wiring must preserve:
+//     (a) return payload unchanged
+//     (b) single-flight conflict message preserved
+//     (c) cancellation routed through worker.postMessage({type:'cancel'})
+//     (d) import:progress phase/count/skipped mapping is unchanged
+//
+// Note on (d): PR4-3 does not touch runWorker's progress-mapping path, so the
+// phase/count/skipped fields are demonstrably identical to pre-PR-4. The
+// expectation below is therefore an equivalent inline assertion of that
+// mapping rather than a byte-for-byte diff against a captured main-branch
+// fixture. The wall-clock `elapsed` field is non-deterministic and excluded.
+// ---------------------------------------------------------------------------
+
+const TEST_CLIENT_CONFIG: PostgresClientConfig = {
+  connectionString: 'postgres://test:secret@localhost:5432/testdb',
+  application_name: 'varlens-test',
+  ssl: { mode: 'disable' }
+}
+
+function makeExecutor(fakeClient: { start: unknown; cancel: unknown }) {
+  return new PostgresImportExecutor({
+    schema: 'public',
+    clientConfig: TEST_CLIENT_CONFIG,
+    workerClientFactory: () => fakeClient as never
+  })
+}
+
+describe('PostgresImportExecutor.importSingleFile — Sprint A D3 (i) / Gate 12', () => {
+  it('(a) return payload: returns StorageImportSingleFileResult unchanged', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'single-file',
+              result: { caseId: 42, variantCount: 300, skipped: 2, errors: ['warn1'], elapsed: 88 }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const result = await executor.importSingleFile({
+      filePath: '/tmp/a.json',
+      caseName: 'CaseA',
+      throttleMs: 0
+    })
+
+    // Exact shape + values are preserved through the JobRunner wiring.
+    expect(result).toEqual({
+      caseId: 42,
+      variantCount: 300,
+      skipped: 2,
+      errors: ['warn1'],
+      elapsed: 88
+    })
+  })
+
+  it('(b) conflict: second concurrent call rejects with "An import is already in progress"', async () => {
+    let capturedCallbacks!: PostgresImportWorkerCallbacks
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          capturedCallbacks = callbacks
+          // Do not complete — keep the import_single slot occupied.
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+
+    const first = executor.importSingleFile({
+      filePath: '/tmp/one.json',
+      caseName: 'C1',
+      throttleMs: 0
+    })
+
+    await expect(
+      executor.importSingleFile({ filePath: '/tmp/two.json', caseName: 'C2', throttleMs: 0 })
+    ).rejects.toThrow('An import is already in progress')
+
+    // Unblock the first import so the import_single slot frees for later tests.
+    capturedCallbacks.onComplete({
+      type: 'complete',
+      mode: 'single-file',
+      result: { caseId: 1, variantCount: 1, skipped: 0, errors: [], elapsed: 1 }
+    })
+    const result = await first
+    expect(result.errors).toEqual([])
+  })
+
+  it('(c) cancellation: jobRunner.cancel triggers worker.postMessage({type:"cancel"}) via client.cancel', async () => {
+    let capturedCallbacks!: PostgresImportWorkerCallbacks
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          capturedCallbacks = callbacks
+          // Do not complete — let the test drive cancellation.
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+
+    const importPromise = executor.importSingleFile({
+      filePath: '/tmp/z.json',
+      caseName: 'CZ',
+      throttleMs: 0
+    })
+
+    // Let enqueue + start run.
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    // Locate the in-flight import_single job and cancel it through the runner.
+    const running = jobRunner.list({ kind: 'import_single', status: 'running' })
+    expect(running.length).toBe(1)
+    await jobRunner.cancel(running[0].id)
+
+    // The registered cancel callback routes to client.cancel(), which posts
+    // { type: 'cancel' } to the worker (NOT terminate()).
+    expect(fakeClient.cancel).toHaveBeenCalledTimes(1)
+
+    // Resolve so the promise settles and the slot frees.
+    capturedCallbacks.onComplete({
+      type: 'complete',
+      mode: 'single-file',
+      result: {
+        caseId: 0,
+        variantCount: 0,
+        skipped: 0,
+        errors: ['Import cancelled by user'],
+        elapsed: 0
+      }
+    })
+    await importPromise
+  })
+
+  it('(d) progress mapping: phase/count/skipped emissions are unchanged from pre-PR-4', async () => {
+    const fakeClient = {
+      start: vi.fn(
+        (_msg: PostgresImportWorkerStartMessage, callbacks: PostgresImportWorkerCallbacks) => {
+          queueMicrotask(() => {
+            callbacks.onProgress({ type: 'progress', phase: 'parsing', rowsProcessed: 0 })
+            callbacks.onProgress({ type: 'progress', phase: 'inserting', rowsProcessed: 50 })
+            callbacks.onProgress({ type: 'progress', phase: 'inserting', rowsProcessed: 100 })
+            callbacks.onComplete({
+              type: 'complete',
+              mode: 'single-file',
+              result: { caseId: 1, variantCount: 100, skipped: 0, errors: [], elapsed: 10 }
+            })
+          })
+        }
+      ),
+      cancel: vi.fn()
+    }
+
+    const executor = makeExecutor(fakeClient)
+    const recorded: Array<{ phase: string; count: number; skipped: number }> = []
+    await executor.importSingleFile({
+      filePath: '/tmp/p.json',
+      caseName: 'CP',
+      throttleMs: 0,
+      onProgress: (data) => {
+        recorded.push({ phase: data.phase, count: data.count, skipped: data.skipped })
+      }
+    })
+
+    // runWorker maps phase + count + skipped identically to pre-PR-4 (the
+    // mapping path is untouched by PR4-3); elapsed is wall-clock and excluded.
+    expect(recorded).toEqual([
+      { phase: 'parsing', count: 0, skipped: 0 },
+      { phase: 'inserting', count: 50, skipped: 0 },
+      { phase: 'inserting', count: 100, skipped: 0 }
+    ])
+  })
+})

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -4,7 +4,7 @@ import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migratio
 
 describe('Postgres migration definitions', () => {
   it('loads the PostgreSQL migrations with SQL and sha256 checksums', () => {
-    expect(POSTGRES_MIGRATIONS).toHaveLength(10)
+    expect(POSTGRES_MIGRATIONS).toHaveLength(11)
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.version)).toEqual([
       '0001',
       '0002',
@@ -15,7 +15,8 @@ describe('Postgres migration definitions', () => {
       '0007',
       '0008',
       '0009',
-      '0010'
+      '0010',
+      '0011'
     ])
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.name)).toEqual([
       'create_cases',
@@ -27,7 +28,8 @@ describe('Postgres migration definitions', () => {
       'perf_indexes',
       'create_users_and_settings',
       'idx_variants_coords',
-      'cohort_summary'
+      'cohort_summary',
+      'projects_registry'
     ])
 
     for (const migration of POSTGRES_MIGRATIONS) {

--- a/tests/main/storage/postgres-projects-registry-migration.test.ts
+++ b/tests/main/storage/postgres-projects-registry-migration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Sprint A PR-4 D5 — projects registry migration (0011) against a real Postgres.
+ *
+ * Verifies the projects table is created, the default row is seeded with the
+ * actual (template-replaced) schema name, and that re-applying the migration is
+ * idempotent (single default row). Mirrors SQLite v31.
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires `make pg-up`.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+describe.skipIf(!RUN)('projects registry migration — Sprint A D5', () => {
+  let schema: string
+  let pool: Pool
+  let probe: Client
+
+  beforeEach(async () => {
+    schema = `varlens_test_proj_${Date.now()}_${randomBytes(4).toString('hex')}`
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+  }, 60_000)
+
+  afterEach(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  it('creates the projects table + seeds the default row with the actual schema name', async () => {
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    const tablesRes = await probe.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = $1`,
+      [schema]
+    )
+    expect(tablesRes.rows.map((r) => r.table_name)).toContain('projects')
+
+    const row = await probe.query<{ id: number; name: string; schema_name: string }>(
+      `SELECT id, name, schema_name FROM "${schema}".projects WHERE id = 1`
+    )
+    expect(row.rows).toHaveLength(1)
+    expect(row.rows[0].id).toBe(1)
+    expect(row.rows[0].name).toBe('default')
+    // schema_name is template-replaced to the real schema, not the literal token.
+    expect(row.rows[0].schema_name).toBe(schema)
+  }, 60_000)
+
+  it('re-applying the migration is idempotent (single default row)', async () => {
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+    // A second migrate() is a no-op for already-applied versions.
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+
+    const count = await probe.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "${schema}".projects`
+    )
+    expect(count.rows[0].count).toBe('1')
+  }, 60_000)
+})
+
+describe.skipIf(RUN)('projects registry migration — Sprint A D5 (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(RUN).toBe(false)
+  })
+})

--- a/tests/main/storage/sqlite-import-executor-job-runner.test.ts
+++ b/tests/main/storage/sqlite-import-executor-job-runner.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SqliteImportExecutor } from '../../../src/main/storage/sqlite/SqliteImportExecutor'
+import { jobRunner } from '../../../src/main/services/jobs/runner'
+
+// ---------------------------------------------------------------------------
+// Gate 12 four-dimension coverage for D3 wire site (v):
+//   SqliteImportExecutor.importSingleFile is routed through the shared
+//   module-singleton JobRunner (`import_single` kind), mirroring site (i)
+//   (the PostgresImportExecutor single-file path). These tests assert the
+//   four invariants the wiring must preserve:
+//     (a) return payload unchanged (StorageImportSingleFileResult)
+//     (b) single-flight conflict message preserved ('An import is already in
+//         progress')
+//     (c) cancellation routed through the SQLite worker's postMessage channel
+//         via worker.cancel() (posts { type: 'cancel' }, NOT terminate())
+//     (d) import:progress phase/count/skipped mapping is unchanged
+//
+// Note on (d): PR4-7 does not touch the worker callback progress-mapping path,
+// so phase/count/skipped fields are demonstrably identical to pre-PR-4. The
+// wall-clock `elapsed` field is non-deterministic and excluded.
+// ---------------------------------------------------------------------------
+
+function makeDb() {
+  return {
+    getPath: () => '/tmp/test.varlens',
+    getEncryptionKey: () => undefined,
+    variants: { updateFrequencies: vi.fn() }
+  } as never
+}
+
+describe('SqliteImportExecutor.importSingleFile — Sprint A D3 (v) / Gate 12', () => {
+  it('(a) return payload: returns StorageImportSingleFileResult unchanged', async () => {
+    const start = vi.fn()
+    const worker = {
+      get isRunning() {
+        return false
+      },
+      start,
+      cancel: vi.fn()
+    }
+    const executor = new SqliteImportExecutor({
+      getDatabaseService: makeDb,
+      createWorkerClient: () => worker as never
+    })
+
+    const promise = executor.importSingleFile({
+      filePath: '/tmp/input.json',
+      caseName: 'Imported',
+      throttleMs: 0
+    })
+
+    // Let enqueue + start run.
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onFileComplete({
+      type: 'file-complete',
+      fileIndex: 0,
+      result: { caseId: 42, caseName: 'Imported', variantCount: 300, skipped: 0, elapsed: 88 }
+    })
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/input.json',
+            fileName: 'input.json',
+            caseName: 'Imported',
+            status: 'success',
+            variantCount: 300
+          }
+        ]
+      }
+    })
+
+    await expect(promise).resolves.toStrictEqual({
+      caseId: 42,
+      variantCount: 300,
+      skipped: 0,
+      errors: [],
+      elapsed: 88
+    })
+  })
+
+  it('(b) conflict: second concurrent call rejects with "An import is already in progress"', async () => {
+    let running = false
+    const start = vi.fn(() => {
+      running = true
+    })
+    const worker = {
+      get isRunning() {
+        return running
+      },
+      start,
+      cancel: vi.fn()
+    }
+    const executor = new SqliteImportExecutor({
+      getDatabaseService: makeDb,
+      createWorkerClient: () => worker as never
+    })
+
+    const first = executor.importSingleFile({
+      filePath: '/tmp/one.json',
+      caseName: 'C1',
+      throttleMs: 0
+    })
+
+    await expect(
+      executor.importSingleFile({ filePath: '/tmp/two.json', caseName: 'C2', throttleMs: 0 })
+    ).rejects.toThrow('An import is already in progress')
+
+    // Unblock the first import so the import_single slot frees for later tests.
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/one.json',
+            fileName: 'one.json',
+            caseName: 'C1',
+            status: 'success',
+            variantCount: 1
+          }
+        ]
+      }
+    })
+    const result = await first
+    expect(result.errors).toEqual([])
+  })
+
+  it('(c) cancellation: jobRunner.cancel triggers the SQLite worker.cancel() (posts {type:"cancel"})', async () => {
+    let running = false
+    const start = vi.fn(() => {
+      running = true
+    })
+    const cancel = vi.fn()
+    const worker = {
+      get isRunning() {
+        return running
+      },
+      start,
+      cancel
+    }
+    const executor = new SqliteImportExecutor({
+      getDatabaseService: makeDb,
+      createWorkerClient: () => worker as never
+    })
+
+    const importPromise = executor.importSingleFile({
+      filePath: '/tmp/z.json',
+      caseName: 'CZ',
+      throttleMs: 0
+    })
+
+    // Let enqueue + start run.
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    // Locate the in-flight import_single job and cancel it through the runner.
+    const inFlight = jobRunner.list({ kind: 'import_single', status: 'running' })
+    expect(inFlight.length).toBe(1)
+    await jobRunner.cancel(inFlight[0].id)
+
+    // The registered cancel callback routes to worker.cancel(), which posts
+    // { type: 'cancel' } to the worker (NOT terminate()).
+    expect(cancel).toHaveBeenCalledTimes(1)
+
+    // Resolve so the promise settles and the slot frees.
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 0,
+        failed: 0,
+        skipped: 0,
+        cancelled: true,
+        details: []
+      }
+    })
+    await importPromise
+  })
+
+  it('(d) progress mapping: phase/count/skipped emissions are unchanged from pre-PR-4', async () => {
+    const start = vi.fn()
+    const worker = {
+      get isRunning() {
+        return false
+      },
+      start,
+      cancel: vi.fn()
+    }
+    const executor = new SqliteImportExecutor({
+      getDatabaseService: makeDb,
+      createWorkerClient: () => worker as never
+    })
+
+    const recorded: Array<{ phase: string; count: number; skipped: number }> = []
+    const promise = executor.importSingleFile({
+      filePath: '/tmp/p.json',
+      caseName: 'CP',
+      throttleMs: 0,
+      onProgress: (data) => {
+        recorded.push({ phase: data.phase, count: data.count, skipped: data.skipped })
+      }
+    })
+
+    // Let enqueue + start run.
+    await new Promise((r) => queueMicrotask(r as () => void))
+
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onProgress({ type: 'progress', fileIndex: 0, phase: 'parsing', variantCount: 0 })
+    callbacks.onProgress({ type: 'progress', fileIndex: 0, phase: 'inserting', variantCount: 50 })
+    callbacks.onProgress({
+      type: 'progress',
+      fileIndex: 0,
+      phase: 'finalizing',
+      variantCount: 100,
+      skipped: 2
+    })
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/p.json',
+            fileName: 'p.json',
+            caseName: 'CP',
+            status: 'success',
+            variantCount: 100
+          }
+        ]
+      }
+    })
+    await promise
+
+    // The worker-callback progress mapping is untouched by PR4-7: 'finalizing'
+    // maps to 'inserting'; the trailing onProgress fired in onComplete reflects
+    // the success branch. elapsed is wall-clock and excluded.
+    expect(recorded).toEqual([
+      { phase: 'parsing', count: 0, skipped: undefined },
+      { phase: 'inserting', count: 50, skipped: undefined },
+      { phase: 'inserting', count: 100, skipped: 2 },
+      { phase: 'inserting', count: 100, skipped: 0 }
+    ])
+  })
+})

--- a/tests/main/storage/sqlite-import-executor.test.ts
+++ b/tests/main/storage/sqlite-import-executor.test.ts
@@ -182,7 +182,7 @@ describe('SqliteImportExecutor', () => {
       createWorkerClient: () => worker as never
     })
 
-    void executor.importSingleFile({
+    const first = executor.importSingleFile({
       filePath: '/tmp/input.json',
       caseName: 'Imported',
       throttleMs: 100
@@ -195,6 +195,31 @@ describe('SqliteImportExecutor', () => {
         throttleMs: 100
       })
     ).rejects.toThrow('An import is already in progress')
+
+    // Single-file imports now share the process-wide JobRunner `import_single`
+    // slot, so the first (still-running) import must be settled before the test
+    // ends — otherwise its slot leaks into later tests in this file.
+    running = false
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/input.json',
+            fileName: 'input.json',
+            caseName: 'Imported',
+            status: 'success',
+            variantCount: 1
+          }
+        ]
+      }
+    })
+    await first
   })
 
   it('translates vcfOptions.selectedSample into vcfSelectedSamples and maps finalizing progress to inserting', async () => {
@@ -217,7 +242,7 @@ describe('SqliteImportExecutor', () => {
     })
 
     const onProgress = vi.fn()
-    void executor.importSingleFile({
+    const promise = executor.importSingleFile({
       filePath: '/tmp/input.vcf',
       caseName: 'Imported',
       vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' },
@@ -254,6 +279,28 @@ describe('SqliteImportExecutor', () => {
       elapsed: 0,
       skipped: 1
     })
+
+    // Settle the import so the shared JobRunner `import_single` slot is freed
+    // for later tests in this file.
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/input.vcf',
+            fileName: 'input.vcf',
+            caseName: 'Imported',
+            status: 'success',
+            variantCount: 10
+          }
+        ]
+      }
+    })
+    await promise
   })
 
   it('clears the worker reference if worker.start() throws synchronously so later imports are not blocked', async () => {
@@ -297,12 +344,38 @@ describe('SqliteImportExecutor', () => {
     expect(cancel).not.toHaveBeenCalled()
 
     // Second attempt reaches start() again rather than being blocked.
-    void executor.importSingleFile({
+    const second = executor.importSingleFile({
       filePath: '/tmp/input2.json',
       caseName: 'Second',
       throttleMs: 100
     })
+    // start() runs synchronously inside the JobRunner handler, so the second
+    // call's start invocation is observable before awaiting.
+    await new Promise((r) => queueMicrotask(r as () => void))
     expect(start).toHaveBeenCalledTimes(2)
+
+    // Settle the second import so the shared JobRunner `import_single` slot is
+    // freed for later tests in this file.
+    const callbacks = start.mock.calls[1][0]
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/input2.json',
+            fileName: 'input2.json',
+            caseName: 'Second',
+            status: 'success',
+            variantCount: 1
+          }
+        ]
+      }
+    })
+    await second
   })
 })
 
@@ -508,7 +581,7 @@ describe('SqliteImportExecutor.importMultiFile', () => {
     })
 
     // Start a single-file import to occupy the worker slot
-    void executor.importSingleFile({
+    const first = executor.importSingleFile({
       filePath: '/tmp/a.vcf',
       caseName: 'First',
       throttleMs: 100
@@ -522,6 +595,30 @@ describe('SqliteImportExecutor.importMultiFile', () => {
         ]
       })
     ).rejects.toThrow('An import is already in progress')
+
+    // Settle the single-file import so the shared JobRunner `import_single` slot
+    // is freed for later tests in this file.
+    running = false
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/a.vcf',
+            fileName: 'a.vcf',
+            caseName: 'First',
+            status: 'success',
+            variantCount: 1
+          }
+        ]
+      }
+    })
+    await first
   })
 
   it('uses fallback elapsed (Date.now() - start) when delegate returns elapsed=0', async () => {

--- a/tests/shared/types/preload-contract.test.ts
+++ b/tests/shared/types/preload-contract.test.ts
@@ -18,6 +18,8 @@ import type { WindowAPI, Case, BatchAnnotationKey } from '../../../src/shared/ty
 import type { IpcResult } from '../../../src/shared/types/errors'
 import type { ImportResult } from '../../../src/shared/types/import'
 import { DEBUG_CHANNELS } from '../../../src/shared/ipc/domains/debug'
+import { JOBS_CHANNELS } from '../../../src/shared/ipc/domains/jobs'
+import type { Job } from '../../../src/shared/types/jobs'
 
 const ROOT = resolve(__dirname, '..', '..', '..')
 
@@ -25,7 +27,8 @@ const DOMAIN_CONTRACT_PATHS: Record<string, string> = {
   CasesDomainContract: 'src/shared/ipc/domains/cases.ts',
   DatabaseDomainContract: 'src/shared/ipc/domains/database.ts',
   FilterPresetsDomainContract: 'src/shared/ipc/domains/filter-presets.ts',
-  DebugApi: 'src/shared/ipc/domains/debug.ts'
+  DebugApi: 'src/shared/ipc/domains/debug.ts',
+  JobsApi: 'src/shared/ipc/domains/jobs.ts'
 }
 
 /**
@@ -580,6 +583,58 @@ describe('debug domain — Sprint A PR-2 Gate 10c', () => {
     expectTypeOf<Awaited<ReturnType<WindowAPI['debug']['queryCountersReset']>>>().toEqualTypeOf<
       IpcResult<{ enabled: boolean }>
     >()
+  })
+})
+
+describe('jobs domain — Sprint A PR-4 Gate 11', () => {
+  it('exposes jobs:list / jobs:get / jobs:progress', () => {
+    expect(JOBS_CHANNELS.list).toBe('jobs:list')
+    expect(JOBS_CHANNELS.get).toBe('jobs:get')
+    expect(JOBS_CHANNELS.progress).toBe('jobs:progress')
+  })
+
+  it('WindowAPI carries a jobs top-level key wired to the JobsApi contract', () => {
+    const apiKeys = extractWindowApiKeys()
+    expect(apiKeys).toContain('jobs')
+
+    const jobsMethods = extractSubInterfaceKeys('JobsAPI')
+    expect(jobsMethods).toEqual(['get', 'list', 'progress'])
+  })
+
+  it('create-window-api assembles the jobs domain', () => {
+    const source = readFileSync(
+      resolve(ROOT, 'src/preload/window-api/create-window-api.ts'),
+      'utf-8'
+    )
+    expect(source).toContain("import { createJobsApi } from '../domains/jobs'")
+    expect(source).toContain('jobs: createJobsApi()')
+  })
+
+  it('main process registers the jobs handlers', () => {
+    const source = readFileSync(resolve(ROOT, 'src/main/ipc/index.ts'), 'utf-8')
+    expect(source).toContain("import { registerJobsHandlers } from './domains/jobs'")
+    expect(source).toContain('registerJobsHandlers()')
+  })
+
+  it('compile-time check: WindowAPI jobs methods return IpcResult', () => {
+    expectTypeOf<Awaited<ReturnType<WindowAPI['jobs']['list']>>>().toEqualTypeOf<IpcResult<Job[]>>()
+    expectTypeOf<Awaited<ReturnType<WindowAPI['jobs']['get']>>>().toEqualTypeOf<
+      IpcResult<Job | null>
+    >()
+    expectTypeOf<Awaited<ReturnType<WindowAPI['jobs']['progress']>>>().toEqualTypeOf<
+      IpcResult<Job['progress']>
+    >()
+  })
+
+  it('existing import contract is unchanged by the jobs domain', () => {
+    // Byte-identity guard: the import domain's start signature and the
+    // import:progress event channel must be untouched by PR-4.
+    expectTypeOf<Awaited<ReturnType<WindowAPI['import']['start']>>>().toEqualTypeOf<
+      IpcResult<ImportResult>
+    >()
+
+    const coreApiSource = readFileSync(resolve(ROOT, 'src/preload/window-api/core-api.ts'), 'utf-8')
+    expect(coreApiSource).toContain("subscribeToIpcEvent('import:progress', callback)")
   })
 })
 

--- a/tests/utils/mock-api.ts
+++ b/tests/utils/mock-api.ts
@@ -53,6 +53,7 @@ export type MockApi = {
   analysisGroups: MockApiDomain<WindowAPI['analysisGroups']>
   perf: MockApiDomain<WindowAPI['perf']>
   debug: MockApiDomain<WindowAPI['debug']>
+  jobs: MockApiDomain<WindowAPI['jobs']>
 }
 
 const TEST_SQLITE_CAPABILITIES: StorageCapabilities = {
@@ -429,6 +430,12 @@ export function createMockApi(): MockApi {
     debug: {
       queryCountersGet: vi.fn().mockResolvedValue({ named: {}, unnamed: 0, enabled: false }),
       queryCountersReset: vi.fn().mockResolvedValue({ enabled: false })
+    },
+
+    jobs: {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+      get: vi.fn().mockResolvedValue({ data: null }),
+      progress: vi.fn().mockResolvedValue({ data: null })
     }
   }
 

--- a/tests/web-gate/user-id-schema.test.ts
+++ b/tests/web-gate/user-id-schema.test.ts
@@ -68,7 +68,14 @@ const EXEMPT_TABLES = new Set([
   'audit_log', // has its own user_name → user_id migration tracked by audit-shape.test.ts
   'users', // identity itself
   'case_import_files', // provenance
-  'api_cache' // ephemeral
+  'api_cache', // ephemeral
+  // Multi-tenancy scope registry (Sprint A PR-4 D5). `projects` maps a project
+  // id to its schema_name, which IS the tenant boundary (PG schema / SQLite
+  // path) threaded through every repository as the `schema` arg. It defines
+  // scopes rather than holding per-user rows; per-project / multi-tenant auth
+  // is explicitly Out of scope (Sprint F+) per .planning/specs/2026-05-28-
+  // multi-project-architecture.md. Like `users`, it never carries user_id.
+  'projects'
 ])
 
 // Snapshot of tables that today lack `user_id` and need it added during


### PR DESCRIPTION
## Summary

Sprint A **PR-4** (sprint exit). Tracking-wrapper `JobRunner` over the five existing long-running-work sites, a new `jobs:` IPC domain (registered, not consumed), the multi-project architecture design doc, and the projects-registry migration.

Spec: `.planning/specs/2026-05-28-sprint-a-foundations.md`

### What landed (D1–D5)
- **D1** — Job primitive types (`src/main/services/jobs/types.ts`).
- **D2** — `JobRunner` tracking-wrapper skeleton (TDD; inline monotonic Crockford-base32 id, no new runtime dep). Single-flight messages preserved verbatim.
- **D3** — wired through **all five** sites (behaviour-preserving): `PostgresImportExecutor.importSingleFile` / `importMultiFile`, `batch-import-logic`, `runGeneBurdenCompare`, SQLite import path. Cancel uses worker `postMessage` (not terminate), Pass-9 #9.
- **D4** — new `jobs:` IPC domain, **registered but not consumed** (Gate 11).
- **D5** — multi-project architecture design doc (`Status: Locked`, Gate 13) + projects registry migration **PG 0011 / SQLite v31** (re-verified; v30 was taken by PR-3's cohort end_pos).

### Verification
- [x] Gate 1 — `make ci` green (3859 pass)
- [x] Gate 2 — `VARLENS_WEB=1 make ci` green (3990 pass)
- [x] Gate 11 — `jobs:` domain registered-not-consumed; preload-contract + import shapes unchanged
- [x] Gate 12 — five sites × four dimensions (behaviour unchanged, job recorded, single-flight preserved, errors propagate)
- [x] Gate 13 — multi-project design doc `Status: Locked`

### Web-gate note
The `projects` registry is the multi-tenancy **scope** table (`schema_name` IS the tenant boundary threaded through every repo as the `schema` arg); per-project/multi-tenant auth is explicitly Out of scope (Sprint F+). It defines scopes rather than holding per-user rows, so it's added to `EXEMPT_TABLES` in the user_id web-gate (like `users`), not given a spurious `user_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)