### PR TITLE
test(storage): real-engine transcript-switch denormalization regression (#207)

### DIFF
--- a/.planning/plans/2026-06-15-issue-207-transcript-switch-denormalization-regression-plan.md
+++ b/.planning/plans/2026-06-15-issue-207-transcript-switch-denormalization-regression-plan.md
@@ -1,0 +1,58 @@
+# Plan: Real-engine regression test for transcript-switch denormalization (issue #207)
+
+Spec: `.planning/specs/2026-06-15-issue-207-transcript-switch-denormalization-regression.md`
+Branch: `test/issue-207-postgres-transcript-switch-regression`
+
+## Task 1 — Write the parameterized test file
+
+Create `tests/main/storage/transcript-switch-denormalization.test.ts`.
+
+- Header comment explaining the gap (real-engine behavioral check through the
+  write-executor seam) and the run command, mirroring `storage-session-contract.test.ts`.
+- `DENORM_COLUMNS` constant + `DenormFields` type for the seven denormalized columns.
+- Transcript A/B/C fixture constants (per spec table).
+- `BackendFixture` interface: `{ name, setup }` where `setup()` returns
+  `{ session, seedVariantWithTranscripts, readVariantDenorm, cleanup }`.
+- `setupSqlite`: `DatabaseService` on a temp-dir file db; `SqliteStorageSession`; seed via
+  `cases.createCase` + `variants.insertVariantsBatch` (variant carries A's values) + raw
+  `database.prepare(...)` inserts for transcripts A (selected) and B; read via raw
+  `SELECT`. Cleanup closes + removes temp dir.
+- `setupPostgres`: unique schema, `createPostgresStorageSession`; a dedicated `pg.Client`
+  for seeding/readback (schema-qualified, explicit columns, no `search_document`).
+  Coerce `id`/`hpo_sim_score` to `Number`. Cleanup closes session + drops schema.
+- `fixtures = [sqlite, ...(POSTGRES_E2E ? [postgres] : [])]`.
+- `describe.each(fixtures)` with two `it`s:
+  1. `transcripts:switch` A→B updates all denormalized columns on `variants`.
+  2. `transcripts:insertAndSwitch` of VEP-only C updates all denormalized columns.
+- Add a `describe.skipIf(POSTGRES_E2E)` marker noting the Postgres half is gated, matching
+  the sibling file.
+
+## Task 2 — Verify SQLite half
+
+- `make rebuild-node` (already done this session, re-run if needed).
+- `npx vitest run --project main tests/main/storage/transcript-switch-denormalization.test.ts`.
+- Expect: SQLite describe block passes; Postgres half skipped.
+
+## Task 3 — Verify Postgres half (real container)
+
+- `make pg-up` (container already running on 55434).
+- `VARLENS_RUN_POSTGRES_E2E=1 VARLENS_PG_URL=postgres://varlens:varlens_dev_password@127.0.0.1:55434/varlens_dev npx vitest run --project main tests/main/storage/transcript-switch-denormalization.test.ts`.
+- Expect: both backends pass.
+
+## Task 4 — Gates
+
+- `make typecheck` clean.
+- `make lint-check` + `make format-check` clean (or `make lint` / `make format` to fix).
+- `make agent-check` (new file is well under 600 lines).
+
+## Task 5 — Commit + PR
+
+- Commit: `test(storage): add real-engine transcript-switch denormalization regression (#207)`.
+- Push branch; open PR referencing #207 and PR #214 (the fix), explaining this hardens the
+  already-shipped fix with the real-container coverage the issue requested.
+- Include `.planning/` spec + plan in the same branch.
+
+## Risk / rollback
+
+- Pure test addition; no production code touched. If the Postgres half is flaky in an
+  environment without the container, it is gated off by default and CI is unaffected.

--- a/.planning/specs/2026-06-15-issue-207-transcript-switch-denormalization-regression.md
+++ b/.planning/specs/2026-06-15-issue-207-transcript-switch-denormalization-regression.md
@@ -1,0 +1,106 @@
+# Spec: Real-engine regression test for transcript-switch denormalization (issue #207)
+
+- **Date:** 2026-06-15
+- **Issue:** [#207](https://github.com/berntpopp/VarLens/issues/207) — "Postgres backend: switching selected transcript does not update parent variants row"
+- **Status:** Approved (autonomous goal directive) → executing
+- **Type:** Test hardening (no production code change)
+
+## Background
+
+Issue #207 reported that on the Postgres backend, switching the selected transcript
+flipped `variant_transcripts.is_selected` but failed to update the denormalized
+transcript columns on the parent `variants` row (`transcript`, `gene_symbol`,
+`consequence`, `cdna`, `aa_change`, `hpo_sim_score`, `moi`). SQLite did this correctly.
+
+**The bug itself is already fixed.** PR #214 ("web 01: add shared contracts and storage
+seams", merged 2026-05-25 — five days after the issue was filed) moved the Postgres
+transcript writes into a single shared module, `PostgresTranscriptsRepository`, whose
+`switchSelectedTranscript` and `insertTranscriptAndSwitch` both call
+`updateVariantFromSelectedTranscript` inside the transaction. Both desktop IPC
+(`PostgresWriteExecutor`) and the web routes (`src/web/server/routes/transcripts.ts`)
+dispatch through the same `StorageWriteExecutor` seam, so the two surfaces cannot drift —
+exactly the architecture the issue's "Suggested fix" recommended.
+
+## The gap this spec closes
+
+The issue's "Regression test" section asked for a Vitest case that runs **against the
+real Postgres test container** (gated by `VARLENS_RUN_POSTGRES_E2E=1`). What exists today:
+
+| Existing coverage | What it proves | What it does NOT prove |
+|---|---|---|
+| `tests/main/storage/postgres-transcripts-repository.test.ts` | The exact `UPDATE <schema>.variants` SQL + params are issued (mocked `pg` client) | That a real Postgres engine applies it to the row |
+| `tests/main/database/transcripts.test.ts` | SQLite repository updates the denormalized columns | Nothing about Postgres; bypasses the write-executor seam |
+| `tests/main/storage/storage-session-contract.test.ts` | The two backends expose the same **interface** | Explicitly **defers** cross-backend **behavioral** parity (see its lines 141-159) |
+
+So no test exercises the issue #207 scenario against a real database engine through the
+production dispatch path. A Postgres migration that renamed a column, a generated-column
+conflict, a type-coercion bug, or a transaction-visibility problem would pass every
+existing test while breaking the feature. That is the regression class this spec covers.
+
+## Goal
+
+Add a behavioral regression test, parameterized over both backends, that:
+
+1. Seeds a `case` + `variant` + two `variant_transcripts` (A selected, B not), with the
+   `variants` row initially carrying transcript A's denormalized values.
+2. Exercises the **production write-executor seam**
+   (`session.getWriteExecutor().execute({ type: 'transcripts:switch', ... })`) to switch
+   A → B.
+3. Reads the `variants` row back from the real engine and asserts every denormalized
+   column now equals transcript B's value.
+4. Repeats for `transcripts:insertAndSwitch` with a VEP-only transcript C.
+
+A and B differ in **every** denormalized field, so a no-op update (the original bug)
+fails every assertion — the test has inherent teeth.
+
+## Scope
+
+- **In:** one new parameterized test file in `tests/main/storage/`. SQLite half always
+  runs; Postgres half gated by `VARLENS_RUN_POSTGRES_E2E=1` + a running dev container,
+  matching `storage-session-contract.test.ts`.
+- **Out:** any production code change (the fix is already correct and shipped); changes to
+  the existing mock/SQLite tests; the web HTTP route layer (covered separately by the
+  web-gate parity scenario).
+
+## Design
+
+New file: `tests/main/storage/transcript-switch-denormalization.test.ts`.
+
+Reuse the `setupSqlite` / `setupPostgres` fixture pattern from
+`storage-session-contract.test.ts` (unique throwaway schema per Postgres run, dropped on
+cleanup; `VARLENS_PG_URL` env override; default left as-is). Each fixture additionally
+exposes:
+
+- `seedVariantWithTranscripts(): Promise<number>` — inserts case + variant + transcripts
+  A/B via the backend's native client (better-sqlite3 for SQLite via
+  `DatabaseService.database`; a dedicated `pg.Client` for Postgres, schema-qualified,
+  never touching the STORED generated `search_document` columns). Returns the variant id.
+- `readVariantDenorm(variantId): Promise<DenormFields>` — reads the seven denormalized
+  columns back from the same engine.
+
+Shared test body operates only on `session.getWriteExecutor()` and the two fixture
+helpers, so the assertions are identical across backends.
+
+### Fixture data
+
+| Transcript | id | gene_symbol | consequence | cdna | aa_change | hpo_sim_score | moi | is_selected |
+|---|---|---|---|---|---|---|---|---|
+| A (initial) | `NM_AAA.1` | `GENEA` | `missense_variant` | `c.1A>G` | `p.Met1Val` | 0.10 | `AD` | 1 |
+| B (switch to) | `NM_BBB.2` | `GENEB` | `stop_gained` | `c.2C>T` | `p.Gln2Ter` | 0.90 | `AR` | 0 |
+| C (insertAndSwitch, VEP-only) | `ENST_CCC.1` | `GENEC` | `splice_acceptor_variant` | `c.3-1G>A` | `null` | 0.55 | `XL` | n/a |
+
+## Verification
+
+- `make rebuild-node` then run the SQLite half (always runs): must pass.
+- `make pg-up`, then
+  `VARLENS_RUN_POSTGRES_E2E=1 VARLENS_PG_URL=postgres://varlens:varlens_dev_password@127.0.0.1:55434/varlens_dev npx vitest run --project main tests/main/storage/transcript-switch-denormalization.test.ts`:
+  both backends must pass.
+- `make typecheck` and `make lint-check` clean.
+- The default `make test` (no env var) runs only the SQLite half, so CI is unaffected and
+  no Postgres container is required for the default suite.
+
+## Out-of-scope follow-ups (not done here)
+
+- Generalizing the deferred cross-backend behavioral-parity harness in
+  `storage-session-contract.test.ts` (rule-of-three; only the second scenario exists after
+  this).

--- a/tests/main/storage/transcript-switch-denormalization.test.ts
+++ b/tests/main/storage/transcript-switch-denormalization.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Transcript-switch denormalization — real-engine behavioral regression (issue #207).
+ *
+ * Issue #207: switching the selected transcript must update the denormalized
+ * transcript columns on the parent `variants` row (transcript, gene_symbol,
+ * consequence, cdna, aa_change, hpo_sim_score, moi), not just flip
+ * `variant_transcripts.is_selected`. The Postgres backend originally missed the
+ * parent-row update; PR #214 fixed it inside `PostgresTranscriptsRepository`.
+ *
+ * Existing coverage stops short of a real engine:
+ *   - postgres-transcripts-repository.test.ts mocks the `pg` client and only
+ *     pins the SQL string + params.
+ *   - transcripts.test.ts exercises the SQLite repository directly, not the seam.
+ *   - storage-session-contract.test.ts pins the *interface* and explicitly defers
+ *     cross-backend *behavioral* parity.
+ *
+ * This test closes that gap: it seeds a real variant + two transcripts, drives the
+ * switch through the production `StorageWriteExecutor` seam, and reads the parent
+ * `variants` row back from the same engine. Transcripts A and B differ in every
+ * denormalized field, so the original no-op bug would fail every assertion.
+ *
+ * SQLite half: always runs.
+ * Postgres half: gated by VARLENS_RUN_POSTGRES_E2E=1 + a running dev container
+ *   (make pg-up). Each run uses a unique schema and drops it on cleanup.
+ *
+ *   make pg-up
+ *   VARLENS_RUN_POSTGRES_E2E=1 \
+ *   VARLENS_PG_URL=postgres://varlens:varlens_dev_password@127.0.0.1:55434/varlens_dev \
+ *     npx vitest run --project main \
+ *     tests/main/storage/transcript-switch-denormalization.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { Client } from 'pg'
+
+import { DatabaseService } from '../../../src/main/database'
+import type { Variant } from '../../../src/main/database/types'
+import { SqliteStorageSession } from '../../../src/main/storage/sqlite/SqliteStorageSession'
+import { createPostgresStorageSession } from '../../../src/main/storage/postgres/createPostgresStorageSession'
+import type { PostgresStorageConfig } from '../../../src/main/storage/config'
+import type { StorageSession } from '../../../src/main/storage/session'
+import type { TranscriptInsertRow } from '../../../src/shared/types/transcript'
+
+const POSTGRES_E2E = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+/** The seven denormalized transcript columns mirrored onto `variants`. */
+interface DenormFields {
+  transcript: string | null
+  gene_symbol: string | null
+  consequence: string | null
+  cdna: string | null
+  aa_change: string | null
+  hpo_sim_score: number | null
+  moi: string | null
+}
+
+/** Shape of a `variant_transcripts` row for seeding, plus its expected denorm projection. */
+interface TranscriptFixture {
+  transcript_id: string
+  gene_symbol: string
+  consequence: string
+  cdna: string
+  aa_change: string | null
+  hpo_sim_score: number
+  moi: string
+}
+
+// A and B differ in EVERY denormalized field so a no-op update (the bug) fails loudly.
+const TRANSCRIPT_A: TranscriptFixture = {
+  transcript_id: 'NM_AAA.1',
+  gene_symbol: 'GENEA',
+  consequence: 'missense_variant',
+  cdna: 'c.1A>G',
+  aa_change: 'p.Met1Val',
+  hpo_sim_score: 0.1,
+  moi: 'AD'
+}
+
+const TRANSCRIPT_B: TranscriptFixture = {
+  transcript_id: 'NM_BBB.2',
+  gene_symbol: 'GENEB',
+  consequence: 'stop_gained',
+  cdna: 'c.2C>T',
+  aa_change: 'p.Gln2Ter',
+  hpo_sim_score: 0.9,
+  moi: 'AR'
+}
+
+// VEP-only transcript: not seeded, supplied to transcripts:insertAndSwitch.
+const TRANSCRIPT_C: TranscriptInsertRow = {
+  transcript_id: 'ENST_CCC.1',
+  gene_symbol: 'GENEC',
+  consequence: 'splice_acceptor_variant',
+  cdna: 'c.3-1G>A',
+  aa_change: null,
+  hpo_sim_score: 0.55,
+  moi: 'XL',
+  is_selected: 1
+}
+
+function denormOf(t: TranscriptFixture): DenormFields {
+  return {
+    transcript: t.transcript_id,
+    gene_symbol: t.gene_symbol,
+    consequence: t.consequence,
+    cdna: t.cdna,
+    aa_change: t.aa_change,
+    hpo_sim_score: t.hpo_sim_score,
+    moi: t.moi
+  }
+}
+
+function denormOfInsert(t: TranscriptInsertRow): DenormFields {
+  return {
+    transcript: t.transcript_id,
+    gene_symbol: t.gene_symbol,
+    consequence: t.consequence,
+    cdna: t.cdna,
+    aa_change: t.aa_change,
+    hpo_sim_score: t.hpo_sim_score,
+    moi: t.moi
+  }
+}
+
+interface BackendHarness {
+  session: StorageSession
+  /** Insert a fresh case + variant (carrying A's values) + transcripts A (selected) and B. */
+  seedVariantWithTranscripts: () => Promise<number>
+  readVariantDenorm: (variantId: number) => Promise<DenormFields>
+  cleanup: () => Promise<void>
+}
+
+interface BackendFixture {
+  name: 'sqlite' | 'postgres'
+  setup: () => Promise<BackendHarness>
+}
+
+function variantSeed(): Omit<Variant, 'id' | 'case_id'> {
+  // The variants row starts out carrying transcript A's denormalized values.
+  return {
+    chr: '17',
+    pos: 43094000,
+    ref: 'A',
+    alt: 'G',
+    gene_symbol: TRANSCRIPT_A.gene_symbol,
+    omim_mim_number: null,
+    consequence: TRANSCRIPT_A.consequence,
+    gnomad_af: 0.001,
+    cadd: 28,
+    clinvar: null,
+    gt_num: '0/1',
+    func: null,
+    qual: 30,
+    hpo_sim_score: TRANSCRIPT_A.hpo_sim_score,
+    transcript: TRANSCRIPT_A.transcript_id,
+    cdna: TRANSCRIPT_A.cdna,
+    aa_change: TRANSCRIPT_A.aa_change,
+    moi: TRANSCRIPT_A.moi
+  }
+}
+
+async function setupSqlite(): Promise<BackendHarness> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'varlens-transcript-switch-sqlite-'))
+  const dbPath = join(tempDir, 'session.db')
+  const db = new DatabaseService(dbPath)
+  const session = new SqliteStorageSession({ databaseService: db, dbPool: null })
+
+  let seedCounter = 0
+  const insertTranscript = db.database.prepare(
+    `INSERT INTO variant_transcripts
+       (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+        hpo_sim_score, moi, is_selected)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+
+  return {
+    session,
+    seedVariantWithTranscripts: async () => {
+      seedCounter += 1
+      const caseId = db.cases.createCase(`issue-207-${seedCounter}`, '/issue-207.json', 100)
+      db.variants.insertVariantsBatch(caseId, [variantSeed()])
+      const variantId = db.variants.getVariants({ case_id: caseId }, 10).data[0].id
+      for (const [t, selected] of [
+        [TRANSCRIPT_A, 1],
+        [TRANSCRIPT_B, 0]
+      ] as const) {
+        insertTranscript.run(
+          variantId,
+          t.transcript_id,
+          t.gene_symbol,
+          t.consequence,
+          t.cdna,
+          t.aa_change,
+          t.hpo_sim_score,
+          t.moi,
+          selected
+        )
+      }
+      return variantId
+    },
+    readVariantDenorm: async (variantId: number) => {
+      const row = db.database
+        .prepare(
+          `SELECT transcript, gene_symbol, consequence, cdna, aa_change, hpo_sim_score, moi
+             FROM variants WHERE id = ?`
+        )
+        .get(variantId) as DenormFields
+      return row
+    },
+    cleanup: async () => {
+      await session.close()
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+async function setupPostgres(): Promise<BackendHarness> {
+  const schema = `varlens_test_${Date.now()}_${randomBytes(4).toString('hex')}`
+
+  const provisioner = new Client({ connectionString: PG_URL })
+  await provisioner.connect()
+  await provisioner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+  await provisioner.end()
+
+  const config: PostgresStorageConfig = {
+    url: PG_URL,
+    schema,
+    applicationName: 'varlens-test',
+    sslMode: 'disable',
+    connectionTimeoutMillis: 5000,
+    statementTimeoutMs: 30_000,
+    queryTimeoutMs: 30_000,
+    lockTimeoutMs: 5_000,
+    idleInTransactionSessionTimeoutMs: 10_000,
+    poolMax: 2
+  }
+
+  const session = await createPostgresStorageSession(config)
+
+  // Dedicated client for seeding + readback against the same schema.
+  const client = new Client({ connectionString: PG_URL })
+  await client.connect()
+
+  let seedCounter = 0
+
+  return {
+    session,
+    seedVariantWithTranscripts: async () => {
+      seedCounter += 1
+      const caseRes = await client.query(
+        `INSERT INTO "${schema}".cases (name, file_path, file_size, variant_count, created_at)
+         VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+        [`issue-207-${seedCounter}`, '/issue-207.json', 100, 0, Date.now()]
+      )
+      const caseId = Number(caseRes.rows[0].id)
+
+      const seed = variantSeed()
+      const variantRes = await client.query(
+        `INSERT INTO "${schema}".variants
+           (case_id, chr, pos, ref, alt, gene_symbol, consequence,
+            hpo_sim_score, transcript, cdna, aa_change, moi)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id`,
+        [
+          caseId,
+          seed.chr,
+          seed.pos,
+          seed.ref,
+          seed.alt,
+          seed.gene_symbol,
+          seed.consequence,
+          seed.hpo_sim_score,
+          seed.transcript,
+          seed.cdna,
+          seed.aa_change,
+          seed.moi
+        ]
+      )
+      const variantId = Number(variantRes.rows[0].id)
+
+      for (const [t, selected] of [
+        [TRANSCRIPT_A, 1],
+        [TRANSCRIPT_B, 0]
+      ] as const) {
+        await client.query(
+          `INSERT INTO "${schema}".variant_transcripts
+             (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+              hpo_sim_score, moi, is_selected)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+          [
+            variantId,
+            t.transcript_id,
+            t.gene_symbol,
+            t.consequence,
+            t.cdna,
+            t.aa_change,
+            t.hpo_sim_score,
+            t.moi,
+            selected
+          ]
+        )
+      }
+      return variantId
+    },
+    readVariantDenorm: async (variantId: number) => {
+      const res = await client.query(
+        `SELECT transcript, gene_symbol, consequence, cdna, aa_change, hpo_sim_score, moi
+           FROM "${schema}".variants WHERE id = $1`,
+        [variantId]
+      )
+      const r = res.rows[0]
+      return {
+        transcript: r.transcript,
+        gene_symbol: r.gene_symbol,
+        consequence: r.consequence,
+        cdna: r.cdna,
+        aa_change: r.aa_change,
+        hpo_sim_score: r.hpo_sim_score === null ? null : Number(r.hpo_sim_score),
+        moi: r.moi
+      }
+    },
+    cleanup: async () => {
+      await client.end()
+      await session.close()
+      const cleaner = new Client({ connectionString: PG_URL })
+      await cleaner.connect()
+      await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+      await cleaner.end()
+    }
+  }
+}
+
+const fixtures: BackendFixture[] = [
+  { name: 'sqlite', setup: setupSqlite },
+  ...(POSTGRES_E2E ? [{ name: 'postgres' as const, setup: setupPostgres }] : [])
+]
+
+describe.each(fixtures)('transcript-switch denormalization — $name', ({ setup }) => {
+  let h: BackendHarness
+
+  beforeAll(async () => {
+    h = await setup()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (h) await h.cleanup()
+  }, 60_000)
+
+  it('transcripts:switch updates the parent variants row to the new transcript', async () => {
+    const variantId = await h.seedVariantWithTranscripts()
+
+    // Precondition: parent row carries transcript A's values.
+    expect(await h.readVariantDenorm(variantId)).toEqual(denormOf(TRANSCRIPT_A))
+
+    await h.session.getWriteExecutor().execute({
+      type: 'transcripts:switch',
+      params: [variantId, TRANSCRIPT_B.transcript_id]
+    })
+
+    expect(await h.readVariantDenorm(variantId)).toEqual(denormOf(TRANSCRIPT_B))
+  })
+
+  it('transcripts:insertAndSwitch syncs the parent variants row to a VEP-only transcript', async () => {
+    const variantId = await h.seedVariantWithTranscripts()
+
+    await h.session.getWriteExecutor().execute({
+      type: 'transcripts:insertAndSwitch',
+      params: [variantId, TRANSCRIPT_C]
+    })
+
+    expect(await h.readVariantDenorm(variantId)).toEqual(denormOfInsert(TRANSCRIPT_C))
+  })
+})
+
+describe.skipIf(POSTGRES_E2E)('transcript-switch denormalization — postgres half (skipped)', () => {
+  it('runs only when VARLENS_RUN_POSTGRES_E2E=1 and `make pg-up` is up', () => {
+    expect(POSTGRES_E2E).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a **real-engine behavioral regression test** for the transcript-switch
denormalization contract from #207, parameterized over both backends and driven
through the production `StorageWriteExecutor` seam.

## Context: the bug is already fixed — this hardens it

[#207](https://github.com/berntpopp/VarLens/issues/207) reported that on Postgres,
switching the selected transcript flipped `variant_transcripts.is_selected` without
updating the denormalized columns on the parent `variants` row (`transcript`,
`gene_symbol`, `consequence`, `cdna`, `aa_change`, `hpo_sim_score`, `moi`). SQLite was
correct.

**The fix already shipped in #214** ("web 01: add shared contracts and storage seams"),
which moved Postgres transcript writes into `PostgresTranscriptsRepository` — both
`switchSelectedTranscript` and `insertTranscriptAndSwitch` call
`updateVariantFromSelectedTranscript` inside the transaction. Desktop IPC and the web
routes dispatch through the same executor seam, so they can't drift — exactly the
architecture the issue's "Suggested fix" recommended. The issue has been closed.

## Why this PR

The issue's "Regression test" section asked specifically for a Vitest case **against the
real Postgres test container** (`VARLENS_RUN_POSTGRES_E2E=1`). That coverage didn't exist:

| Existing | Proves | Doesn't prove |
|---|---|---|
| `postgres-transcripts-repository.test.ts` | the exact `UPDATE <schema>.variants` SQL is issued (mocked `pg`) | a real engine applies it |
| `transcripts.test.ts` | SQLite repository updates the columns | anything about Postgres / the seam |
| `storage-session-contract.test.ts` | the two backends share an **interface** | behavioral parity (explicitly deferred, lines 141-159) |

A column rename in a migration, a generated-column conflict, a type-coercion bug, or a
transaction-visibility issue would pass all of the above while breaking the feature. This
PR closes that gap.

## What it does

`tests/main/storage/transcript-switch-denormalization.test.ts`:
1. Seeds a `case` + `variant` + two `variant_transcripts` (A selected, B not), with the
   `variants` row initially carrying transcript A's values.
2. Asserts the precondition (row == A), then drives `transcripts:switch` A→B through
   `session.getWriteExecutor().execute(...)`.
3. Reads the `variants` row back from the same engine and asserts every denormalized
   column == B.
4. Repeats for `transcripts:insertAndSwitch` with a VEP-only transcript C.

A and B differ in **every** denormalized field, so the original no-op bug fails every
assertion.

## Verification

- **SQLite half** (always runs): 3 passed.
- **Postgres half** (real container, port 55434): both backends pass — 4 passed, 1 skipped.
- **Teeth proven empirically**: temporarily removing the parent-row `UPDATE` from
  `TranscriptRepository` makes both cases fail (variants row stuck on A); reverted.
- `make typecheck`, `make lint-check`, `make format-check`, `make agent-check`: clean.
- Default `make test` (no env var) runs only the SQLite half — CI and Postgres-less
  contributors are unaffected.

Spec + plan included under `.planning/`.

Closes the test-coverage follow-up to #207; complements the fix in #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)