### PR TITLE
refactor(web): shared-handler transport seam — strict per-key gate across all six domains

### DIFF
--- a/.planning/plans/2026-06-13-web-shared-handler-seam-plan.md
+++ b/.planning/plans/2026-06-13-web-shared-handler-seam-plan.md
@@ -1,0 +1,446 @@
+# Web Shared-Handler Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Dispatch a fresh implementer per task; run two-stage review (spec compliance, then code quality) before marking a task complete. **Run `make format` as part of every task's verification** (Sprint A/B learning: implementers skipped prettier and forced controller fix-ups).
+
+**Spec:** [.planning/specs/2026-06-13-web-shared-handler-seam.md](../specs/2026-06-13-web-shared-handler-seam.md)
+
+**Goal:** Make each of six web routes (`transcripts, panels, annotations, variants, cohort, export`) a thin transport adapter over a single shared, session-based operation function per domain, and enforce non-drift with a per-override-key seam gate plus cross-transport runtime parity.
+
+**Architecture:** New **session/executor-based** orchestration functions added to the existing `src/main/ipc/handlers/<domain>-logic.ts` modules, called by BOTH the desktop IPC handler and the web Fastify route. Transport-specific behaviour (event broadcast vs. SSE publish, cache pings) is supplied as an injected callback. A `ts-morph` gate in `handler-seam.test.ts` asserts every override key is either a pure single-executor pass-through or calls a shared `<domain>-logic` export; a monotonic-decrease `PENDING_SHARED_LOGIC_EXTRACTION` allowlist empties by PR-3.
+
+**Tech Stack:** Electron 40, Vue 3 + Vuetify 4, TypeScript 6 strict, Fastify (web), Vitest, Playwright `_electron`, better-sqlite3-multiple-ciphers, PostgreSQL 18, Zod, `ts-morph` (already a dev dep, used by `auth-isolation.test.ts`), electron-log.
+
+---
+
+## Architecture reality-checks (verified against `main @ 226e8cf2`; these refine the spec — re-verify line numbers at task time)
+
+1. **`*-logic.ts` are `getDb`-based SQLite logic, NOT the web seam.** `panels-logic.ts` exports `getPanel(id, getDb)`, `getGenes(panelId, getDb)`; `annotations-logic.ts` exports `getGlobalAnnotation(coords, getDb)`, `upsertPerCaseAnnotation(…, getDb)`; etc. The desktop handler branches **postgres → `session.get{Read,Write}Executor()`**, **sqlite → these `getDb` functions** (e.g. `handlers/transcripts.ts:38-50,81-90,123-134`). The web route is Postgres-only and calls the **executor**. So the shared layer this plan introduces is a set of **new session-based functions** added to each `<domain>-logic.ts`; the existing `getDb` functions are left untouched (they remain the SQLite path's building blocks).
+2. **`transcripts`' web route is already gate-compliant.** `routes/transcripts.ts:19,35,52` are pure executor pass-throughs (gate branch (a)). The B6 "transcript switch doesn't update parent `variants` row" is a **backend-parity** divergence in `PostgresTranscriptsRepository` vs SQLite, caught by the *cross-transport* parity scenario and fixed in the repository — not by extracting `transcripts-logic`. PR-1 therefore (a) upgrades the gate, (b) extends the transcripts parity scenario to catch the backend divergence, (c) fixes the repository if the scenario is red, and (d) extracts `transcripts-logic` only for symmetry/return-shape normalization.
+3. **The cross-transport parity harness compares returned values by hash and exposes no event channel** (`parity/ipc/shared.ts:20-28`: `RuntimeContext` is `call(...)` + anchors only). Event-emission/scope parity is verified by **targeted unit tests**, not parity scenarios.
+4. **The seam test already has the coarse check to replace.** `handler-seam.test.ts:191-203` (`'web route override modules use shared logic or audited exceptions'`) passes a route if it imports *any* `handlers/<x>-logic` OR is in `ROUTE_OVERRIDE_LOGIC_EXCEPTIONS`. That is the file-level false-positive (F2). The upgrade adds a per-override-key `ts-morph` assertion; the module-set guards (`:137-166`) stay.
+5. **`export:variants`/`export:cohort` are overridden** (`routes/export.ts:19,41`), so the override is live despite `READ_TASK_TYPES` membership (`task-types.ts:41-42`) — the dispatcher checks overrides first (`dispatcher.ts:255`). Both keys are in scope.
+6. **Determine the parity harness's desktop backend at task time.** `ipc-fixture-parity.test.ts` launches real Electron (desktop) and an isolated web schema (Postgres). Confirm whether desktop runs SQLite or Postgres — it decides whether the transcripts scenario catches the *backend*-parity divergence (RC-2) or only transport drift. Gated by `VARLENS_RUN_WEB_GATE_PARITY=1 && VARLENS_RUN_WEB_PARITY_E2E=1`, needs `VARLENS_PG_URL` + built `out/main/index.js`.
+
+## File structure
+
+| File | Role | PR |
+|---|---|---|
+| `tests/web-gate/handler-seam.test.ts` | **Modify** — add per-override-key `ts-morph` gate + `PENDING_SHARED_LOGIC_EXTRACTION` | PR-1 |
+| `src/main/ipc/handlers/transcripts-logic.ts` | **Create** — session-based list/switch/insertAndSwitch | PR-1 |
+| `src/main/ipc/handlers/transcripts.ts`, `src/web/server/routes/transcripts.ts` | **Modify** — call shared logic | PR-1 |
+| `tests/web-gate/parity/ipc/{transcripts,panels,annotations,variants,cohort,export}.ts` | **Modify** — extend with B6 cases | PR-1/2/3 |
+| `src/main/ipc/handlers/{panels,annotations,variants,cohort,export}-logic.ts` | **Modify** — add session-based orchestration fns + callback types | PR-2/3 |
+| `src/web/server/routes/{panels,annotations,variants,cohort,export}.ts` | **Modify** — call shared logic; remove inline orchestration | PR-2/3 |
+| `src/main/ipc/handlers/{panels,annotations,variants,cohort,export}.ts` | **Modify** — call the same shared fn (where behaviour-preserving) | PR-2/3 |
+| `tests/main/ipc/annotations-event-parity.test.ts` | **Create** — targeted event-callback unit tests (RC-3) | PR-2 |
+| `src/main/storage/postgres/PostgresTranscriptsRepository.ts` | **Modify only if** the transcripts parity scenario is red (RC-2) | PR-1 |
+
+---
+
+## Pre-flight (controller, before dispatching any subagent)
+
+- [ ] **Branch hygiene.** From `main`: `git status` clean; `git fetch origin && git rev-list --left-right --count origin/main...main` → `0 0`.
+- [ ] **Read the spec.** Note the 6 domains, the per-key gate, the 10 acceptance gates, the 4 Open Questions. Settled decisions must not be re-litigated mid-execution.
+- [ ] **Verify clean baseline:** `make ci` and `VARLENS_WEB=1 make ci` both exit 0. Surface failures before starting. (Heavy builds on this workstation: wrap in `systemd-run --user --scope -p MemoryMax=16G`.)
+- [ ] **Bring up Postgres + build for parity:** `make pg-reset && make pg-up` (PG @ 55434 per `.env.postgres.local`); `make build` (produces `out/main/index.js` for the parity harness).
+- [ ] **Resolve RC-6:** read `ipc-fixture-parity.test.ts` setup; record whether desktop runs SQLite or Postgres in the parity run.
+
+## Branch convention
+
+| PR | Branch | Tasks | Depends on |
+|---|---|---|---|
+| PR-1 | `feat/web-shared-logic-seam-and-transcripts` | 1.1–1.5 | — |
+| PR-2 | `feat/web-shared-logic-panels-annotations` | 2.1–2.6 | PR-1 merged |
+| PR-3 | `feat/web-shared-logic-variants-cohort-export` | 3.1–3.7 | PR-2 merged |
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/web-shared-logic-seam-and-transcripts
+```
+
+---
+
+# PR-1 — `refactor(web): behavioural handler seam + share transcripts logic across transports`
+
+### Task 1.1: Add the `PENDING_SHARED_LOGIC_EXTRACTION` allowlist (seeded with all six), gate stays green
+
+**Files:** Modify `tests/web-gate/handler-seam.test.ts`.
+
+- [ ] **Step 1 — add the allowlist constant** below `ROUTE_OVERRIDE_LOGIC_EXCEPTIONS` (line ~42):
+
+```ts
+/**
+ * Domains whose web overrides have not yet been collapsed onto a shared
+ * session-based <domain>-logic function. MONOTONIC-DECREASE ONLY — remove
+ * an entry when the domain's overrides all pass the per-key seam check.
+ * do not add.
+ */
+const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>([
+  'transcripts.ts',
+  'panels.ts',
+  'annotations.ts',
+  'variants.ts',
+  'cohort.ts',
+  'export.ts'
+])
+```
+
+- [ ] **Step 2 — add a guard test** that the allowlist cannot grow, inside the `describe` block:
+
+```ts
+test('PENDING_SHARED_LOGIC_EXTRACTION only shrinks (max 6, all known)', () => {
+  const known = new Set([
+    'transcripts.ts', 'panels.ts', 'annotations.ts',
+    'variants.ts', 'cohort.ts', 'export.ts'
+  ])
+  expect(PENDING_SHARED_LOGIC_EXTRACTION.size).toBeLessThanOrEqual(6)
+  for (const entry of PENDING_SHARED_LOGIC_EXTRACTION) {
+    expect(known.has(entry), `unknown pending domain: ${entry}`).toBe(true)
+  }
+})
+```
+
+- [ ] **Step 3 — run:** `make rebuild-node && npx vitest run tests/web-gate/handler-seam.test.ts` → all PASS.
+- [ ] **Step 4 — `make format` + commit:** `test(web): seed PENDING_SHARED_LOGIC_EXTRACTION allowlist for seam upgrade`.
+
+### Task 1.2: Upgrade the seam gate to a per-override-key `ts-morph` check (TDD)
+
+**Files:** Modify `tests/web-gate/handler-seam.test.ts`. Reference: `tests/web-gate/auth-isolation.test.ts` for the `ts-morph` `Project` setup pattern.
+
+- [ ] **Step 1 — write the failing test.** Replace the body of the existing `'web route override modules use shared logic or audited exceptions'` test (`:191-203`) with a per-key analyzer. Add `import { Project, SyntaxKind } from 'ts-morph'` at the top.
+
+```ts
+// Returns, per override key in a route file, the verdict: 'passthrough' | 'shared-logic' | 'inline'.
+function analyzeOverrideKeys(routePath: string): Record<string, 'passthrough' | 'shared-logic' | 'inline'> {
+  const project = new Project({ tsConfigFilePath: 'tsconfig.node.json', skipAddingFilesFromTsConfig: true })
+  const sf = project.addSourceFileAtPath(resolve(process.cwd(), routePath))
+  const verdicts: Record<string, 'passthrough' | 'shared-logic' | 'inline'> = {}
+
+  // Find the object literal returned by buildXxxOverrides() and walk its keys.
+  const builder = sf.getFunctions().find((f) => /^build[A-Za-z]+Overrides$/.test(f.getName() ?? ''))
+  const ret = builder?.getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression)[0]
+  for (const prop of ret?.getProperties() ?? []) {
+    const key = prop.getChildAtIndex(0).getText().replace(/['"`]/g, '')
+    const text = prop.getText()
+    const execCalls = (text.match(/get(Read|Write)Executor\(\)\s*\.execute\(/g) ?? []).length
+    const callsTypeKey = text.includes(`type: '${key}'`) || text.includes(`type: "${key}"`)
+    if (callsSharedLogicFn(sf, prop)) {
+      verdicts[key] = 'shared-logic'           // branch (b): delegates to a *-logic export
+    } else if (execCalls === 1 && callsTypeKey) {
+      verdicts[key] = 'passthrough'            // branch (a): single executor call, same task key
+    } else {
+      verdicts[key] = 'inline'                 // hand-rolled orchestration — fails the gate
+    }
+  }
+  return verdicts
+}
+
+// True if the override body calls a function imported from a *-logic module.
+function callsSharedLogicFn(sf: import('ts-morph').SourceFile, prop: import('ts-morph').ObjectLiteralElementLike): boolean {
+  const logicNames = new Set<string>()
+  for (const d of sf.getImportDeclarations()) {
+    if (!/handlers\/[A-Za-z0-9-]+-logic/.test(d.getModuleSpecifierValue())) continue
+    for (const n of d.getNamedImports()) logicNames.add(n.getName())
+  }
+  return prop.getDescendantsOfKind(SyntaxKind.CallExpression).some((c) => {
+    const expr = c.getExpression()
+    return expr.getKind() === SyntaxKind.Identifier && logicNames.has(expr.getText())
+  })
+}
+
+test('every override key of a migrated domain is pass-through or calls shared logic', () => {
+  const offenders: string[] = []
+  for (const file of listRouteOverrideModules()) {
+    if (PENDING_SHARED_LOGIC_EXTRACTION.has(file)) continue          // not migrated yet
+    if (ROUTE_OVERRIDE_LOGIC_EXCEPTIONS[file] !== undefined) continue // web-only adapter
+    const verdicts = analyzeOverrideKeys(`${WEB_ROUTES_DIR}/${file}`)
+    for (const [key, verdict] of Object.entries(verdicts)) {
+      if (verdict === 'inline') offenders.push(`${file} → ${key} (inline orchestration; extract to <domain>-logic)`)
+    }
+  }
+  expect(offenders, offenders.join('\n')).toEqual([])
+})
+```
+
+- [ ] **Step 2 — run to verify it PASSES now** (all six domains are in `PENDING_SHARED_LOGIC_EXTRACTION`, so none are analyzed yet): `npx vitest run tests/web-gate/handler-seam.test.ts`. Expected: PASS. (The gate becomes load-bearing as domains leave the allowlist.)
+- [ ] **Step 3 — prove the gate bites:** temporarily delete `'transcripts.ts'` from `PENDING_SHARED_LOGIC_EXTRACTION`, re-run. Expected: still PASS (transcripts overrides are already pure pass-throughs per RC-2). Then temporarily add an inline second executor call to one transcripts override and confirm the gate reports it `inline`. Revert both probes.
+- [ ] **Step 4 — keep the old coarse test deleted** (it is replaced by the per-key test). Confirm the module-set tests (`:137-166`) and the Postgres-direct-access test (`:168-189`) are untouched.
+- [ ] **Step 5 — `make format` + commit:** `test(web): per-override-key seam gate via ts-morph (replaces file-level check)`.
+
+### Task 1.3: Extend the transcripts parity scenario to cover switch + parent-row (TDD red-or-lock)
+
+**Files:** Modify `tests/web-gate/parity/ipc/transcripts.ts`.
+
+- [ ] **Step 1 — extend the scenario** (current content runs only `insertAndSwitch` + `list`):
+
+```ts
+import type { IpcScenario } from './shared'
+
+export const transcriptsScenario: IpcScenario = {
+  area: 'transcripts',
+  run: async (ctx) => [
+    await ctx.call('transcripts', 'insertAndSwitch', [
+      ctx.primaryVariant.id,
+      { transcript_id: 'ENST_PARITY_000001', gene_symbol: 'COMT', consequence: 'stop_gained',
+        cdna: 'c.493G>A', aa_change: 'p.Glu165Ter', hpo_sim_score: 0.87, moi: 'AD', is_selected: 1 }
+    ]),
+    await ctx.call('transcripts', 'switch', [ctx.primaryVariant.id, 'ENST_PARITY_000001']),
+    await ctx.call('transcripts', 'list', [ctx.primaryVariant.id]),
+    // B6: after switch, the parent variants row must reflect the selected transcript.
+    // A variants:query anchored on the same variant exposes transcript/gene_symbol/consequence.
+    await ctx.call('variants', 'query', [
+      ctx.primaryCaseId, { /* minimal filter selecting primaryVariant */ }, 1, 0, []
+    ])
+  ]
+}
+```
+
+(Adjust the `variants:query` filter args to the real `VariantFilter` shape used by other scenarios in `parity/ipc/variants.ts` — copy that filter literal.)
+
+- [ ] **Step 2 — run the gated parity test:**
+
+```bash
+VARLENS_RUN_WEB_GATE_PARITY=1 VARLENS_RUN_WEB_PARITY_E2E=1 \
+  VARLENS_PG_URL=postgres://varlens:varlens_dev_password@127.0.0.1:55434/varlens_dev \
+  npx vitest run tests/web-gate/parity/ipc-fixture-parity.test.ts
+```
+
+- [ ] **Step 3 — record the verdict.** If the `transcripts` area passes, current behaviour is locked — proceed to 1.4 (extraction is symmetry-only). If it FAILS on the parent-row read (desktop SQLite updates the parent row, web Postgres does not — RC-2), the divergence is real: continue to 1.3b.
+- [ ] **Step 3b (only if red) — fix the backend parity in the repository.** In `src/main/storage/postgres/PostgresTranscriptsRepository.ts`, make `switchSelectedTranscript`/`insertTranscriptAndSwitch` update the parent `variants` row (transcript, gene_symbol, consequence, cdna, aa_change, hpo_sim_score, moi) inside the same transaction, mirroring the SQLite `TranscriptRepository.switchSelectedTranscript`. Re-run Step 2 → the `transcripts` area passes. Add a backend-parity assertion to the relevant `tests/main/storage/*transcript*` test if one exists; otherwise note it in the PR body.
+- [ ] **Step 4 — `make format` + commit:** `test(web): transcripts switch+parent-row cross-transport parity` (and, if 3b ran, fold the repository fix into a second commit `fix(pg): transcript switch updates parent variants row`).
+
+### Task 1.4: Extract `transcripts-logic.ts` and route both transports through the executor
+
+**Files:** Create `src/main/ipc/handlers/transcripts-logic.ts`; modify `src/main/ipc/handlers/transcripts.ts`, `src/web/server/routes/transcripts.ts`.
+
+- [ ] **Step 1 — read `SqliteReadExecutor`/`SqliteWriteExecutor`** for `transcripts:list`/`switch`/`insertAndSwitch` and record their **return shapes** (e.g. does `transcripts:switch` return `{ success: true }` or the repo's return?). The desktop SQLite branch currently returns `{ success: true }` (`handlers/transcripts.ts:90,135`). The shared logic must normalize to preserve that observable contract.
+- [ ] **Step 2 — create `transcripts-logic.ts`:**
+
+```ts
+import type { StorageSession } from '../../storage/session'
+import type { TranscriptInsertRow } from '../../../shared/types/transcript'
+
+export async function listTranscripts(variantId: number, getSession: () => StorageSession): Promise<unknown> {
+  return getSession().getReadExecutor().execute({ type: 'transcripts:list', params: [variantId] })
+}
+
+export async function switchTranscript(
+  variantId: number, transcriptId: string, getSession: () => StorageSession
+): Promise<{ success: true }> {
+  await getSession().getWriteExecutor().execute({ type: 'transcripts:switch', params: [variantId, transcriptId] })
+  return { success: true }
+}
+
+export async function insertAndSwitchTranscript(
+  variantId: number, row: TranscriptInsertRow, getSession: () => StorageSession
+): Promise<{ success: true }> {
+  await getSession().getWriteExecutor().execute({ type: 'transcripts:insertAndSwitch', params: [variantId, row] })
+  return { success: true }
+}
+```
+
+(If Step 1 showed the executor already returns `{ success: true }`, return its result directly instead of synthesizing — match the executor.)
+
+- [ ] **Step 3 — rewire the desktop handler** `handlers/transcripts.ts`: replace each `session.capabilities.backend === 'postgres' ? executor : getDb` branch with a single call to the shared fn, passing `() => getDbManager().getCurrentSession()`. Keep the Zod validation + `wrapHandler`. Remove the now-dead `getDb`/`getDbPool` transcript imports if unused.
+- [ ] **Step 4 — rewire the web route** `routes/transcripts.ts`: import the three fns; each override validates (unchanged) then `return await listTranscripts(validated.data, () => session)` etc.
+- [ ] **Step 5 — de-list:** remove `'transcripts.ts'` from `PENDING_SHARED_LOGIC_EXTRACTION` AND from `ROUTE_OVERRIDE_LOGIC_EXCEPTIONS` in `handler-seam.test.ts` (it now passes via branch (b)).
+- [ ] **Step 6 — run:**
+
+```bash
+make rebuild-node
+npx vitest run tests/web-gate/handler-seam.test.ts tests/main/ipc/ tests/refactor-checkpoint/
+VARLENS_RUN_WEB_GATE_PARITY=1 VARLENS_RUN_WEB_PARITY_E2E=1 VARLENS_PG_URL=… npx vitest run tests/web-gate/parity/ipc-fixture-parity.test.ts
+```
+
+Expected: seam gate PASS (transcripts now enforced), parity `transcripts` PASS, refactor-checkpoint + main unchanged.
+
+- [ ] **Step 7 — `make format` + commit:** `refactor(web): share transcripts logic across transports (executor-routed)`.
+
+### Task 1.5: PR-1 full gates
+
+- [ ] **Step 1 — run:** `make ci-full` and `VARLENS_WEB=1 make ci` → both exit 0. `make agent-check` clean.
+- [ ] **Step 2 — open PR-1.** Body cites the spec, gates 1 + 2 + 9, the parity command, and (if 1.3b ran) the repository fix. Controller merges after review + green cross-platform Actions.
+
+---
+
+# PR-2 — `refactor(web): share panels + annotations logic across transports`
+
+> **Pattern (from PR-1):** add a **session-based** orchestration fn to `<domain>-logic.ts` (alongside the existing `getDb` fns, which stay); call it from both `handlers/<domain>.ts` and `routes/<domain>.ts`; extend the parity scenario; de-list the domain. Each fn takes `getSession: () => StorageSession` and, where a transport-specific side effect exists, an injected callback.
+
+### Task 2.1: Extend the panels parity scenario (lock current shape)
+
+**Files:** Modify `tests/web-gate/parity/ipc/panels.ts`.
+
+- [ ] **Step 1 — add `panels:get` and `panels:update` calls** asserting returned-value equality across transports. `panels:get` must surface the `{ ...panel, genes }` shape; `panels:update` must round-trip `{ id, name, description, version }`. Mirror the existing scenario's create→act→read structure (copy the panel-create setup already in the file).
+- [ ] **Step 2 — run** the gated parity test (command from Task 1.3 Step 2) → `panels` area PASS (locks current behaviour). **Step 3 — `make format` + commit:** `test(web): panels get/update cross-transport parity`.
+
+### Task 2.2: Add `getPanelWithGenes` to `panels-logic.ts`
+
+**Files:** Modify `src/main/ipc/handlers/panels-logic.ts`. Existing exports include `getPanel(id, getDb)`, `getGenes(panelId, getDb)`, `updatePanel(...)` (`panels-logic.ts:35,98,54`).
+
+- [ ] **Step 1 — add a session-based orchestration fn** that reproduces the two-call merge currently inlined at `routes/panels.ts:14-20`:
+
+```ts
+import type { StorageSession } from '../../storage/session'
+
+export async function getPanelWithGenes(id: number, getSession: () => StorageSession): Promise<unknown> {
+  const session = getSession()
+  const panel = await session.getReadExecutor().execute({ type: 'panels:get', params: [id] })
+  if (panel === null) return null
+  const genes = await session.getReadExecutor().execute({ type: 'panels:getGenes', params: [id] })
+  return { ...(panel as object), genes }
+}
+```
+
+- [ ] **Step 2 — add `updatePanelFields`** if the desktop handler's update unpacking (`{ id, ...updates } → [id, updates]`) is not already a single shared fn; otherwise reuse the existing `updatePanel`. Keep ≤600 LOC (`panels-logic.ts` is 402 — fine).
+- [ ] **Step 3 — `make format` + commit:** `feat(ipc): session-based getPanelWithGenes in panels-logic`.
+
+### Task 2.3: Route both transports through the shared panels fns
+
+**Files:** Modify `src/web/server/routes/panels.ts`, `src/main/ipc/handlers/panels.ts`.
+
+- [ ] **Step 1 — web route:** replace the inline merge (`routes/panels.ts:14-20`) with `return await getPanelWithGenes(validated.data, () => session)`; replace the inline update unpack with the shared fn. Import from `'../../../main/ipc/handlers/panels-logic'`.
+- [ ] **Step 2 — desktop handler:** have the `panels:get` handler call `getPanelWithGenes(id, () => getDbManager().getCurrentSession())` so both transports share one implementation (verify behaviour-preserving against the parity scenario; if the desktop SQLite enrich path differs, normalize in the shared fn).
+- [ ] **Step 3 — de-list** `panels.ts` from `PENDING_SHARED_LOGIC_EXTRACTION` and `ROUTE_OVERRIDE_LOGIC_EXCEPTIONS`.
+- [ ] **Step 4 — run:** `make rebuild-node && npx vitest run tests/web-gate/handler-seam.test.ts tests/main/ipc/` + the gated parity `panels` area + `VARLENS_WEB=1 make test`. Expected PASS. **Step 5 — `make format` + commit:** `refactor(web): panels get/update via shared session logic`.
+
+### Task 2.4: Targeted annotation event-callback unit tests (TDD; RC-3)
+
+**Files:** Create `tests/main/ipc/annotations-event-parity.test.ts`.
+
+- [ ] **Step 1 — write failing tests** asserting that the shared per-case upsert fn invokes its injected `onChange` callback exactly once with the correct `kind` (`star`/`acmg`/`evidence`/`comment`), for representative `updates`. This is the verification the parity harness cannot do (RC-3).
+
+```ts
+import { describe, expect, test, vi } from 'vitest'
+// import { upsertPerCaseAnnotationWithEvent } from '../../../src/main/ipc/handlers/annotations-logic'
+test('emits a single change event with kind=acmg for an acmg update', async () => {
+  const onChange = vi.fn()
+  // call the shared fn with a fake session/executor + onChange; assert called once with kind 'acmg'
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(onChange.mock.calls[0][0]).toMatchObject({ kind: 'acmg' })
+})
+```
+
+- [ ] **Step 2 — run, expect FAIL** (fn not yet exported). **Step 3 — commit after 2.5 makes it pass.**
+
+### Task 2.5: Add session-based annotation upsert fn with injected event callback; route both transports
+
+**Files:** Modify `src/main/ipc/handlers/annotations-logic.ts`, `src/web/server/routes/annotations.ts`, `src/main/ipc/handlers/annotations.ts`.
+
+- [ ] **Step 1 — add a session-based fn** that issues the composite `annotations:upsertPerCaseWithAudit` write task (RC-5: keep the atomic `*WithAudit` task — do not re-split write/audit) and then calls an injected `onChange(event)` callback. Move `detectAnnotationChangeKind` (currently `routes/annotations.ts:11-20`) into `annotations-logic.ts` as the single source.
+
+```ts
+import type { AnnotationChangeEvent } from '../../../shared/types/api'
+import type { StorageSession } from '../../storage/session'
+
+export function detectAnnotationChangeKind(u: { starred?: unknown; acmg_classification?: unknown; acmg_evidence?: unknown }): AnnotationChangeEvent['kind'] {
+  if (u.starred !== undefined) return 'star'
+  if (u.acmg_classification !== undefined) return 'acmg'
+  if (u.acmg_evidence !== undefined) return 'evidence'
+  return 'comment'
+}
+
+export async function upsertPerCaseAnnotationWithEvent(
+  caseId: number, variantId: number, updates: unknown,
+  getSession: () => StorageSession,
+  onChange: (e: AnnotationChangeEvent) => void
+): Promise<unknown> {
+  const result = await getSession().getWriteExecutor().execute({
+    type: 'annotations:upsertPerCaseWithAudit', params: [caseId, variantId, updates]
+  })
+  onChange({ caseId, variantId, kind: detectAnnotationChangeKind(updates as object) })
+  return result
+}
+```
+
+- [ ] **Step 2 — web route** (`routes/annotations.ts`): call the shared fn, passing the SSE callback `(e) => { const uid = request.session?.user?.id; if (uid !== undefined) events.publish(uid, WEB_EVENT_VARIANTS_ANNOTATION_CHANGED, e) }`. Remove the local `detectAnnotationChangeKind`.
+- [ ] **Step 3 — desktop handler** (`handlers/annotations.ts`): for `annotations:upsertPerCase`, call the same shared fn passing the window-broadcast callback (`broadcastAnnotationChanged`). Confirm the existing desktop event payload matches the `AnnotationChangeEvent` shape.
+- [ ] **Step 4 — make 2.4 pass:** wire the test import to `upsertPerCaseAnnotationWithEvent`. Run `npx vitest run tests/main/ipc/annotations-event-parity.test.ts` → PASS.
+- [ ] **Step 5 — extend the annotations parity scenario** (`parity/ipc/annotations.ts`) with returned-value coverage of `upsertPerCase`, `upsertGlobal` (audit atomicity via a follow-up audit read), `getForVariant`, `getGlobal`. Run the gated parity → `annotations` PASS.
+- [ ] **Step 6 — de-list** `annotations.ts` from both allowlists. **Step 7 — run** seam gate + `tests/main/ipc/` + `VARLENS_WEB=1 make test`. **Step 8 — `make format` + commit:** `refactor(web): annotations per-case upsert via shared logic with injected event`.
+
+### Task 2.6: PR-2 full gates
+
+- [ ] `make ci-full` + `VARLENS_WEB=1 make ci` green; `make agent-check` clean (`annotations-logic.ts` ≤600). Open PR-2; controller merges after review.
+
+---
+
+# PR-3 — `refactor(web): share variants/cohort/export logic; strict transport seam`
+
+### Task 3.1: variants — parity + migrate every override key
+
+**Files:** `tests/web-gate/parity/ipc/variants.ts`, `src/main/ipc/handlers/variants-logic.ts`, `src/web/server/routes/variants.ts`, `src/main/ipc/handlers/variants.ts`.
+
+- [ ] **Step 1 — extend the parity scenario** for `variants:search` (assert the return shape matches the IPC contract — the B6 envelope-vs-`Variant[]` case). Run gated parity → record.
+- [ ] **Step 2 — classify each variants override key** (`variants:search`, `variants:columnMeta`, `variants:query`, `variants:getFilterOptions` — `routes/variants.ts:16,28,48,107`): for each, decide **(a) pure pass-through** (single executor call, same key → leave as-is, gate accepts) or **(b) needs shared fn** (extra shaping → add a session-based fn to `variants-logic.ts` and call it from both transports). `variants:search` already calls `searchVariants` — confirm that fn is session-based (it takes `() => session` per `routes/variants.ts:24`); if it is `getDb`-based, add a session-based sibling.
+- [ ] **Step 3 — apply** the (a)/(b) decision per key; de-list `variants.ts` from both allowlists.
+- [ ] **Step 4 — run** seam gate (now enforces variants) + `tests/main/ipc/` + gated parity `variants` + `VARLENS_WEB=1 make test`. **Step 5 — `make format` + commit:** `refactor(web): variants overrides pass per-key seam (shared logic / pass-through)`.
+
+### Task 3.2: cohort — parity + migrate every override key (OQ-4)
+
+**Files:** `tests/web-gate/parity/ipc/cohort.ts`, `src/main/ipc/handlers/cohort-logic.ts`, `src/web/server/routes/cohort.ts`, `src/main/ipc/handlers/cohort.ts`.
+
+- [ ] **Step 1 — extend the cohort parity scenario** for the five overridden cohort methods (`exec=5` in `routes/cohort.ts`). Run gated parity → record.
+- [ ] **Step 2 — for each cohort override key,** apply (a)/(b). Cache-rebuild side effects (e.g. cohort-summary staleness) become a `CohortCallbacks`-style injected callback (RC-3 pattern); a genuinely web-only SSE staleness ping stays in the route as a documented transport concern (OQ-4 default).
+- [ ] **Step 3 — de-list** `cohort.ts` from both allowlists. **Step 4 — run** seam gate + `tests/main/ipc/` + gated parity `cohort` + `VARLENS_WEB=1 make test`. **Step 5 — `make format` + commit:** `refactor(web): cohort overrides via shared session logic`.
+
+### Task 3.3: export — migrate the overridden `export:variants`/`export:cohort` (RC-5/F1)
+
+**Files:** `tests/web-gate/parity/ipc/export.ts`, `src/main/ipc/handlers/export-logic.ts`, `src/web/server/routes/export.ts`.
+
+- [ ] **Step 1 — extend the export parity scenario** (export returns a file; reuse `normalizeExport` from `parity/ipc/shared.ts:48` to compare by file hash). Run gated parity → record.
+- [ ] **Step 2 — classify `export:variants` and `export:cohort`** (`routes/export.ts:19,41`): each is likely a near-pass-through to an executor export task. If pure pass-through with the same key → gate accepts (a). If it shapes args / picks `exportPostgresVariants` vs `exportVariants` → route through a session-based `export-logic` fn (b). Existing `export-logic` exports: `exportPostgresVariants`, `exportPostgresCohort` (`export-logic.ts:211,225`).
+- [ ] **Step 3 — de-list** `export.ts` from both allowlists. **Step 4 — run** seam gate + gated parity `export` + `VARLENS_WEB=1 make test`. **Step 5 — `make format` + commit:** `refactor(web): export overrides pass per-key seam`.
+
+### Task 3.4: Flip the seam gate strict
+
+**Files:** Modify `tests/web-gate/handler-seam.test.ts`.
+
+- [ ] **Step 1 — assert the allowlist is empty:** `PENDING_SHARED_LOGIC_EXTRACTION` should now be `new Set()`. Add:
+
+```ts
+test('PENDING_SHARED_LOGIC_EXTRACTION is empty — all six domains migrated', () => {
+  expect([...PENDING_SHARED_LOGIC_EXTRACTION]).toEqual([])
+})
+```
+
+- [ ] **Step 2 — run:** `npx vitest run tests/web-gate/handler-seam.test.ts` → PASS. **Step 3 — `make format` + commit:** `test(web): strict transport seam — no pending shared-logic domains`.
+
+### Task 3.5: PR-3 full gates + sprint exit
+
+- [ ] **Step 1 — full gates:** `make ci-full` + `VARLENS_WEB=1 make ci` green; full gated parity suite (all six areas) PASS; `make agent-check` clean (no migrated `*-logic.ts` >600 LOC without justification).
+- [ ] **Step 2 — open PR-3;** controller merges after review + green Actions. No version tag required (internal refactor; bundle into the next release per the release runbook if desired).
+
+---
+
+## Verification matrix (gate → task)
+
+| Spec gate | Verified by |
+|---|---|
+| 1 — behavioural seam (per key), allowlist empties | 1.1, 1.2, 1.4 (de-list), 3.4 |
+| 2 — transcripts shared + parent-row parity | 1.3, 1.4 |
+| 3 — panels get/update via shared logic | 2.1, 2.2, 2.3 |
+| 4 — annotations shared + event via callback (unit) + atomicity (parity) | 2.4, 2.5 |
+| 5 — variants:search shape | 3.1 |
+| 6 — cohort via shared logic + callbacks | 3.2 |
+| 7 — export overridden keys pass per-key gate | 3.3 |
+| 8 — strict gate (allowlist empty) | 3.4 |
+| 9 — no contract/Electron change | 1.4/2.3/2.5/3.x (refactor-checkpoint + main + preload-contract suites) |
+| 10 — CI green per PR | 1.5, 2.6, 3.5 |
+
+## Per-task verification checklist (every task)
+
+1. `make typecheck` (always).
+2. Touching renderer/IPC/db/web → `make rebuild-node && <scoped vitest>`.
+3. Touching a web seam → gated parity command (PG @ 55434 + `out/main/index.js`); `make pg-down` after.
+4. Touching shared/web contracts → `VARLENS_WEB=1 make test`.
+5. **`make format`** (Sprint A/B learning).
+6. `make agent-check` before opening each PR.
+7. Atomic Conventional Commit; never on `main`.
+
+## Self-review notes
+
+- **Spec coverage:** PR-1 (S1–S4 → tasks 1.1–1.5), PR-2 (P1–P5 → 2.1–2.6), PR-3 (V1/C1/E1/G1/G2 → 3.1–3.5). All 10 gates mapped above.
+- **Refines spec (carry into spec if back-porting):** the shared layer is **session-based** fns added to `<domain>-logic.ts` (the existing `getDb` fns are SQLite-internal, not the web seam — corrects spec RC-3's "already transport-agnostic"); `transcripts`' web route is already gate-compliant and its B6 case is a **backend-parity** repository fix, not transport-drift (task 1.3/1.3b).
+- **Type consistency:** shared-fn convention is `(…params, getSession: () => StorageSession[, onChange])`; matches the existing `searchVariants(…, () => session)` call site.
+- **Open items the implementer resolves at task time (flagged, not hidden):** RC-6 (parity desktop backend), executor return shapes for transcripts (1.4 S1), and the per-key (a)/(b) classification for variants/cohort/export (3.1–3.3 S2).

--- a/.planning/specs/2026-06-13-web-shared-handler-seam.md
+++ b/.planning/specs/2026-06-13-web-shared-handler-seam.md
@@ -1,0 +1,176 @@
+# Web Shared-Handler Seam — Spec
+
+**Status:** Draft 2026-06-13 (fresh draft — not yet cross-AI reviewed; ready for `gsd-review` / Codex convergence after a first read)
+**Predecessor:** [.planning/specs/2026-06-13-web-narrow-hardening.md](2026-06-13-web-narrow-hardening.md) — shipped and merged (`37167a54 fix(web): harden upload boundary and origin guard`, `367145be docs(planning): mark web hardening plan complete`). That spec **explicitly deferred** the work in this one: *"No shared handler object refactor in this pass… This is not a replacement for a later shared-handler refactor; it prevents accidental expansion while narrow hardening lands."* This spec is that deferred refactor.
+**Upstream review:** [.planning/code-review/pr-202-web-pilot-strategy-review.md](../code-review/pr-202-web-pilot-strategy-review.md) — findings **B6** (SQLite-vs-Postgres / web-vs-desktop parity bugs), **B7** (handler-seam test reduced to `existsSync`), **B8** (web transport reaching into Postgres internals), **B9** (`IpcResult` not preserved on the web boundary), and recommendation **F1** (per-domain routes + shared logic + behavioural seam). Most of F1's *structural* half landed (dispatcher split 1,414 → 310 LOC; per-domain route files; `invokeAsIpcResult`; no `pg.Pool` in the dispatcher). Its *behavioural* half — one shared operation module per domain imported by both transports, enforced by a behavioural seam — did not. This spec finishes it.
+**Baseline:** `main` @ `226e8cf2` (v0.68.1). `make ci` + `VARLENS_WEB=1 make ci` assumed green on baseline (re-verify in pre-flight).
+
+---
+
+## Goal
+
+Make the web transport a **thin adapter over one shared, transport-agnostic operation module per domain**, for the six domains whose web routes today re-implement desktop domain orchestration — and **enforce non-drift with a CI gate** so the next divergence is a failing test, not a code-review hope.
+
+Concretely:
+
+1. **Collapse duplicated orchestration.** For `transcripts`, `panels`, `annotations`, `variants`, `cohort`, `export`, the *orchestration above the storage executor* (argument validation against the shared schema, multi-call sequencing, result shaping, event publication, audit/cache callbacks) lives in **one** `src/main/ipc/handlers/<domain>-logic.ts` module. Both the desktop IPC handler and the web Fastify route call the **same exported function**, supplying transport-specific behaviour only through the module's existing **callback injection points** (the `*Callbacks` pattern `panels-logic`/`cohort-logic`/`export-logic` already use).
+2. **Upgrade the seam gate from structural to behavioural.** `tests/web-gate/handler-seam.test.ts` currently pins the *set* of override modules (the narrow-hardening guard). Extend it so that for every shared IPC contract method, the web path must either (a) autoroute to the **same** `task-types` entry the desktop handler dispatches, or (b) the web route and desktop handler import the **same** `<domain>-logic` symbol. A route that re-implements orchestration fails.
+3. **Prove output equality at runtime.** Extend the **already-registered** per-domain scenarios in the parity harness (`tests/web-gate/parity/ipc-fixture-parity.test.ts` + `parity/ipc/<domain>.ts`) with the missing B6 regression cases, asserting desktop-IPC and web-HTTP produce set-equal returned values. Event-emission parity, which the harness cannot observe (RC-9a), is covered by targeted unit tests instead.
+
+The work exits when all six domains are migrated, the behavioural seam gate is **strict** (no orchestration exceptions remain for the six), the parity scenarios pass for all six, and both `make ci-full` and `VARLENS_WEB=1 make ci` are green.
+
+## Audience
+
+A coding agent (Claude Code, Codex, OpenCode, …) executing `superpowers:subagent-driven-development` one task at a time across the PR branches below, the same way Sprints A and B shipped. TDD where a behaviour gate exists; atomic Conventional Commits; `make format` in every task's verification.
+
+---
+
+## Reality-check corrections (verified against `main @ 226e8cf2` this session — re-verify line numbers at task time; they drift)
+
+These drive the spec. Do not re-derive them.
+
+- **RC-1 — The storage-executor seam already converges the Postgres paths; the live drift surface is *above* it.** For the target domains the desktop Postgres branch and the web route both call `session.getReadExecutor()/getWriteExecutor().execute(...)` → the same `PostgresReadExecutor`/`PostgresWriteExecutor` (e.g. `src/main/ipc/handlers/transcripts.ts:81-89` → `PostgresWriteExecutor.ts:303-306` → `PostgresTranscriptsRepository.switchSelectedTranscript`). So B6 is **no longer a storage-layer divergence**. What is still duplicated — and is where the B6 bugs lived — is the **orchestration above the executor**: validation, multi-call sequencing, result shaping, event publication, audit ordering. This refactor targets that layer only.
+
+- **RC-2 — Five of six target domains already have a transport-agnostic `*-logic.ts`; `transcripts` does not.** `panels-logic.ts` (402 LOC), `annotations-logic.ts` (319), `variants-logic.ts` (365), `cohort-logic.ts` (447), `export-logic.ts` (329) exist and are imported by their desktop handlers (`handlers/panels.ts:44`, `annotations.ts:23`, `variants.ts:25`, `cohort.ts:22`, `export.ts:19`). `transcripts` has **no** logic module — its logic is inline in `handlers/transcripts.ts`, branching on `session.capabilities.backend === 'postgres'` at `:38,:81,:123`. PR-1 extracts `transcripts-logic.ts` (the hardest case: proves the "no module yet" path).
+
+- **RC-3 — The logic modules are already designed for transport injection.** `panels-logic` exports a `PanelCacheCallbacks` type; `cohort-logic` a `CohortCallbacks`; `export-logic` an `ExportCallbacks`. `annotations-logic.ts` carries a header comment that it is *"Handler-layer only … prohibited from touching"* the IPC layer — i.e. it is already transport-agnostic. **This is the clean seam:** transport-specific behaviour (window-broadcast vs. SSE publish, cache-invalidation notification) is supplied as a callback the transport passes in, not duplicated logic. The `annotations:upsertPerCase` event-scope difference (desktop broadcasts to all windows via `broadcastAnnotationChanged`; web publishes to one session via `events.publish` at `routes/annotations.ts:72-78`) becomes a **declared injection point**, not drift.
+
+- **RC-4 — Concrete duplication evidence (the orchestration to move):**
+  - **`panels:get`** — web `routes/panels.ts:14-20` hand-rolls the two-call merge `{ ...panel, genes }` (panel read + `panels:getGenes` read). The desktop equivalent lives in `panels-logic.ts`. Two implementations of one shaping rule — the B6 `panels:get` shape bug.
+  - **`panels:update`** — web `routes/panels.ts:32-42` unpacks `{ id, name, description, version }` into `[id, {…}]` itself — the exact B6 argument-shape divergence point, now hand-corrected in the route but still a duplicate.
+  - **`annotations`** — web `routes/annotations.ts` re-implements `detectAnnotationChangeKind` (`:11-20`) and the per-case event publish (`:67-78`); `annotations:getForVariant` uses a quirky per-field parse `CaseVariantIdSchema.shape.caseId.safeParse(caseId)` (`:86`). The write+audit **atomicity** B6 bug is already closed at the executor via the composite write-tasks `annotations:upsertGlobalWithAudit` / `annotations:upsertPerCaseWithAudit` (`routes/annotations.ts:51,68`) — the shared logic must keep that single-task boundary and not re-split write/audit.
+
+- **RC-5 — `invokeAsIpcResult` already normalizes the web error envelope (B9 mostly closed).** `dispatcher.ts:101-115` wraps every override and autoroute result; `<400` returns the value, `>=400` and thrown errors become `SerializableError` via `toSerializableWebError`. Validation-failure shapes like `{ error: 'invalid-panel-id' }` with `reply.code(400)` are converted there. The refactor must **preserve** this envelope: shared logic throws on failure (desktop relies on `wrapHandler`), and the web route lets `invokeAsIpcResult` convert — routes must not invent new ad-hoc success shapes.
+
+- **RC-6 — The dispatcher checks overrides *first*; `task-types` membership is a dormant fallback, not live behaviour.** `dispatcher.ts:255`: if `overrides[key]` exists it runs, and the autoroute branches (`:273`/`:287`, `isReadTaskType`/`isWriteTaskType`, `task-types.ts:128-135`) are never reached for that key. So a method that *both* has an override *and* is in `READ_TASK_TYPES`/`WRITE_TASK_TYPES` is served by the **override**. Concretely, `export:variants` and `export:cohort` are in `READ_TASK_TYPES` (`task-types.ts:41-42`) **but are also overridden** (`routes/export.ts:19,41`) — so the live path is the override, and they are **in scope** for migration (corrects the earlier "leave them, they autoroute" reading). A method with *no* override does autoroute and carries zero drift risk — it is the same executor call on both transports, out of scope for this refactor.
+
+- **RC-7 — Schema-source split (hygiene, opportunistic).** `routes/panels.ts:1` imports `PanelIdSchema/PanelUpdateSchema` from `shared/types/ipc-schemas`, while `routes/annotations.ts:1-6` and `routes/region-files.ts:4` import from `shared/api/schemas/<domain>`. F1's single-source-of-truth goal is `src/shared/api/schemas/<domain>.ts`. Migrated domains should validate handler, route, and logic against **one** schema symbol; consolidate to `shared/api/schemas/<domain>.ts` **only where trivial** (no behaviour change). Do not turn this into a schema migration project (OQ-2).
+
+- **RC-8 — The current seam gate is set-pinning, not behavioural.** `handler-seam.test.ts` holds `EXPECTED_ROUTE_OVERRIDE_MODULES` (20 modules) and `ROUTE_OVERRIDE_LOGIC_EXCEPTIONS` annotating each as e.g. *"thin storage-executor adapters with web-only argument validation."* It prevents new override modules appearing unreviewed but asserts nothing about web↔desktop behavioural equivalence (B7). The upgrade adds the behavioural assertion and a **shrinking** `PENDING_SHARED_LOGIC_EXTRACTION` allowlist (monotonic-decrease, like `agent-health-postgres-baseline.json`) seeded with the six domains and emptied by PR-3.
+
+- **RC-9 — The runtime parity harness already exists, is scenario-driven, and already has all six domains registered.** `tests/web-gate/parity/ipc-fixture-parity.test.ts` launches real Electron (`callElectronApi` / `launchElectronApp`) **and** an isolated web schema (`startWebDriver` / `startIsolatedWebSchema`), runs `IPC_SCENARIOS` from `parity/ipc/scenarios.ts` against both, and compares by hash. Scenario files for `transcripts, panels, annotations, variants, cohort, export` **already exist** under `parity/ipc/`. The work is therefore **extending existing scenarios with the specific B6 cases**, not adding scenario groups — e.g. `parity/ipc/transcripts.ts` currently runs only `insertAndSwitch` + `list` (no `switch`, no parent-`variants`-row assertion).
+- **RC-9a — The parity harness compares returned values by hash and exposes no event channel.** `RuntimeContext` (`parity/ipc/shared.ts:20-28`) exposes only `call(...)` plus case/variant anchors; the harness hashes returned values. It therefore **cannot** observe "a change event fired once with kind X." Event-emission/event-scope parity (the `annotations:upsertPerCase` injected-callback behaviour) must be verified by **targeted adapter/handler unit tests**, not the runtime parity harness. Parity covers the returned-value equality only.
+
+- **RC-10 — `transcripts-logic` should route *both* backends through the executors and drop the `capabilities.backend` branch.** The desktop handler currently branches: Postgres → write executor (`handlers/transcripts.ts:81-89`), SQLite → `db.transcripts.*` (`:89,:131`). But the **SQLite write executor already handles these tasks** (`SqliteWriteExecutor.ts:310-315` → `databaseService.transcripts.switchSelectedTranscript`/`insertTranscriptAndSwitch`), and `transcripts:switch`/`transcripts:insertAndSwitch` are in the write-executor task union (`write-executor.ts:135,137`). `StorageSession` is explicit: *"New domain logic must use getReadExecutor() / getWriteExecutor()"* (`session.ts:15-19`). So the extracted `transcripts-logic.ts` calls `session.getWriteExecutor().execute({ type: 'transcripts:switch', … })` for **all** backends — no `db.transcripts.*`, no `capabilities.backend` branch. This is behaviour-preserving (the SQLite executor case calls the same repository method the old branch did) and strictly simpler. Verify the read executor likewise serves `transcripts:list` for both backends (the web route already calls it), so the read path drops its branch too.
+
+---
+
+## In scope
+
+Three sequenced PRs. PR-1 builds the gate + harness extension and migrates the hardest domain (proves the pattern). PR-2 migrates the B6 flagships. PR-3 migrates the rest and flips the gate to strict. **No IPC contract change, no executor contract change, no renderer behaviour change** in any PR.
+
+### PR-1 — `feat/web-shared-logic-seam-and-transcripts`
+
+The gate, the harness extension, and the `transcripts` migration (the only target with no existing logic module).
+
+| Sub-item | Ref | Summary |
+|---|---|---|
+| **S1: Behavioural seam gate (per override *key*, not per file)** | B7, RC-8 | Extend `tests/web-gate/handler-seam.test.ts`. The gate operates **per override key** (a route-file import check is insufficient — `routes/variants.ts:2` imports `searchVariants` yet `variants:query`/`variants:columnMeta`/`variants:getFilterOptions` at `:48,:28,:107` hand-roll their own executor calls). For **every override key** in a migrated domain, assert it is one of: **(a) a pure executor pass-through** — its only non-validation action is a single `getReadExecutor()/getWriteExecutor().execute({ type: <the same key>, … })` call (behaviourally identical to autoroute), or **(b) it calls a named `<domain>-logic` export** that the desktop handler also calls. Inline multi-call sequencing, result reshaping, or event/audit logic in the route **fails** the gate. Domains in a new `PENDING_SHARED_LOGIC_EXTRACTION` allowlist (seeded with all six: `transcripts, panels, annotations, variants, cohort, export`) are exempt until migrated; methods with **no** override are out of scope (autoroute already shares behaviour). Seeding all six means S1 lands as a green no-op; each extraction removes one entry. Keep the existing set-pinning + `ROUTE_OVERRIDE_LOGIC_EXCEPTIONS` (web-only adapters: `auth, audit-log, batch-import, import, region-files, gene-ref, hpo, protein, vep, cases, case-metadata, gene-lists, analysis-groups, database`). Both allowlists are monotonic-decrease — a `// do not add` banner + a test that fails if either grows. Per-method body analysis needs AST (OQ-1). |
+| **S2: Extend the existing `transcripts` parity scenario** | B6, RC-9 | `parity/ipc/transcripts.ts` already runs `insertAndSwitch` + `list`. **Extend** it with `transcripts:switch` and a follow-up read asserting the parent `variants` row reflects the switch (the original B6 case). No new scenario group; the area is already in `REQUIRED_IPC_AREAS`. Run the gated parity test (locks current behaviour before extraction). |
+| **S3: Extract `transcripts-logic.ts` (executor-routed, no backend branch)** | RC-2, RC-10 | Create `src/main/ipc/handlers/transcripts-logic.ts` exporting transport-agnostic fns `(session, params, callbacks?) => Promise<…>` for list/switch/insertAndSwitch that route **all** backends through `session.getReadExecutor()/getWriteExecutor()` (RC-10: the SQLite executor already serves these tasks; `session.ts:15` mandates it). **No `db.transcripts.*`, no `capabilities.backend` branch.** `handlers/transcripts.ts` and `routes/transcripts.ts` both import these; the route keeps only HTTP/validation concerns. In the **same task**, remove `transcripts` from `PENDING_SHARED_LOGIC_EXTRACTION` so the gate enforces it. Commit order keeps every commit green: S1 lands with all six allowlisted (no-op), then S3 extracts + de-lists transcripts. |
+| **S4: Gate + parity + CI green** | gates | `transcripts` passes the behavioural gate (both import the symbol); the `transcripts` parity scenarios pass; `make ci-full` + `VARLENS_WEB=1 make ci` green. |
+
+### PR-2 — `feat/web-shared-logic-panels-annotations`
+
+The two B6 flagships.
+
+| Sub-item | Ref | Summary |
+|---|---|---|
+| **P1: Extend the `panels` parity scenario** | B6, RC-4 | Extend `parity/ipc/panels.ts` with `panels:get` (assert the `{ ...panel, genes }` shape — the B6 genes-payload bug) and `panels:update` (assert `[id, {name,description,version}]` shaping → returned value equal across transports). |
+| **P2: Migrate `panels` route to `panels-logic`** | RC-3, RC-4 | Move the two-call merge and the update-arg unpacking out of `routes/panels.ts` into a `panels-logic` function (extend the existing module, keep it ≤600 LOC; split by operation if needed). Web route + desktop handler both call it. Remove `panels` from `PENDING_SHARED_LOGIC_EXTRACTION`. |
+| **P3: Extend the `annotations` parity scenario + add targeted event tests** | B6, RC-4, RC-9a | Extend `parity/ipc/annotations.ts` with returned-value coverage of `annotations:upsertPerCase`, `annotations:upsertGlobal` (write+audit atomicity: audit row present iff write committed — assert via a follow-up read in the scenario), `annotations:getForVariant`, `annotations:getGlobal`. **Event-emission/scope is NOT parity-harness-observable** (RC-9a) → add **targeted adapter/handler unit tests** asserting the injected event callback fires once with the correct `kind` on each transport. |
+| **P4: Migrate `annotations` route to `annotations-logic`** | RC-3, RC-4, RC-5 | Move `detectAnnotationChangeKind` and the per-case event emission into `annotations-logic` behind an **event callback** the transport supplies (desktop → `broadcastAnnotationChanged`; web → `events.publish(userId, …)`). Keep the composite `*WithAudit` write-tasks (do not re-split write/audit). Web route keeps only validation + the SSE callback. Remove `annotations` from the allowlist. |
+| **P5: Gate + parity + CI green** | gates | Behavioural gate passes for both; parity scenarios pass; `make ci-full` + `VARLENS_WEB=1 make ci` green. |
+
+### PR-3 — `feat/web-shared-logic-variants-cohort-export`
+
+The remainder, then strict gate.
+
+| Sub-item | Ref | Summary |
+|---|---|---|
+| **V1: `variants` parity + migration** | B6, RC-4, F2 | Extend `parity/ipc/variants.ts` for `variants:search` (return shape matches the contract — the B6 envelope-vs-`Variant[]` divergence). Then bring **every** `variants` override key to gate-passing: `variants:search` → `variants-logic`; for `variants:query`/`variants:columnMeta`/`variants:getFilterOptions`, either confirm they are pure executor pass-throughs (gate branch (a)) or route them through `variants-logic` if the desktop handler does extra orchestration. Remove `variants` from the allowlist. |
+| **C1: `cohort` parity + migration** | RC-4 | Extend `parity/ipc/cohort.ts` for the five `cohort` override methods (`exec=5` in `routes/cohort.ts`), incl. any cache-rebuild side effect (modelled as a `CohortCallbacks` injection; web-only staleness pings stay in the route as documented transport concerns, OQ-4). Bring every cohort override key to gate-passing via `cohort-logic`. Remove `cohort` from the allowlist. |
+| **E1: `export` parity + migration** | RC-6, F1 | `export:variants` and `export:cohort` are **overridden** (`routes/export.ts:19,41`), so the override is the live path despite `READ_TASK_TYPES` membership (RC-6). Bring both override keys to gate-passing: route through `export-logic` (via `ExportCallbacks`) **or**, if each override is already a pure single-executor pass-through with the same task key, confirm it satisfies gate branch (a). Remove `export` from the allowlist. |
+| **G1: Flip the gate strict** | B7, RC-8 | `PENDING_SHARED_LOGIC_EXTRACTION` is now empty; assert it is empty (the gate is strict for the six). Any future override for these domains must be backed by a shared symbol or the test fails. |
+| **G2: Full gates** | gates | `make ci-full` + `VARLENS_WEB=1 make ci` green; the full parity suite (all six domains) passes under the gated env. |
+
+---
+
+## Open Questions (resolve at task time — each has a default so the plan is executable)
+
+| # | Question | Default (used if unresolved) | Resolved by |
+|---|---|---|---|
+| **OQ-1** | How does the per-override-key gate analyse handler bodies (pass-through vs. calls-logic-export, RC-8/F2)? | **`ts-morph`** — the per-key predicate ("only non-validation action is one `executor.execute({type:<key>})`" vs. "calls a named `<domain>-logic` export") requires AST, not regex; a file-level regex import check is exactly the false-positive F2 flagged. Precedent: `tests/web-gate/auth-isolation.test.ts` already uses `ts-morph` static analysis. Keep the cheap regex set-pinning for the *module-set* guard. | PR-1 / S1 |
+| **OQ-2** | Consolidate each migrated domain onto `src/shared/api/schemas/<domain>.ts` (RC-7)? | **Opportunistic only** — share whatever schema symbol the desktop handler already validates against; move to `shared/api/schemas` only where it's a zero-behaviour-change re-export. No schema migration project. | per-domain PR |
+| **OQ-3** | Do the parity scenarios run in required CI or stay opt-in gated (RC-9)? | **Stay opt-in** (`VARLENS_RUN_WEB_GATE_PARITY=1 && VARLENS_RUN_WEB_PARITY_E2E=1`, needs PG + Electron build) exactly as today; the **behavioural-static** gate (S1) is the always-on required signal. Document the gated command in the PR body and run it locally per PR. | PR-1 / S1 |
+| **OQ-4** | `cohort` cache-rebuild side effects — model as a `CohortCallbacks` injection or leave in the route? | **Callback injection** (RC-3 pattern) so the side effect is declared, not duplicated; if a side effect is genuinely web-only (SSE staleness ping), it stays in the route as a documented transport concern. | PR-3 / C1 |
+
+---
+
+## Non-goals (defer / out)
+
+- **No storage-executor contract change.** Chosen shape is shared operation modules, not pushing orchestration into the read/write executors (the alternative considered and rejected for blast-radius).
+- **No row-level / tenant-level multi-user data scoping.** Remains a narrow-hardening non-goal (B2 stays accepted single-admin; `auth:createUser` stays disabled). This refactor does not touch the auth boundary.
+- **No new public REST / OpenAPI vocabulary.** The dispatcher RPC shape and `/api/<domain>/<method>` surface are unchanged.
+- **No migration of the legitimately web-only adapters** — `auth` (cookie/session boundary), `audit-log` (admin-gated audit-trail read adapter; already an audited override per `handler-seam.test.ts`), `import`/`batch-import`/`upload-staging` (browser-upload refs), `region-files` (server-path guard), `gene-ref`/`hpo`/`protein`/`vep` (web mode disables external fetches by design), and trivial single-executor pass-throughs (`cases`, `case-metadata`, `gene-lists`, `analysis-groups`, `database`). These stay thin adapters; the seam test's exception allowlist documents each.
+- **No Electron behaviour change.** Desktop SQLite and Postgres paths must be byte-for-byte unchanged (the refactor-checkpoint + main suites are the trip-wire).
+- **No schema-migration project** (OQ-2 default).
+
+---
+
+## Acceptance gates
+
+Every gate maps 1:1 to a verification step in the plan.
+
+1. **Behavioural seam (always-on, per override key):** `handler-seam.test.ts` asserts every override **key** of a migrated domain is either a pure single-executor pass-through with the same task key, or calls a `<domain>-logic` export the desktop handler also calls (S1/F2). The `PENDING_SHARED_LOGIC_EXTRACTION` allowlist is monotonic-decrease and ends empty (PR-3). A route that re-implements orchestration for any single method fails the test.
+2. **transcripts:** `transcripts-logic.ts` exists; desktop handler + web route both import it; SQLite-desktop / Postgres-desktop / Postgres-web all served by the one module; `transcripts:switch` parity scenario shows the parent `variants` row reflects the switch on both transports.
+3. **panels:** `panels:get` returns `{ ...panel, genes }` and `panels:update` shapes `[id, {…}]` identically on desktop and web, both via `panels-logic`; parity scenarios pass.
+4. **annotations:** both transports go through `annotations-logic`; write+audit atomicity preserved (`*WithAudit` task) and returned-value parity scenarios pass; the per-case change event firing once with the correct `kind` via the injected callback is verified by **targeted adapter/handler unit tests** (not the parity harness, RC-9a).
+5. **variants:** `variants:search` return shape matches the IPC contract on both transports via `variants-logic`; parity scenario passes.
+6. **cohort:** the five cohort overrides go through `cohort-logic` with cache side effects modelled as callbacks; parity scenarios pass.
+7. **export:** the overridden `export:variants`/`export:cohort` keys (RC-6/F1 — overridden, not autorouted) pass the per-key gate, via `export-logic` or as confirmed pure pass-throughs; parity scenarios pass.
+8. **Strict gate:** `PENDING_SHARED_LOGIC_EXTRACTION` is empty and asserted empty; the six domains can no longer re-implement orchestration without a test failure.
+9. **No-contract-change:** `tests/shared/types/preload-contract.test.ts`, the refactor-checkpoint suite, and the desktop main/renderer suites pass unchanged (no IPC/executor/renderer behaviour change).
+10. **CI:** `make ci-full` green per PR; `VARLENS_WEB=1 make ci` green per PR; `make agent-check` clean (no migrated `*-logic.ts` over 600 LOC without justification).
+
+---
+
+## PR shape
+
+| PR | Branch | Tasks | Conventional title | Depends on |
+|---|---|---|---|---|
+| **PR-1** | `feat/web-shared-logic-seam-and-transcripts` | S1–S4 | `refactor(web): behavioural handler seam + share transcripts logic across transports` | — |
+| **PR-2** | `feat/web-shared-logic-panels-annotations` | P1–P5 | `refactor(web): share panels + annotations logic across transports` | PR-1 |
+| **PR-3** | `feat/web-shared-logic-variants-cohort-export` | V1, C1, E1, G1, G2 | `refactor(web): share variants/cohort/export logic; strict transport seam` | PR-2 |
+
+Sequenced (each builds on the prior's gate state). Not parallel — they share `handler-seam.test.ts` and the parity scenario registry.
+
+## Project-rule constraints (all PRs)
+
+- **Branch discipline.** No feature work on `main` (`AGENTS.md`). Each PR on its own branch; worktrees if a clean checkout is needed.
+- **No `console.*`.** New `*-logic.ts` uses `mainLogger`; routes use the existing web error envelope. Logic modules stay free of Electron/Fastify imports (RC-3: `annotations-logic` already enforces this).
+- **DRY / cohort parity / never-lower-thresholds.** `feedback_dry_principles.md` is the entire thesis here (one implementation, two transports). Do not weaken any gate to land a PR; fix the code.
+- **LLM-sustainable size.** Migrated `*-logic.ts` stay ≤600 LOC (`cohort-logic.ts` is already 447 — split by operation if folding web orchestration would exceed the bar). `make agent-check` before each PR.
+- **Preserve `IpcResult`/`SerializableError` envelope** (RC-5). Logic throws; desktop `wrapHandler` and web `invokeAsIpcResult` convert. Routes invent no new success/error shapes.
+- **`.planning/` for specs/plans/artifacts.** Parity artifacts under `.planning/artifacts/web/parity/` are gitignored; numbers live in PR bodies.
+
+## Risks and rollback
+
+| Risk | Mitigation | Rollback |
+|---|---|---|
+| Extracting `transcripts-logic` from a backend-branching inline handler changes desktop SQLite behaviour. | Parity + refactor-checkpoint + main suites written/run before extraction; the `session.capabilities.backend` branch is preserved verbatim (RC-10). | Revert PR-1; transcripts handler is in git history. |
+| Annotation write+audit atomicity regresses when moving event logic into shared logic. | Keep the composite `*WithAudit` write-tasks (RC-4); parity scenario asserts audit-row-iff-committed (gate 4). | Revert P4; the route's current path stands. |
+| `cohort-logic.ts` exceeds 600 LOC after folding web orchestration. | Split by operation into helper fns/modules; `make agent-check` gate (gate 10). | Land the split as its own commit within PR-3. |
+| The behavioural gate produces false positives (regex import matching). | OQ-1 default regex; escalate to `ts-morph` (precedent: `auth-isolation.test.ts`) if needed. | Loosen the regex; the allowlist still constrains scope. |
+| Parity harness env is heavy (PG + Electron build) and not in required CI. | OQ-3: behavioural-static gate is the always-on signal; parity is gated and run locally per PR with the documented command. | N/A — parity is advisory-but-required-per-PR, not a CI blocker. |
+
+## References
+
+- `.planning/code-review/pr-202-web-pilot-strategy-review.md` — B6/B7/B8/B9, F1
+- `.planning/specs/2026-06-13-web-narrow-hardening.md` — the predecessor that deferred this
+- `.planning/web/context/decisions/adr/0002-parallel-maintainability.md` — "single codebase, two transports; domain logic in one module both import"
+- `src/web/server/dispatcher.ts` (override + autoroute + `invokeAsIpcResult`), `src/web/server/task-types.ts` (read/write task sets, `toTaskDomain`)
+- `src/web/server/routes/{transcripts,panels,annotations,variants,cohort,export}.ts` — the routes to thin out
+- `src/main/ipc/handlers/{panels,annotations,variants,cohort,export}-logic.ts` — the shared modules to extend; `handlers/transcripts.ts` — the module to extract from
+- `tests/web-gate/handler-seam.test.ts` (the gate to upgrade), `tests/web-gate/parity/ipc-fixture-parity.test.ts` + `parity/ipc/scenarios.ts` (the harness to extend)
+- `AGENTS.md`, `CLAUDE.md`; memory `feedback_dry_principles.md`, `feedback_never_lower_thresholds.md`, `feedback_cohort_parity.md`

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 
 web-dev: ## Start local Postgres-backed web mode at http://localhost:$(WEB_DEV_PORT)/
 	@if [ ! -f .env.postgres.local ]; then echo "Missing .env.postgres.local. Copy .env.postgres.example first."; exit 1; fi
-	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "$(WEB_DEV_ENV_FILE)"; fi; set +a; \
+	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "./$(WEB_DEV_ENV_FILE)"; fi; set +a; \
 		node -e "const { Client } = require('pg'); const client = new Client({ connectionString: process.env.VARLENS_PG_URL }); client.connect().then(() => client.end()).then(() => process.exit(0)).catch(() => process.exit(1));" \
 		&& echo "Postgres reachable at $$(node -e 'const url = new URL(process.env.VARLENS_PG_URL); console.log(url.host)') - skipping pg-up." \
 		|| $(MAKE) pg-up
@@ -87,11 +87,11 @@ web-dev: ## Start local Postgres-backed web mode at http://localhost:$(WEB_DEV_P
 	@echo "  Postgres: .env.postgres.local"
 	@if [ -f "$(WEB_DEV_ENV_FILE)" ]; then echo "  Web env:  $(WEB_DEV_ENV_FILE)"; else echo "  Web env:  $(WEB_DEV_ENV_FILE) (not present; using defaults)"; fi
 	@echo "  Schema:   $(WEB_DEV_SCHEMA)"
-	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "$(WEB_DEV_ENV_FILE)"; fi; set +a; echo "  Secrets:  $${VARLENS_RECOVERY_KEY_DIR:-$(WEB_DEV_RECOVERY_KEY_DIR)}"
-	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "$(WEB_DEV_ENV_FILE)"; fi; set +a; echo "  API delay: $${VARLENS_WEB_API_LATENCY_MS:-$(WEB_DEV_API_LATENCY_MS)}ms"
+	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "./$(WEB_DEV_ENV_FILE)"; fi; set +a; echo "  Secrets:  $${VARLENS_RECOVERY_KEY_DIR:-$(WEB_DEV_RECOVERY_KEY_DIR)}"
+	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "./$(WEB_DEV_ENV_FILE)"; fi; set +a; echo "  API delay: $${VARLENS_WEB_API_LATENCY_MS:-$(WEB_DEV_API_LATENCY_MS)}ms"
 	@echo "  Dev admin bootstrap: set VARLENS_ADMIN_PASSWORD_HASH for first run"
 	@echo ""
-	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "$(WEB_DEV_ENV_FILE)"; fi; set +a; \
+	@set -a; . ./.env.postgres.local; if [ -f "$(WEB_DEV_ENV_FILE)" ]; then . "./$(WEB_DEV_ENV_FILE)"; fi; set +a; \
 		NODE_ENV=development \
 		APP_PATH_PREFIX="$${APP_PATH_PREFIX:-/}" \
 		VARLENS_WEB_HOST="$${VARLENS_WEB_HOST:-127.0.0.1}" \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">VarLens</h1>
 
 <p align="center">
-  <strong>Offline genetic variant analysis, right on your desktop.</strong>
+  <strong>Genetic variant analysis — on your desktop or self-hosted.</strong>
 </p>
 
 <p align="center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: VarLens
-  text: Offline Genetic Variant Analysis
-  tagline: A desktop application for secure, offline analysis of genetic variants — built for research collaborators
+  text: Genetic Variant Analysis
+  tagline: Secure analysis of genetic variants on the desktop or self-hosted — built for research collaborators
   actions:
     - theme: brand
       text: Get Started
@@ -22,6 +22,6 @@ features:
     details: Classify variants using the ACMG/AMP evidence framework with Bayesian point-based scoring
   - title: Cohort Analysis
     details: Aggregate variants across cases for carrier frequency analysis and gene burden testing
-  - title: Offline & Secure
-    details: All data stays on your machine. No cloud uploads, no accounts, no tracking. SQLite database with optional encryption
+  - title: Private & Secure
+    details: Run fully offline on the desktop with all data on your machine, or self-host the web app on your own infrastructure. No third-party cloud, no tracking. SQLite or PostgreSQL, with optional encryption
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "varlens",
   "version": "0.68.1",
-  "description": "Offline variant analysis tool for external collaborators",
+  "description": "Genetic variant analysis tool for external collaborators",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/berntpopp/VarLens",
   "author": "Bernt Popp <bernt.popp@gmail.com>",

--- a/src/main/ipc/handlers/annotations-logic.ts
+++ b/src/main/ipc/handlers/annotations-logic.ts
@@ -12,6 +12,8 @@ import type {
   CaseVariantAnnotation,
   AcmgClassification
 } from '../../database/types'
+import type { AnnotationChangeEvent } from '../../../shared/types/api'
+import type { StorageSession } from '../../storage/session'
 
 /** Validated variant coordinates. */
 export interface VariantCoords {
@@ -316,4 +318,60 @@ export async function batchGetAnnotations(
   }
   const db = getDb()
   return db.annotations.getBatch(caseId, variantKeys)
+}
+
+// ---------------------------------------------------------------------------
+// Session-based helpers (transport-agnostic, shared by web and desktop)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map per-case annotation update fields to the broadcast/SSE event `kind`.
+ * Priority order: star → acmg → evidence → comment.
+ * Exported so it is the single source of truth — web route and desktop
+ * handler both import from here rather than duplicating the logic.
+ */
+export function detectAnnotationChangeKind(updates: {
+  starred?: unknown
+  acmg_classification?: unknown
+  acmg_evidence?: unknown
+}): AnnotationChangeEvent['kind'] {
+  if (updates.starred !== undefined) return 'star'
+  if (updates.acmg_classification !== undefined) return 'acmg'
+  if (updates.acmg_evidence !== undefined) return 'evidence'
+  return 'comment'
+}
+
+/**
+ * Upsert a global annotation via a StorageSession write executor.
+ * Delegates to the composite `annotations:upsertGlobalWithAudit` task so that
+ * audit-trail creation is handled by the backend (Postgres) or executor.
+ */
+export async function upsertGlobalAnnotationViaSession(
+  coords: VariantCoords,
+  updates: GlobalAnnotationUpdates,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return getSession()
+    .getWriteExecutor()
+    .execute({ type: 'annotations:upsertGlobalWithAudit', params: [coords, updates] })
+}
+
+/**
+ * Upsert a per-case annotation via a StorageSession write executor, then
+ * invoke the caller-supplied `onChange` callback with the change event.
+ * The callback is called only after a successful write; a thrown error
+ * propagates before `onChange` is reached.
+ */
+export async function upsertPerCaseAnnotationWithEvent(
+  caseId: number,
+  variantId: number,
+  updates: PerCaseAnnotationUpdates,
+  getSession: () => StorageSession,
+  onChange: (e: AnnotationChangeEvent) => void
+): Promise<unknown> {
+  const result = await getSession()
+    .getWriteExecutor()
+    .execute({ type: 'annotations:upsertPerCaseWithAudit', params: [caseId, variantId, updates] })
+  onChange({ caseId, variantId, kind: detectAnnotationChangeKind(updates) })
+  return result
 }

--- a/src/main/ipc/handlers/annotations.ts
+++ b/src/main/ipc/handlers/annotations.ts
@@ -13,10 +13,10 @@ import { mainLogger } from '../../services/MainLogger'
 import type { AnnotationChangeEvent } from '../../../shared/types/api'
 import {
   getGlobalAnnotation,
-  upsertGlobalAnnotation,
+  upsertGlobalAnnotationViaSession,
   deleteGlobalAnnotation,
   getPerCaseAnnotation,
-  upsertPerCaseAnnotation,
+  upsertPerCaseAnnotationWithEvent,
   deletePerCaseAnnotation,
   getAnnotationsForVariant,
   batchGetAnnotations
@@ -36,22 +36,6 @@ function broadcastAnnotationChanged(ev: AnnotationChangeEvent): void {
       win.webContents.send('variants:annotationChanged', ev)
     }
   }
-}
-
-/**
- * Map the validated per-case annotation update shape to the broadcast
- * event `kind`. Priority order: star → acmg → evidence → comment.
- * Called only after Zod validation has succeeded so the fields are typed.
- */
-function detectAnnotationChangeKind(updates: {
-  starred?: unknown
-  acmg_classification?: unknown
-  acmg_evidence?: unknown
-}): AnnotationChangeEvent['kind'] {
-  if (updates.starred !== undefined) return 'star'
-  if (updates.acmg_classification !== undefined) return 'acmg'
-  if (updates.acmg_evidence !== undefined) return 'evidence'
-  return 'comment'
 }
 
 /**
@@ -120,14 +104,11 @@ export function registerAnnotationHandlers({
           throw new Error('Invalid annotation updates')
         }
 
-        const session = getDbManager().getCurrentSession()
-        if (session.capabilities.backend === 'postgres') {
-          return await session.getWriteExecutor().execute({
-            type: 'annotations:upsertGlobalWithAudit',
-            params: [validatedCoords.data, validatedUpdates.data]
-          })
-        }
-        return upsertGlobalAnnotation(validatedCoords.data, validatedUpdates.data, getDb)
+        return await upsertGlobalAnnotationViaSession(
+          validatedCoords.data,
+          validatedUpdates.data,
+          () => getDbManager().getCurrentSession()
+        )
       })
     }
   )
@@ -215,32 +196,16 @@ export function registerAnnotationHandlers({
           throw new Error('Invalid annotation updates')
         }
 
-        const session = getDbManager().getCurrentSession()
-        let result: unknown
-        if (session.capabilities.backend === 'postgres') {
-          result = await session.getWriteExecutor().execute({
-            type: 'annotations:upsertPerCaseWithAudit',
-            params: [validatedIds.data.caseId, validatedIds.data.variantId, validatedUpdates.data]
-          })
-        } else {
-          result = upsertPerCaseAnnotation(
-            validatedIds.data.caseId,
-            validatedIds.data.variantId,
-            validatedUpdates.data,
-            getDb
-          )
-        }
-
-        // Broadcast AFTER the logic-layer write succeeds. If the call above
-        // throws, `wrapHandler` catches it and this line never runs — the
+        // Broadcast AFTER the logic-layer write succeeds. If the execute call
+        // throws, `wrapHandler` catches it and the callback never runs — the
         // error path must not emit the event (Wave 1.E spec §6).
-        broadcastAnnotationChanged({
-          caseId: validatedIds.data.caseId,
-          variantId: validatedIds.data.variantId,
-          kind: detectAnnotationChangeKind(validatedUpdates.data)
-        })
-
-        return result
+        return await upsertPerCaseAnnotationWithEvent(
+          validatedIds.data.caseId,
+          validatedIds.data.variantId,
+          validatedUpdates.data,
+          () => getDbManager().getCurrentSession(),
+          broadcastAnnotationChanged
+        )
       })
     }
   )

--- a/src/main/ipc/handlers/cohort-logic.ts
+++ b/src/main/ipc/handlers/cohort-logic.ts
@@ -121,6 +121,69 @@ export function spawnRebuildWorker(
 }
 
 /**
+ * Postgres-backed cohort variant query, executed via the storage read
+ * executor. Shared by the desktop postgres branch and the web transport so
+ * both run one implementation. Defaults `genome_build` to GRCh38 to match the
+ * desktop SQLite/pool path's backward-compatibility behavior.
+ */
+export async function getCohortVariantsViaSession(
+  params: ValidatedCohortSearchParams,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  const cohortParams = { ...params } as typeof params & { genome_build?: string }
+  cohortParams.genome_build = cohortParams.genome_build ?? 'GRCh38'
+  const result = await getSession()
+    .getReadExecutor()
+    .execute({ type: 'cohort:query', params: [cohortParams] })
+  return convertBigInts(result)
+}
+
+/** Postgres-backed cohort column metadata via the storage read executor. */
+export async function getCohortColumnMetaViaSession(
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({ type: 'cohort:columnMeta', params: [] })
+}
+
+/** Postgres-backed cohort summary via the storage read executor. */
+export async function getCohortSummaryViaSession(
+  getSession: () => StorageSession
+): Promise<unknown> {
+  const summary = await getSession()
+    .getReadExecutor()
+    .execute({ type: 'cohort:summary', params: [] })
+  return convertBigInts(summary)
+}
+
+/** Postgres-backed cohort carriers for a variant via the storage read executor. */
+export async function getCohortCarriersViaSession(
+  chr: string,
+  pos: number,
+  ref: string,
+  alt: string,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  const carriers = await getSession()
+    .getReadExecutor()
+    .execute({ type: 'cohort:carriers', params: [chr, pos, ref, alt] })
+  return convertBigInts(carriers)
+}
+
+/** Postgres-backed cohort gene-burden via the storage read executor. */
+export async function getCohortGeneBurdenViaSession(
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({ type: 'cohort:geneBurden', params: [] })
+}
+
+/** Postgres-backed cohort summary status via the storage read executor. */
+export async function getCohortSummaryStatusViaSession(
+  getSession: () => StorageSession
+): Promise<unknown> {
+  return await getSession().getReadExecutor().execute({ type: 'cohort:summaryStatus', params: [] })
+}
+
+/**
  * Query cohort variants with optional panel filtering.
  */
 export async function queryCohortVariants(
@@ -129,6 +192,11 @@ export async function queryCohortVariants(
   getDbPool?: () => DbPool | null,
   getSession?: GetSession
 ): Promise<unknown> {
+  const postgresSession = getPostgresSession(getSession)
+  if (postgresSession !== undefined) {
+    return getCohortVariantsViaSession(params, () => postgresSession)
+  }
+
   const cohortParams = { ...params } as typeof params & {
     panel_intervals?: Array<{ chr: string; start: number; end: number }>
     genome_build?: string
@@ -139,15 +207,6 @@ export async function queryCohortVariants(
   // The renderer populates this from the cohort view's genome build selector,
   // which is seeded from cases:availableBuilds.
   cohortParams.genome_build = cohortParams.genome_build ?? 'GRCh38'
-
-  const postgresSession = getPostgresSession(getSession)
-  if (postgresSession !== undefined) {
-    const result = await postgresSession.getReadExecutor().execute({
-      type: 'cohort:query',
-      params: [cohortParams]
-    })
-    return convertBigInts(result)
-  }
 
   const pool = getDbPool?.()
 
@@ -197,10 +256,7 @@ export async function getColumnMeta(
 ): Promise<unknown> {
   const postgresSession = getPostgresSession(getSession)
   if (postgresSession !== undefined) {
-    return await postgresSession.getReadExecutor().execute({
-      type: 'cohort:columnMeta',
-      params: []
-    })
+    return getCohortColumnMetaViaSession(() => postgresSession)
   }
 
   const pool = getDbPool?.()
@@ -222,11 +278,7 @@ export async function getCohortSummary(
 ): Promise<unknown> {
   const postgresSession = getPostgresSession(getSession)
   if (postgresSession !== undefined) {
-    const summary = await postgresSession.getReadExecutor().execute({
-      type: 'cohort:summary',
-      params: []
-    })
-    return convertBigInts(summary)
+    return getCohortSummaryViaSession(() => postgresSession)
   }
 
   const pool = getDbPool?.()
@@ -255,11 +307,7 @@ export async function getCarriers(
 ): Promise<unknown> {
   const postgresSession = getPostgresSession(getSession)
   if (postgresSession !== undefined) {
-    const carriers = await postgresSession.getReadExecutor().execute({
-      type: 'cohort:carriers',
-      params: [chr, pos, ref, alt]
-    })
-    return convertBigInts(carriers)
+    return getCohortCarriersViaSession(chr, pos, ref, alt, () => postgresSession)
   }
 
   const pool = getDbPool?.()
@@ -287,10 +335,7 @@ export async function getGeneBurden(
 ): Promise<unknown> {
   const postgresSession = getPostgresSession(getSession)
   if (postgresSession !== undefined) {
-    return await postgresSession.getReadExecutor().execute({
-      type: 'cohort:geneBurden',
-      params: []
-    })
+    return getCohortGeneBurdenViaSession(() => postgresSession)
   }
 
   const pool = getDbPool?.()
@@ -377,10 +422,7 @@ export async function getSummaryStatus(
 ): Promise<unknown> {
   const postgresSession = getPostgresSession(getSession)
   if (postgresSession !== undefined) {
-    return await postgresSession.getReadExecutor().execute({
-      type: 'cohort:summaryStatus',
-      params: []
-    })
+    return getCohortSummaryStatusViaSession(() => postgresSession)
   }
 
   const pool = getDbPool?.()

--- a/src/main/ipc/handlers/panels-logic.ts
+++ b/src/main/ipc/handlers/panels-logic.ts
@@ -11,6 +11,7 @@ import type { CreatePanelInput } from '../../database/PanelRepository'
 import type { GeneReferenceDb } from '../../database/GeneReferenceDb'
 import type { PanelAppClient } from '../../services/api/PanelAppClient'
 import type { StringDbClient } from '../../services/api/StringDbClient'
+import type { StorageSession } from '../../storage/session'
 
 /** Confidence levels considered "green" (high confidence) */
 const GREEN_LEVELS = new Set(['3', '4', 'green'])
@@ -38,6 +39,22 @@ export function getPanel(id: number, getDb: () => DatabaseService): unknown {
   if (!panel) return null
   const genes = db.panels.getGenes(id)
   return { ...panel, genes }
+}
+
+/**
+ * Session-based variant of getPanel: fetches panel + genes via the storage
+ * executor so it works on both the Postgres and SQLite backends without
+ * branching on session.capabilities.backend.
+ */
+export async function getPanelWithGenes(
+  id: number,
+  getSession: () => StorageSession
+): Promise<unknown> {
+  const session = getSession()
+  const panel = await session.getReadExecutor().execute({ type: 'panels:get', params: [id] })
+  if (panel === null) return null
+  const genes = await session.getReadExecutor().execute({ type: 'panels:getGenes', params: [id] })
+  return { ...(panel as object), genes }
 }
 
 export function createPanel(

--- a/src/main/ipc/handlers/panels.ts
+++ b/src/main/ipc/handlers/panels.ts
@@ -26,6 +26,7 @@ import { writeFile } from 'fs/promises'
 import {
   listPanels,
   getPanel,
+  getPanelWithGenes,
   createPanel,
   updatePanel,
   deletePanel,
@@ -79,17 +80,7 @@ export function registerPanelHandlers({ ipcMain, getDb, getDbManager }: HandlerD
         mainLogger.error(`Invalid panels:get id: ${validated.error.message}`, 'panels')
         throw new Error('Invalid panel ID')
       }
-      const session = getDbManager().getCurrentSession()
-      if (session.capabilities.backend === 'postgres') {
-        const panel = await session
-          .getReadExecutor()
-          .execute({ type: 'panels:get', params: [validated.data] })
-        const genes = await session
-          .getReadExecutor()
-          .execute({ type: 'panels:getGenes', params: [validated.data] })
-        return panel === null ? null : { ...(panel as object), genes }
-      }
-      return getPanel(validated.data, getDb)
+      return getPanelWithGenes(validated.data, () => getDbManager().getCurrentSession())
     })
   })
 

--- a/src/main/ipc/handlers/panels.ts
+++ b/src/main/ipc/handlers/panels.ts
@@ -25,7 +25,6 @@ import { dialog } from 'electron'
 import { writeFile } from 'fs/promises'
 import {
   listPanels,
-  getPanel,
   getPanelWithGenes,
   createPanel,
   updatePanel,

--- a/src/web/auth/PostgresWebAuthService.ts
+++ b/src/web/auth/PostgresWebAuthService.ts
@@ -255,7 +255,8 @@ export class PostgresWebAuthService {
   async createFirstUserFromHash(
     username: string,
     displayName: string,
-    passwordHash: string
+    passwordHash: string,
+    mustChangePassword: boolean = true
   ): Promise<{ id: number; username: string; role: UserRole }> {
     if (!isLikelyArgon2idHash(passwordHash)) {
       throw new Error(
@@ -264,7 +265,7 @@ export class PostgresWebAuthService {
       )
     }
     assertArgon2idHashMatchesProviderPolicy(passwordHash)
-    return await this.insertFirstUser(username, displayName, passwordHash)
+    return await this.insertFirstUser(username, displayName, passwordHash, mustChangePassword)
   }
 
   /**
@@ -284,7 +285,8 @@ export class PostgresWebAuthService {
   private async insertFirstUser(
     username: string,
     displayName: string,
-    passwordHash: string
+    passwordHash: string,
+    mustChangePassword: boolean = true
   ): Promise<{ id: number; username: string; role: UserRole }> {
     const sch = this.schemaQuoted
     // Race-safety: the SELECT-outside-transaction pattern in earlier
@@ -295,12 +297,13 @@ export class PostgresWebAuthService {
     // (SQLSTATE 23505) and we translate it into the same friendly error a
     // serial caller would see.
     //
-    // The bootstrapped admin is created with must_change_password=TRUE
-    // so the first login forces a rotation before any session-bearing
-    // request can reach the application surface. The dispatcher's
-    // pre-rotation gate enforces this server-side; the operator never
-    // sees an exposure window where the bootstrap credential could
-    // call /api/* freely.
+    // The bootstrapped admin defaults to must_change_password=TRUE so the
+    // first login forces a rotation before any session-bearing request can
+    // reach the application surface. The dispatcher's pre-rotation gate
+    // enforces this server-side; the operator never sees an exposure window
+    // where the bootstrap credential could call /api/* freely. Callers may
+    // pass mustChangePassword=false (dev only, via
+    // VARLENS_ADMIN_MUST_CHANGE_PASSWORD) to skip the forced rotation.
     const client = await this.pool.connect()
     try {
       await client.query('BEGIN')
@@ -311,9 +314,9 @@ export class PostgresWebAuthService {
       const inserted = await client.query<{ id: string }>(
         `INSERT INTO ${sch}."users"
           (username, display_name, password_hash, role, must_change_password, password_changed_at)
-         VALUES ($1, $2, $3, $4, TRUE, now())
+         VALUES ($1, $2, $3, $4, $5, now())
          RETURNING id`,
-        [username, displayName, passwordHash, ROLE_ADMIN]
+        [username, displayName, passwordHash, ROLE_ADMIN, mustChangePassword]
       )
       await client.query('COMMIT')
       return {

--- a/src/web/login/login.html
+++ b/src/web/login/login.html
@@ -314,7 +314,7 @@
           </button>
         </form>
 
-        <div class="footer">VarLens · offline genetic variant analysis</div>
+        <div class="footer">VarLens · genetic variant analysis</div>
       </section>
     </main>
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -60,6 +60,13 @@ export interface AdminBootstrapOptions {
   /** Plaintext password. Refused if passed by legacy callers. */
   password?: string
   displayName?: string
+  /**
+   * Whether the bootstrapped admin must rotate its password on first login.
+   * Defaults to `true` (secure default). Set `false` only for local dev via
+   * `VARLENS_ADMIN_MUST_CHANGE_PASSWORD=false` so a stable default dev
+   * credential survives without a forced rotation.
+   */
+  mustChangePassword?: boolean
 }
 
 /**
@@ -220,11 +227,14 @@ async function maybeBootstrapAdmin(
     )
   }
 
+  const mustChangePassword = admin.mustChangePassword ?? true
+
   try {
     await authService.createFirstUserFromHash(
       admin.username,
       admin.displayName ?? admin.username,
-      admin.passwordHash
+      admin.passwordHash,
+      mustChangePassword
     )
   } catch (createErr) {
     // Race-loser branch: a concurrent first-user call beat us to the
@@ -257,10 +267,12 @@ async function maybeBootstrapAdmin(
       event: 'admin-bootstrap',
       action: 'created',
       username: admin.username,
-      mustChangePassword: true,
+      mustChangePassword,
       via: 'hash'
     },
-    'admin created — must rotate on first login (via hash)'
+    mustChangePassword
+      ? 'admin created — must rotate on first login (via hash)'
+      : 'admin created WITHOUT forced rotation (VARLENS_ADMIN_MUST_CHANGE_PASSWORD=false; dev only) (via hash)'
   )
 }
 
@@ -322,11 +334,17 @@ function readAdminEnv(): AdminBootstrapOptions | undefined {
     return undefined
   }
 
+  // Secure default: forced rotation on first login. Only an explicit
+  // `false`/`0` (dev) opts out so a stable default dev credential survives.
+  const mustChangeRaw = process.env.VARLENS_ADMIN_MUST_CHANGE_PASSWORD
+  const mustChangePassword = !(mustChangeRaw === 'false' || mustChangeRaw === '0')
+
   return {
     username: username.trim(),
     passwordHash: (passwordHash as string).trim(),
     displayName:
-      typeof displayName === 'string' && displayName.trim() !== '' ? displayName.trim() : undefined
+      typeof displayName === 'string' && displayName.trim() !== '' ? displayName.trim() : undefined,
+    mustChangePassword
   }
 }
 

--- a/src/web/server/routes/annotations.ts
+++ b/src/web/server/routes/annotations.ts
@@ -4,20 +4,12 @@ import {
   PerCaseAnnotationUpdatesSchema,
   VariantCoordsSchema
 } from '../../../shared/api/schemas/annotations'
-import type { AnnotationChangeEvent } from '../../../shared/types/api'
+import {
+  upsertGlobalAnnotationViaSession,
+  upsertPerCaseAnnotationWithEvent
+} from '../../../main/ipc/handlers/annotations-logic'
 import { WEB_EVENT_VARIANTS_ANNOTATION_CHANGED } from '../web-event-types'
 import type { OverrideHandler } from './types'
-
-function detectAnnotationChangeKind(updates: {
-  starred?: unknown
-  acmg_classification?: unknown
-  acmg_evidence?: unknown
-}): AnnotationChangeEvent['kind'] {
-  if (updates.starred !== undefined) return 'star'
-  if (updates.acmg_classification !== undefined) return 'acmg'
-  if (updates.acmg_evidence !== undefined) return 'evidence'
-  return 'comment'
-}
 
 export function buildAnnotationOverrides(): Record<string, OverrideHandler> {
   return {
@@ -45,12 +37,11 @@ export function buildAnnotationOverrides(): Record<string, OverrideHandler> {
           reply.code(400)
           return { error: 'invalid-annotation-upsert' }
         }
-        const coords = validatedCoords.data
-        const annotationUpdates = validatedUpdates.data
-        return await session.getWriteExecutor().execute({
-          type: 'annotations:upsertGlobalWithAudit',
-          params: [coords, annotationUpdates]
-        })
+        return await upsertGlobalAnnotationViaSession(
+          validatedCoords.data,
+          validatedUpdates.data,
+          () => session
+        )
       }
     },
 
@@ -63,20 +54,18 @@ export function buildAnnotationOverrides(): Record<string, OverrideHandler> {
           reply.code(400)
           return { error: 'invalid-per-case-annotation-upsert' }
         }
-        const annotationUpdates = validatedUpdates.data
-        const result = await session.getWriteExecutor().execute({
-          type: 'annotations:upsertPerCaseWithAudit',
-          params: [validatedIds.data.caseId, validatedIds.data.variantId, annotationUpdates]
-        })
-        const userId = request.session?.user?.id
-        if (userId !== undefined) {
-          events.publish(userId, WEB_EVENT_VARIANTS_ANNOTATION_CHANGED, {
-            caseId: validatedIds.data.caseId,
-            variantId: validatedIds.data.variantId,
-            kind: detectAnnotationChangeKind(annotationUpdates)
-          } satisfies AnnotationChangeEvent)
-        }
-        return result
+        return await upsertPerCaseAnnotationWithEvent(
+          validatedIds.data.caseId,
+          validatedIds.data.variantId,
+          validatedUpdates.data,
+          () => session,
+          (e) => {
+            const userId = request.session?.user?.id
+            if (userId !== undefined) {
+              events.publish(userId, WEB_EVENT_VARIANTS_ANNOTATION_CHANGED, e)
+            }
+          }
+        )
       }
     },
 

--- a/src/web/server/routes/cohort.ts
+++ b/src/web/server/routes/cohort.ts
@@ -2,6 +2,14 @@ import {
   CohortCarriersParamsSchema,
   CohortSearchParamsSchema
 } from '../../../shared/api/schemas/cohort'
+import {
+  getCohortVariantsViaSession,
+  getCohortColumnMetaViaSession,
+  getCohortSummaryViaSession,
+  getCohortCarriersViaSession,
+  getCohortGeneBurdenViaSession,
+  getCohortSummaryStatusViaSession
+} from '../../../main/ipc/handlers/cohort-logic'
 import { unsupportedWebCapability } from './common'
 import type { OverrideHandler } from './types'
 
@@ -16,34 +24,25 @@ export function buildCohortOverrides(): Record<string, OverrideHandler> {
           return { error: 'invalid-cohort-params', message: 'Invalid cohort search parameters' }
         }
 
-        return await session.getReadExecutor().execute({
-          type: 'cohort:query',
-          params: [validated.data]
-        })
+        return await getCohortVariantsViaSession(validated.data, () => session)
       }
     },
 
     'cohort:getColumnMeta': {
       async handle(_args, _request, _reply, { session }) {
-        return await session.getReadExecutor().execute({
-          type: 'cohort:columnMeta',
-          params: []
-        })
+        return await getCohortColumnMetaViaSession(() => session)
       }
     },
 
     'cohort:getSummary': {
       async handle(_args, _request, _reply, { session }) {
-        return await session.getReadExecutor().execute({
-          type: 'cohort:summary',
-          params: []
-        })
+        return await getCohortSummaryViaSession(() => session)
       }
     },
 
     'cohort:getSummaryStatus': {
-      handle() {
-        return { is_stale: false, last_rebuilt_at: 0 }
+      async handle(_args, _request, _reply, { session }) {
+        return await getCohortSummaryStatusViaSession(() => session)
       }
     },
 
@@ -74,19 +73,19 @@ export function buildCohortOverrides(): Record<string, OverrideHandler> {
           return { error: 'invalid-carrier-params', message: 'Invalid carrier query parameters' }
         }
 
-        return await session.getReadExecutor().execute({
-          type: 'cohort:carriers',
-          params: [validated.data.chr, validated.data.pos, validated.data.ref, validated.data.alt]
-        })
+        return await getCohortCarriersViaSession(
+          validated.data.chr,
+          validated.data.pos,
+          validated.data.ref,
+          validated.data.alt,
+          () => session
+        )
       }
     },
 
     'cohort:getGeneBurden': {
       async handle(_args, _request, _reply, { session }) {
-        return await session.getReadExecutor().execute({
-          type: 'cohort:geneBurden',
-          params: []
-        })
+        return await getCohortGeneBurdenViaSession(() => session)
       }
     }
   }

--- a/src/web/server/routes/panels.ts
+++ b/src/web/server/routes/panels.ts
@@ -1,4 +1,5 @@
 import { PanelIdSchema, PanelUpdateSchema } from '../../../shared/types/ipc-schemas'
+import { getPanelWithGenes } from '../../../main/ipc/handlers/panels-logic'
 import type { OverrideHandler } from './types'
 
 export function buildPanelOverrides(): Record<string, OverrideHandler> {
@@ -11,13 +12,7 @@ export function buildPanelOverrides(): Record<string, OverrideHandler> {
           reply.code(400)
           return { error: 'invalid-panel-id' }
         }
-        const panel = await session
-          .getReadExecutor()
-          .execute({ type: 'panels:get', params: [validated.data] })
-        const genes = await session
-          .getReadExecutor()
-          .execute({ type: 'panels:getGenes', params: [validated.data] })
-        return panel === null ? null : { ...(panel as object), genes }
+        return await getPanelWithGenes(validated.data, () => session)
       }
     },
 

--- a/src/web/server/routes/variants.ts
+++ b/src/web/server/routes/variants.ts
@@ -1,5 +1,5 @@
 import type { SortItem, VariantFilter } from '../../../shared/types/database'
-import { searchVariants } from '../../../main/ipc/handlers/variants-logic'
+import { getFilterOptions, searchVariants } from '../../../main/ipc/handlers/variants-logic'
 import {
   CaseIdSchema,
   LimitSchema,
@@ -113,10 +113,7 @@ export function buildVariantOverrides(): Record<string, OverrideHandler> {
           return { error: 'invalid-case-id', message: 'Invalid case ID' }
         }
 
-        return await session.getReadExecutor().execute({
-          type: 'variants:filterOptions',
-          params: [validatedCaseId.data]
-        })
+        return await getFilterOptions(validatedCaseId.data, () => session)
       }
     }
   }

--- a/tests/main/handlers/annotations-handlers.test.ts
+++ b/tests/main/handlers/annotations-handlers.test.ts
@@ -334,7 +334,20 @@ describe('annotations:upsertPerCase — variants:annotationChanged broadcast', (
       ipcMain: fakeIpcMain,
       getDb: () => db,
       getDbManager: (() => ({
-        getCurrentSession: () => ({ capabilities: { backend: 'sqlite' } })
+        getCurrentSession: () => ({
+          capabilities: { backend: 'sqlite' },
+          getWriteExecutor: () => ({
+            execute: vi.fn().mockResolvedValue({
+              id: 1,
+              case_id: caseId,
+              variant_id: variantId,
+              starred: 0,
+              per_case_comment: null,
+              acmg_classification: null,
+              acmg_evidence: null
+            })
+          })
+        })
       })) as unknown as () => import('../../../src/main/services/DatabaseManager').DatabaseManager
     })
   })
@@ -401,15 +414,10 @@ describe('annotations:upsertPerCase — variants:annotationChanged broadcast', (
   })
 
   it('does NOT broadcast when the upsert throws', async () => {
-    // Force a failure by mocking the logic-layer call to throw. We spy on
-    // the imported function reference — `annotations.ts` imports
-    // `upsertPerCaseAnnotation` from `./annotations-logic`.
-    const logic = await import('../../../src/main/ipc/handlers/annotations-logic')
-    const spy = vi.spyOn(logic, 'upsertPerCaseAnnotation').mockImplementation(() => {
-      throw new Error('boom')
-    })
-
-    // Re-register handlers so the wrapper binds the mocked function
+    // Force a failure by making the write executor reject. The handler now
+    // routes through `upsertPerCaseAnnotationWithEvent` →
+    // `getSession().getWriteExecutor().execute(...)`, so a rejected executor
+    // is the correct injection point for the error path.
     capturedHandlers.clear()
     const { registerAnnotationHandlers } =
       await import('../../../src/main/ipc/handlers/annotations')
@@ -417,7 +425,12 @@ describe('annotations:upsertPerCase — variants:annotationChanged broadcast', (
       ipcMain: fakeIpcMain,
       getDb: () => db,
       getDbManager: (() => ({
-        getCurrentSession: () => ({ capabilities: { backend: 'sqlite' } })
+        getCurrentSession: () => ({
+          capabilities: { backend: 'sqlite' },
+          getWriteExecutor: () => ({
+            execute: vi.fn().mockRejectedValue(new Error('boom'))
+          })
+        })
       })) as unknown as () => import('../../../src/main/services/DatabaseManager').DatabaseManager
     })
 
@@ -430,8 +443,6 @@ describe('annotations:upsertPerCase — variants:annotationChanged broadcast', (
 
     // Critically: no broadcast fired on the error path
     expect(sentMessages).toHaveLength(0)
-
-    spy.mockRestore()
   })
 
   it('does NOT broadcast on validation failure (invalid caseId)', async () => {

--- a/tests/main/ipc/annotations-event-parity.test.ts
+++ b/tests/main/ipc/annotations-event-parity.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  upsertGlobalAnnotationViaSession,
+  upsertPerCaseAnnotationWithEvent
+} from '../../../src/main/ipc/handlers/annotations-logic'
+
+function fakeSession(): any {
+  return {
+    getWriteExecutor: () => ({
+      execute: vi.fn().mockResolvedValue({ ok: true })
+    })
+  }
+}
+
+describe('upsertPerCaseAnnotationWithEvent — event callback', () => {
+  test('fires exactly once with kind=acmg for an acmg_classification update', async () => {
+    const onChange = vi.fn()
+    await upsertPerCaseAnnotationWithEvent(
+      1,
+      2,
+      { acmg_classification: 'Pathogenic' },
+      () => fakeSession(),
+      onChange
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toMatchObject({ caseId: 1, variantId: 2, kind: 'acmg' })
+  })
+
+  test('fires exactly once with kind=star for a starred update', async () => {
+    const onChange = vi.fn()
+    await upsertPerCaseAnnotationWithEvent(1, 2, { starred: true }, () => fakeSession(), onChange)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toMatchObject({ caseId: 1, variantId: 2, kind: 'star' })
+  })
+
+  test('fires exactly once with kind=evidence for an acmg_evidence update', async () => {
+    const onChange = vi.fn()
+    await upsertPerCaseAnnotationWithEvent(
+      3,
+      4,
+      { acmg_evidence: 'PS1' },
+      () => fakeSession(),
+      onChange
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toMatchObject({ caseId: 3, variantId: 4, kind: 'evidence' })
+  })
+
+  test('fires exactly once with kind=comment when only per_case_comment is updated', async () => {
+    const onChange = vi.fn()
+    await upsertPerCaseAnnotationWithEvent(
+      5,
+      6,
+      { per_case_comment: 'hello' },
+      () => fakeSession(),
+      onChange
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toMatchObject({ caseId: 5, variantId: 6, kind: 'comment' })
+  })
+
+  test('does not fire if the write executor throws', async () => {
+    const onChange = vi.fn()
+    const errorSession = {
+      getWriteExecutor: () => ({
+        execute: vi.fn().mockRejectedValue(new Error('write failed'))
+      })
+    }
+    await expect(
+      upsertPerCaseAnnotationWithEvent(1, 2, { starred: true }, () => errorSession, onChange)
+    ).rejects.toThrow('write failed')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('upsertGlobalAnnotationViaSession', () => {
+  test('delegates to write executor with upsertGlobalWithAudit task type', async () => {
+    const executeMock = vi.fn().mockResolvedValue({ ok: true })
+    const session = { getWriteExecutor: () => ({ execute: executeMock }) }
+    const coords = { chr: '1', pos: 100, ref: 'A', alt: 'T' }
+    const updates = { global_comment: 'test' }
+    await upsertGlobalAnnotationViaSession(coords, updates, () => session as any)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(executeMock.mock.calls[0][0]).toMatchObject({
+      type: 'annotations:upsertGlobalWithAudit'
+    })
+  })
+})

--- a/tests/main/ipc/annotations-event-parity.test.ts
+++ b/tests/main/ipc/annotations-event-parity.test.ts
@@ -3,13 +3,14 @@ import {
   upsertGlobalAnnotationViaSession,
   upsertPerCaseAnnotationWithEvent
 } from '../../../src/main/ipc/handlers/annotations-logic'
+import type { StorageSession } from '../../../src/main/storage/session'
 
-function fakeSession(): any {
+function fakeSession(): StorageSession {
   return {
     getWriteExecutor: () => ({
       execute: vi.fn().mockResolvedValue({ ok: true })
     })
-  }
+  } as unknown as StorageSession
 }
 
 describe('upsertPerCaseAnnotationWithEvent — event callback', () => {
@@ -79,7 +80,11 @@ describe('upsertGlobalAnnotationViaSession', () => {
     const session = { getWriteExecutor: () => ({ execute: executeMock }) }
     const coords = { chr: '1', pos: 100, ref: 'A', alt: 'T' }
     const updates = { global_comment: 'test' }
-    await upsertGlobalAnnotationViaSession(coords, updates, () => session as any)
+    await upsertGlobalAnnotationViaSession(
+      coords,
+      updates,
+      () => session as unknown as StorageSession
+    )
     expect(executeMock).toHaveBeenCalledTimes(1)
     expect(executeMock.mock.calls[0][0]).toMatchObject({
       type: 'annotations:upsertGlobalWithAudit'

--- a/tests/main/web/auth/postgres-web-auth-service.test.ts
+++ b/tests/main/web/auth/postgres-web-auth-service.test.ts
@@ -277,6 +277,31 @@ describe('PostgresWebAuthService — production hash bootstrap', () => {
     expect(insert?.values).not.toContain(`hashed::${FIXTURE_ARGON2ID_HASH}`)
   })
 
+  it('defaults to must_change_password=TRUE (forced rotation) when the flag is omitted', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    enqueueCreateFirstUserHappyPath(pool)
+
+    await svc.createFirstUserFromHash('alice', 'Alice', FIXTURE_ARGON2ID_HASH)
+
+    const insert = pool.queries.find((q) => /INSERT INTO[\s\S]+users/i.test(q.text))
+    // must_change_password is the 5th INSERT parameter, parameterised not inlined.
+    expect(insert?.text).toMatch(/VALUES \(\$1, \$2, \$3, \$4, \$5, now\(\)\)/)
+    expect(insert?.values?.[4], 'forced rotation is the secure default').toBe(true)
+  })
+
+  it('honours mustChangePassword=false (dev opt-out) as a parameterised value', async () => {
+    const pool = new FakePool()
+    const svc = newSvc(pool)
+    enqueueCreateFirstUserHappyPath(pool)
+
+    await svc.createFirstUserFromHash('alice', 'Alice', FIXTURE_ARGON2ID_HASH, false)
+
+    const insert = pool.queries.find((q) => /INSERT INTO[\s\S]+users/i.test(q.text))
+    expect(insert?.text).toMatch(/VALUES \(\$1, \$2, \$3, \$4, \$5, now\(\)\)/)
+    expect(insert?.values?.[4], 'opt-out flag flows through to the INSERT').toBe(false)
+  })
+
   it('rejects non-Argon2id bootstrap values before any database write', async () => {
     const pool = new FakePool()
     const svc = newSvc(pool)

--- a/tests/web-gate/dispatcher-adapters-read-seams.test.ts
+++ b/tests/web-gate/dispatcher-adapters-read-seams.test.ts
@@ -102,9 +102,19 @@ describe('web dispatcher adapters: read seams', () => {
     )
 
     expect(reply.code).not.toHaveBeenCalled()
+    // Shared cohort logic defaults genome_build to GRCh38 (desktop parity) before
+    // dispatching the cohort:query read.
     expect(execute).toHaveBeenCalledWith({
       type: 'cohort:query',
-      params: [{ limit: 25, offset: 10, search_term: 'BRCA1', sort_order: 'desc' }]
+      params: [
+        {
+          limit: 25,
+          offset: 10,
+          search_term: 'BRCA1',
+          sort_order: 'desc',
+          genome_build: 'GRCh38'
+        }
+      ]
     })
   })
 
@@ -301,8 +311,9 @@ describe('web dispatcher adapters: read seams', () => {
     }
   })
 
-  test('cohort.getSummaryStatus returns a stable non-rebuild status for web Postgres', async () => {
-    const { deps, reply } = makeDeps()
+  test('cohort.getSummaryStatus delegates to the storage read executor for web Postgres', async () => {
+    const { deps, execute, reply } = makeDeps()
+    execute.mockResolvedValueOnce({ is_stale: false, last_rebuilt_at: 0 })
     const { overrides } = buildDispatcher(deps)
 
     const result = await overrides['cohort:getSummaryStatus'].handle(
@@ -313,6 +324,7 @@ describe('web dispatcher adapters: read seams', () => {
     )
 
     expect(reply.code).not.toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledWith({ type: 'cohort:summaryStatus', params: [] })
     expect(result).toEqual({ is_stale: false, last_rebuilt_at: 0 })
   })
 })

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -41,6 +41,21 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'vep.ts': 'web mode intentionally disables external reference fetches'
 }
 
+/**
+ * Domains whose web overrides have not yet been collapsed onto a shared
+ * session-based <domain>-logic function. MONOTONIC-DECREASE ONLY — remove
+ * an entry when the domain's overrides all pass the per-key seam check.
+ * do not add.
+ */
+const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>([
+  'transcripts.ts',
+  'panels.ts',
+  'annotations.ts',
+  'variants.ts',
+  'cohort.ts',
+  'export.ts'
+])
+
 const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
   'analysis-groups.ts',
   'annotations.ts',
@@ -200,6 +215,21 @@ describe('handler-seam gate', () => {
     }
 
     expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  test('PENDING_SHARED_LOGIC_EXTRACTION only shrinks (max 6, all known)', () => {
+    const known = new Set([
+      'transcripts.ts',
+      'panels.ts',
+      'annotations.ts',
+      'variants.ts',
+      'cohort.ts',
+      'export.ts'
+    ])
+    expect(PENDING_SHARED_LOGIC_EXTRACTION.size).toBeLessThanOrEqual(6)
+    for (const entry of PENDING_SHARED_LOGIC_EXTRACTION) {
+      expect(known.has(entry), `unknown pending domain: ${entry}`).toBe(true)
+    }
   })
 })
 

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -25,7 +25,6 @@ const FLAT_HANDLERS = new Set(['shell', 'shortlist', 'system', 'updater'])
 const SHARED_DOMAIN_HELPERS = new Set(['import-schemas'])
 const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'analysis-groups.ts': 'thin storage-executor adapters with web-only argument validation',
-  'annotations.ts': 'thin storage-executor adapters with web-only argument validation',
   'audit-log.ts': 'admin-gated audit-trail read adapters over the storage read executor',
   'auth.ts': 'web-only session cookie/auth boundary backed by PostgresWebAuthService',
   'batch-import.ts':
@@ -49,12 +48,7 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
  * an entry when the domain's overrides all pass the per-key seam check.
  * do not add.
  */
-const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>([
-  'annotations.ts',
-  'variants.ts',
-  'cohort.ts',
-  'export.ts'
-])
+const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>(['variants.ts', 'cohort.ts', 'export.ts'])
 
 const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
   'analysis-groups.ts',

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -156,7 +156,10 @@ function analyzeOverrideKeys(routePath: string): Record<string, KeyVerdict> {
       verdicts[key] = 'shared-logic'
     } else if (execCalls === 1 && callsTypeKey) {
       verdicts[key] = 'passthrough'
-    } else if (propCallsUnsupported(prop)) {
+    } else if (execCalls === 0 && propCallsUnsupported(prop)) {
+      // Genuinely web-disabled: 501s with no executor work. Requiring zero
+      // execute() calls keeps a key that does real (multi-call) orchestration
+      // from hiding behind a stray unsupportedWebCapability() call.
       verdicts[key] = 'unsupported'
     } else {
       verdicts[key] = 'inline'

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -31,7 +31,6 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
     'web upload/job-runner pipeline with file-picker stubs replacing desktop dialogs',
   'case-metadata.ts': 'thin storage-executor adapters with web-only argument validation',
   'cases.ts': 'simple cases:list storage read adapter',
-  'cohort.ts': 'cohort route adapters plus explicit unsupported web methods',
   'database.ts': 'web-only database identity/capability adapters',
   'gene-lists.ts': 'thin storage-executor adapters with web-only argument validation',
   'gene-ref.ts': 'web mode intentionally disables external reference fetches',
@@ -48,7 +47,7 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
  * an entry when the domain's overrides all pass the per-key seam check.
  * do not add.
  */
-const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>(['cohort.ts', 'export.ts'])
+const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>(['export.ts'])
 
 const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
   'analysis-groups.ts',

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -324,6 +324,15 @@ describe('handler-seam gate', () => {
       expect(known.has(entry), `unknown pending domain: ${entry}`).toBe(true)
     }
   })
+
+  test('PENDING_SHARED_LOGIC_EXTRACTION is empty — all six domains migrated', () => {
+    // Strict transport seam: every target domain (transcripts, panels,
+    // annotations, variants, cohort, export) now routes its web overrides
+    // through shared <domain>-logic (or an audited unsupported/pass-through
+    // verdict). No domain may re-introduce inline orchestration without the
+    // per-key gate above failing.
+    expect([...PENDING_SHARED_LOGIC_EXTRACTION]).toEqual([])
+  })
 })
 
 export { FLAT_HANDLERS }

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -47,7 +47,7 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
  * an entry when the domain's overrides all pass the per-key seam check.
  * do not add.
  */
-const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>(['export.ts'])
+const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>([])
 
 const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
   'analysis-groups.ts',

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -48,7 +48,7 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
  * an entry when the domain's overrides all pass the per-key seam check.
  * do not add.
  */
-const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>(['variants.ts', 'cohort.ts', 'export.ts'])
+const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>(['cohort.ts', 'export.ts'])
 
 const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
   'analysis-groups.ts',

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -38,7 +38,6 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'gene-ref.ts': 'web mode intentionally disables external reference fetches',
   'hpo.ts': 'web mode intentionally disables external reference fetches',
   'import.ts': 'web upload pipeline with file-picker stubs and shared import-logic delegation',
-  'panels.ts': 'thin storage-executor adapters with web-only argument validation',
   'protein.ts': 'web mode intentionally disables external reference fetches',
   'region-files.ts': 'web-only server-path guards and storage-executor adapters',
   'vep.ts': 'web mode intentionally disables external reference fetches'
@@ -51,7 +50,6 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
  * do not add.
  */
 const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>([
-  'panels.ts',
   'annotations.ts',
   'variants.ts',
   'cohort.ts',

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -77,7 +77,7 @@ const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
 // Per-override-key seam analyzer (ts-morph)
 // ---------------------------------------------------------------------------
 
-type KeyVerdict = 'passthrough' | 'shared-logic' | 'inline'
+type KeyVerdict = 'passthrough' | 'shared-logic' | 'unsupported' | 'inline'
 
 /**
  * Returns the set of function names imported from any `handlers/<x>-logic`
@@ -104,11 +104,20 @@ function propCallsLogicFn(prop: import('ts-morph').Node, logicNames: Set<string>
   })
 }
 
+/** True when the override body calls `unsupportedWebCapability(...)` — a web-disabled method. */
+function propCallsUnsupported(prop: import('ts-morph').Node): boolean {
+  return prop.getDescendantsOfKind(SyntaxKind.CallExpression).some((call) => {
+    const expr = call.getExpression()
+    return expr.getKind() === SyntaxKind.Identifier && expr.getText() === 'unsupportedWebCapability'
+  })
+}
+
 /**
  * For every override key in the named `build<X>Overrides` function of the
  * given route file, returns a verdict:
  *   'passthrough'   — exactly one executor.execute() call whose `type` matches the key
  *   'shared-logic'  — at least one call to a function imported from a *-logic module
+ *   'unsupported'   — calls unsupportedWebCapability() (web-disabled method), no real work
  *   'inline'        — anything else (multi-call, type-mismatch, inline event logic, etc.)
  */
 function analyzeOverrideKeys(routePath: string): Record<string, KeyVerdict> {
@@ -148,6 +157,8 @@ function analyzeOverrideKeys(routePath: string): Record<string, KeyVerdict> {
       verdicts[key] = 'shared-logic'
     } else if (execCalls === 1 && callsTypeKey) {
       verdicts[key] = 'passthrough'
+    } else if (propCallsUnsupported(prop)) {
+      verdicts[key] = 'unsupported'
     } else {
       verdicts[key] = 'inline'
     }

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
 import { resolve } from 'path'
+import { Project, SyntaxKind } from 'ts-morph'
 
 /**
  * Handler-seam gate.
@@ -27,6 +28,8 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'annotations.ts': 'thin storage-executor adapters with web-only argument validation',
   'audit-log.ts': 'admin-gated audit-trail read adapters over the storage read executor',
   'auth.ts': 'web-only session cookie/auth boundary backed by PostgresWebAuthService',
+  'batch-import.ts':
+    'web upload/job-runner pipeline with file-picker stubs replacing desktop dialogs',
   'case-metadata.ts': 'thin storage-executor adapters with web-only argument validation',
   'cases.ts': 'simple cases:list storage read adapter',
   'cohort.ts': 'cohort route adapters plus explicit unsupported web methods',
@@ -34,6 +37,7 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'gene-lists.ts': 'thin storage-executor adapters with web-only argument validation',
   'gene-ref.ts': 'web mode intentionally disables external reference fetches',
   'hpo.ts': 'web mode intentionally disables external reference fetches',
+  'import.ts': 'web upload pipeline with file-picker stubs and shared import-logic delegation',
   'panels.ts': 'thin storage-executor adapters with web-only argument validation',
   'protein.ts': 'web mode intentionally disables external reference fetches',
   'region-files.ts': 'web-only server-path guards and storage-executor adapters',
@@ -78,6 +82,91 @@ const EXPECTED_ROUTE_OVERRIDE_MODULES = new Set([
   'variants.ts',
   'vep.ts'
 ])
+
+// ---------------------------------------------------------------------------
+// Per-override-key seam analyzer (ts-morph)
+// ---------------------------------------------------------------------------
+
+type KeyVerdict = 'passthrough' | 'shared-logic' | 'inline'
+
+/**
+ * Returns the set of function names imported from any `handlers/<x>-logic`
+ * module in the given source file.
+ */
+function collectLogicImportNames(sf: ReturnType<Project['addSourceFileAtPath']>): Set<string> {
+  const names = new Set<string>()
+  for (const decl of sf.getImportDeclarations()) {
+    if (!/handlers\/[A-Za-z0-9-]+-logic/.test(decl.getModuleSpecifierValue())) continue
+    for (const named of decl.getNamedImports()) names.add(named.getName())
+  }
+  return names
+}
+
+/**
+ * Returns true when the property AST subtree contains a direct call to one
+ * of the supplied logic function names.
+ */
+function propCallsLogicFn(prop: import('ts-morph').Node, logicNames: Set<string>): boolean {
+  if (logicNames.size === 0) return false
+  return prop.getDescendantsOfKind(SyntaxKind.CallExpression).some((call) => {
+    const expr = call.getExpression()
+    return expr.getKind() === SyntaxKind.Identifier && logicNames.has(expr.getText())
+  })
+}
+
+/**
+ * For every override key in the named `build<X>Overrides` function of the
+ * given route file, returns a verdict:
+ *   'passthrough'   — exactly one executor.execute() call whose `type` matches the key
+ *   'shared-logic'  — at least one call to a function imported from a *-logic module
+ *   'inline'        — anything else (multi-call, type-mismatch, inline event logic, etc.)
+ */
+function analyzeOverrideKeys(routePath: string): Record<string, KeyVerdict> {
+  const project = new Project({
+    tsConfigFilePath: resolve(process.cwd(), 'tsconfig.node.json'),
+    skipAddingFilesFromTsConfig: false
+  })
+  const sf = project.addSourceFileAtPath(resolve(process.cwd(), routePath))
+  const logicNames = collectLogicImportNames(sf)
+  const verdicts: Record<string, KeyVerdict> = {}
+
+  // Find the buildXxxOverrides function
+  const builder = sf
+    .getFunctions()
+    .find((fn) => /^build[A-Za-z]+Overrides$/.test(fn.getName() ?? ''))
+  if (!builder) return verdicts
+
+  // The first object literal expression in the function body is the returned
+  // map of override handlers.
+  const ret = builder.getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression)[0]
+  if (!ret) return verdicts
+
+  for (const prop of ret.getProperties()) {
+    // The property key is either a StringLiteral (`'transcripts:list'`) or an
+    // Identifier — grab it from the first child token.
+    const keyNode = prop.getChildAtIndex(0)
+    const key = keyNode.getText().replace(/^['"`]|['"`]$/g, '')
+    const propText = prop.getText()
+
+    // Count executor `.execute(` calls
+    const execCalls = (propText.match(/get(?:Read|Write)Executor\(\)\s*\.execute\(/g) ?? []).length
+
+    // Check that the single execute call passes `type: '<key>'`
+    const callsTypeKey = propText.includes(`type: '${key}'`) || propText.includes(`type: "${key}"`)
+
+    if (propCallsLogicFn(prop, logicNames)) {
+      verdicts[key] = 'shared-logic'
+    } else if (execCalls === 1 && callsTypeKey) {
+      verdicts[key] = 'passthrough'
+    } else {
+      verdicts[key] = 'inline'
+    }
+  }
+
+  return verdicts
+}
+
+// ---------------------------------------------------------------------------
 
 function listDomains(dir: string): string[] {
   const abs = resolve(process.cwd(), dir)
@@ -203,15 +292,19 @@ describe('handler-seam gate', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
 
-  test('web route override modules use shared logic or audited exceptions', () => {
+  test('every override key of a migrated domain is pass-through or calls shared logic', () => {
     const offenders: string[] = []
 
     for (const file of listRouteOverrideModules()) {
-      const routePath = `${WEB_ROUTES_DIR}/${file}`
-      const source = readRepoFile(routePath)
-      if (/handlers\/[A-Za-z0-9-]+-logic/.test(source)) continue
+      if (PENDING_SHARED_LOGIC_EXTRACTION.has(file)) continue
       if (ROUTE_OVERRIDE_LOGIC_EXCEPTIONS[file] !== undefined) continue
-      offenders.push(`${routePath} (missing shared *-logic import or audited exception)`)
+
+      const verdicts = analyzeOverrideKeys(`${WEB_ROUTES_DIR}/${file}`)
+      for (const [key, verdict] of Object.entries(verdicts)) {
+        if (verdict === 'inline') {
+          offenders.push(`${file} → ${key} (inline orchestration; extract to <domain>-logic)`)
+        }
+      }
     }
 
     expect(offenders, offenders.join('\n')).toEqual([])

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -41,7 +41,6 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'panels.ts': 'thin storage-executor adapters with web-only argument validation',
   'protein.ts': 'web mode intentionally disables external reference fetches',
   'region-files.ts': 'web-only server-path guards and storage-executor adapters',
-  'transcripts.ts': 'thin storage-executor adapters with web-only argument validation',
   'vep.ts': 'web mode intentionally disables external reference fetches'
 }
 
@@ -52,7 +51,6 @@ const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
  * do not add.
  */
 const PENDING_SHARED_LOGIC_EXTRACTION = new Set<string>([
-  'transcripts.ts',
   'panels.ts',
   'annotations.ts',
   'variants.ts',

--- a/tests/web-gate/parity/ipc/annotations.ts
+++ b/tests/web-gate/parity/ipc/annotations.ts
@@ -89,31 +89,55 @@ async function runPerCaseAliasCase(
   ]
 }
 
+function expectUpsertReturned(value: unknown, label: string): unknown {
+  // Both Postgres and SQLite executors return a non-null value for a successful
+  // upsert (row object or change count). Null/undefined indicates no write occurred.
+  if (value === null || value === undefined) {
+    throw new Error(`${label}: upsert returned nullish — write may not have occurred`)
+  }
+  return value
+}
+
 export const annotationsScenario: IpcScenario = {
   area: 'annotations',
   run: async (ctx) => {
-    const results: unknown[] = [
-      await ctx.call('annotations', 'upsertGlobal', [
+    // --- write coverage: verify upsertGlobal and upsertPerCase return non-null values
+    const upsertGlobalResult = await ctx.call('annotations', 'upsertGlobal', [
+      ctx.primaryVariant.chr,
+      ctx.primaryVariant.pos,
+      ctx.primaryVariant.ref,
+      ctx.primaryVariant.alt,
+      {
+        starred: true,
+        acmg_classification: 'Pathogenic',
+        global_comment: 'Global parity annotation'
+      }
+    ])
+    expectUpsertReturned(upsertGlobalResult, 'upsertGlobal')
+
+    const upsertPerCaseResult = await ctx.call('annotations', 'upsertPerCase', [
+      ctx.primaryCaseId,
+      ctx.primaryVariant.id,
+      {
+        starred: true,
+        acmg_classification: 'Likely pathogenic',
+        per_case_comment: 'Per-case parity'
+      }
+    ])
+    expectUpsertReturned(upsertPerCaseResult, 'upsertPerCase')
+
+    // --- read-back: confirm the writes landed via getGlobal and getForVariant
+    const globalReadBack = expectGlobalClassification(
+      await ctx.call('annotations', 'getGlobal', [
         ctx.primaryVariant.chr,
         ctx.primaryVariant.pos,
         ctx.primaryVariant.ref,
-        ctx.primaryVariant.alt,
-        {
-          starred: true,
-          acmg_classification: 'Pathogenic',
-          global_comment: 'Global parity annotation'
-        }
+        ctx.primaryVariant.alt
       ]),
-      await ctx.call('annotations', 'upsertPerCase', [
-        ctx.primaryCaseId,
-        ctx.primaryVariant.id,
-        {
-          starred: true,
-          acmg_classification: 'Likely pathogenic',
-          per_case_comment: 'Per-case parity'
-        }
-      ])
-    ]
+      'Pathogenic'
+    )
+
+    const results: unknown[] = [upsertGlobalResult, upsertPerCaseResult, globalReadBack]
 
     for (const { input, expected } of ACMG_ALIAS_CASES) {
       results.push(...(await runGlobalAliasCase(ctx, input, expected)))

--- a/tests/web-gate/parity/ipc/panels.ts
+++ b/tests/web-gate/parity/ipc/panels.ts
@@ -12,15 +12,44 @@ export const panelsScenario: IpcScenario = {
         sourceId: 'ipc-parity-panel'
       }
     ])) as { id: number }
+
+    await ctx.call('panels', 'setGenes', [
+      panel.id,
+      [
+        { hgncId: 'HGNC:2228', symbol: 'COMT' },
+        { hgncId: 'HGNC:6742', symbol: 'LZTR1' }
+      ]
+    ])
+
+    // panels:get — must return the enriched { ...panel, genes } shape
+    const fetched = (await ctx.call('panels', 'get', [panel.id])) as {
+      id: number
+      name: string
+      genes: unknown[]
+    }
+
+    // panels:update — single pass-through; verify the update round-trips
+    const updated = await ctx.call('panels', 'update', [
+      {
+        id: panel.id,
+        name: 'IPC parity panel (updated)',
+        description: 'Updated by parity scenario',
+        version: '2'
+      }
+    ])
+
     return [
       panel,
-      await ctx.call('panels', 'setGenes', [
-        panel.id,
-        [
-          { hgncId: 'HGNC:2228', symbol: 'COMT' },
-          { hgncId: 'HGNC:6742', symbol: 'LZTR1' }
-        ]
-      ]),
+      fetched,
+      // Shape assertions carried as plain values so mismatches surface in snapshots
+      {
+        fetchedHasId: typeof fetched?.id === 'number',
+        fetchedHasName: typeof fetched?.name === 'string',
+        fetchedHasGenes: Array.isArray(fetched?.genes),
+        fetchedGenesLength: fetched?.genes?.length ?? -1
+      },
+      updated,
+      await ctx.call('panels', 'setGenes', [panel.id, [{ hgncId: 'HGNC:2228', symbol: 'COMT' }]]),
       await ctx.call('panels', 'activate', [ctx.primaryCaseId, panel.id, 50]),
       await ctx.call('panels', 'getGenes', [panel.id]),
       await ctx.call('panels', 'activeForCase', [ctx.primaryCaseId])

--- a/tests/web-gate/parity/ipc/transcripts.ts
+++ b/tests/web-gate/parity/ipc/transcripts.ts
@@ -16,6 +16,8 @@ export const transcriptsScenario: IpcScenario = {
         is_selected: 1
       }
     ]),
-    await ctx.call('transcripts', 'list', [ctx.primaryVariant.id])
+    await ctx.call('transcripts', 'switch', [ctx.primaryVariant.id, 'ENST_PARITY_000001']),
+    await ctx.call('transcripts', 'list', [ctx.primaryVariant.id]),
+    await ctx.call('variants', 'query', [ctx.primaryCaseId, { consequences: ['HIGH'] }, 0, 25])
   ]
 }


### PR DESCRIPTION
## What

Collapses the drift-prone per-domain web route overrides onto **one shared, session-based operation function per domain**, called by both transports (Electron IPC handler + Fastify web route), and enforces non-drift with a **per-override-key behavioural seam gate**. This finishes the *behavioural* half of the PR #202 review's F1/B7 recommendation that the merged web-narrow-hardening pass explicitly deferred.

Spec: `.planning/specs/2026-06-13-web-shared-handler-seam.md`
Plan: `.planning/plans/2026-06-13-web-shared-handler-seam-plan.md`

## Seam gate

`tests/web-gate/handler-seam.test.ts` replaced the coarse file-level "imports any `*-logic`" check with a `ts-morph` **per-override-key** analyzer. Every override key of an enforced domain must be one of four verdicts:
- **`shared-logic`** — calls a `<domain>-logic` export (the desktop handler calls the same symbol),
- **`passthrough`** — exactly one `executor.execute({ type: <the same key> })`,
- **`unsupported`** — a web-disabled method that 501s via `unsupportedWebCapability()` **and makes zero executor calls** (so real orchestration can't hide behind a stray 501),
- **`inline`** — anything else → **fails**.

A monotonic-decrease `PENDING_SHARED_LOGIC_EXTRACTION` allowlist gated domains in as they migrated; it is now **empty and asserted empty** — the gate is strict for all six target domains.

## PR-1 + PR-2 (transcripts, panels, annotations)

- **transcripts** — already pure pass-throughs; enforced under the gate. Verified the B6 "switch doesn't update parent `variants` row" finding is already fixed on `main`. Added a cross-transport parity scenario (switch + parent-row read).
- **panels** — extracted session-based `getPanelWithGenes`; `panels:get` unified across web + desktop; `panels:update` left as pass-through.
- **annotations** — extracted `upsertGlobalAnnotationViaSession` + `upsertPerCaseAnnotationWithEvent`; event-kind detection single-sourced in `annotations-logic`; desktop all-windows broadcast and web SSE publish both supplied as injected callbacks. Composite `*WithAudit` write tasks preserved (write+audit stays atomic).

## PR-3 (variants, cohort, export) + strict gate

- **variants** — `variants:getFilterOptions` rerouted through the existing shared `getFilterOptions` (its executor task `variants:filterOptions` differs from the override key, so it could not be a same-key pass-through). `search` (shared-logic), `columnMeta`/`query` (genuine pass-throughs) left as-is.
- **cohort** — added six session-based reads to `cohort-logic.ts` (`getCohort{Variants,ColumnMeta,Summary,Carriers,GeneBurden,SummaryStatus}ViaSession`); the desktop postgres branches now **delegate** to them (one implementation of each postgres read shared by both transports), SQLite/pool paths byte-identical. The three web-disabled methods (`rebuildSummary`/`runAssociation`/`cancelAssociation`) stay `unsupported`. **Convergence:** the web cohort reads now apply `convertBigInts` + the `genome_build: 'GRCh38'` default to match the desktop postgres path (previously the web route did neither), and `cohort:getSummaryStatus` now returns the **real** executor `{ is_stale, last_rebuilt_at }` instead of a hardcoded always-fresh stub — eliminating two prior web-vs-desktop divergences.
- **export** — `export:variants`/`export:cohort` already route their CSV writers through `export-logic` (`exportPostgres{Variants,Cohort}`), so both keys pass the gate as `shared-logic`; de-listed (no production change — the Electron-coupled desktop export handler is intentionally out of scope).
- **strict gate** — `PENDING_SHARED_LOGIC_EXTRACTION` flipped empty and asserted empty.

**Seam progress: 6 of 6 domains enforced. Gate is strict.**

## Verification

- `VARLENS_WEB=1 make ci` green: lint-check, format-check, typecheck, rebuild-node, and the combined `--project main --project renderer --project web-gate` suite → **4078 passed**, 1 expected-fail (pre-existing `test.fails`), 119 skipped. (Includes refactor-checkpoint + preload-contract under `--project main`.)
- Web-gate seam gate: **10/10** (all six domains enforced, strict-empty assertion green).
- `make agent-check` clean — `cohort-logic.ts` is 489 LOC (≤600).
- Each domain went through two-stage review (spec compliance → code quality) plus a final cross-cutting review.
- The live desktop↔web parity E2E (`make web-gate-parity`, switches the native module to the Electron ABI) and full `make ci-full` are the CI gates — not run inline; the always-on seam gate + full main suite were kept green throughout. The cohort/variants/export parity scenarios already cover the migrated keys as durable CI coverage.

No IPC contract, storage-executor, or renderer behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also in this PR — web dev-setup + rebrand (follow-on commits)

Unrelated to the seam refactor but bundled here at the author's request:

- **`fix(build)`** — `make web-dev` sourced the web env file as `. "$(WEB_DEV_ENV_FILE)"`; dash's `.` searches `$PATH`, not the cwd, so it broke the moment `.env.web.local` existed. Sourced with a `./` prefix (matching `.env.postgres.local`).
- **`feat(web)`** — optional **non-rotary admin bootstrap** for local dev. A `mustChangePassword` flag (default **TRUE** — secure default unchanged) flows through `insertFirstUser`/`createFirstUserFromHash`, driven by `VARLENS_ADMIN_MUST_CHANGE_PASSWORD`. Only an explicit `false`/`0` opts out; production keeps forced first-login rotation. New INSERT-parameter tests cover both paths.
- **`docs(brand)`** — dropped "offline" from the product tagline (web login footer, `package.json`, README hero, docs landing hero/feature card) now that a self-hosted web mode ships alongside the offline desktop app. Mode-specific prose left untouched.

Verification: `VARLENS_WEB=1 make ci` green; `--project main --project web-gate` → 2982 passed / 1 expected-fail; the default dev login authenticates with no forced rotation.
