### PR TITLE
chore(deps): batch 5 pinned GitHub Actions bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7.0.0
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # dorny/paths-filter@v4.0.1
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # dorny/paths-filter@v4.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -137,10 +137,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # docker/setup-buildx-action@v4.2.0
 
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # docker/login-action@v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # docker/login-action@v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -157,7 +157,7 @@ jobs:
             type=sha,format=short
 
       - name: Build image for security gate
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7.3.0
         with:
           context: .
           platforms: linux/amd64
@@ -192,14 +192,14 @@ jobs:
       - name: Upload SARIF
         if: always() && hashFiles('trivy-results.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # github/codeql-action/upload-sarif@v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # github/codeql-action/upload-sarif@v4.36.3
         with:
           sarif_file: trivy-results.sarif
           category: trivy-web-image
 
       - name: Push scanned image
         id: push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7.3.0
         with:
           context: .
           platforms: linux/amd64


### PR DESCRIPTION
Consolidates five Dependabot GitHub Actions bumps into a single, reviewable change. All actions stay SHA-pinned with their human-readable tag comment (per the repo's workflow-maintenance convention), and each new SHA was verified to resolve to its claimed upstream tag before pinning.

| Action | From | To | Supersedes |
| --- | --- | --- | --- |
| `dorny/paths-filter` | v4.0.1 | v4.0.2 | #300 |
| `docker/build-push-action` | v7.2.0 | v7.3.0 | #299 |
| `docker/login-action` | v4.2.0 | v4.4.0 | #298 |
| `docker/setup-buildx-action` | v4.1.0 | v4.2.0 | #297 |
| `github/codeql-action/upload-sarif` | v4.36.2 | v4.36.3 | #296 |

Files touched: `.github/workflows/build.yml` (paths-filter) and `.github/workflows/publish-web.yml` (the four docker/codeql pins). No `with:` blocks changed — SHA + tag-comment only.

Supersedes #296, #297, #298, #299, #300 — those Dependabot PRs will be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)