### PR TITLE
chore(release): bump version to 0.68.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "varlens",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "varlens",
-      "version": "0.68.0",
+      "version": "0.68.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varlens",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "description": "Offline variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/berntpopp/VarLens",


### PR DESCRIPTION
## Summary
- bump package version from 0.68.0 to 0.68.1
- keep package-lock root metadata in sync

## Test Plan
- npx prettier --check package.json package-lock.json
- node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if(p.version!=='0.68.1'||l.version!=='0.68.1'||l.packages[''].version!=='0.68.1') process.exit(1); console.log(p.version)"