### PR TITLE
chore(deps): bump markdown-it, @electron/fuses, vue-tsc (consolidated #292 + #293)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "file-saver": "^2.0.5",
         "jstat": "^1.9.6",
         "kysely": "^0.29.2",
-        "markdown-it": "^14.2.0",
+        "markdown-it": "^14.3.0",
         "nanoid": "^5.1.16",
         "pdbe-molstar": "^3.12.0",
         "pg": "^8.22.0",
@@ -47,7 +47,7 @@
       "devDependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
-        "@electron/fuses": "^2.1.2",
+        "@electron/fuses": "^2.1.3",
         "@electron/rebuild": "^4.0.6",
         "@eslint/js": "^10.0.1",
         "@mdi/js": "^7.4.47",
@@ -89,7 +89,7 @@
         "vitest": "^4.0.18",
         "vue": "^3.5.39",
         "vue-eslint-parser": "^10.4.1",
-        "vue-tsc": "^3.3.5"
+        "vue-tsc": "^3.3.6"
       },
       "engines": {
         "node": ">=24.15.0 <25",
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@electron/fuses": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.1.2.tgz",
-      "integrity": "sha512-x083OSf4xO9CKUKmJFYW+Egua9y/v2XOCcCIuWnM4RlpMj8xHwKICezlVN6vZyI2cZTr/ysZXRU5AKtYPJivBQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.1.3.tgz",
+      "integrity": "sha512-LoKJUXNiJ4JM8IIrUltSHI+8pkogaGj5wmJx81jE/Wk3g2w1/kfMbTEKNoY5kitGE8hiC12h32R/1SlywFtxXg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4783,9 +4783,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.5.tgz",
-      "integrity": "sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.6.tgz",
+      "integrity": "sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10736,9 +10736,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -10954,9 +10954,9 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "funding": [
         {
           "type": "github",
@@ -10970,8 +10970,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -16739,14 +16739,14 @@
       "license": "MIT"
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.5.tgz",
-      "integrity": "sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.6.tgz",
+      "integrity": "sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.5"
+        "@vue/language-core": "3.3.6"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
-    "@electron/fuses": "^2.1.2",
+    "@electron/fuses": "^2.1.3",
     "@electron/rebuild": "^4.0.6",
     "@eslint/js": "^10.0.1",
     "@mdi/js": "^7.4.47",
@@ -95,7 +95,7 @@
     "vitest": "^4.0.18",
     "vue": "^3.5.39",
     "vue-eslint-parser": "^10.4.1",
-    "vue-tsc": "^3.3.5"
+    "vue-tsc": "^3.3.6"
   },
   "build": {
     "appId": "com.varlens.app",
@@ -193,7 +193,7 @@
     "file-saver": "^2.0.5",
     "jstat": "^1.9.6",
     "kysely": "^0.29.2",
-    "markdown-it": "^14.2.0",
+    "markdown-it": "^14.3.0",
     "nanoid": "^5.1.16",
     "pdbe-molstar": "^3.12.0",
     "pg": "^8.22.0",

--- a/src/renderer/src/components/panels/PanelEditorDialog.vue
+++ b/src/renderer/src/components/panels/PanelEditorDialog.vue
@@ -153,8 +153,8 @@
                     placeholder="Choose..."
                     class="ambiguous-select"
                     @update:model-value="
-                      (chosen: { symbol: string; hgncId: string }) =>
-                        resolveAmbiguous(index, chosen)
+                      (chosen: { symbol: string; hgncId: string } | null) =>
+                        chosen && resolveAmbiguous(index, chosen)
                     "
                   />
                   <v-btn


### PR DESCRIPTION
## Summary

Consolidates the two outstanding Dependabot PRs into one, following the v0.69.4 sweep.

- **production-dependencies (#292):** markdown-it 14.2.0 → 14.3.0
- **development-dependencies (#293):** @electron/fuses 2.1.2 → 2.1.3, vue-tsc 3.3.5 → 3.3.6

Supersedes #292 and #293. No new security advisories (the 5 remaining low `npm audit` findings are the pre-existing `elliptic → pdbe-molstar` chain, unchanged and out of scope).

## Necessitated fix

**vue-tsc 3.3.6 surfaces a latent type error** that 3.3.5 missed: in `PanelEditorDialog.vue`, Vuetify's `return-object` `v-select` emits `{ symbol, hgncId } | null` on `update:model-value` (null when cleared), but the inline handler only accepted the non-null shape. Widened the handler and added a null-guard so a cleared select can't call `resolveAmbiguous` with null. Strictly safer behaviour; no threshold was lowered.

## Verification (full local gate, run before pushing)

- `make ci` ✓ — lint-check, format-check, typecheck (vue-tsc 3.3.6), rebuild-node, **3892 tests**
- `VARLENS_WEB=1 make test` ✓ — 4083 tests
- `make agent-check` ✓

`@electron/fuses` 2.1.3 is a patch bump; the `strictlyRequireAllFuses` baseline is validated by the packaging (Package) CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2A6iMmSL4An41C8BCUkGZ