### PR TITLE
fix(import,query): eliminate silent-failure degradation (C2, C8) [PR-B]

### DIFF
--- a/.planning/plans/2026-07-13-pr307-zip-hardening-plan.md
+++ b/.planning/plans/2026-07-13-pr307-zip-hardening-plan.md
@@ -1,0 +1,44 @@
+# PR307 ZIP Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ZIP password checks exhaustive and bounded, and reject flattened extraction collisions before any output is written.
+
+**Architecture:** Keep the behavior in `ZipExtractor`: aggregate password outcomes in one pass, enforce injectable pre/post-decode byte budgets, and preflight extraction destinations before the write loop. Keep batch-import cleanup at its existing ownership boundary and lock it with regression tests.
+
+**Tech Stack:** TypeScript 6, adm-zip, Vitest, Electron main-process services.
+
+---
+
+### Task 1: Exhaustive bounded password validation
+
+**Files:**
+- Modify: `tests/main/import/ZipExtractor.test.ts`
+- Modify: `src/main/import/ZipExtractor.ts`
+
+- [ ] Add failing real-fixture tests proving a leading wrong-password entry cannot hide later corruption, unencrypted-only archives return false, per-entry and cumulative limits reject before excessive decoding, and logger arguments never contain a sentinel password.
+- [ ] Run `npx vitest run tests/main/import/ZipExtractor.test.ts` and confirm the regressions fail for the current early return/unbounded implementation.
+- [ ] Add constructor-injectable `ZipPasswordValidationLimits`, validate declared and actual byte counts, aggregate wrong-password state, and return `encryptedEntryCount > 0 && !passwordRejected` only after the full pass.
+- [ ] Re-run the focused test and confirm it passes.
+
+### Task 2: Collision-free extraction and cleanup
+
+**Files:**
+- Modify: `tests/main/import/ZipExtractor.test.ts`
+- Modify: `tests/main/handlers/batch-import-logic.test.ts`
+- Modify: `src/main/import/ZipExtractor.ts`
+
+- [ ] Add failing tests for nested entries with the same case-insensitive basename, asserting zero extracted files and an unchanged target directory.
+- [ ] Add a batch-boundary regression asserting rejected partial extraction invokes cleanup and leaves no VarLens ZIP temp directory behind.
+- [ ] Run both focused test files and confirm the collision regression fails.
+- [ ] Preflight importable entries for path safety and flattened-basename uniqueness before the write loop; return preflight errors without writing.
+- [ ] Re-run both focused test files and confirm they pass.
+
+### Task 3: Verification and commit
+
+**Files:**
+- Verify all files above plus `.planning/specs/2026-07-13-pr307-zip-hardening.md` and this plan.
+
+- [ ] Run `npx vitest run tests/main/import/ZipExtractor.test.ts tests/main/handlers/batch-import-logic.test.ts`.
+- [ ] Run `make typecheck`, `make lint-check`, `make format-check`, and `make agent-check`.
+- [ ] Inspect `git diff --check`, confirm no unrelated changes, and commit with `fix(import): harden zip validation and extraction`.

--- a/.planning/specs/2026-07-13-pr307-zip-hardening.md
+++ b/.planning/specs/2026-07-13-pr307-zip-hardening.md
@@ -1,0 +1,23 @@
+# PR307 ZIP Hardening Design
+
+## Goal
+
+Make ZIP password validation and flattened extraction fail closed without exposing passwords or allowing unbounded synchronous decompression in Electron's main process.
+
+## Password classification
+
+`ZipExtractor.testPassword` performs one exhaustive pass over every non-directory entry. It records whether at least one encrypted entry exists and whether any encrypted entry explicitly rejected the supplied password. A wrong-password error does not end the pass; any later CRC, decompression, parsing, or other non-password error throws as archive corruption. The final result is `true` only when at least one encrypted entry exists and every encrypted entry decrypted successfully. A valid unencrypted archive therefore returns `false`.
+
+The method never includes the supplied password in logs or constructed errors. Tests spy on the structured logger with a sentinel password to lock this boundary.
+
+## Resource bounds
+
+Password validation checks each entry's declared uncompressed size before decoding and checks the returned buffer size afterward. It also tracks a cumulative uncompressed-byte budget. Limits are constructor-injectable for deterministic small-fixture tests, while production uses ZIP-specific conservative defaults. PR310's active limits are not imported because they exist only as uncommitted work in another worktree and target streamed VCF/BED input rather than synchronous ZIP materialization.
+
+## Extraction preflight
+
+Before writing any file, extraction preflights all importable candidates (`.json`, `.gz`, and `.json.gz`). It rejects unsafe paths and case-insensitive collisions of flattened basenames. Any preflight error returns no extracted files and performs no writes, allowing the batch-import boundary to surface one fail-closed archive error and clean its temporary directory.
+
+## Verification
+
+Real ZIP fixtures cover exhaustive password classification, validation limits, duplicate basenames, zero writes, cleanup, and secret non-leakage. Focused Vitest, typecheck, lint, format-check, and agent-check must pass before commit.

--- a/src/main/import/TempDirectoryManager.ts
+++ b/src/main/import/TempDirectoryManager.ts
@@ -6,6 +6,8 @@ import { mainLogger } from '../services/MainLogger'
 export class TempDirectoryManager {
   private tempDir: string | null = null
 
+  constructor(private readonly removeDirectory: typeof rmSync = rmSync) {}
+
   create(): string {
     this.tempDir = mkdtempSync(join(tmpdir(), 'varlens-zip-'))
     return this.tempDir
@@ -14,9 +16,24 @@ export class TempDirectoryManager {
   cleanup(): void {
     if (this.tempDir !== null) {
       try {
-        rmSync(this.tempDir, { recursive: true, force: true })
+        this.removeDirectory(this.tempDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 3,
+          retryDelay: 100
+        })
       } catch (error) {
         mainLogger.error(`Failed to clean up temp directory: ${error}`, 'import')
+        // Retain the path so a later cleanup attempt can retry. Reporting
+        // success and forgetting the directory would orphan extracted clinical
+        // data, especially on Windows where transient open handles can make a
+        // recursive removal fail.
+        throw new Error(
+          `Failed to clean up temporary ZIP directory: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          { cause: error }
+        )
       }
       this.tempDir = null
     }

--- a/src/main/import/ZipExtractor.ts
+++ b/src/main/import/ZipExtractor.ts
@@ -106,13 +106,17 @@ export class ZipExtractor {
    * Test if a ZIP archive can be opened with the given password.
    * Attempts to read the first entry as a verification check.
    *
-   * Distinguishes two failure classes deliberately:
+   * Distinguishes three outcomes deliberately:
    * - The archive itself cannot be opened/parsed (corrupt file, wrong format,
    *   unreadable path) — this is an infrastructure fault, not a password
    *   problem, so it throws rather than being reported as "wrong password".
-   * - The archive opens fine but decrypting the first entry with the given
-   *   password fails — this is the legitimate "wrong password" outcome and
-   *   is reported as `false`.
+   * - The first entry IS encrypted and decoding it with the given password
+   *   fails — this is the legitimate "wrong password" outcome and is
+   *   reported as `false`.
+   * - The first entry is NOT encrypted but decoding/CRC-checking it still
+   *   fails — the archive is corrupt, not password-protected, so this must
+   *   throw too. Otherwise a corrupt-but-unencrypted entry is indistinguishable
+   *   from a genuine wrong-password result.
    */
   testPassword(zipPath: string, password: string): boolean {
     let entries: AdmZip.IZipEntry[]
@@ -129,6 +133,9 @@ export class ZipExtractor {
     const firstFile = entries.find((e) => !e.isDirectory)
     if (firstFile === undefined) return true
 
+    const header = firstFile.header as unknown as Record<string, unknown>
+    const isEntryEncrypted = header['encrypted'] === true || header['encripted'] === true
+
     try {
       // adm-zip runtime accepts password arg but @types/adm-zip doesn't declare it
       const getDataWithPassword = firstFile as unknown as {
@@ -137,10 +144,21 @@ export class ZipExtractor {
       getDataWithPassword.getData(password)
       return true
     } catch (e) {
-      mainLogger.warn(
-        'ZIP password test failed: ' + (e instanceof Error ? e.message : String(e)),
-        'ZipExtractor'
-      )
+      const message = e instanceof Error ? e.message : String(e)
+
+      if (!isEntryEncrypted) {
+        // A non-encrypted entry that fails to read/decode/CRC-check is a
+        // corrupt archive, not a wrong password — must not be reported as
+        // `false`, which would be indistinguishable from a genuine
+        // wrong-password result.
+        mainLogger.error(
+          `ZIP entry is corrupt (unencrypted entry failed to read): ${message}`,
+          'ZipExtractor'
+        )
+        throw new Error(`Corrupt ZIP archive entry: ${message}`, { cause: e })
+      }
+
+      mainLogger.warn('ZIP password test failed: ' + message, 'ZipExtractor')
       return false
     }
   }

--- a/src/main/import/ZipExtractor.ts
+++ b/src/main/import/ZipExtractor.ts
@@ -9,7 +9,33 @@ export interface ZipExtractionResult {
   totalEntries: number
 }
 
+export interface ZipPasswordValidationLimits {
+  maxEntryUncompressedBytes: number
+  maxTotalUncompressedBytes: number
+}
+
+const DEFAULT_ZIP_PASSWORD_VALIDATION_LIMITS: ZipPasswordValidationLimits = {
+  // Validation materializes entries synchronously on Electron's main thread,
+  // so these are intentionally tighter than the streaming import caps.
+  maxEntryUncompressedBytes: 512 * 1024 * 1024,
+  maxTotalUncompressedBytes: 2 * 1024 * 1024 * 1024
+}
+
+type ZipArchive = Pick<AdmZip, 'getEntries'>
+type OpenZipArchive = (zipPath: string) => ZipArchive
+
+interface ZipExtractionCandidate {
+  entry: AdmZip.IZipEntry
+  entryName: string
+  extractedPath: string
+}
+
 export class ZipExtractor {
+  constructor(
+    private readonly passwordValidationLimits = DEFAULT_ZIP_PASSWORD_VALIDATION_LIMITS,
+    private readonly openArchive: OpenZipArchive = (zipPath) => new AdmZip(zipPath)
+  ) {}
+
   /**
    * Check if a ZIP file is password-protected.
    * Checks both "encrypted" (current adm-zip) and "encripted" (legacy typo)
@@ -17,7 +43,7 @@ export class ZipExtractor {
    */
   isEncrypted(zipPath: string): boolean {
     try {
-      const zip = new AdmZip(zipPath)
+      const zip = this.openArchive(zipPath)
       const entries = zip.getEntries()
       return entries.some((entry) => {
         const header = entry.header as unknown as Record<string, unknown>
@@ -48,7 +74,7 @@ export class ZipExtractor {
     targetDir: string,
     password?: string
   ): Promise<ZipExtractionResult> {
-    const zip = new AdmZip(zipPath)
+    const zip = this.openArchive(zipPath)
     const entries = zip.getEntries()
     const result: ZipExtractionResult = {
       extractedFiles: [],
@@ -56,24 +82,10 @@ export class ZipExtractor {
       totalEntries: entries.length
     }
 
-    for (const entry of entries) {
-      if (entry.isDirectory) continue
+    const candidates = this.preflightExtraction(entries, targetDir, result.errors)
+    if (result.errors.length > 0) return result
 
-      const entryName = entry.entryName
-      const lowerName = entryName.toLowerCase()
-      if (
-        !lowerName.endsWith('.json.gz') &&
-        !lowerName.endsWith('.gz') &&
-        !lowerName.endsWith('.json')
-      ) {
-        continue
-      }
-
-      if (!this.validatePath(targetDir, entryName)) {
-        result.errors.push(`Rejected path traversal attempt: ${entryName}`)
-        continue
-      }
-
+    for (const { entry, entryName, extractedPath } of candidates) {
       try {
         // Use getData(password) for decryption — extractEntryTo() and extractAllTo()
         // can trigger uncaught async zlib errors that crash Electron.
@@ -82,18 +94,13 @@ export class ZipExtractor {
         const data =
           password !== undefined && password !== '' ? getDataFn.getData(password) : entry.getData()
 
-        const fileName = basename(entryName)
-        const extractedPath = resolve(targetDir, fileName)
-        const normalizedTarget = resolve(targetDir)
-        if (!extractedPath.startsWith(normalizedTarget + sep)) {
-          result.errors.push(`Rejected path traversal attempt: ${entryName}`)
-          continue
-        }
         await writeFile(extractedPath, data)
         result.extractedFiles.push(resolve(extractedPath))
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error)
-        result.errors.push(`Failed to extract ${entryName}: ${errorMsg}`)
+        result.errors.push(
+          `Failed to extract ${entryName}: ${this.redactSecret(errorMsg, password ?? '')}`
+        )
       }
     }
 
@@ -108,18 +115,21 @@ export class ZipExtractor {
    * - The archive itself cannot be opened/parsed (corrupt file, wrong format,
    *   unreadable path) — this is an infrastructure fault, not a password
    *   problem, so it throws rather than being reported as "wrong password".
-   * - An encrypted entry rejects the supplied password explicitly
-   *   fails — this is the legitimate "wrong password" outcome and is
-   *   reported as `false`.
+   * - An encrypted entry explicitly rejects the supplied password — this is
+   *   recorded as the legitimate "wrong password" outcome, but validation
+   *   continues so a later corrupt entry cannot be hidden by entry ordering.
    * - Any entry decodes far enough to report CRC/decompression failure
    *   fails — the archive is corrupt, not password-protected, so this must
    *   throw too. Otherwise a corrupt-but-unencrypted entry is indistinguishable
    *   from a genuine wrong-password result.
+   *
+   * Returns `true` only when at least one encrypted entry exists and all
+   * encrypted entries accept the supplied password.
    */
   testPassword(zipPath: string, password: string): boolean {
     let entries: AdmZip.IZipEntry[]
     try {
-      const zip = new AdmZip(zipPath)
+      const zip = this.openArchive(zipPath)
       entries = zip.getEntries()
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -127,30 +137,125 @@ export class ZipExtractor {
       throw new Error(`Failed to open ZIP archive: ${message}`, { cause: e })
     }
 
+    let encryptedEntryCount = 0
+    let passwordRejected = false
+    let declaredTotalBytes = 0
+    let actualTotalBytes = 0
+
     for (const entry of entries) {
       if (entry.isDirectory) continue
       const header = entry.header as unknown as Record<string, unknown>
       const isEntryEncrypted = header['encrypted'] === true || header['encripted'] === true
+      if (isEntryEncrypted) encryptedEntryCount++
 
+      const declaredSize = header['size']
+      this.assertEntrySizeWithinLimit(entry.entryName, declaredSize)
+      declaredTotalBytes += declaredSize
+      this.assertTotalSizeWithinLimit(declaredTotalBytes)
+
+      let data: Buffer
       try {
         // adm-zip runtime accepts password arg but @types/adm-zip doesn't declare it
         const getDataWithPassword = entry as unknown as {
           getData: (pass: string) => Buffer
         }
-        getDataWithPassword.getData(password)
+        data = getDataWithPassword.getData(password)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (isEntryEncrypted && /wrong password/i.test(message)) {
           mainLogger.warn(`ZIP password rejected for ${entry.entryName}`, 'ZipExtractor')
-          return false
+          passwordRejected = true
+          continue
         }
 
-        mainLogger.error(`ZIP archive entry is corrupt: ${entry.entryName}`, 'ZipExtractor')
-        throw new Error(`Corrupt ZIP archive entry ${entry.entryName}: ${message}`, { cause: e })
+        this.throwCorruptEntry(entry.entryName, message, password)
       }
+
+      this.assertEntrySizeWithinLimit(entry.entryName, data.length)
+      actualTotalBytes += data.length
+      this.assertTotalSizeWithinLimit(actualTotalBytes)
     }
 
-    return true
+    return encryptedEntryCount > 0 && !passwordRejected
+  }
+
+  private assertEntrySizeWithinLimit(entryName: string, size: unknown): asserts size is number {
+    if (!Number.isSafeInteger(size) || (size as number) < 0) {
+      throw new Error(`Invalid uncompressed size for ZIP archive entry ${entryName}`)
+    }
+    if ((size as number) > this.passwordValidationLimits.maxEntryUncompressedBytes) {
+      throw new Error(
+        `ZIP password validation limit exceeded for entry ${entryName}: maximum ${this.passwordValidationLimits.maxEntryUncompressedBytes} bytes`
+      )
+    }
+  }
+
+  private assertTotalSizeWithinLimit(size: number): void {
+    if (size > this.passwordValidationLimits.maxTotalUncompressedBytes) {
+      throw new Error(
+        `ZIP password validation total limit exceeded: maximum ${this.passwordValidationLimits.maxTotalUncompressedBytes} bytes`
+      )
+    }
+  }
+
+  private redactSecret(message: string, secret: string): string {
+    return secret === '' ? message : message.split(secret).join('[REDACTED]')
+  }
+
+  private throwCorruptEntry(entryName: string, message: string, password: string): never {
+    mainLogger.error(`ZIP archive entry is corrupt: ${entryName}`, 'ZipExtractor')
+    const sanitizedMessage = this.redactSecret(message, password)
+    throw new Error(`Corrupt ZIP archive entry ${entryName}: ${sanitizedMessage}`, {
+      cause: new Error(sanitizedMessage)
+    })
+  }
+
+  private preflightExtraction(
+    entries: AdmZip.IZipEntry[],
+    targetDir: string,
+    errors: string[]
+  ): ZipExtractionCandidate[] {
+    const candidates: ZipExtractionCandidate[] = []
+    const flattenedNames = new Map<string, string>()
+    const normalizedTarget = resolve(targetDir)
+
+    for (const entry of entries) {
+      if (entry.isDirectory || !this.isImportableEntry(entry.entryName)) continue
+
+      const entryName = entry.entryName
+      if (!this.validatePath(targetDir, entryName)) {
+        errors.push(`Rejected path traversal attempt: ${entryName}`)
+        continue
+      }
+
+      const fileName = basename(entryName)
+      const extractedPath = resolve(targetDir, fileName)
+      if (!extractedPath.startsWith(normalizedTarget + sep)) {
+        errors.push(`Rejected path traversal attempt: ${entryName}`)
+        continue
+      }
+
+      const collisionKey = fileName.normalize('NFC').toLowerCase()
+      const existingEntry = flattenedNames.get(collisionKey)
+      if (existingEntry !== undefined) {
+        errors.push(
+          `Duplicate flattened basename ${fileName}: entries ${existingEntry} and ${entryName}`
+        )
+        continue
+      }
+
+      flattenedNames.set(collisionKey, entryName)
+      candidates.push({ entry, entryName, extractedPath })
+    }
+
+    return errors.length === 0 ? candidates : []
+  }
+
+  private isImportableEntry(entryName: string): boolean {
+    const lowerName = entryName.toLowerCase()
+    return (
+      lowerName.endsWith('.json.gz') || lowerName.endsWith('.gz') || lowerName.endsWith('.json')
+    )
   }
 
   /**

--- a/src/main/import/ZipExtractor.ts
+++ b/src/main/import/ZipExtractor.ts
@@ -1,6 +1,6 @@
 import AdmZip from 'adm-zip'
-import { writeFile } from 'node:fs/promises'
-import { resolve, relative, basename, sep } from 'node:path'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, relative, basename, dirname, sep } from 'node:path'
 import { mainLogger } from '../services/MainLogger'
 
 export interface ZipExtractionResult {
@@ -23,6 +23,8 @@ const DEFAULT_ZIP_PASSWORD_VALIDATION_LIMITS: ZipPasswordValidationLimits = {
 
 type ZipArchive = Pick<AdmZip, 'getEntries'>
 type OpenZipArchive = (zipPath: string) => ZipArchive
+
+class ZipResourceLimitError extends Error {}
 
 interface ZipExtractionCandidate {
   entry: AdmZip.IZipEntry
@@ -85,6 +87,7 @@ export class ZipExtractor {
     const candidates = this.preflightExtraction(entries, targetDir, result.errors)
     if (result.errors.length > 0) return result
 
+    let actualTotalBytes = 0
     for (const { entry, entryName, extractedPath } of candidates) {
       try {
         // Use getData(password) for decryption — extractEntryTo() and extractAllTo()
@@ -94,6 +97,11 @@ export class ZipExtractor {
         const data =
           password !== undefined && password !== '' ? getDataFn.getData(password) : entry.getData()
 
+        this.assertEntrySizeWithinLimit(entryName, data.length, 'extraction')
+        actualTotalBytes += data.length
+        this.assertTotalSizeWithinLimit(actualTotalBytes, 'extraction')
+
+        await mkdir(dirname(extractedPath))
         await writeFile(extractedPath, data)
         result.extractedFiles.push(resolve(extractedPath))
       } catch (error) {
@@ -101,6 +109,7 @@ export class ZipExtractor {
         result.errors.push(
           `Failed to extract ${entryName}: ${this.redactSecret(errorMsg, password ?? '')}`
         )
+        if (error instanceof ZipResourceLimitError) break
       }
     }
 
@@ -149,9 +158,9 @@ export class ZipExtractor {
       if (isEntryEncrypted) encryptedEntryCount++
 
       const declaredSize = header['size']
-      this.assertEntrySizeWithinLimit(entry.entryName, declaredSize)
+      this.assertEntrySizeWithinLimit(entry.entryName, declaredSize, 'password validation')
       declaredTotalBytes += declaredSize
-      this.assertTotalSizeWithinLimit(declaredTotalBytes)
+      this.assertTotalSizeWithinLimit(declaredTotalBytes, 'password validation')
 
       let data: Buffer
       try {
@@ -171,29 +180,36 @@ export class ZipExtractor {
         this.throwCorruptEntry(entry.entryName, message, password)
       }
 
-      this.assertEntrySizeWithinLimit(entry.entryName, data.length)
+      this.assertEntrySizeWithinLimit(entry.entryName, data.length, 'password validation')
       actualTotalBytes += data.length
-      this.assertTotalSizeWithinLimit(actualTotalBytes)
+      this.assertTotalSizeWithinLimit(actualTotalBytes, 'password validation')
     }
 
     return encryptedEntryCount > 0 && !passwordRejected
   }
 
-  private assertEntrySizeWithinLimit(entryName: string, size: unknown): asserts size is number {
+  private assertEntrySizeWithinLimit(
+    entryName: string,
+    size: unknown,
+    operation: 'password validation' | 'extraction'
+  ): asserts size is number {
     if (!Number.isSafeInteger(size) || (size as number) < 0) {
       throw new Error(`Invalid uncompressed size for ZIP archive entry ${entryName}`)
     }
     if ((size as number) > this.passwordValidationLimits.maxEntryUncompressedBytes) {
-      throw new Error(
-        `ZIP password validation limit exceeded for entry ${entryName}: maximum ${this.passwordValidationLimits.maxEntryUncompressedBytes} bytes`
+      throw new ZipResourceLimitError(
+        `ZIP ${operation} limit exceeded for entry ${entryName}: maximum ${this.passwordValidationLimits.maxEntryUncompressedBytes} bytes`
       )
     }
   }
 
-  private assertTotalSizeWithinLimit(size: number): void {
+  private assertTotalSizeWithinLimit(
+    size: number,
+    operation: 'password validation' | 'extraction'
+  ): void {
     if (size > this.passwordValidationLimits.maxTotalUncompressedBytes) {
-      throw new Error(
-        `ZIP password validation total limit exceeded: maximum ${this.passwordValidationLimits.maxTotalUncompressedBytes} bytes`
+      throw new ZipResourceLimitError(
+        `ZIP ${operation} total limit exceeded: maximum ${this.passwordValidationLimits.maxTotalUncompressedBytes} bytes`
       )
     }
   }
@@ -218,6 +234,7 @@ export class ZipExtractor {
     const candidates: ZipExtractionCandidate[] = []
     const flattenedNames = new Map<string, string>()
     const normalizedTarget = resolve(targetDir)
+    let declaredTotalBytes = 0
 
     for (const entry of entries) {
       if (entry.isDirectory || !this.isImportableEntry(entry.entryName)) continue
@@ -229,7 +246,19 @@ export class ZipExtractor {
       }
 
       const fileName = basename(entryName)
-      const extractedPath = resolve(targetDir, fileName)
+      try {
+        const header = entry.header as unknown as Record<string, unknown>
+        const declaredSize = header['size']
+        this.assertEntrySizeWithinLimit(entryName, declaredSize, 'extraction')
+        declaredTotalBytes += declaredSize
+        this.assertTotalSizeWithinLimit(declaredTotalBytes, 'extraction')
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : String(error))
+        continue
+      }
+
+      const childDirectory = `entry-${String(candidates.length + 1).padStart(6, '0')}`
+      const extractedPath = resolve(targetDir, childDirectory, fileName)
       if (!extractedPath.startsWith(normalizedTarget + sep)) {
         errors.push(`Rejected path traversal attempt: ${entryName}`)
         continue

--- a/src/main/import/ZipExtractor.ts
+++ b/src/main/import/ZipExtractor.ts
@@ -105,14 +105,31 @@ export class ZipExtractor {
   /**
    * Test if a ZIP archive can be opened with the given password.
    * Attempts to read the first entry as a verification check.
+   *
+   * Distinguishes two failure classes deliberately:
+   * - The archive itself cannot be opened/parsed (corrupt file, wrong format,
+   *   unreadable path) — this is an infrastructure fault, not a password
+   *   problem, so it throws rather than being reported as "wrong password".
+   * - The archive opens fine but decrypting the first entry with the given
+   *   password fails — this is the legitimate "wrong password" outcome and
+   *   is reported as `false`.
    */
   testPassword(zipPath: string, password: string): boolean {
+    let entries: AdmZip.IZipEntry[]
     try {
       const zip = new AdmZip(zipPath)
-      const entries = zip.getEntries()
-      if (entries.length === 0) return true
-      const firstFile = entries.find((e) => !e.isDirectory)
-      if (firstFile === undefined) return true
+      entries = zip.getEntries()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      mainLogger.error(`Failed to open ZIP archive for password test: ${message}`, 'ZipExtractor')
+      throw new Error(`Failed to open ZIP archive: ${message}`, { cause: e })
+    }
+
+    if (entries.length === 0) return true
+    const firstFile = entries.find((e) => !e.isDirectory)
+    if (firstFile === undefined) return true
+
+    try {
       // adm-zip runtime accepts password arg but @types/adm-zip doesn't declare it
       const getDataWithPassword = firstFile as unknown as {
         getData: (pass: string) => Buffer

--- a/src/main/import/ZipExtractor.ts
+++ b/src/main/import/ZipExtractor.ts
@@ -24,11 +24,9 @@ export class ZipExtractor {
         return header['encrypted'] === true || header['encripted'] === true
       })
     } catch (e) {
-      mainLogger.warn(
-        'Failed to check ZIP encryption: ' + (e instanceof Error ? e.message : String(e)),
-        'ZipExtractor'
-      )
-      return false
+      const message = e instanceof Error ? e.message : String(e)
+      mainLogger.error(`Failed to inspect ZIP archive encryption: ${message}`, 'ZipExtractor')
+      throw new Error(`Failed to inspect ZIP archive: ${message}`, { cause: e })
     }
   }
 
@@ -104,16 +102,16 @@ export class ZipExtractor {
 
   /**
    * Test if a ZIP archive can be opened with the given password.
-   * Attempts to read the first entry as a verification check.
+   * Attempts to read every file entry as a verification check.
    *
    * Distinguishes three outcomes deliberately:
    * - The archive itself cannot be opened/parsed (corrupt file, wrong format,
    *   unreadable path) — this is an infrastructure fault, not a password
    *   problem, so it throws rather than being reported as "wrong password".
-   * - The first entry IS encrypted and decoding it with the given password
+   * - An encrypted entry rejects the supplied password explicitly
    *   fails — this is the legitimate "wrong password" outcome and is
    *   reported as `false`.
-   * - The first entry is NOT encrypted but decoding/CRC-checking it still
+   * - Any entry decodes far enough to report CRC/decompression failure
    *   fails — the archive is corrupt, not password-protected, so this must
    *   throw too. Otherwise a corrupt-but-unencrypted entry is indistinguishable
    *   from a genuine wrong-password result.
@@ -129,38 +127,30 @@ export class ZipExtractor {
       throw new Error(`Failed to open ZIP archive: ${message}`, { cause: e })
     }
 
-    if (entries.length === 0) return true
-    const firstFile = entries.find((e) => !e.isDirectory)
-    if (firstFile === undefined) return true
+    for (const entry of entries) {
+      if (entry.isDirectory) continue
+      const header = entry.header as unknown as Record<string, unknown>
+      const isEntryEncrypted = header['encrypted'] === true || header['encripted'] === true
 
-    const header = firstFile.header as unknown as Record<string, unknown>
-    const isEntryEncrypted = header['encrypted'] === true || header['encripted'] === true
+      try {
+        // adm-zip runtime accepts password arg but @types/adm-zip doesn't declare it
+        const getDataWithPassword = entry as unknown as {
+          getData: (pass: string) => Buffer
+        }
+        getDataWithPassword.getData(password)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (isEntryEncrypted && /wrong password/i.test(message)) {
+          mainLogger.warn(`ZIP password rejected for ${entry.entryName}`, 'ZipExtractor')
+          return false
+        }
 
-    try {
-      // adm-zip runtime accepts password arg but @types/adm-zip doesn't declare it
-      const getDataWithPassword = firstFile as unknown as {
-        getData: (pass: string) => Buffer
+        mainLogger.error(`ZIP archive entry is corrupt: ${entry.entryName}`, 'ZipExtractor')
+        throw new Error(`Corrupt ZIP archive entry ${entry.entryName}: ${message}`, { cause: e })
       }
-      getDataWithPassword.getData(password)
-      return true
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e)
-
-      if (!isEntryEncrypted) {
-        // A non-encrypted entry that fails to read/decode/CRC-check is a
-        // corrupt archive, not a wrong password — must not be reported as
-        // `false`, which would be indistinguishable from a genuine
-        // wrong-password result.
-        mainLogger.error(
-          `ZIP entry is corrupt (unencrypted entry failed to read): ${message}`,
-          'ZipExtractor'
-        )
-        throw new Error(`Corrupt ZIP archive entry: ${message}`, { cause: e })
-      }
-
-      mainLogger.warn('ZIP password test failed: ' + message, 'ZipExtractor')
-      return false
     }
+
+    return true
   }
 
   /**

--- a/src/main/import/ZipExtractor.ts
+++ b/src/main/import/ZipExtractor.ts
@@ -1,4 +1,5 @@
 import AdmZip from 'adm-zip'
+import { statSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { resolve, relative, basename, dirname, sep } from 'node:path'
 import { mainLogger } from '../services/MainLogger'
@@ -9,16 +10,27 @@ export interface ZipExtractionResult {
   totalEntries: number
 }
 
-export interface ZipPasswordValidationLimits {
+export interface ZipResourceLimits {
+  maxArchiveBytes: number
+  maxEntries: number
   maxEntryUncompressedBytes: number
   maxTotalUncompressedBytes: number
 }
 
-const DEFAULT_ZIP_PASSWORD_VALIDATION_LIMITS: ZipPasswordValidationLimits = {
-  // Validation materializes entries synchronously on Electron's main thread,
-  // so these are intentionally tighter than the streaming import caps.
-  maxEntryUncompressedBytes: 512 * 1024 * 1024,
-  maxTotalUncompressedBytes: 2 * 1024 * 1024 * 1024
+/** @deprecated Use ZipResourceLimits for archive-wide bounds as well. */
+export type ZipPasswordValidationLimits = Pick<
+  ZipResourceLimits,
+  'maxEntryUncompressedBytes' | 'maxTotalUncompressedBytes'
+>
+
+const DEFAULT_ZIP_RESOURCE_LIMITS: ZipResourceLimits = {
+  // adm-zip reads/parses archives and decodes entries synchronously on the
+  // Electron main thread. ZIP is a batch convenience path; larger clinical
+  // inputs should use the directly streamed JSON/VCF import paths.
+  maxArchiveBytes: 256 * 1024 * 1024,
+  maxEntries: 10_000,
+  maxEntryUncompressedBytes: 128 * 1024 * 1024,
+  maxTotalUncompressedBytes: 512 * 1024 * 1024
 }
 
 type ZipArchive = Pick<AdmZip, 'getEntries'>
@@ -33,10 +45,15 @@ interface ZipExtractionCandidate {
 }
 
 export class ZipExtractor {
+  private readonly resourceLimits: ZipResourceLimits
+
   constructor(
-    private readonly passwordValidationLimits = DEFAULT_ZIP_PASSWORD_VALIDATION_LIMITS,
-    private readonly openArchive: OpenZipArchive = (zipPath) => new AdmZip(zipPath)
-  ) {}
+    resourceLimits: Partial<ZipResourceLimits> = {},
+    private readonly openArchive: OpenZipArchive = (zipPath) => new AdmZip(zipPath),
+    private readonly archiveSize: (zipPath: string) => number = (zipPath) => statSync(zipPath).size
+  ) {
+    this.resourceLimits = { ...DEFAULT_ZIP_RESOURCE_LIMITS, ...resourceLimits }
+  }
 
   /**
    * Check if a ZIP file is password-protected.
@@ -45,8 +62,10 @@ export class ZipExtractor {
    */
   isEncrypted(zipPath: string): boolean {
     try {
+      this.assertArchiveSizeWithinLimit(zipPath)
       const zip = this.openArchive(zipPath)
       const entries = zip.getEntries()
+      this.assertEntryCountWithinLimit(entries.length)
       return entries.some((entry) => {
         const header = entry.header as unknown as Record<string, unknown>
         return header['encrypted'] === true || header['encripted'] === true
@@ -76,8 +95,10 @@ export class ZipExtractor {
     targetDir: string,
     password?: string
   ): Promise<ZipExtractionResult> {
+    this.assertArchiveSizeWithinLimit(zipPath)
     const zip = this.openArchive(zipPath)
     const entries = zip.getEntries()
+    this.assertEntryCountWithinLimit(entries.length)
     const result: ZipExtractionResult = {
       extractedFiles: [],
       errors: [],
@@ -138,8 +159,10 @@ export class ZipExtractor {
   testPassword(zipPath: string, password: string): boolean {
     let entries: AdmZip.IZipEntry[]
     try {
+      this.assertArchiveSizeWithinLimit(zipPath)
       const zip = this.openArchive(zipPath)
       entries = zip.getEntries()
+      this.assertEntryCountWithinLimit(entries.length)
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       mainLogger.error(`Failed to open ZIP archive for password test: ${message}`, 'ZipExtractor')
@@ -196,9 +219,9 @@ export class ZipExtractor {
     if (!Number.isSafeInteger(size) || (size as number) < 0) {
       throw new Error(`Invalid uncompressed size for ZIP archive entry ${entryName}`)
     }
-    if ((size as number) > this.passwordValidationLimits.maxEntryUncompressedBytes) {
+    if ((size as number) > this.resourceLimits.maxEntryUncompressedBytes) {
       throw new ZipResourceLimitError(
-        `ZIP ${operation} limit exceeded for entry ${entryName}: maximum ${this.passwordValidationLimits.maxEntryUncompressedBytes} bytes`
+        `ZIP ${operation} limit exceeded for entry ${entryName}: maximum ${this.resourceLimits.maxEntryUncompressedBytes} bytes`
       )
     }
   }
@@ -207,9 +230,32 @@ export class ZipExtractor {
     size: number,
     operation: 'password validation' | 'extraction'
   ): void {
-    if (size > this.passwordValidationLimits.maxTotalUncompressedBytes) {
+    if (size > this.resourceLimits.maxTotalUncompressedBytes) {
       throw new ZipResourceLimitError(
-        `ZIP ${operation} total limit exceeded: maximum ${this.passwordValidationLimits.maxTotalUncompressedBytes} bytes`
+        `ZIP ${operation} total limit exceeded: maximum ${this.resourceLimits.maxTotalUncompressedBytes} bytes`
+      )
+    }
+  }
+
+  private assertArchiveSizeWithinLimit(zipPath: string): void {
+    const size = this.archiveSize(zipPath)
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new ZipResourceLimitError(`Invalid ZIP archive size for ${zipPath}`)
+    }
+    if (size > this.resourceLimits.maxArchiveBytes) {
+      throw new ZipResourceLimitError(
+        `ZIP archive size limit exceeded: maximum ${this.resourceLimits.maxArchiveBytes} bytes`
+      )
+    }
+  }
+
+  private assertEntryCountWithinLimit(count: number): void {
+    if (!Number.isSafeInteger(count) || count < 0) {
+      throw new ZipResourceLimitError('Invalid ZIP archive entry count')
+    }
+    if (count > this.resourceLimits.maxEntries) {
+      throw new ZipResourceLimitError(
+        `ZIP archive entry count limit exceeded: maximum ${this.resourceLimits.maxEntries} entries`
       )
     }
   }

--- a/src/main/import/index.ts
+++ b/src/main/import/index.ts
@@ -12,4 +12,8 @@ export type {
   BatchImportOptions,
   DuplicateChoice
 } from './types'
-export type { ZipExtractionResult, ZipPasswordValidationLimits } from './ZipExtractor'
+export type {
+  ZipExtractionResult,
+  ZipPasswordValidationLimits,
+  ZipResourceLimits
+} from './ZipExtractor'

--- a/src/main/import/index.ts
+++ b/src/main/import/index.ts
@@ -12,4 +12,4 @@ export type {
   BatchImportOptions,
   DuplicateChoice
 } from './types'
-export type { ZipExtractionResult } from './ZipExtractor'
+export type { ZipExtractionResult, ZipPasswordValidationLimits } from './ZipExtractor'

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -287,6 +287,20 @@ export async function extractZip(
 
     const result = await zipExtractor.extract(zipPath, targetDir, password)
 
+    // An archive where every candidate entry failed to extract (0 files
+    // extracted, but 1+ per-entry errors) is a genuine extraction failure,
+    // not a legitimate empty result — the renderer only inspects `files`
+    // (see ImportWizard.vue's extractAndAdvance), so returning this shape
+    // as a success would be a silent no-op. A genuinely empty/benign
+    // archive (0 files, 0 errors — nothing importable present) and a
+    // partial success (some files, some errors) both remain unchanged.
+    if (result.errors.length > 0 && result.extractedFiles.length === 0) {
+      throw new Error(
+        `ZIP extraction failed for all ${result.errors.length} candidate ` +
+          `entr${result.errors.length === 1 ? 'y' : 'ies'}: ${result.errors.join('; ')}`
+      )
+    }
+
     return JSON.parse(
       JSON.stringify({
         files: result.extractedFiles,
@@ -295,10 +309,11 @@ export async function extractZip(
     )
   } catch (error) {
     // A genuinely empty/all-benign extraction is reported by ZipExtractor.extract
-    // as a normal resolved result ({ extractedFiles: [], errors: [...] }) — it
+    // as a normal resolved result ({ extractedFiles: [], errors: [] }) — it
     // never reaches this catch. Anything that lands here (unreadable/corrupt
-    // archive, fs failure) is an infrastructure fault and must not be reshaped
-    // into a fake-success zero-file result.
+    // archive, fs failure, or the all-entries-failed case thrown above) is an
+    // infrastructure fault and must not be reshaped into a fake-success
+    // zero-file result.
     mainLogger.error(`batch-import:extractZip error: ${error}`, 'import')
     if (zipTempManager !== null) {
       zipTempManager.cleanup()

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -6,6 +6,7 @@
  * without mocking Electron internals.
  */
 import { basename } from 'path'
+import { randomUUID } from 'node:crypto'
 import { mainLogger } from '../../services/MainLogger'
 import { jobRunner } from '../../services/jobs/runner'
 import { checkDuplicates } from '../../import/batch-utils'
@@ -29,7 +30,9 @@ let workerClient: ImportWorkerClient | null = null
 
 // ZIP extraction utilities
 const zipExtractor = new ZipExtractor()
-let zipTempManager: TempDirectoryManager | null = null
+const zipExtractions = new Map<string, TempDirectoryManager>()
+const orphanedZipExtractions = new Set<string>()
+const MAX_ACTIVE_ZIP_EXTRACTIONS = 4
 
 /**
  * Check which files have duplicate case names in the database.
@@ -276,14 +279,17 @@ export function testZipPassword(zipPath: string, password: string): { success: b
 export async function extractZip(
   zipPath: string,
   password?: string
-): Promise<{ files: string[]; errors: string[] }> {
+): Promise<{ files: string[]; errors: string[]; extractionId: string }> {
+  const manager = new TempDirectoryManager()
+  let extractionId: string | null = null
   try {
-    if (zipTempManager !== null) {
-      zipTempManager.cleanup()
+    retryOrphanedZipCleanups()
+    if (zipExtractions.size >= MAX_ACTIVE_ZIP_EXTRACTIONS) {
+      throw new Error('Too many active ZIP extractions; clean up an existing extraction first')
     }
-
-    zipTempManager = new TempDirectoryManager()
-    const targetDir = zipTempManager.create()
+    const targetDir = manager.create()
+    extractionId = randomUUID()
+    zipExtractions.set(extractionId, manager)
 
     const result = await zipExtractor.extract(zipPath, targetDir, password)
 
@@ -301,7 +307,8 @@ export async function extractZip(
     return JSON.parse(
       JSON.stringify({
         files: result.extractedFiles,
-        errors: result.errors
+        errors: result.errors,
+        extractionId
       })
     )
   } catch (error) {
@@ -312,9 +319,15 @@ export async function extractZip(
     // infrastructure fault and must not be reshaped into a fake-success
     // zero-file result.
     mainLogger.error(`batch-import:extractZip error: ${error}`, 'import')
-    if (zipTempManager !== null) {
-      zipTempManager.cleanup()
-      zipTempManager = null
+    try {
+      if (extractionId !== null) cleanupZipTemp(extractionId)
+    } catch (cleanupError) {
+      if (extractionId !== null) orphanedZipExtractions.add(extractionId)
+      const cleanupMessage = formatErrorMessage(cleanupError, 'cleanup failed')
+      throw new Error(
+        `${formatErrorMessage(error, 'ZIP extraction failed')}; temporary-file cleanup also failed: ${cleanupMessage}`,
+        { cause: cleanupError }
+      )
     }
     throw error
   }
@@ -323,9 +336,21 @@ export async function extractZip(
 /**
  * Clean up temporary ZIP extraction directory.
  */
-export function cleanupZipTemp(): void {
-  if (zipTempManager !== null) {
-    zipTempManager.cleanup()
-    zipTempManager = null
+export function cleanupZipTemp(extractionId: string): void {
+  const manager = zipExtractions.get(extractionId)
+  if (manager === undefined) return
+  try {
+    manager.cleanup()
+  } catch (error) {
+    orphanedZipExtractions.add(extractionId)
+    throw error
+  }
+  zipExtractions.delete(extractionId)
+  orphanedZipExtractions.delete(extractionId)
+}
+
+function retryOrphanedZipCleanups(): void {
+  for (const extractionId of [...orphanedZipExtractions]) {
+    cleanupZipTemp(extractionId)
   }
 }

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -287,16 +287,13 @@ export async function extractZip(
 
     const result = await zipExtractor.extract(zipPath, targetDir, password)
 
-    // An archive where every candidate entry failed to extract (0 files
-    // extracted, but 1+ per-entry errors) is a genuine extraction failure,
-    // not a legitimate empty result — the renderer only inspects `files`
-    // (see ImportWizard.vue's extractAndAdvance), so returning this shape
-    // as a success would be a silent no-op. A genuinely empty/benign
-    // archive (0 files, 0 errors — nothing importable present) and a
-    // partial success (some files, some errors) both remain unchanged.
-    if (result.errors.length > 0 && result.extractedFiles.length === 0) {
+    // Partial extraction is not a safe success state: the renderer cannot
+    // know whether a missing case is optional, corrupt, or failed to write.
+    // Fail the whole archive on any candidate error; the catch below removes
+    // the temporary directory so already-written files cannot be imported.
+    if (result.errors.length > 0) {
       throw new Error(
-        `ZIP extraction failed for all ${result.errors.length} candidate ` +
+        `ZIP extraction failed for ${result.errors.length} candidate ` +
           `entr${result.errors.length === 1 ? 'y' : 'ies'}: ${result.errors.join('; ')}`
       )
     }

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -56,8 +56,11 @@ export function checkDuplicateFiles(
       duplicateCount: result.duplicateCount
     }
   } catch (error) {
+    // A DB/lookup failure here is not the same as "no duplicates found" — let
+    // it propagate so wrapHandler structures it and the caller sees an error
+    // instead of a falsely-empty duplicate check.
     mainLogger.error(`checkDuplicates error: ${error}`, 'import')
-    return { files: [], duplicateCount: 0 }
+    throw error
   }
 }
 
@@ -251,6 +254,11 @@ export function cancelBatchImport(): void {
 
 /**
  * Test a ZIP file password.
+ *
+ * `ZipExtractor.testPassword` already distinguishes a genuine wrong-password
+ * outcome (returns `false`) from an unopenable/corrupt archive (throws). Do
+ * not re-collapse that distinction here: a corrupt archive must propagate as
+ * an error, not be reported as "incorrect password".
  */
 export function testZipPassword(zipPath: string, password: string): { success: boolean } {
   try {
@@ -258,7 +266,7 @@ export function testZipPassword(zipPath: string, password: string): { success: b
     return { success }
   } catch (error) {
     mainLogger.error(`batch-import:testZipPassword error: ${error}`, 'import')
-    return { success: false }
+    throw error
   }
 }
 
@@ -286,15 +294,17 @@ export async function extractZip(
       })
     )
   } catch (error) {
+    // A genuinely empty/all-benign extraction is reported by ZipExtractor.extract
+    // as a normal resolved result ({ extractedFiles: [], errors: [...] }) — it
+    // never reaches this catch. Anything that lands here (unreadable/corrupt
+    // archive, fs failure) is an infrastructure fault and must not be reshaped
+    // into a fake-success zero-file result.
     mainLogger.error(`batch-import:extractZip error: ${error}`, 'import')
     if (zipTempManager !== null) {
       zipTempManager.cleanup()
       zipTempManager = null
     }
-    return {
-      files: [],
-      errors: [error instanceof Error ? error.message : 'Extraction failed']
-    }
+    throw error
   }
 }
 

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -183,9 +183,12 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
     })
   })
 
-  ipcMain.handle('batch-import:cleanupZipTemp', async () => {
+  ipcMain.handle('batch-import:cleanupZipTemp', async (_event, extractionId: unknown) => {
     return wrapHandler(async () => {
-      cleanupZipTemp()
+      if (typeof extractionId !== 'string' || extractionId.length === 0) {
+        throw new Error('Invalid ZIP extraction cleanup authority')
+      }
+      cleanupZipTemp(extractionId)
     })
   })
 }

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -72,26 +72,28 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
       const folderPath = result.filePaths[0]
       await saveSettings({ ...settings, lastImportDirectory: folderPath })
 
-      try {
-        const entries = await readdir(folderPath, { withFileTypes: true })
-
-        const files = entries
-          .filter((entry) => {
-            if (entry.isFile() === false) return false
-            const name = entry.name.toLowerCase()
-            return (
-              name.endsWith('.json') === true ||
-              name.endsWith('.json.gz') === true ||
-              name.endsWith('.gz') === true
-            )
-          })
-          .map((entry) => join(folderPath, entry.name))
-
-        return files
-      } catch (error) {
+      // A genuinely empty folder resolves normally with zero filtered entries
+      // below. A readdir failure (permission denied, folder removed after
+      // selection, etc.) is an infrastructure fault and must not masquerade
+      // as an empty folder — let it propagate so wrapHandler structures it.
+      const entries = await readdir(folderPath, { withFileTypes: true }).catch((error) => {
         mainLogger.error(`Failed to read directory: ${error}`, 'import')
-        return []
-      }
+        throw error
+      })
+
+      const files = entries
+        .filter((entry) => {
+          if (entry.isFile() === false) return false
+          const name = entry.name.toLowerCase()
+          return (
+            name.endsWith('.json') === true ||
+            name.endsWith('.json.gz') === true ||
+            name.endsWith('.gz') === true
+          )
+        })
+        .map((entry) => join(folderPath, entry.name))
+
+      return files
     })
   })
 
@@ -133,6 +135,10 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
 
   ipcMain.handle('batch-import:selectZip', async () => {
     return wrapHandler(async () => {
+      // `null` is the legitimate "user cancelled the dialog" outcome, handled
+      // explicitly below. A dialog/settings/fs failure is a different, real
+      // failure and must not be swallowed into that same `null` — that would
+      // be indistinguishable from a cancel and hide a genuine error.
       try {
         const settings = await loadSettings()
 
@@ -157,7 +163,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
         return { filePath, isEncrypted }
       } catch (error) {
         mainLogger.error(`batch-import:selectZip error: ${error}`, 'import')
-        return null
+        throw error
       }
     })
   })

--- a/src/main/ipc/handlers/cohort-logic.ts
+++ b/src/main/ipc/handlers/cohort-logic.ts
@@ -218,6 +218,8 @@ export async function queryCohortVariants(
     } else {
       // Fallback (no pool): compute panel intervals on the main thread
       const dbRef = getDb()
+      // Throws if the computation itself fails — never treat that as "no
+      // panel configured" (see panelIntervalHelper.ts for the contract).
       const intervals = computePanelIntervals(
         dbRef,
         {
@@ -227,9 +229,7 @@ export async function queryCohortVariants(
         undefined, // cohort mode: no specific case, sample any variant
         'cohort'
       )
-      if (intervals) {
-        cohortParams.panel_intervals = intervals
-      }
+      cohortParams.panel_intervals = intervals
       // Clean up IPC-only fields that shouldn't reach the service
       delete cohortParams.active_panel_ids
       delete cohortParams.panel_padding_bp

--- a/src/main/ipc/handlers/panelIntervalHelper.ts
+++ b/src/main/ipc/handlers/panelIntervalHelper.ts
@@ -45,14 +45,22 @@ export interface PanelIntervalParams {
  * @param caseId - Optional case ID for detecting chr prefix from variants.
  *                 If omitted, falls back to sampling any variant in the database.
  * @param source - Logging source identifier (e.g. 'variants', 'cohort')
- * @returns Array of genomic intervals, or undefined if computation fails
+ * @returns Array of genomic intervals. Empty when the active panel(s) have no
+ *          genes/coordinates to restrict on — that is a legitimate "no
+ *          restriction" result and callers may run the query unfiltered.
+ * @throws If the computation itself fails (e.g. the bundled gene reference
+ *         DB cannot be opened, or the panel/gene lookup errors). Callers
+ *         MUST let this propagate — a caught computation failure must never
+ *         be treated the same as "no panel configured", since that would
+ *         silently widen the query to return unfiltered results under an
+ *         active gene-panel restriction (a clinical-safety hazard).
  */
 export function computePanelIntervals(
   db: DatabaseService,
   params: PanelIntervalParams,
   caseId: number | undefined,
   source: string
-): GenomicInterval[] | undefined {
+): GenomicInterval[] {
   const paddingBp = params.panel_padding_bp ?? 5000
   const genomeBuild = params.genome_build ?? 'GRCh38'
 
@@ -67,19 +75,19 @@ export function computePanelIntervals(
     chrPrefix = sampleRow?.chr?.startsWith('chr') ?? false
   }
 
+  const cacheKey = JSON.stringify({
+    panelIds: params.active_panel_ids,
+    assembly: genomeBuild,
+    paddingBp,
+    chrPrefix
+  })
+
+  const cached = panelIntervalCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
   try {
-    const cacheKey = JSON.stringify({
-      panelIds: params.active_panel_ids,
-      assembly: genomeBuild,
-      paddingBp,
-      chrPrefix
-    })
-
-    const cached = panelIntervalCache.get(cacheKey)
-    if (cached) {
-      return cached
-    }
-
     const geneRefDb = getGeneReferenceDb()
     const intervals = db.panels.computeIntervals(
       params.active_panel_ids,
@@ -91,11 +99,16 @@ export function computePanelIntervals(
     panelIntervalCache.set(cacheKey, intervals)
     return intervals
   } catch (error) {
-    mainLogger.warn(
-      `Failed to compute panel intervals: ${error instanceof Error ? error.message : String(error)}`,
+    const message = error instanceof Error ? error.message : String(error)
+    // Do NOT swallow this into "no panel filter" — a panel IS configured here
+    // (callers only invoke computePanelIntervals when active_panel_ids is
+    // non-empty), so a failure must surface rather than silently widen the
+    // query to unfiltered results. Log for diagnostics, then propagate so
+    // wrapHandler turns it into a SerializableError at the IPC boundary.
+    mainLogger.error(
+      `Failed to compute panel intervals for active gene panel(s): ${message}`,
       source
     )
-    // Continue without panel filtering rather than failing the query
-    return undefined
+    throw error instanceof Error ? error : new Error(message)
   }
 }

--- a/src/main/ipc/handlers/variants-logic.ts
+++ b/src/main/ipc/handlers/variants-logic.ts
@@ -102,6 +102,8 @@ export function buildVariantFilter(
       const caseData = dbRef.cases.getCase(fullFilter.case_id)
       const genomeBuild = caseData?.genome_build ?? 'GRCh38'
 
+      // Throws if the computation itself fails — never treat that as "no
+      // panel configured" (see panelIntervalHelper.ts for the contract).
       const intervals = computePanelIntervals(
         dbRef,
         {
@@ -112,9 +114,7 @@ export function buildVariantFilter(
         fullFilter.case_id,
         'variants'
       )
-      if (intervals) {
-        fullFilter.panel_intervals = intervals
-      }
+      fullFilter.panel_intervals = intervals
 
       // Clean up IPC-only fields that shouldn't reach the repository
       delete fullFilter.active_panel_ids

--- a/src/main/storage/postgres/PostgresCohortRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortRepository.ts
@@ -641,11 +641,6 @@ export class PostgresCohortRepository {
       return withoutActivePanelFields(params)
     }
 
-    // A panel IS active here (panelIds is non-empty), so a thrown error means
-    // the interval computation itself failed. It must propagate rather than
-    // silently degrade to an unfiltered cohort query — a dropped panel filter
-    // must not look identical to "panel matched everything" (clinical-safety
-    // hazard; see panelIntervalHelper.ts for the equivalent SQLite contract).
     try {
       const intervals = await this.panelIntervalResolver(
         panelIds,
@@ -662,12 +657,11 @@ export class PostgresCohortRepository {
         panel_intervals: intervals
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
       mainLogger.error(
-        `Failed to resolve PostgreSQL cohort panel intervals for active gene panel(s): ${message}`,
+        `Failed to resolve PostgreSQL cohort panel intervals for active gene panel(s): ${error instanceof Error ? error.message : String(error)}`,
         'cohort'
       )
-      throw error instanceof Error ? error : new Error(message)
+      throw error
     }
   }
 

--- a/src/main/storage/postgres/PostgresCohortRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortRepository.ts
@@ -641,6 +641,11 @@ export class PostgresCohortRepository {
       return withoutActivePanelFields(params)
     }
 
+    // A panel IS active here (panelIds is non-empty), so a thrown error means
+    // the interval computation itself failed. It must propagate rather than
+    // silently degrade to an unfiltered cohort query — a dropped panel filter
+    // must not look identical to "panel matched everything" (clinical-safety
+    // hazard; see panelIntervalHelper.ts for the equivalent SQLite contract).
     try {
       const intervals = await this.panelIntervalResolver(
         panelIds,
@@ -657,11 +662,12 @@ export class PostgresCohortRepository {
         panel_intervals: intervals
       }
     } catch (error) {
-      mainLogger.warn(
-        `Failed to resolve PostgreSQL cohort panel intervals: ${error instanceof Error ? error.message : String(error)}`,
+      const message = error instanceof Error ? error.message : String(error)
+      mainLogger.error(
+        `Failed to resolve PostgreSQL cohort panel intervals for active gene panel(s): ${message}`,
         'cohort'
       )
-      return withoutActivePanelFields(params)
+      throw error instanceof Error ? error : new Error(message)
     }
   }
 

--- a/src/main/workers/db-worker-dispatch.ts
+++ b/src/main/workers/db-worker-dispatch.ts
@@ -41,7 +41,8 @@ export interface PanelAwareFilter {
  * `active_panel_ids` / `panel_padding_bp` / `genome_build` so the
  * repository does not see IPC-only fields.
  *
- * No-op when the gene reference DB is unavailable.
+ * No-op only when NO panel is actually configured (`active_panel_ids` is
+ * absent or empty) — that is the sole legitimate "nothing to resolve" case.
  *
  * @param filter    Query filter object (variants or cohort)
  * @param repos     Repository collection (for variant chr-prefix detection)
@@ -49,13 +50,15 @@ export interface PanelAwareFilter {
  * @param db        Raw database handle (for cohort-mode chr-prefix detection)
  * @param caseId    When set, chr prefix is derived from the specified case.
  *                  Omit for cohort mode — a sample variant row is queried instead.
- * @throws If a configured panel's interval computation itself fails (e.g. a
- *         corrupt gene reference DB or a panel/gene lookup error). This MUST
- *         propagate — `dispatchTask` lets it bubble to the pool caller so the
- *         failure surfaces as a SerializableError instead of silently running
- *         the query unfiltered under an active gene-panel restriction (a
- *         clinical-safety hazard: a dropped filter must not look identical to
- *         "panel matched everything").
+ * @throws If a panel IS configured (`active_panel_ids` non-empty) but
+ *         `geneRefDb` is unavailable, or if a configured panel's interval
+ *         computation itself fails (e.g. a corrupt gene reference DB or a
+ *         panel/gene lookup error). This MUST propagate — `dispatchTask`
+ *         lets it bubble to the pool caller so the failure surfaces as a
+ *         SerializableError instead of silently running the query unfiltered
+ *         under an active gene-panel restriction (a clinical-safety hazard:
+ *         a dropped filter must not look identical to "panel matched
+ *         everything").
  */
 export function resolvePanelIntervalsInPlace(
   filter: PanelAwareFilter,
@@ -65,11 +68,24 @@ export function resolvePanelIntervalsInPlace(
   caseId?: number
 ): void {
   const panelIds = filter.active_panel_ids
-  if (panelIds === undefined || panelIds.length === 0 || geneRefDb === null) {
+  if (panelIds === undefined || panelIds.length === 0) {
     delete filter.active_panel_ids
     delete filter.panel_padding_bp
     delete filter.genome_build
     return
+  }
+
+  if (geneRefDb === null) {
+    // A panel IS configured (active_panel_ids is non-empty) but there is no
+    // gene reference DB to resolve it against. This must not be treated as
+    // "no panel" and silently run the query unfiltered — that would look
+    // identical to the panel legitimately matching every variant, which is
+    // a clinical-safety hazard for a diagnostic tool. Throw so the caller
+    // sees a structured error instead of a silently dropped filter.
+    const message =
+      'Cannot resolve active gene panel filter: gene reference database is unavailable'
+    mainLogger.error(message, 'db-worker')
+    throw new Error(message)
   }
 
   const paddingBp = filter.panel_padding_bp ?? 5000

--- a/src/main/workers/db-worker-dispatch.ts
+++ b/src/main/workers/db-worker-dispatch.ts
@@ -15,6 +15,7 @@ import { AssociationDataBuilder } from '../database/AssociationDataBuilder'
 import type { VariantFilters } from '../statistics/types'
 import type { VariantFilter } from '../database/types'
 import { convertBigInts } from '../utils/convertBigInts'
+import { mainLogger } from '../services/MainLogger'
 
 /** Dependencies injected by the caller (db-worker or tests) */
 export interface DispatchDependencies {
@@ -48,6 +49,13 @@ export interface PanelAwareFilter {
  * @param db        Raw database handle (for cohort-mode chr-prefix detection)
  * @param caseId    When set, chr prefix is derived from the specified case.
  *                  Omit for cohort mode — a sample variant row is queried instead.
+ * @throws If a configured panel's interval computation itself fails (e.g. a
+ *         corrupt gene reference DB or a panel/gene lookup error). This MUST
+ *         propagate — `dispatchTask` lets it bubble to the pool caller so the
+ *         failure surfaces as a SerializableError instead of silently running
+ *         the query unfiltered under an active gene-panel restriction (a
+ *         clinical-safety hazard: a dropped filter must not look identical to
+ *         "panel matched everything").
  */
 export function resolvePanelIntervalsInPlace(
   filter: PanelAwareFilter,
@@ -79,6 +87,9 @@ export function resolvePanelIntervalsInPlace(
           return sampleRow?.chr?.startsWith('chr') === true
         })()
 
+  // A panel IS active here (panelIds is non-empty and geneRefDb is available),
+  // so a thrown error means the computation itself failed — it must propagate
+  // rather than be swallowed into a silent unfiltered query.
   try {
     const intervals = repos.panels.computeIntervals(
       panelIds,
@@ -90,11 +101,13 @@ export function resolvePanelIntervalsInPlace(
     if (intervals.length > 0) {
       filter.panel_intervals = intervals
     }
-  } catch (e) {
-    console.warn(
-      '[db-worker] Panel interval computation failed (proceeding without panel filtering):',
-      e instanceof Error ? e.message : String(e)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    mainLogger.error(
+      `Failed to compute panel intervals for active gene panel(s): ${message}`,
+      'db-worker'
     )
+    throw error instanceof Error ? error : new Error(message)
   }
 
   delete filter.active_panel_ids

--- a/src/preload/domains/batch-import.ts
+++ b/src/preload/domains/batch-import.ts
@@ -15,6 +15,7 @@ export function createBatchImportApi(): BatchImportDomainContract {
       ipcRenderer.invoke('batch-import:testZipPassword', zipPath, password),
     extractZip: (zipPath, password) =>
       ipcRenderer.invoke('batch-import:extractZip', zipPath, password),
-    cleanupZipTemp: () => ipcRenderer.invoke('batch-import:cleanupZipTemp')
+    cleanupZipTemp: (extractionId) =>
+      ipcRenderer.invoke('batch-import:cleanupZipTemp', extractionId)
   }
 }

--- a/src/preload/window-api/core-api.ts
+++ b/src/preload/window-api/core-api.ts
@@ -137,7 +137,7 @@ export function createCoreApi(domains: PreloadDomainApis): CoreWindowApi {
       selectZip: () => batchImportDomain.selectZip(),
       testZipPassword: (zipPath, password) => batchImportDomain.testZipPassword(zipPath, password),
       extractZip: (zipPath, password) => batchImportDomain.extractZip(zipPath, password),
-      cleanupZipTemp: () => batchImportDomain.cleanupZipTemp(),
+      cleanupZipTemp: (extractionId) => batchImportDomain.cleanupZipTemp(extractionId),
       onProgress: (callback) => subscribeToIpcEvent('batch-import:progress', callback),
       onComplete: (callback) => subscribeToIpcEvent('batch-import:complete', callback)
     } as WindowAPI['batchImport'],

--- a/src/renderer/src/components/BatchImportDialog.vue
+++ b/src/renderer/src/components/BatchImportDialog.vue
@@ -115,6 +115,7 @@ const fileCount = ref(0)
 const duplicateStrategy = ref<DuplicateChoice>('skip')
 const stripText = ref('')
 const isZipImport = ref(false)
+const zipExtractionId = ref('')
 
 // ZIP state
 const zipPath = ref('')
@@ -176,7 +177,9 @@ let recheckTimeout: ReturnType<typeof setTimeout> | null = null
 watch(dialog, (newVal, oldVal) => {
   if (oldVal === true && newVal === false && phase.value === 'summary') {
     if (isZipImport.value === true) {
-      api!.batchImport.cleanupZipTemp()
+      if (zipExtractionId.value !== '') {
+        void api!.batchImport.cleanupZipTemp(zipExtractionId.value)
+      }
     }
     if (summary.value.succeeded > 0) {
       emit('batch-import-complete', { totalImported: summary.value.succeeded })
@@ -203,6 +206,9 @@ watch(stripText, () => {
  * Show dialog and start the batch import flow
  */
 const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
+  if (zipExtractionId.value !== '') {
+    unwrapIpcResult(await api!.batchImport.cleanupZipTemp(zipExtractionId.value))
+  }
   resetState()
 
   if (mode === 'zip') {
@@ -247,13 +253,15 @@ const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
 const extractAndShowReview = async (zipFilePath: string, password?: string): Promise<void> => {
   try {
     const result = unwrapIpcResult(await api!.batchImport.extractZip(zipFilePath, password))
+    zipExtractionId.value = result.extractionId
 
     if (result.files.length === 0) {
       zipErrorMessage.value = 'No importable files found in archive.'
       if (result.errors.length > 0) {
         zipErrorMessage.value += ' Errors: ' + result.errors.join('; ')
       }
-      unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+      unwrapIpcResult(await api!.batchImport.cleanupZipTemp(result.extractionId))
+      zipExtractionId.value = ''
       return
     }
 
@@ -271,7 +279,10 @@ const extractAndShowReview = async (zipFilePath: string, password?: string): Pro
         : isIpcError(error)
           ? (error.userMessage ?? error.message)
           : 'Failed to extract archive'
-    unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+    if (zipExtractionId.value !== '') {
+      unwrapIpcResult(await api!.batchImport.cleanupZipTemp(zipExtractionId.value))
+      zipExtractionId.value = ''
+    }
   }
 }
 
@@ -373,7 +384,10 @@ const handleZipUnlock = async (): Promise<void> => {
  * Cancel ZIP flow and clean up temp directory
  */
 const handleZipCancel = async (): Promise<void> => {
-  unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+  if (zipExtractionId.value !== '') {
+    unwrapIpcResult(await api!.batchImport.cleanupZipTemp(zipExtractionId.value))
+    zipExtractionId.value = ''
+  }
   dialog.value = false
 }
 
@@ -402,7 +416,10 @@ const continueInBackground = (): void => {
  */
 const closeDialog = async (): Promise<void> => {
   if (isZipImport.value === true) {
-    unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+    if (zipExtractionId.value !== '') {
+      unwrapIpcResult(await api!.batchImport.cleanupZipTemp(zipExtractionId.value))
+      zipExtractionId.value = ''
+    }
   }
   dialog.value = false
 }
@@ -426,6 +443,7 @@ const resetState = (): void => {
   variantCount.value = 0
   summary.value = { succeeded: 0, failed: 0, skipped: 0, cancelled: false, details: [] }
   zipPath.value = ''
+  zipExtractionId.value = ''
   zipPassword.value = ''
   showZipPassword.value = false
   zipErrorMessage.value = ''

--- a/src/renderer/src/components/BatchImportDialog.vue
+++ b/src/renderer/src/components/BatchImportDialog.vue
@@ -224,9 +224,9 @@ const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
   let filePaths: string[]
 
   if (mode === 'files') {
-    filePaths = await api!.batchImport.selectFiles()
+    filePaths = unwrapIpcResult(await api!.batchImport.selectFiles())
   } else {
-    filePaths = await api!.batchImport.selectFolder()
+    filePaths = unwrapIpcResult(await api!.batchImport.selectFolder())
   }
 
   if (filePaths.length === 0) return

--- a/src/renderer/src/components/import/ImportWizard.vue
+++ b/src/renderer/src/components/import/ImportWizard.vue
@@ -283,7 +283,9 @@ const selectedMode = ref<ImportMode | null>(null)
 const selectedFilePaths = ref<string[]>([])
 const isZipImport = ref(false)
 const zipPath = ref('')
+const zipExtractionId = ref('')
 const sourceSelectionPending = ref(false)
+const cancellationPending = ref(false)
 const uploadFileName = ref('')
 const uploadFileIndex = ref(1)
 const uploadTotalFiles = ref(0)
@@ -378,13 +380,14 @@ function formatIpcError(error: unknown, fallback: string): string {
 
 const {
   cleanupZipTemp,
-  abandonZipImport,
+  cleanupZipExtraction,
+  abandonZipImport: abandonZipImportState,
   handleBack,
   checkDuplicatesAndAdvance,
   scheduleDuplicateRecheck,
   cancelDuplicateRecheck
 } = useZipImportCleanup({
-  cleanupRequest: () => api!.batchImport.cleanupZipTemp(),
+  cleanupRequest: (extractionId) => api!.batchImport.cleanupZipTemp(extractionId),
   checkDuplicatesRequest: (filePaths, strip) => api!.batchImport.checkDuplicates(filePaths, strip),
   importStore,
   state: {
@@ -395,6 +398,7 @@ const {
     stripText,
     isZipImport,
     zipPath,
+    zipExtractionId,
     zipPasswordNeeded,
     zipPassword,
     zipError,
@@ -403,17 +407,26 @@ const {
   }
 })
 
+let sourceFlowGeneration = 0
+
+function abandonZipImport(context: string): void {
+  sourceFlowGeneration += 1
+  abandonZipImportState(context)
+}
+
 // Re-check duplicates when strip text changes
 watch(stripText, scheduleDuplicateRecheck)
 
 async function selectSource(mode: ImportMode): Promise<void> {
   if (sourceSelectionPending.value) return
+  const generation = sourceFlowGeneration
   selectedMode.value = mode
   sourceSelectionPending.value = true
   resetUploadState()
   try {
     if (mode === 'zip') {
       const result = unwrapIpcResult(await api!.batchImport.selectZip())
+      if (generation !== sourceFlowGeneration) return
       if (result === null) return
       zipPath.value = result.filePath
       isZipImport.value = true
@@ -421,7 +434,7 @@ async function selectSource(mode: ImportMode): Promise<void> {
         zipPasswordNeeded.value = true
         return
       }
-      await extractAndAdvance(result.filePath)
+      await extractAndAdvance(result.filePath, generation)
       return
     }
     let filePaths: string[]
@@ -463,10 +476,18 @@ async function selectSource(mode: ImportMode): Promise<void> {
   }
 }
 
-async function extractAndAdvance(path: string): Promise<void> {
-  const { files } = unwrapIpcResult(
+async function extractAndAdvance(
+  path: string,
+  generation: number = sourceFlowGeneration
+): Promise<void> {
+  const { files, extractionId } = unwrapIpcResult(
     await api!.batchImport.extractZip(path, zipPassword.value || undefined)
   )
+  if (generation !== sourceFlowGeneration || !dialog.value) {
+    await cleanupZipExtraction(extractionId, 'stale ZIP extraction completion')
+    return
+  }
+  zipExtractionId.value = extractionId
   if (files.length === 0) {
     abandonZipImport('empty ZIP extraction')
     throw new Error('No importable files found in archive')
@@ -478,6 +499,7 @@ async function extractAndAdvance(path: string): Promise<void> {
 }
 
 async function unlockZip(): Promise<void> {
+  const generation = sourceFlowGeneration
   zipUnlocking.value = true
   zipError.value = ''
   try {
@@ -490,7 +512,7 @@ async function unlockZip(): Promise<void> {
       return
     }
 
-    await extractAndAdvance(zipPath.value)
+    await extractAndAdvance(zipPath.value, generation)
   } catch (err) {
     const message = formatErrorMessage(err, 'Could not unlock ZIP archive')
     zipError.value = message
@@ -669,49 +691,30 @@ async function startImport(): Promise<void> {
       }
       step.value = 4
     }
+    if (isZipImport.value) {
+      await cleanupZipTemp('import start failure')
+    }
     importStore.importError(message)
   }
 }
 
-function cancelImport(): void {
-  if (isWebRuntime() && isVcfImport.value) {
-    void api!.import.cancel().catch((error) => {
-      logService.warn(
-        `VCF import cancel failed: ${formatIpcError(error, 'cancel failed')}`,
-        'ImportWizard'
-      )
-    })
-  } else {
-    void api!.batchImport
-      .cancel()
-      .then((result) => {
-        unwrapIpcResult(result)
-      })
-      .catch((error) => {
-        logService.warn(
-          `Batch import cancel failed: ${formatIpcError(error, 'cancel failed')}`,
-          'ImportWizard'
-        )
-      })
+async function cancelImport(): Promise<void> {
+  if (cancellationPending.value) return
+  cancellationPending.value = true
+  try {
+    if (isWebRuntime() && isVcfImport.value) {
+      await api!.import.cancel()
+    } else {
+      unwrapIpcResult(await api!.batchImport.cancel())
+    }
+    // Terminal result handlers own the summary and extraction cleanup.
+  } catch (error) {
+    const message = formatIpcError(error, 'cancel failed')
+    logService.warn(`Import cancel failed: ${message}`, 'ImportWizard')
+    importStore.importError(message)
+  } finally {
+    cancellationPending.value = false
   }
-  // Transition to summary step showing cancellation, and reset import store.
-  // The onComplete callback may also fire with cancelled=true, but we handle
-  // it here immediately so the user sees feedback right away.
-  summary.value = {
-    succeeded: 0,
-    failed: 0,
-    skipped: 0,
-    cancelled: true,
-    details: []
-  }
-  step.value = 4
-  importStore.importComplete({
-    succeeded: 0,
-    failed: 0,
-    skipped: 0,
-    cancelled: true,
-    details: []
-  })
 }
 
 function continueInBackground(): void {
@@ -743,6 +746,7 @@ function resetState(): void {
   vcfCaseNames.value = new Map()
   isZipImport.value = false
   zipPath.value = ''
+  zipExtractionId.value = ''
   sourceSelectionPending.value = false
   resetUploadState()
   zipPasswordNeeded.value = false
@@ -750,6 +754,7 @@ function resetState(): void {
   zipError.value = ''
   showZipPassword.value = false
   zipUnlocking.value = false
+  cancellationPending.value = false
   reviewFiles.value = []
   duplicateCount.value = 0
   duplicateStrategy.value = 'skip'

--- a/src/renderer/src/components/import/ImportWizard.vue
+++ b/src/renderer/src/components/import/ImportWizard.vue
@@ -411,26 +411,20 @@ async function selectSource(mode: ImportMode): Promise<void> {
   selectedMode.value = mode
   sourceSelectionPending.value = true
   resetUploadState()
-
   try {
     if (mode === 'zip') {
       const result = unwrapIpcResult(await api!.batchImport.selectZip())
       if (result === null) return
-
       zipPath.value = result.filePath
       isZipImport.value = true
-
       if (result.isEncrypted) {
         zipPasswordNeeded.value = true
         return
       }
-
       await extractAndAdvance(result.filePath)
       return
     }
-
     let filePaths: string[]
-
     if (mode === 'single') {
       const path = await api!.import.selectFile()
       if (path === null) return
@@ -440,11 +434,8 @@ async function selectSource(mode: ImportMode): Promise<void> {
     } else {
       filePaths = unwrapIpcResult(await api!.batchImport.selectFolder())
     }
-
     if (filePaths.length === 0) return
-
     selectedFilePaths.value = filePaths
-
     // Detect VCF file: single file with .vcf or .vcf.gz extension
     if (filePaths.length === 1) {
       const fp = filePaths[0].toLowerCase()
@@ -455,7 +446,6 @@ async function selectSource(mode: ImportMode): Promise<void> {
         return
       }
     }
-
     await checkDuplicatesAndAdvance(filePaths)
   } catch (err) {
     if (err instanceof Error && err.message === 'Upload cancelled') {
@@ -477,7 +467,9 @@ async function extractAndAdvance(path: string): Promise<void> {
   const { files } = unwrapIpcResult(
     await api!.batchImport.extractZip(path, zipPassword.value || undefined)
   )
-  if (files.length === 0) return
+  if (files.length === 0) {
+    throw new Error('No importable files found in archive')
+  }
 
   selectedFilePaths.value = files
   zipPasswordNeeded.value = false

--- a/src/renderer/src/components/import/ImportWizard.vue
+++ b/src/renderer/src/components/import/ImportWizard.vue
@@ -134,7 +134,7 @@
 
       <!-- Actions -->
       <v-card-actions>
-        <v-btn v-if="step === 2" variant="text" size="small" @click="step = 1">Back</v-btn>
+        <v-btn v-if="step === 2" variant="text" size="small" @click="handleBack">Back</v-btn>
         <v-spacer />
         <v-btn v-if="step === 3" variant="text" size="small" @click="continueInBackground">
           Continue in Background
@@ -191,6 +191,7 @@ import type {
 } from '../../../../shared/types/api'
 import type { VcfPreviewResult } from '../../../../shared/types/vcf'
 import { useApiService } from '../../composables/useApiService'
+import { useZipImportCleanup } from '../../composables/useZipImportCleanup'
 import { useImportStatusStore } from '../../stores/importStatusStore'
 import { logService } from '../../services/LogService'
 import { unwrapIpcResult } from '../../../../shared/types/errors'
@@ -322,7 +323,6 @@ const summary = ref<BatchResult>({
 let cleanupProgress: (() => void) | null = null
 let cleanupImportProgress: (() => void) | null = null
 let cleanupComplete: (() => void) | null = null
-let recheckTimeout: ReturnType<typeof setTimeout> | null = null
 
 function resetUploadState(): void {
   uploadFileName.value = ''
@@ -376,35 +376,35 @@ function formatIpcError(error: unknown, fallback: string): string {
   return formatErrorMessage(error, fallback)
 }
 
-function cleanupZipTempInBackground(context: string): void {
-  void api!.batchImport
-    .cleanupZipTemp()
-    .then((cleanupResult) => {
-      unwrapIpcResult(cleanupResult)
-    })
-    .catch((error) => {
-      logService.warn(
-        `ZIP temp cleanup failed after ${context}: ${formatIpcError(error, 'cleanup failed')}`,
-        'ImportWizard'
-      )
-    })
-}
+const {
+  cleanupZipTemp,
+  abandonZipImport,
+  handleBack,
+  checkDuplicatesAndAdvance,
+  scheduleDuplicateRecheck,
+  cancelDuplicateRecheck
+} = useZipImportCleanup({
+  cleanupRequest: () => api!.batchImport.cleanupZipTemp(),
+  checkDuplicatesRequest: (filePaths, strip) => api!.batchImport.checkDuplicates(filePaths, strip),
+  importStore,
+  state: {
+    step,
+    selectedFilePaths,
+    reviewFiles,
+    duplicateCount,
+    stripText,
+    isZipImport,
+    zipPath,
+    zipPasswordNeeded,
+    zipPassword,
+    zipError,
+    showZipPassword,
+    zipUnlocking
+  }
+})
 
 // Re-check duplicates when strip text changes
-watch(stripText, () => {
-  if (recheckTimeout !== null) clearTimeout(recheckTimeout)
-  recheckTimeout = setTimeout(async () => {
-    if (selectedFilePaths.value.length === 0) return
-    const result = unwrapIpcResult(
-      await api!.batchImport.checkDuplicates(
-        [...selectedFilePaths.value],
-        stripText.value || undefined
-      )
-    )
-    reviewFiles.value = result.files
-    duplicateCount.value = result.duplicateCount
-  }, 300)
-})
+watch(stripText, scheduleDuplicateRecheck)
 
 async function selectSource(mode: ImportMode): Promise<void> {
   if (sourceSelectionPending.value) return
@@ -468,22 +468,13 @@ async function extractAndAdvance(path: string): Promise<void> {
     await api!.batchImport.extractZip(path, zipPassword.value || undefined)
   )
   if (files.length === 0) {
+    abandonZipImport('empty ZIP extraction')
     throw new Error('No importable files found in archive')
   }
 
   selectedFilePaths.value = files
   zipPasswordNeeded.value = false
   await checkDuplicatesAndAdvance(files)
-}
-
-async function checkDuplicatesAndAdvance(filePaths: string[]): Promise<void> {
-  const result = unwrapIpcResult(
-    await api!.batchImport.checkDuplicates(filePaths, stripText.value || undefined)
-  )
-
-  reviewFiles.value = result.files
-  duplicateCount.value = result.duplicateCount
-  step.value = 2
 }
 
 async function unlockZip(): Promise<void> {
@@ -510,9 +501,7 @@ async function unlockZip(): Promise<void> {
 }
 
 function cancelZip(): void {
-  zipPasswordNeeded.value = false
-  zipPassword.value = ''
-  zipError.value = ''
+  abandonZipImport('password prompt cancellation')
 }
 
 function onVcfPreviewLoaded(_preview: VcfPreviewResult): void {
@@ -657,7 +646,7 @@ async function startImport(): Promise<void> {
       })
 
       if (isZipImport.value) {
-        cleanupZipTempInBackground('import completion')
+        void cleanupZipTemp('import completion')
       }
 
       if (result.succeeded > 0) {
@@ -735,6 +724,7 @@ function handleClose(): void {
     continueInBackground()
     return
   }
+  abandonZipImport('dialog close')
   dialog.value = false
   // Reset import store when closing from summary/error step
   if (step.value === 4 || importStore.phase === 'error') {
@@ -773,6 +763,7 @@ function resetState(): void {
 }
 
 const show = (): void => {
+  abandonZipImport('next wizard open')
   resetState()
   dialog.value = true
 }
@@ -781,6 +772,9 @@ const show = (): void => {
 // handleClose() covers explicit close, but the dialog can also close via v-model
 // when persistent=false (step !== 3).
 watch(dialog, (open) => {
+  if (!open && step.value !== 3) {
+    abandonZipImport('dialog dismissal')
+  }
   if (!open && (step.value === 4 || importStore.phase === 'error')) {
     importStore.reset()
   }
@@ -854,7 +848,7 @@ onMounted(() => {
         })
 
         if (isZipImport.value) {
-          cleanupZipTempInBackground('dialog close')
+          void cleanupZipTemp('import completion event')
         }
       }
     })
@@ -868,7 +862,8 @@ onUnmounted(() => {
   cleanupProgress?.()
   cleanupImportProgress?.()
   cleanupComplete?.()
-  if (recheckTimeout !== null) clearTimeout(recheckTimeout)
+  cancelDuplicateRecheck()
+  if (step.value !== 3) abandonZipImport('component unmount')
 })
 
 defineExpose({ show, reopen })

--- a/src/renderer/src/components/import/ImportWizard.vue
+++ b/src/renderer/src/components/import/ImportWizard.vue
@@ -436,9 +436,9 @@ async function selectSource(mode: ImportMode): Promise<void> {
       if (path === null) return
       filePaths = [path]
     } else if (mode === 'files') {
-      filePaths = await api!.batchImport.selectFiles()
+      filePaths = unwrapIpcResult(await api!.batchImport.selectFiles())
     } else {
-      filePaths = await api!.batchImport.selectFolder()
+      filePaths = unwrapIpcResult(await api!.batchImport.selectFolder())
     }
 
     if (filePaths.length === 0) return
@@ -497,17 +497,24 @@ async function checkDuplicatesAndAdvance(filePaths: string[]): Promise<void> {
 async function unlockZip(): Promise<void> {
   zipUnlocking.value = true
   zipError.value = ''
-  const { success } = unwrapIpcResult(
-    await api!.batchImport.testZipPassword(zipPath.value, zipPassword.value)
-  )
-  zipUnlocking.value = false
+  try {
+    const { success } = unwrapIpcResult(
+      await api!.batchImport.testZipPassword(zipPath.value, zipPassword.value)
+    )
 
-  if (!success) {
-    zipError.value = 'Incorrect password'
-    return
+    if (!success) {
+      zipError.value = 'Incorrect password'
+      return
+    }
+
+    await extractAndAdvance(zipPath.value)
+  } catch (err) {
+    const message = formatErrorMessage(err, 'Could not unlock ZIP archive')
+    zipError.value = message
+    logService.error(`ZIP unlock failed: ${message}`, 'ImportWizard')
+  } finally {
+    zipUnlocking.value = false
   }
-
-  await extractAndAdvance(zipPath.value)
 }
 
 function cancelZip(): void {

--- a/src/renderer/src/composables/useZipImportCleanup.ts
+++ b/src/renderer/src/composables/useZipImportCleanup.ts
@@ -14,6 +14,7 @@ interface ZipImportCleanupState {
   stripText: Ref<string>
   isZipImport: Ref<boolean>
   zipPath: Ref<string>
+  zipExtractionId: Ref<string>
   zipPasswordNeeded: Ref<boolean>
   zipPassword: Ref<string>
   zipError: Ref<string>
@@ -22,7 +23,7 @@ interface ZipImportCleanupState {
 }
 
 interface ZipImportCleanupOptions {
-  cleanupRequest: () => Promise<IpcResult<void>>
+  cleanupRequest: (extractionId: string) => Promise<IpcResult<void>>
   checkDuplicatesRequest: (
     filePaths: string[],
     stripText?: string
@@ -38,6 +39,7 @@ export function useZipImportCleanup({
   state
 }: ZipImportCleanupOptions): {
   cleanupZipTemp: (context: string) => Promise<void>
+  cleanupZipExtraction: (extractionId: string, context: string) => Promise<boolean>
   abandonZipImport: (context: string) => void
   handleDuplicateCheckFailure: (error: unknown) => Promise<void>
   handleBack: () => void
@@ -46,20 +48,45 @@ export function useZipImportCleanup({
   cancelDuplicateRecheck: () => void
 } {
   let recheckTimeout: ReturnType<typeof setTimeout> | null = null
+  let duplicateRequestGeneration = 0
+  const pendingCleanupIds = new Set<string>()
 
-  async function cleanupZipTemp(context: string): Promise<void> {
+  async function cleanupZipExtraction(extractionId: string, context: string): Promise<boolean> {
     try {
-      unwrapIpcResult(await cleanupRequest())
+      unwrapIpcResult(await cleanupRequest(extractionId))
+      pendingCleanupIds.delete(extractionId)
+      return true
     } catch (error) {
+      pendingCleanupIds.add(extractionId)
       const message = formatErrorMessage(error, 'ZIP temp cleanup failed')
       logService.warn(`ZIP temp cleanup failed after ${context}: ${message}`, 'ImportWizard')
       importStore.importError(message)
+      return false
+    }
+  }
+
+  async function cleanupZipTemp(context: string): Promise<void> {
+    const extractionId = state.zipExtractionId.value
+    const pendingBeforeAttempt = [...pendingCleanupIds].filter((id) => id !== extractionId)
+    if (extractionId !== '') {
+      const cleaned = await cleanupZipExtraction(extractionId, context)
+      if (cleaned && state.zipExtractionId.value === extractionId) {
+        state.zipExtractionId.value = ''
+      }
+    }
+    await retryPendingZipCleanups(pendingBeforeAttempt, context)
+  }
+
+  async function retryPendingZipCleanups(ids: string[], context: string): Promise<void> {
+    for (const extractionId of ids) {
+      await cleanupZipExtraction(extractionId, `${context} retry`)
     }
   }
 
   function clearZipSelectionState(): void {
     state.isZipImport.value = false
     state.zipPath.value = ''
+    state.zipExtractionId.value = ''
     state.zipPasswordNeeded.value = false
     state.zipPassword.value = ''
     state.zipError.value = ''
@@ -74,17 +101,33 @@ export function useZipImportCleanup({
   }
 
   function abandonZipImport(context: string): void {
-    if (!state.isZipImport.value) return
+    const extractionId = state.zipExtractionId.value
+    const pendingBeforeAttempt = [...pendingCleanupIds].filter((id) => id !== extractionId)
+    if (!state.isZipImport.value) {
+      void retryPendingZipCleanups(pendingBeforeAttempt, context)
+      return
+    }
+    invalidateDuplicateRequests()
     clearZipSelectionState()
     invalidateReviewState()
-    void cleanupZipTemp(context)
+    void (async () => {
+      if (extractionId !== '') await cleanupZipExtraction(extractionId, context)
+      await retryPendingZipCleanups(pendingBeforeAttempt, context)
+    })()
   }
 
   async function handleDuplicateCheckFailure(error: unknown): Promise<void> {
+    const extractionId = state.zipExtractionId.value
     const message = formatErrorMessage(error, 'Could not check duplicate cases')
     invalidateReviewState()
     state.step.value = 1
-    await cleanupZipTemp('duplicate check failure')
+    if (extractionId !== '') {
+      await cleanupZipExtraction(extractionId, 'duplicate check failure')
+    }
+    await retryPendingZipCleanups(
+      [...pendingCleanupIds].filter((id) => id !== extractionId),
+      'duplicate check failure'
+    )
     clearZipSelectionState()
     logService.error(`Duplicate check failed: ${message}`, 'ImportWizard')
     importStore.importError(message)
@@ -100,14 +143,17 @@ export function useZipImportCleanup({
   }
 
   async function checkDuplicatesAndAdvance(filePaths: string[]): Promise<void> {
+    const generation = beginDuplicateRequest()
     try {
       const result = unwrapIpcResult(
         await checkDuplicatesRequest(filePaths, state.stripText.value || undefined)
       )
+      if (generation !== duplicateRequestGeneration) return
       state.reviewFiles.value = result.files
       state.duplicateCount.value = result.duplicateCount
       state.step.value = 2
     } catch (error) {
+      if (generation !== duplicateRequestGeneration) return
       await handleDuplicateCheckFailure(error)
       throw error
     }
@@ -115,19 +161,19 @@ export function useZipImportCleanup({
 
   function scheduleDuplicateRecheck(): void {
     cancelDuplicateRecheck()
+    const generation = duplicateRequestGeneration
+    const filePaths = [...state.selectedFilePaths.value]
+    const stripText = state.stripText.value || undefined
     recheckTimeout = setTimeout(() => {
       void (async () => {
-        if (state.selectedFilePaths.value.length === 0) return
+        if (filePaths.length === 0) return
         try {
-          const result = unwrapIpcResult(
-            await checkDuplicatesRequest(
-              [...state.selectedFilePaths.value],
-              state.stripText.value || undefined
-            )
-          )
+          const result = unwrapIpcResult(await checkDuplicatesRequest(filePaths, stripText))
+          if (generation !== duplicateRequestGeneration) return
           state.reviewFiles.value = result.files
           state.duplicateCount.value = result.duplicateCount
         } catch (error) {
+          if (generation !== duplicateRequestGeneration) return
           await handleDuplicateCheckFailure(error)
         }
       })()
@@ -137,10 +183,21 @@ export function useZipImportCleanup({
   function cancelDuplicateRecheck(): void {
     if (recheckTimeout !== null) clearTimeout(recheckTimeout)
     recheckTimeout = null
+    invalidateDuplicateRequests()
+  }
+
+  function beginDuplicateRequest(): number {
+    invalidateDuplicateRequests()
+    return duplicateRequestGeneration
+  }
+
+  function invalidateDuplicateRequests(): void {
+    duplicateRequestGeneration += 1
   }
 
   return {
     cleanupZipTemp,
+    cleanupZipExtraction,
     abandonZipImport,
     handleDuplicateCheckFailure,
     handleBack,

--- a/src/renderer/src/composables/useZipImportCleanup.ts
+++ b/src/renderer/src/composables/useZipImportCleanup.ts
@@ -1,0 +1,151 @@
+import type { Ref } from 'vue'
+import type { DuplicateCheckItem, DuplicateCheckResult } from '../../../shared/types/api'
+import type { IpcResult } from '../../../shared/types/errors'
+import { formatErrorMessage } from '../../../shared/errors/format-error-message'
+import { unwrapIpcResult } from '../../../shared/types/errors'
+import { logService } from '../services/LogService'
+import type { useImportStatusStore } from '../stores/importStatusStore'
+
+interface ZipImportCleanupState {
+  step: Ref<number>
+  selectedFilePaths: Ref<string[]>
+  reviewFiles: Ref<DuplicateCheckItem[]>
+  duplicateCount: Ref<number>
+  stripText: Ref<string>
+  isZipImport: Ref<boolean>
+  zipPath: Ref<string>
+  zipPasswordNeeded: Ref<boolean>
+  zipPassword: Ref<string>
+  zipError: Ref<string>
+  showZipPassword: Ref<boolean>
+  zipUnlocking: Ref<boolean>
+}
+
+interface ZipImportCleanupOptions {
+  cleanupRequest: () => Promise<IpcResult<void>>
+  checkDuplicatesRequest: (
+    filePaths: string[],
+    stripText?: string
+  ) => Promise<IpcResult<DuplicateCheckResult>>
+  importStore: ReturnType<typeof useImportStatusStore>
+  state: ZipImportCleanupState
+}
+
+export function useZipImportCleanup({
+  cleanupRequest,
+  checkDuplicatesRequest,
+  importStore,
+  state
+}: ZipImportCleanupOptions): {
+  cleanupZipTemp: (context: string) => Promise<void>
+  abandonZipImport: (context: string) => void
+  handleDuplicateCheckFailure: (error: unknown) => Promise<void>
+  handleBack: () => void
+  checkDuplicatesAndAdvance: (filePaths: string[]) => Promise<void>
+  scheduleDuplicateRecheck: () => void
+  cancelDuplicateRecheck: () => void
+} {
+  let recheckTimeout: ReturnType<typeof setTimeout> | null = null
+
+  async function cleanupZipTemp(context: string): Promise<void> {
+    try {
+      unwrapIpcResult(await cleanupRequest())
+    } catch (error) {
+      const message = formatErrorMessage(error, 'ZIP temp cleanup failed')
+      logService.warn(`ZIP temp cleanup failed after ${context}: ${message}`, 'ImportWizard')
+      importStore.importError(message)
+    }
+  }
+
+  function clearZipSelectionState(): void {
+    state.isZipImport.value = false
+    state.zipPath.value = ''
+    state.zipPasswordNeeded.value = false
+    state.zipPassword.value = ''
+    state.zipError.value = ''
+    state.showZipPassword.value = false
+    state.zipUnlocking.value = false
+  }
+
+  function invalidateReviewState(): void {
+    state.selectedFilePaths.value = []
+    state.reviewFiles.value = []
+    state.duplicateCount.value = 0
+  }
+
+  function abandonZipImport(context: string): void {
+    if (!state.isZipImport.value) return
+    clearZipSelectionState()
+    invalidateReviewState()
+    void cleanupZipTemp(context)
+  }
+
+  async function handleDuplicateCheckFailure(error: unknown): Promise<void> {
+    const message = formatErrorMessage(error, 'Could not check duplicate cases')
+    invalidateReviewState()
+    state.step.value = 1
+    await cleanupZipTemp('duplicate check failure')
+    clearZipSelectionState()
+    logService.error(`Duplicate check failed: ${message}`, 'ImportWizard')
+    importStore.importError(message)
+  }
+
+  function handleBack(): void {
+    if (state.isZipImport.value) {
+      abandonZipImport('review back navigation')
+    } else {
+      invalidateReviewState()
+    }
+    state.step.value = 1
+  }
+
+  async function checkDuplicatesAndAdvance(filePaths: string[]): Promise<void> {
+    try {
+      const result = unwrapIpcResult(
+        await checkDuplicatesRequest(filePaths, state.stripText.value || undefined)
+      )
+      state.reviewFiles.value = result.files
+      state.duplicateCount.value = result.duplicateCount
+      state.step.value = 2
+    } catch (error) {
+      await handleDuplicateCheckFailure(error)
+      throw error
+    }
+  }
+
+  function scheduleDuplicateRecheck(): void {
+    cancelDuplicateRecheck()
+    recheckTimeout = setTimeout(() => {
+      void (async () => {
+        if (state.selectedFilePaths.value.length === 0) return
+        try {
+          const result = unwrapIpcResult(
+            await checkDuplicatesRequest(
+              [...state.selectedFilePaths.value],
+              state.stripText.value || undefined
+            )
+          )
+          state.reviewFiles.value = result.files
+          state.duplicateCount.value = result.duplicateCount
+        } catch (error) {
+          await handleDuplicateCheckFailure(error)
+        }
+      })()
+    }, 300)
+  }
+
+  function cancelDuplicateRecheck(): void {
+    if (recheckTimeout !== null) clearTimeout(recheckTimeout)
+    recheckTimeout = null
+  }
+
+  return {
+    cleanupZipTemp,
+    abandonZipImport,
+    handleDuplicateCheckFailure,
+    handleBack,
+    checkDuplicatesAndAdvance,
+    scheduleDuplicateRecheck,
+    cancelDuplicateRecheck
+  }
+}

--- a/src/renderer/src/mocks/mockApi.ts
+++ b/src/renderer/src/mocks/mockApi.ts
@@ -364,8 +364,8 @@ export const mockApi: WindowAPI = {
     onComplete: () => () => {},
     selectZip: async () => null,
     testZipPassword: async () => ({ success: false }),
-    extractZip: async () => ({ files: [], errors: [] }),
-    cleanupZipTemp: async () => {}
+    extractZip: async () => ({ files: [], errors: [], extractionId: 'mock-extraction-id' }),
+    cleanupZipTemp: async (_extractionId: string) => {}
   },
 
   cohort: {

--- a/src/shared/api/schemas/batch-import.ts
+++ b/src/shared/api/schemas/batch-import.ts
@@ -8,7 +8,7 @@ export const BatchImportInvokeBodySchemas = {
     args: z.tuple([z.string().min(1), z.string()])
   }),
   cleanupZipTemp: z.object({
-    args: z.tuple([])
+    args: z.tuple([z.string().uuid()])
   })
 } as const
 

--- a/src/shared/ipc/domains/batch-import.ts
+++ b/src/shared/ipc/domains/batch-import.ts
@@ -19,6 +19,6 @@ export interface BatchImportDomainContract {
   extractZip: (
     zipPath: string,
     password?: string
-  ) => Promise<IpcResult<{ files: string[]; errors: string[] }>>
-  cleanupZipTemp: () => Promise<IpcResult<void>>
+  ) => Promise<IpcResult<{ files: string[]; errors: string[]; extractionId: string }>>
+  cleanupZipTemp: (extractionId: string) => Promise<IpcResult<void>>
 }

--- a/src/shared/ipc/domains/batch-import.ts
+++ b/src/shared/ipc/domains/batch-import.ts
@@ -2,8 +2,8 @@ import type { BatchResult, DuplicateCheckResult, DuplicateChoice } from '../../t
 import type { IpcResult } from '../../types/errors'
 
 export interface BatchImportDomainContract {
-  selectFiles: () => Promise<string[]>
-  selectFolder: () => Promise<string[]>
+  selectFiles: () => Promise<IpcResult<string[]>>
+  selectFolder: () => Promise<IpcResult<string[]>>
   checkDuplicates: (
     filePaths: string[],
     stripText?: string

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -371,8 +371,8 @@ export interface BatchImportAPI {
   extractZip: (
     zipPath: string,
     password?: string
-  ) => Promise<IpcResult<{ files: string[]; errors: string[] }>>
-  cleanupZipTemp: () => Promise<IpcResult<void>>
+  ) => Promise<IpcResult<{ files: string[]; errors: string[]; extractionId: string }>>
+  cleanupZipTemp: (extractionId: string) => Promise<IpcResult<void>>
 }
 
 export interface CohortAPI {

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -352,8 +352,8 @@ export interface DuplicateCheckResult {
 }
 
 export interface BatchImportAPI {
-  selectFiles: () => Promise<string[]>
-  selectFolder: () => Promise<string[]>
+  selectFiles: () => Promise<IpcResult<string[]>>
+  selectFolder: () => Promise<IpcResult<string[]>>
   checkDuplicates: (
     filePaths: string[],
     stripText?: string

--- a/src/web/server/routes/batch-import.ts
+++ b/src/web/server/routes/batch-import.ts
@@ -218,8 +218,13 @@ export function buildBatchImportOverrides(): Record<string, OverrideHandler> {
     },
 
     'batch-import:cleanupZipTemp': {
-      handle() {
-        cleanupZipTemp()
+      handle(args, _request, reply) {
+        const [extractionId] = args
+        if (typeof extractionId !== 'string' || extractionId.length === 0) {
+          reply.code(400)
+          return { error: 'invalid-extraction-id', message: 'extractionId is required' }
+        }
+        cleanupZipTemp(extractionId)
       }
     }
   }
@@ -240,25 +245,29 @@ async function extractWebUploadZip(
   zipRef: string,
   userId: number | undefined,
   password: string | undefined
-): Promise<{ files: string[]; errors: string[] } | null> {
+): Promise<{ files: string[]; errors: string[]; extractionId: string } | null> {
   const upload = resolveUploadedFile(zipRef, userId)
   if (upload === null || userId === undefined) return null
 
   const result = await extractZip(upload.storedPath, password)
-  const stagedFiles = []
-  for (const filePath of result.files) {
-    stagedFiles.push(
-      await stageExistingFileUpload({
-        userId,
-        originalName: basename(filePath),
-        sourcePath: filePath
-      })
-    )
-  }
-  cleanupZipTemp()
-  return {
-    files: stagedFiles.map((file) => file.ref),
-    errors: result.errors
+  try {
+    const stagedFiles = []
+    for (const filePath of result.files) {
+      stagedFiles.push(
+        await stageExistingFileUpload({
+          userId,
+          originalName: basename(filePath),
+          sourcePath: filePath
+        })
+      )
+    }
+    return {
+      files: stagedFiles.map((file) => file.ref),
+      errors: result.errors,
+      extractionId: result.extractionId
+    }
+  } finally {
+    cleanupZipTemp(result.extractionId)
   }
 }
 

--- a/tests/fixtures/ipc-parity/manifest.json
+++ b/tests/fixtures/ipc-parity/manifest.json
@@ -268,7 +268,7 @@
         {
           "domain": "batch-import",
           "method": "cleanupZipTemp",
-          "args": []
+          "args": ["$batchImport.zip.extractionId"]
         }
       ],
       "assertion": "normalized-result-hash"

--- a/tests/main/handlers/batch-import-cleanup-retry.test.ts
+++ b/tests/main/handlers/batch-import-cleanup-retry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const cleanupState = vi.hoisted(() => ({
+  calls: 0,
+  failNext: true,
+  nextDirectory: 0
+}))
+
+vi.mock('../../../src/main/import', () => ({
+  ZipExtractor: class {
+    async extract(zipPath: string): Promise<{
+      extractedFiles: string[]
+      errors: string[]
+      totalEntries: number
+    }> {
+      if (zipPath === 'broken.zip') throw new Error('archive decode failed')
+      return { extractedFiles: [], errors: [], totalEntries: 0 }
+    }
+  },
+  TempDirectoryManager: class {
+    create(): string {
+      cleanupState.nextDirectory += 1
+      return `/tmp/mock-zip-${cleanupState.nextDirectory}`
+    }
+
+    cleanup(): void {
+      cleanupState.calls += 1
+      if (cleanupState.failNext) {
+        cleanupState.failNext = false
+        throw new Error('directory is busy')
+      }
+    }
+  }
+}))
+
+import { cleanupZipTemp, extractZip } from '../../../src/main/ipc/handlers/batch-import-logic'
+
+describe('batch-import orphaned ZIP cleanup', () => {
+  it('retries an unreturned extraction cleanup before accepting another extraction', async () => {
+    await expect(extractZip('broken.zip')).rejects.toThrow(/cleanup also failed/)
+    expect(cleanupState.calls).toBe(1)
+
+    const next = await extractZip('next.zip')
+
+    expect(cleanupState.calls).toBe(2)
+    cleanupZipTemp(next.extractionId)
+    expect(cleanupState.calls).toBe(3)
+  })
+})

--- a/tests/main/handlers/batch-import-logic.test.ts
+++ b/tests/main/handlers/batch-import-logic.test.ts
@@ -106,7 +106,19 @@ describe('extractZip', () => {
     entry.entryName = '../evil.json'
     zip.writeZip(traversalPath)
 
-    await expect(logic.extractZip(traversalPath)).rejects.toThrow(/all 1 candidate entry/)
+    await expect(logic.extractZip(traversalPath)).rejects.toThrow(/1 candidate entry/)
+  })
+
+  it('fails the archive when any candidate entry fails instead of silently importing a partial set', async () => {
+    const dir = makeTempDir()
+    const partialPath = join(dir, 'partial.zip')
+    const zip = new AdmZip()
+    zip.addFile('good.json', Buffer.from('{}'))
+    zip.addFile('placeholder.json', Buffer.from('{}'))
+    zip.getEntries()[1].entryName = '../evil.json'
+    zip.writeZip(partialPath)
+
+    await expect(logic.extractZip(partialPath)).rejects.toThrow(/candidate entry/)
   })
 
   it('preserves the legitimate outcome: an archive with no importable files resolves to an empty result', async () => {

--- a/tests/main/handlers/batch-import-logic.test.ts
+++ b/tests/main/handlers/batch-import-logic.test.ts
@@ -92,6 +92,23 @@ describe('extractZip', () => {
     await expect(logic.extractZip(garbagePath)).rejects.toThrow()
   })
 
+  it('throws when every candidate entry fails to extract (0 files, N errors) instead of returning a silent no-op success', async () => {
+    // Every importable-looking entry is rejected as a path-traversal attempt,
+    // so ZipExtractor.extract resolves with { extractedFiles: [], errors: [...] }
+    // -- zero files but non-empty errors. A caller reading only `.files` (see
+    // ImportWizard.vue's extractAndAdvance) would otherwise see this as an
+    // empty-but-successful extraction and silently no-op.
+    const dir = makeTempDir()
+    const traversalPath = join(dir, 'all-entries-rejected.zip')
+    const zip = new AdmZip()
+    zip.addFile('placeholder.json', Buffer.from('{}'))
+    const entry = zip.getEntries()[0]
+    entry.entryName = '../evil.json'
+    zip.writeZip(traversalPath)
+
+    await expect(logic.extractZip(traversalPath)).rejects.toThrow(/all 1 candidate entry/)
+  })
+
   it('preserves the legitimate outcome: an archive with no importable files resolves to an empty result', async () => {
     const dir = makeTempDir()
     const validPath = join(dir, 'no-importable-files.zip')

--- a/tests/main/handlers/batch-import-logic.test.ts
+++ b/tests/main/handlers/batch-import-logic.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest'
 import AdmZip from 'adm-zip'
-import { mkdtempSync, readdirSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import * as logic from '../../../src/main/ipc/handlers/batch-import-logic'
@@ -122,7 +122,6 @@ describe('extractZip', () => {
   })
 
   it('removes its temporary directory after rejecting a partial extraction', async () => {
-    logic.cleanupZipTemp()
     const before = readdirSync(tmpdir())
       .filter((name) => name.startsWith('varlens-zip-'))
       .sort()
@@ -151,6 +150,56 @@ describe('extractZip', () => {
 
     const result = await logic.extractZip(validPath)
 
-    expect(result).toEqual({ files: [], errors: [] })
+    expect(result).toMatchObject({ files: [], errors: [] })
+    expect(result.extractionId).toMatch(/^[0-9a-f-]{36}$/i)
+    logic.cleanupZipTemp(result.extractionId)
+  })
+
+  it('keeps extraction directories independent and scopes cleanup authority', async () => {
+    const dir = makeTempDir()
+    const firstPath = join(dir, 'first.zip')
+    const secondPath = join(dir, 'second.zip')
+    const first = new AdmZip()
+    first.addFile('first.json', Buffer.from('{}'))
+    first.writeZip(firstPath)
+    const second = new AdmZip()
+    second.addFile('second.json', Buffer.from('{}'))
+    second.writeZip(secondPath)
+
+    const firstResult = await logic.extractZip(firstPath)
+    const secondResult = await logic.extractZip(secondPath)
+    const firstExtractedPath = firstResult.files[0]
+    const secondExtractedPath = secondResult.files[0]
+
+    expect(existsSync(firstExtractedPath)).toBe(true)
+    expect(existsSync(secondExtractedPath)).toBe(true)
+
+    logic.cleanupZipTemp(firstResult.extractionId)
+    expect(existsSync(firstExtractedPath)).toBe(false)
+    expect(existsSync(secondExtractedPath)).toBe(true)
+
+    logic.cleanupZipTemp(secondResult.extractionId)
+    expect(existsSync(secondExtractedPath)).toBe(false)
+  })
+
+  it('bounds active extraction directories when callers omit cleanup', async () => {
+    const dir = makeTempDir()
+    const archivePath = join(dir, 'bounded.zip')
+    const zip = new AdmZip()
+    zip.addFile('case.json', Buffer.from('{}'))
+    zip.writeZip(archivePath)
+    const activeExtractions = []
+
+    try {
+      for (let index = 0; index < 4; index++) {
+        activeExtractions.push(await logic.extractZip(archivePath))
+      }
+
+      await expect(logic.extractZip(archivePath)).rejects.toThrow(/Too many active ZIP extractions/)
+    } finally {
+      for (const extraction of activeExtractions) {
+        logic.cleanupZipTemp(extraction.extractionId)
+      }
+    }
   })
 })

--- a/tests/main/handlers/batch-import-logic.test.ts
+++ b/tests/main/handlers/batch-import-logic.test.ts
@@ -1,9 +1,19 @@
 /**
  * Batch import logic smoke tests — verifies module exports are intact after extraction.
+ *
+ * Also covers the failure-classification fix for finding C8 / Codex F-05: a
+ * genuine DB/fs/archive failure must throw (so wrapHandler structures it),
+ * not be reshaped into a value that looks like a legitimate benign outcome
+ * ("no duplicates", "wrong password", "empty extraction").
  */
 
 import { describe, it, expect } from 'vitest'
+import AdmZip from 'adm-zip'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import * as logic from '../../../src/main/ipc/handlers/batch-import-logic'
+import type { DatabaseService } from '../../../src/main/database/DatabaseService'
 
 describe('batch-import-logic exports', () => {
   it('exports expected functions', () => {
@@ -13,5 +23,84 @@ describe('batch-import-logic exports', () => {
     expect(typeof logic.testZipPassword).toBe('function')
     expect(typeof logic.extractZip).toBe('function')
     expect(typeof logic.cleanupZipTemp).toBe('function')
+  })
+})
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'varlens-batch-import-logic-test-'))
+}
+
+describe('checkDuplicateFiles', () => {
+  it('throws on a DB lookup failure instead of returning a false "no duplicates" result', () => {
+    const brokenDb = {
+      cases: {
+        getExistingCaseNames: () => {
+          throw new Error('database is locked')
+        }
+      }
+    } as unknown as DatabaseService
+
+    expect(() => logic.checkDuplicateFiles(() => brokenDb, ['/data/a.json'])).toThrow(
+      'database is locked'
+    )
+  })
+
+  it('preserves the legitimate outcome: a real DB lookup with no duplicates returns an empty result', () => {
+    const workingDb = {
+      cases: {
+        getExistingCaseNames: () => new Set<string>()
+      }
+    } as unknown as DatabaseService
+
+    const result = logic.checkDuplicateFiles(() => workingDb, ['/data/a.json'])
+
+    expect(result).toEqual({
+      files: [{ filePath: '/data/a.json', fileName: 'a.json', caseName: 'a', isDuplicate: false }],
+      duplicateCount: 0
+    })
+  })
+})
+
+describe('testZipPassword', () => {
+  it('throws on a corrupt/unreadable archive instead of reporting it as "wrong password"', () => {
+    const dir = makeTempDir()
+    const garbagePath = join(dir, 'garbage.zip')
+    writeFileSync(garbagePath, Buffer.from('not a zip file at all'))
+
+    expect(() => logic.testZipPassword(garbagePath, 'anypassword')).toThrow()
+  })
+
+  it('preserves the legitimate outcome: a real password check on a valid archive returns a structured result', () => {
+    const dir = makeTempDir()
+    const validPath = join(dir, 'valid.zip')
+    const zip = new AdmZip()
+    zip.addFile('case.json', Buffer.from('{}'))
+    zip.writeZip(validPath)
+
+    const result = logic.testZipPassword(validPath, 'irrelevant')
+
+    expect(result).toEqual({ success: true })
+  })
+})
+
+describe('extractZip', () => {
+  it('throws on a corrupt/unreadable archive instead of returning a fake-success zero-file result', async () => {
+    const dir = makeTempDir()
+    const garbagePath = join(dir, 'garbage.zip')
+    writeFileSync(garbagePath, Buffer.from('not a zip file at all'))
+
+    await expect(logic.extractZip(garbagePath)).rejects.toThrow()
+  })
+
+  it('preserves the legitimate outcome: an archive with no importable files resolves to an empty result', async () => {
+    const dir = makeTempDir()
+    const validPath = join(dir, 'no-importable-files.zip')
+    const zip = new AdmZip()
+    zip.addFile('readme.txt', Buffer.from('not a variant file'))
+    zip.writeZip(validPath)
+
+    const result = await logic.extractZip(validPath)
+
+    expect(result).toEqual({ files: [], errors: [] })
   })
 })

--- a/tests/main/handlers/batch-import-logic.test.ts
+++ b/tests/main/handlers/batch-import-logic.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest'
 import AdmZip from 'adm-zip'
-import { mkdtempSync, writeFileSync } from 'fs'
+import { mkdtempSync, readdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import * as logic from '../../../src/main/ipc/handlers/batch-import-logic'
@@ -70,7 +70,7 @@ describe('testZipPassword', () => {
     expect(() => logic.testZipPassword(garbagePath, 'anypassword')).toThrow()
   })
 
-  it('preserves the legitimate outcome: a real password check on a valid archive returns a structured result', () => {
+  it('returns false when a readable archive has no encrypted entries', () => {
     const dir = makeTempDir()
     const validPath = join(dir, 'valid.zip')
     const zip = new AdmZip()
@@ -79,7 +79,7 @@ describe('testZipPassword', () => {
 
     const result = logic.testZipPassword(validPath, 'irrelevant')
 
-    expect(result).toEqual({ success: true })
+    expect(result).toEqual({ success: false })
   })
 })
 
@@ -119,6 +119,27 @@ describe('extractZip', () => {
     zip.writeZip(partialPath)
 
     await expect(logic.extractZip(partialPath)).rejects.toThrow(/candidate entry/)
+  })
+
+  it('removes its temporary directory after rejecting a partial extraction', async () => {
+    logic.cleanupZipTemp()
+    const before = readdirSync(tmpdir())
+      .filter((name) => name.startsWith('varlens-zip-'))
+      .sort()
+    const dir = makeTempDir()
+    const partialPath = join(dir, 'partial-cleanup.zip')
+    const zip = new AdmZip()
+    zip.addFile('good.json', Buffer.from('{}'))
+    zip.addFile('placeholder.json', Buffer.from('{}'))
+    zip.getEntries()[1].entryName = '../evil.json'
+    zip.writeZip(partialPath)
+
+    await expect(logic.extractZip(partialPath)).rejects.toThrow(/candidate entry/)
+
+    const after = readdirSync(tmpdir())
+      .filter((name) => name.startsWith('varlens-zip-'))
+      .sort()
+    expect(after).toEqual(before)
   })
 
   it('preserves the legitimate outcome: an archive with no importable files resolves to an empty result', async () => {

--- a/tests/main/handlers/panel-interval-offload.test.ts
+++ b/tests/main/handlers/panel-interval-offload.test.ts
@@ -21,6 +21,7 @@ import type { HandlerDependencies } from '../../../src/main/ipc/types'
 import type { IpcMain } from 'electron'
 import type { DbPool } from '../../../src/main/database/DbPool'
 import type { DatabaseManager } from '../../../src/main/services/DatabaseManager'
+import { isIpcError } from '../../../src/shared/types/errors'
 
 // ── Test helpers ────────────────────────────────────────────────
 
@@ -198,6 +199,206 @@ describe('variants:query — no pool fallback path', () => {
 
     expect(computeSpy).toHaveBeenCalled()
     computeSpy.mockRestore()
+  })
+})
+
+// ── Suite 2b: panel-interval computation failure must surface as an error ──
+//
+// Clinical-safety guarantee: a panel is configured (active_panel_ids is
+// non-empty) but the interval computation itself throws. The query must
+// error visibly, never silently fall back to an unfiltered result — a
+// dropped panel filter must not look identical to "panel returned everything".
+
+describe('panel-interval computation failure surfaces as an error (no silent unfiltered fallback)', () => {
+  let dbService: DatabaseService
+
+  beforeEach(() => {
+    dbService = new DatabaseService(':memory:')
+  })
+
+  afterEach(() => {
+    dbService.close()
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * Stubs getGeneReferenceDb() so the failure test exercises the intended
+   * PanelRepository.computeIntervals() failure path rather than tripping over
+   * Electron's `app` module being unavailable in this test environment.
+   */
+  async function stubGeneReferenceDb(): Promise<void> {
+    const geneRefLoaderModule = await import('../../../src/main/database/geneReferenceLoader')
+    vi.spyOn(geneRefLoaderModule, 'getGeneReferenceDb').mockReturnValue(
+      {} as unknown as import('../../../src/main/database/GeneReferenceDb').GeneReferenceDb
+    )
+  }
+
+  it('computePanelIntervals throws (does not return undefined) when computation fails', async () => {
+    const panel = dbService.panels.createPanel({ name: 'TestPanel', source: 'manual' })
+    dbService.panels.setGenes(panel.id, [{ hgncId: 'HGNC:1100', symbol: 'BRCA1' }])
+
+    await stubGeneReferenceDb()
+    vi.spyOn(dbService.panels, 'computeIntervals').mockImplementation(() => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+
+    const { computePanelIntervals } =
+      await import('../../../src/main/ipc/handlers/panelIntervalHelper')
+
+    expect(() =>
+      computePanelIntervals(dbService, { active_panel_ids: [panel.id] }, undefined, 'variants')
+    ).toThrow('Simulated panel interval computation failure')
+  })
+
+  it('variants:query (no pool, case view) surfaces a SerializableError instead of unfiltered variants', async () => {
+    const caseId = dbService.database
+      .prepare(
+        'INSERT INTO cases (name, file_path, file_size, variant_count, created_at, genome_build) VALUES (?,?,?,?,?,?)'
+      )
+      .run('test-panel-fail', '/t.vcf', 0, 0, Date.now(), 'GRCh38').lastInsertRowid as number
+
+    const panel = dbService.panels.createPanel({ name: 'TestPanel', source: 'manual' })
+    dbService.panels.setGenes(panel.id, [{ hgncId: 'HGNC:1100', symbol: 'BRCA1' }])
+
+    await stubGeneReferenceDb()
+    vi.spyOn(dbService.panels, 'computeIntervals').mockImplementation(() => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+
+    const deps: HandlerDependencies = {
+      ipcMain: { handle: vi.fn() } as unknown as IpcMain,
+      getDb: () => dbService,
+      getDbManager: vi.fn() as unknown as () => DatabaseManager,
+      getDbPool: () => null
+    }
+
+    const { registerVariantHandlers } = await import('../../../src/main/ipc/handlers/variants')
+    let capturedHandler: ((...args: unknown[]) => Promise<unknown>) | null = null
+    ;(deps.ipcMain.handle as ReturnType<typeof vi.fn>).mockImplementation(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        if (channel === 'variants:query') capturedHandler = handler
+      }
+    )
+    registerVariantHandlers(deps)
+
+    const filter = { active_panel_ids: [panel.id], panel_padding_bp: 0 }
+    const result = await capturedHandler!(
+      {} as Electron.IpcMainInvokeEvent,
+      caseId,
+      filter,
+      0,
+      50,
+      undefined
+    )
+
+    expect(isIpcError(result)).toBe(true)
+    expect((result as Record<string, unknown>).data).toBeUndefined()
+  })
+
+  it('cohort:variants (no pool, cohort view) surfaces a SerializableError instead of unfiltered variants', async () => {
+    const panel = dbService.panels.createPanel({ name: 'TestPanel', source: 'manual' })
+    dbService.panels.setGenes(panel.id, [{ hgncId: 'HGNC:1100', symbol: 'BRCA1' }])
+
+    await stubGeneReferenceDb()
+    vi.spyOn(dbService.panels, 'computeIntervals').mockImplementation(() => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+
+    const deps: HandlerDependencies = {
+      ipcMain: { handle: vi.fn() } as unknown as IpcMain,
+      getDb: () => dbService,
+      getDbManager: (() => ({
+        getCurrentSession: () => ({ capabilities: { backend: 'sqlite' } })
+      })) as unknown as () => DatabaseManager,
+      getDbPool: () => null
+    }
+
+    const { registerCohortHandlers } = await import('../../../src/main/ipc/handlers/cohort')
+    let capturedHandler: ((...args: unknown[]) => Promise<unknown>) | null = null
+    ;(deps.ipcMain.handle as ReturnType<typeof vi.fn>).mockImplementation(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        if (channel === 'cohort:variants') capturedHandler = handler
+      }
+    )
+    registerCohortHandlers(deps)
+
+    const cohortParams = { active_panel_ids: [panel.id], panel_padding_bp: 0 }
+    const result = await capturedHandler!({} as Electron.IpcMainInvokeEvent, cohortParams)
+
+    expect(isIpcError(result)).toBe(true)
+  })
+
+  it('variants:query (pool available) surfaces a SerializableError when the worker rejects on panel-interval failure', async () => {
+    const caseId = dbService.database
+      .prepare(
+        'INSERT INTO cases (name, file_path, file_size, variant_count, created_at, genome_build) VALUES (?,?,?,?,?,?)'
+      )
+      .run('test-panel-fail-pool', '/t.vcf', 0, 0, Date.now(), 'GRCh38').lastInsertRowid as number
+
+    const poolRunSpy = vi.fn(async () => {
+      // Simulates the worker thread throwing inside resolvePanelIntervalsInPlace
+      // and Piscina surfacing it as a rejected task promise.
+      throw new Error('Simulated panel interval computation failure')
+    })
+    const fakePool = { run: poolRunSpy } as unknown as DbPool
+
+    const deps: HandlerDependencies = {
+      ipcMain: { handle: vi.fn() } as unknown as IpcMain,
+      getDb: () => dbService,
+      getDbManager: vi.fn() as unknown as () => DatabaseManager,
+      getDbPool: () => fakePool
+    }
+
+    const { registerVariantHandlers } = await import('../../../src/main/ipc/handlers/variants')
+    let capturedHandler: ((...args: unknown[]) => Promise<unknown>) | null = null
+    ;(deps.ipcMain.handle as ReturnType<typeof vi.fn>).mockImplementation(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        if (channel === 'variants:query') capturedHandler = handler
+      }
+    )
+    registerVariantHandlers(deps)
+
+    const filter = { active_panel_ids: [1], panel_padding_bp: 0 }
+    const result = await capturedHandler!(
+      {} as Electron.IpcMainInvokeEvent,
+      caseId,
+      filter,
+      0,
+      50,
+      undefined
+    )
+
+    expect(isIpcError(result)).toBe(true)
+  })
+
+  it('cohort:variants (pool available) surfaces a SerializableError when the worker rejects on panel-interval failure', async () => {
+    const poolRunSpy = vi.fn(async () => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+    const fakePool = { run: poolRunSpy } as unknown as DbPool
+
+    const deps: HandlerDependencies = {
+      ipcMain: { handle: vi.fn() } as unknown as IpcMain,
+      getDb: () => dbService,
+      getDbManager: (() => ({
+        getCurrentSession: () => ({ capabilities: { backend: 'sqlite' } })
+      })) as unknown as () => DatabaseManager,
+      getDbPool: () => fakePool
+    }
+
+    const { registerCohortHandlers } = await import('../../../src/main/ipc/handlers/cohort')
+    let capturedHandler: ((...args: unknown[]) => Promise<unknown>) | null = null
+    ;(deps.ipcMain.handle as ReturnType<typeof vi.fn>).mockImplementation(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        if (channel === 'cohort:variants') capturedHandler = handler
+      }
+    )
+    registerCohortHandlers(deps)
+
+    const cohortParams = { active_panel_ids: [3, 4], panel_padding_bp: 2000 }
+    const result = await capturedHandler!({} as Electron.IpcMainInvokeEvent, cohortParams)
+
+    expect(isIpcError(result)).toBe(true)
   })
 })
 

--- a/tests/main/import/TempDirectoryManager.test.ts
+++ b/tests/main/import/TempDirectoryManager.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { existsSync } from 'node:fs'
+import type { rmSync } from 'node:fs'
+
+import { TempDirectoryManager } from '../../../src/main/import/TempDirectoryManager'
+
+describe('TempDirectoryManager cleanup', () => {
+  it('propagates removal failure and retains the directory for a retry', () => {
+    const remove = vi
+      .fn<typeof rmSync>()
+      .mockImplementationOnce(() => {
+        throw new Error('file is busy')
+      })
+      .mockImplementationOnce(() => undefined)
+    const manager = new TempDirectoryManager(remove)
+    const directory = manager.create()
+
+    expect(() => manager.cleanup()).toThrow(/file is busy/)
+    expect(manager.getPath()).toBe(directory)
+    expect(existsSync(directory)).toBe(true)
+
+    manager.cleanup()
+    expect(manager.getPath()).toBeNull()
+    expect(remove).toHaveBeenCalledTimes(2)
+    expect(remove).toHaveBeenCalledWith(directory, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100
+    })
+  })
+})

--- a/tests/main/import/ZipExtractor.test.ts
+++ b/tests/main/import/ZipExtractor.test.ts
@@ -529,6 +529,31 @@ describe('ZipExtractor.testPassword', () => {
 })
 
 describe('ZipExtractor.extract', () => {
+  it('rejects an oversized archive before opening it', async () => {
+    const openArchive = vi.fn(() => ({ getEntries: () => [] }) as unknown as AdmZip)
+    const dir = makeTempDir()
+    const zipPath = join(dir, 'oversized.zip')
+    writeFileSync(zipPath, Buffer.alloc(11))
+    const extractor = new ZipExtractor({ maxArchiveBytes: 10 }, openArchive)
+
+    await expect(extractor.extract(zipPath, makeTempDir())).rejects.toThrow(/archive size limit/i)
+    expect(openArchive).not.toHaveBeenCalled()
+  })
+
+  it('rejects an archive with too many entries before decoding any entry', async () => {
+    const firstRead = vi.fn(() => Buffer.from('{}'))
+    const secondRead = vi.fn(() => Buffer.from('{}'))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'first.json', encrypted: false, declaredSize: 2, getData: firstRead },
+      { entryName: 'second.json', encrypted: false, declaredSize: 2, getData: secondRead }
+    ])
+    const extractor = new ZipExtractor({ maxEntries: 1 }, openArchive)
+
+    await expect(extractor.extract(zipPath, makeTempDir())).rejects.toThrow(/entry count limit/i)
+    expect(firstRead).not.toHaveBeenCalled()
+    expect(secondRead).not.toHaveBeenCalled()
+  })
+
   it('rejects a declared entry size above the extraction limit before decoding', async () => {
     const getData = vi.fn(() => Buffer.alloc(5))
     const { zipPath, openArchive } = makeStubArchive([

--- a/tests/main/import/ZipExtractor.test.ts
+++ b/tests/main/import/ZipExtractor.test.ts
@@ -22,7 +22,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import AdmZip from 'adm-zip'
-import { mkdtempSync, writeFileSync } from 'fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
@@ -150,35 +150,37 @@ function writeEncryptedZip(
   path: string,
   entryName: string,
   plaintext: string,
-  password: string
+  password: string,
+  plainFirst = false
 ): void {
   const zip = new AdmZip()
+  if (plainFirst) {
+    zip.addFile('plain.json', Buffer.from('{"plain":true}'))
+  }
   zip.addFile(entryName, Buffer.from(plaintext))
-  const entry = zip.getEntries()[0]
-  entry.header.method = 0 // STORED — avoids deflate so the plaintext is byte-identical
+  for (const entry of zip.getEntries()) {
+    entry.header.method = 0 // STORED — plaintext is byte-identical before encryption
+  }
 
   const buf = zip.toBuffer()
+  const local = findLocalEntry(buf, entryName)
+  const compressedSize = local.compressedSize
+  const crc = buf.readUInt32LE(local.headerOffset + 14)
 
-  const fnameLen = buf.readUInt16LE(26)
-  const extraLen = buf.readUInt16LE(28)
-  const localDataOffset = 30 + fnameLen + extraLen
-  const compressedSize = buf.readUInt32LE(18)
-  const crc = buf.readUInt32LE(14)
-
-  const plainData = buf.subarray(localDataOffset, localDataOffset + compressedSize)
+  const plainData = buf.subarray(local.dataOffset, local.dataOffset + compressedSize)
   const encrypted = zipCryptoEncrypt(Buffer.from(plainData), crc, password)
   const delta = encrypted.length - plainData.length
 
-  // Local header + filename + extra, with FLG_ENC (bit 0) set and the
-  // compressed-size field updated to the encrypted (12 bytes longer) length.
-  const partA = Buffer.from(buf.subarray(0, localDataOffset))
-  partA.writeUInt16LE(partA.readUInt16LE(6) | 0x1, 6)
-  partA.writeUInt32LE(encrypted.length, 18)
+  const partA = Buffer.from(buf.subarray(0, local.dataOffset))
+  partA.writeUInt16LE(partA.readUInt16LE(local.headerOffset + 6) | 0x1, local.headerOffset + 6)
+  partA.writeUInt32LE(encrypted.length, local.headerOffset + 18)
 
   // Everything after the local file data: central directory + EOCD.
-  const partC = Buffer.from(buf.subarray(localDataOffset + compressedSize))
-  partC.writeUInt16LE(partC.readUInt16LE(8) | 0x1, 8) // CENFLG |= FLG_ENC
-  partC.writeUInt32LE(encrypted.length, 20) // CENSIZ
+  const originalDataEnd = local.dataOffset + compressedSize
+  const partC = Buffer.from(buf.subarray(originalDataEnd))
+  const centralOffset = findCentralEntry(buf, entryName) - originalDataEnd
+  partC.writeUInt16LE(partC.readUInt16LE(centralOffset + 8) | 0x1, centralOffset + 8)
+  partC.writeUInt32LE(encrypted.length, centralOffset + 20)
 
   const eocdSig = 0x06054b50
   let eocdOffset = -1
@@ -197,7 +199,66 @@ function writeEncryptedZip(
   writeFileSync(path, Buffer.concat([partA, encrypted, partC]))
 }
 
+interface LocalZipEntry {
+  headerOffset: number
+  dataOffset: number
+  compressedSize: number
+}
+
+function findLocalEntry(buf: Buffer, entryName: string): LocalZipEntry {
+  let offset = 0
+  while (offset + 30 <= buf.length && buf.readUInt32LE(offset) === 0x04034b50) {
+    const compressedSize = buf.readUInt32LE(offset + 18)
+    const nameLength = buf.readUInt16LE(offset + 26)
+    const extraLength = buf.readUInt16LE(offset + 28)
+    const name = buf.subarray(offset + 30, offset + 30 + nameLength).toString('utf8')
+    const dataOffset = offset + 30 + nameLength + extraLength
+    if (name === entryName) return { headerOffset: offset, dataOffset, compressedSize }
+    offset = dataOffset + compressedSize
+  }
+  throw new Error(`Test fixture builder could not find local entry ${entryName}`)
+}
+
+function findCentralEntry(buf: Buffer, entryName: string): number {
+  const eocdOffset = findSignatureFromEnd(buf, 0x06054b50)
+  let offset = buf.readUInt32LE(eocdOffset + 16)
+  while (offset + 46 <= eocdOffset && buf.readUInt32LE(offset) === 0x02014b50) {
+    const nameLength = buf.readUInt16LE(offset + 28)
+    const extraLength = buf.readUInt16LE(offset + 30)
+    const commentLength = buf.readUInt16LE(offset + 32)
+    const name = buf.subarray(offset + 46, offset + 46 + nameLength).toString('utf8')
+    if (name === entryName) return offset
+    offset += 46 + nameLength + extraLength + commentLength
+  }
+  throw new Error(`Test fixture builder could not find central entry ${entryName}`)
+}
+
+function findSignatureFromEnd(buf: Buffer, signature: number): number {
+  for (let offset = buf.length - 4; offset >= 0; offset--) {
+    if (buf.readUInt32LE(offset) === signature) return offset
+  }
+  throw new Error(`Test fixture builder could not find ZIP signature ${signature.toString(16)}`)
+}
+
+function corruptEncryptedPayload(path: string, entryName: string): void {
+  const buf = readFileSync(path)
+  const local = findLocalEntry(buf, entryName)
+  const corrupted = Buffer.from(buf)
+  const payloadOffset = local.dataOffset + 12 + Math.floor((local.compressedSize - 12) / 2)
+  corrupted[payloadOffset] ^= 0xff
+  writeFileSync(path, corrupted)
+}
+
 describe('ZipExtractor.testPassword', () => {
+  it('does not classify an unreadable archive as unencrypted', () => {
+    const dir = makeTempDir()
+    const garbagePath = join(dir, 'garbage-encryption-check.zip')
+    writeGarbageFile(garbagePath)
+
+    const extractor = new ZipExtractor()
+    expect(() => extractor.isEncrypted(garbagePath)).toThrow(/ZIP archive/i)
+  })
+
   it('throws when the archive itself cannot be opened (corrupt/not a zip)', () => {
     const dir = makeTempDir()
     const garbagePath = join(dir, 'garbage.zip')
@@ -250,6 +311,36 @@ describe('ZipExtractor.testPassword', () => {
     const extractor = new ZipExtractor()
 
     expect(extractor.testPassword(encryptedPath, 'correct-password')).toBe(true)
+  })
+
+  it('throws for corrupt encrypted data even when the password is correct', () => {
+    const dir = makeTempDir()
+    const encryptedPath = join(dir, 'encrypted-corrupt.zip')
+    writeEncryptedZip(
+      encryptedPath,
+      'case.json',
+      JSON.stringify({ hello: 'world' }),
+      'correct-password'
+    )
+    corruptEncryptedPayload(encryptedPath, 'case.json')
+
+    const extractor = new ZipExtractor()
+    expect(() => extractor.testPassword(encryptedPath, 'correct-password')).toThrow(/corrupt/i)
+  })
+
+  it('checks every encrypted entry when an unencrypted file appears first', () => {
+    const dir = makeTempDir()
+    const encryptedPath = join(dir, 'mixed.zip')
+    writeEncryptedZip(
+      encryptedPath,
+      'secret.json',
+      JSON.stringify({ secret: true }),
+      'correct-password',
+      true
+    )
+
+    const extractor = new ZipExtractor()
+    expect(extractor.testPassword(encryptedPath, 'wrong-password')).toBe(false)
   })
 
   it('preserves the legitimate outcome: a valid, readable archive does not throw', () => {

--- a/tests/main/import/ZipExtractor.test.ts
+++ b/tests/main/import/ZipExtractor.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ZipExtractor.testPassword must distinguish two failure classes:
+ *
+ * - The archive itself cannot be opened/parsed (corrupt file, bad format,
+ *   truncated data) — an infrastructure fault. This must throw, not be
+ *   reported as "wrong password".
+ * - The archive opens fine but the given password fails to decrypt the
+ *   first entry — the legitimate "wrong password" domain outcome. This
+ *   must still return `false`, not throw.
+ *
+ * Before the fix, both classes were caught by a single try/catch and
+ * collapsed into `false`, making a corrupt archive indistinguishable from
+ * an incorrect password (finding C8 / Codex F-05).
+ */
+import { describe, it, expect } from 'vitest'
+import AdmZip from 'adm-zip'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomBytes } from 'crypto'
+import { ZipExtractor } from '../../../src/main/import/ZipExtractor'
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'varlens-zipextractor-test-'))
+}
+
+/** Build a well-formed, unencrypted zip with one small JSON entry. */
+function writeValidZip(path: string): void {
+  const zip = new AdmZip()
+  zip.addFile('case.json', Buffer.from(JSON.stringify({ hello: 'world' })))
+  zip.writeZip(path)
+}
+
+/**
+ * Build a zip whose central directory / local headers parse fine (so
+ * `getEntries()` succeeds) but whose compressed entry data is corrupted, so
+ * reading it fails with a CRC mismatch — standing in for "data can't be
+ * decrypted/decoded with the given input" without needing real ZipCrypto
+ * write support (adm-zip does not expose password-protected writes).
+ *
+ * Uses a large incompressible (random) payload so the local file data region
+ * is big and comfortably clear of the central directory/EOCD trailer, then
+ * flips bytes squarely in the middle of the whole buffer — safely inside the
+ * entry's compressed data, not its header or the trailing directory.
+ */
+function writeZipWithCorruptEntryData(path: string): void {
+  const zip = new AdmZip()
+  zip.addFile('case.json', randomBytes(4000))
+  const buf = zip.toBuffer()
+  const corrupted = Buffer.from(buf)
+  const mid = Math.floor(buf.length / 2)
+  for (let i = mid; i < mid + 20; i++) {
+    corrupted[i] = corrupted[i] ^ 0xff
+  }
+  writeFileSync(path, corrupted)
+}
+
+function writeGarbageFile(path: string): void {
+  writeFileSync(path, Buffer.from('this is not a zip file, just plain bytes'))
+}
+
+describe('ZipExtractor.testPassword', () => {
+  it('throws when the archive itself cannot be opened (corrupt/not a zip)', () => {
+    const dir = makeTempDir()
+    const garbagePath = join(dir, 'garbage.zip')
+    writeGarbageFile(garbagePath)
+
+    const extractor = new ZipExtractor()
+
+    expect(() => extractor.testPassword(garbagePath, 'anypassword')).toThrow()
+  })
+
+  it('returns false (not throw) when the archive opens but entry data fails to read — legitimate wrong-password-shaped outcome', () => {
+    const dir = makeTempDir()
+    const corruptEntryPath = join(dir, 'corrupt-entry.zip')
+    writeZipWithCorruptEntryData(corruptEntryPath)
+
+    const extractor = new ZipExtractor()
+
+    let result: boolean | undefined
+    expect(() => {
+      result = extractor.testPassword(corruptEntryPath, 'anypassword')
+    }).not.toThrow()
+    expect(result).toBe(false)
+  })
+
+  it('preserves the legitimate outcome: a valid, readable archive does not throw', () => {
+    const dir = makeTempDir()
+    const validPath = join(dir, 'valid.zip')
+    writeValidZip(validPath)
+
+    const extractor = new ZipExtractor()
+
+    expect(() => extractor.testPassword(validPath, 'irrelevant')).not.toThrow()
+  })
+})

--- a/tests/main/import/ZipExtractor.test.ts
+++ b/tests/main/import/ZipExtractor.test.ts
@@ -1,16 +1,24 @@
 /**
- * ZipExtractor.testPassword must distinguish two failure classes:
+ * ZipExtractor.testPassword must distinguish three outcomes:
  *
  * - The archive itself cannot be opened/parsed (corrupt file, bad format,
  *   truncated data) — an infrastructure fault. This must throw, not be
  *   reported as "wrong password".
- * - The archive opens fine but the given password fails to decrypt the
- *   first entry — the legitimate "wrong password" domain outcome. This
- *   must still return `false`, not throw.
+ * - The first entry IS encrypted and the given password fails to decrypt
+ *   it — the legitimate "wrong password" domain outcome. This must still
+ *   return `false`, not throw.
+ * - The first entry is NOT encrypted but still fails to read/decode/CRC
+ *   check (a corrupt, unencrypted archive) — this is an infrastructure
+ *   fault too and must throw, not be reported as "wrong password".
  *
- * Before the fix, both classes were caught by a single try/catch and
- * collapsed into `false`, making a corrupt archive indistinguishable from
- * an incorrect password (finding C8 / Codex F-05).
+ * Before the first fix, the unopenable-archive and corrupt-entry-data
+ * classes were both caught by a single try/catch and collapsed into
+ * `false`, making a corrupt archive indistinguishable from an incorrect
+ * password (finding C8 / Codex F-05). A follow-up review found the second
+ * fix still collapsed a corrupt UNENCRYPTED entry into the same `false`
+ * "wrong password" shape as a genuinely encrypted entry with the wrong
+ * password — this file now covers both classes explicitly by checking the
+ * entry's encryption flag before deciding.
  */
 import { describe, it, expect } from 'vitest'
 import AdmZip from 'adm-zip'
@@ -42,6 +50,9 @@ function writeValidZip(path: string): void {
  * is big and comfortably clear of the central directory/EOCD trailer, then
  * flips bytes squarely in the middle of the whole buffer — safely inside the
  * entry's compressed data, not its header or the trailing directory.
+ *
+ * This entry is NOT encrypted (adm-zip's `header.encrypted` is `false`) —
+ * it stands in for a corrupt-but-unencrypted archive.
  */
 function writeZipWithCorruptEntryData(path: string): void {
   const zip = new AdmZip()
@@ -59,6 +70,133 @@ function writeGarbageFile(path: string): void {
   writeFileSync(path, Buffer.from('this is not a zip file, just plain bytes'))
 }
 
+// ── Minimal traditional PKZIP (ZipCrypto) encryption ──────────────────────
+//
+// adm-zip can DECRYPT ZipCrypto-encrypted entries (used by `getData(pass)`)
+// but has no public or internal path to WRITE them — `methods/zipcrypto.js`
+// exports an `encrypt` helper that nothing in the library's write pipeline
+// ever calls. To build a genuinely encrypted fixture (so `header.encrypted`
+// is really `true`, exercising the same code path a real password-protected
+// archive would), this reimplements the well-known algorithm directly
+// (PKWARE traditional/ZipCrypto stream cipher, keyed by a CRC-32 table) so
+// the fixture does not depend on adm-zip's private module layout.
+
+const ZIPCRYPTO_CRC_TABLE = ((): Uint32Array => {
+  const table = new Uint32Array(256)
+  for (let n = 0; n < 256; n++) {
+    let c = n
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) !== 0 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    }
+    table[n] = c >>> 0
+  }
+  return table
+})()
+
+function makeZipCryptoKeys(password: string): {
+  keys: Uint32Array
+  update: (byte: number) => void
+} {
+  const keys = new Uint32Array([0x12345678, 0x23456789, 0x34567890])
+  const update = (byte: number): void => {
+    keys[0] = ZIPCRYPTO_CRC_TABLE[(keys[0] ^ byte) & 0xff] ^ (keys[0] >>> 8)
+    keys[1] = (keys[1] + (keys[0] & 0xff)) >>> 0
+    keys[1] = (Math.imul(keys[1], 134775813) + 1) >>> 0
+    keys[2] = ZIPCRYPTO_CRC_TABLE[(keys[2] ^ (keys[1] >>> 24)) & 0xff] ^ (keys[2] >>> 8)
+  }
+  for (const byte of Buffer.from(password)) update(byte)
+  return { keys, update }
+}
+
+function zipCryptoDecryptByte(keys: Uint32Array): number {
+  const temp = (keys[2] | 2) >>> 0
+  return (Math.imul(temp, temp ^ 1) >>> 8) & 0xff
+}
+
+/**
+ * Encrypt `data` (the entry's uncompressed/STORED bytes) with traditional
+ * PKZIP encryption under `password`. `crc` is the CRC-32 of the plaintext,
+ * used as the salt's verification byte per the ZipCrypto spec. Returns the
+ * 12-byte encryption header followed by the encrypted bytes.
+ */
+function zipCryptoEncrypt(data: Buffer, crc: number, password: string): Buffer {
+  const { keys, update } = makeZipCryptoKeys(password)
+  const header = Buffer.from(randomBytes(12))
+  header[11] = (crc >>> 24) & 0xff
+
+  const out = Buffer.alloc(12 + data.length)
+  for (let i = 0; i < 12; i++) {
+    const plain = header[i]
+    out[i] = plain ^ zipCryptoDecryptByte(keys)
+    update(plain)
+  }
+  for (let i = 0; i < data.length; i++) {
+    const plain = data[i]
+    out[12 + i] = plain ^ zipCryptoDecryptByte(keys)
+    update(plain)
+  }
+  return out
+}
+
+/**
+ * Build a genuinely password-protected (ZipCrypto-encrypted) single-entry
+ * ZIP archive. Builds an ordinary STORED (uncompressed) zip via adm-zip,
+ * then encrypts the entry's data in place and patches the general-purpose
+ * "encrypted" flag bit + compressed-size field on both the local file
+ * header and the central directory record, plus the EOCD's central
+ * directory offset (shifted by the encryption header's 12 extra bytes).
+ */
+function writeEncryptedZip(
+  path: string,
+  entryName: string,
+  plaintext: string,
+  password: string
+): void {
+  const zip = new AdmZip()
+  zip.addFile(entryName, Buffer.from(plaintext))
+  const entry = zip.getEntries()[0]
+  entry.header.method = 0 // STORED — avoids deflate so the plaintext is byte-identical
+
+  const buf = zip.toBuffer()
+
+  const fnameLen = buf.readUInt16LE(26)
+  const extraLen = buf.readUInt16LE(28)
+  const localDataOffset = 30 + fnameLen + extraLen
+  const compressedSize = buf.readUInt32LE(18)
+  const crc = buf.readUInt32LE(14)
+
+  const plainData = buf.subarray(localDataOffset, localDataOffset + compressedSize)
+  const encrypted = zipCryptoEncrypt(Buffer.from(plainData), crc, password)
+  const delta = encrypted.length - plainData.length
+
+  // Local header + filename + extra, with FLG_ENC (bit 0) set and the
+  // compressed-size field updated to the encrypted (12 bytes longer) length.
+  const partA = Buffer.from(buf.subarray(0, localDataOffset))
+  partA.writeUInt16LE(partA.readUInt16LE(6) | 0x1, 6)
+  partA.writeUInt32LE(encrypted.length, 18)
+
+  // Everything after the local file data: central directory + EOCD.
+  const partC = Buffer.from(buf.subarray(localDataOffset + compressedSize))
+  partC.writeUInt16LE(partC.readUInt16LE(8) | 0x1, 8) // CENFLG |= FLG_ENC
+  partC.writeUInt32LE(encrypted.length, 20) // CENSIZ
+
+  const eocdSig = 0x06054b50
+  let eocdOffset = -1
+  for (let i = 0; i <= partC.length - 4; i++) {
+    if (partC.readUInt32LE(i) === eocdSig) {
+      eocdOffset = i
+      break
+    }
+  }
+  if (eocdOffset === -1) {
+    throw new Error('Test fixture builder could not locate the EOCD record')
+  }
+  const endOff = partC.readUInt32LE(eocdOffset + 16)
+  partC.writeUInt32LE(endOff + delta, eocdOffset + 16)
+
+  writeFileSync(path, Buffer.concat([partA, encrypted, partC]))
+}
+
 describe('ZipExtractor.testPassword', () => {
   it('throws when the archive itself cannot be opened (corrupt/not a zip)', () => {
     const dir = makeTempDir()
@@ -70,18 +208,48 @@ describe('ZipExtractor.testPassword', () => {
     expect(() => extractor.testPassword(garbagePath, 'anypassword')).toThrow()
   })
 
-  it('returns false (not throw) when the archive opens but entry data fails to read — legitimate wrong-password-shaped outcome', () => {
+  it('throws when a NON-encrypted entry fails to read (corrupt archive, not a wrong password)', () => {
     const dir = makeTempDir()
     const corruptEntryPath = join(dir, 'corrupt-entry.zip')
     writeZipWithCorruptEntryData(corruptEntryPath)
 
     const extractor = new ZipExtractor()
 
+    expect(() => extractor.testPassword(corruptEntryPath, 'anypassword')).toThrow()
+  })
+
+  it('returns false (not throw) when an ENCRYPTED entry fails to decrypt with the given password — legitimate wrong-password outcome', () => {
+    const dir = makeTempDir()
+    const encryptedPath = join(dir, 'encrypted.zip')
+    writeEncryptedZip(
+      encryptedPath,
+      'case.json',
+      JSON.stringify({ hello: 'world' }),
+      'correct-password'
+    )
+
+    const extractor = new ZipExtractor()
+
     let result: boolean | undefined
     expect(() => {
-      result = extractor.testPassword(corruptEntryPath, 'anypassword')
+      result = extractor.testPassword(encryptedPath, 'totally-wrong-password')
     }).not.toThrow()
     expect(result).toBe(false)
+  })
+
+  it('returns true for an ENCRYPTED entry when the correct password is given', () => {
+    const dir = makeTempDir()
+    const encryptedPath = join(dir, 'encrypted-correct.zip')
+    writeEncryptedZip(
+      encryptedPath,
+      'case.json',
+      JSON.stringify({ hello: 'world' }),
+      'correct-password'
+    )
+
+    const extractor = new ZipExtractor()
+
+    expect(extractor.testPassword(encryptedPath, 'correct-password')).toBe(true)
   })
 
   it('preserves the legitimate outcome: a valid, readable archive does not throw', () => {

--- a/tests/main/import/ZipExtractor.test.ts
+++ b/tests/main/import/ZipExtractor.test.ts
@@ -4,12 +4,14 @@
  * - The archive itself cannot be opened/parsed (corrupt file, bad format,
  *   truncated data) — an infrastructure fault. This must throw, not be
  *   reported as "wrong password".
- * - The first entry IS encrypted and the given password fails to decrypt
- *   it — the legitimate "wrong password" domain outcome. This must still
- *   return `false`, not throw.
- * - The first entry is NOT encrypted but still fails to read/decode/CRC
- *   check (a corrupt, unencrypted archive) — this is an infrastructure
- *   fault too and must throw, not be reported as "wrong password".
+ * - An encrypted entry rejects the given password — the legitimate "wrong
+ *   password" domain outcome. Validation must continue through later entries
+ *   before returning `false`, so ordering cannot hide corruption.
+ * - A non-password read/decode/CRC failure is an infrastructure fault and
+ *   must throw, whether its entry is encrypted or not.
+ * - A readable archive without encrypted entries returns `false`; success
+ *   requires at least one encrypted entry and a password accepted by all of
+ *   them.
  *
  * Before the first fix, the unopenable-archive and corrupt-entry-data
  * classes were both caught by a single try/catch and collapsed into
@@ -17,16 +19,21 @@
  * password (finding C8 / Codex F-05). A follow-up review found the second
  * fix still collapsed a corrupt UNENCRYPTED entry into the same `false`
  * "wrong password" shape as a genuinely encrypted entry with the wrong
- * password — this file now covers both classes explicitly by checking the
- * entry's encryption flag before deciding.
+ * password. A later review found password rejection also returned early and
+ * could hide corruption in subsequent entries. This file locks all outcomes.
  */
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import AdmZip from 'adm-zip'
-import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
 import { ZipExtractor } from '../../../src/main/import/ZipExtractor'
+import { mainLogger } from '../../../src/main/services/MainLogger'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), 'varlens-zipextractor-test-'))
@@ -68,6 +75,33 @@ function writeZipWithCorruptEntryData(path: string): void {
 
 function writeGarbageFile(path: string): void {
   writeFileSync(path, Buffer.from('this is not a zip file, just plain bytes'))
+}
+
+function makeStubArchive(
+  entries: Array<{
+    entryName: string
+    encrypted: boolean
+    declaredSize: number
+    getData: (password: string) => Buffer
+  }>
+): { zipPath: string; openArchive: () => AdmZip } {
+  const dir = makeTempDir()
+  const zipPath = join(dir, 'stub-source.zip')
+  writeValidZip(zipPath)
+  const zipEntries = entries.map(
+    ({ entryName, encrypted, declaredSize, getData }) =>
+      ({
+        entryName,
+        isDirectory: false,
+        header: { encrypted, size: declaredSize },
+        getData
+      }) as unknown as AdmZip.IZipEntry
+  )
+
+  return {
+    zipPath,
+    openArchive: () => ({ getEntries: () => zipEntries }) as unknown as AdmZip
+  }
 }
 
 // ── Minimal traditional PKZIP (ZipCrypto) encryption ──────────────────────
@@ -343,13 +377,187 @@ describe('ZipExtractor.testPassword', () => {
     expect(extractor.testPassword(encryptedPath, 'wrong-password')).toBe(false)
   })
 
-  it('preserves the legitimate outcome: a valid, readable archive does not throw', () => {
+  it('continues after a wrong-password result and throws when a later entry is corrupt', () => {
+    const wrongPasswordRead = vi.fn(() => {
+      throw new Error('Wrong Password')
+    })
+    const corruptRead = vi.fn(() => {
+      throw new Error('CRC mismatch')
+    })
+    const { zipPath, openArchive } = makeStubArchive([
+      {
+        entryName: 'first.json',
+        encrypted: true,
+        declaredSize: 2,
+        getData: wrongPasswordRead
+      },
+      {
+        entryName: 'second.json',
+        encrypted: true,
+        declaredSize: 2,
+        getData: corruptRead
+      }
+    ])
+
+    const extractor = new ZipExtractor(undefined, openArchive)
+
+    expect(() => extractor.testPassword(zipPath, 'wrong')).toThrow(/corrupt/i)
+    expect(wrongPasswordRead).toHaveBeenCalledOnce()
+    expect(corruptRead).toHaveBeenCalledOnce()
+  })
+
+  it('checks later encrypted entries before returning the aggregated wrong-password result', () => {
+    const wrongPasswordRead = vi.fn(() => {
+      throw new Error('Wrong Password')
+    })
+    const successfulRead = vi.fn(() => Buffer.from('{}'))
+    const { zipPath, openArchive } = makeStubArchive([
+      {
+        entryName: 'first.json',
+        encrypted: true,
+        declaredSize: 2,
+        getData: wrongPasswordRead
+      },
+      {
+        entryName: 'second.json',
+        encrypted: true,
+        declaredSize: 2,
+        getData: successfulRead
+      }
+    ])
+
+    const extractor = new ZipExtractor(undefined, openArchive)
+
+    expect(extractor.testPassword(zipPath, 'wrong')).toBe(false)
+    expect(wrongPasswordRead).toHaveBeenCalledOnce()
+    expect(successfulRead).toHaveBeenCalledOnce()
+  })
+
+  it('returns false when no encrypted entry exists', () => {
     const dir = makeTempDir()
     const validPath = join(dir, 'valid.zip')
     writeValidZip(validPath)
 
     const extractor = new ZipExtractor()
 
-    expect(() => extractor.testPassword(validPath, 'irrelevant')).not.toThrow()
+    expect(extractor.testPassword(validPath, 'irrelevant')).toBe(false)
+  })
+
+  it('rejects a declared entry size above the password-validation limit before decoding', () => {
+    const getData = vi.fn(() => Buffer.alloc(5))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'large.json', encrypted: true, declaredSize: 5, getData }
+    ])
+
+    const extractor = new ZipExtractor(
+      {
+        maxEntryUncompressedBytes: 4,
+        maxTotalUncompressedBytes: 10
+      },
+      openArchive
+    )
+
+    expect(() => extractor.testPassword(zipPath, 'secret')).toThrow(/limit/i)
+    expect(getData).not.toHaveBeenCalled()
+  })
+
+  it('rejects actual decoded data above the declared per-entry limit', () => {
+    const getData = vi.fn(() => Buffer.alloc(5))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'lying-header.json', encrypted: true, declaredSize: 1, getData }
+    ])
+
+    const extractor = new ZipExtractor(
+      {
+        maxEntryUncompressedBytes: 4,
+        maxTotalUncompressedBytes: 10
+      },
+      openArchive
+    )
+
+    expect(() => extractor.testPassword(zipPath, 'secret')).toThrow(/limit/i)
+    expect(getData).toHaveBeenCalledOnce()
+  })
+
+  it('rejects entries whose cumulative declared size exceeds the validation limit', () => {
+    const firstRead = vi.fn(() => Buffer.alloc(4))
+    const secondRead = vi.fn(() => Buffer.alloc(4))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'first.json', encrypted: true, declaredSize: 4, getData: firstRead },
+      { entryName: 'second.json', encrypted: true, declaredSize: 4, getData: secondRead }
+    ])
+
+    const extractor = new ZipExtractor(
+      {
+        maxEntryUncompressedBytes: 5,
+        maxTotalUncompressedBytes: 6
+      },
+      openArchive
+    )
+
+    expect(() => extractor.testPassword(zipPath, 'secret')).toThrow(/limit/i)
+    expect(firstRead).toHaveBeenCalledOnce()
+    expect(secondRead).not.toHaveBeenCalled()
+  })
+
+  it('does not expose the supplied password through corruption errors or logs', () => {
+    const password = 'sentinel-password-never-log'
+    const getData = vi.fn(() => {
+      throw new Error(`CRC mismatch while using ${password}`)
+    })
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'corrupt.json', encrypted: true, declaredSize: 2, getData }
+    ])
+    const errorSpy = vi.spyOn(mainLogger, 'error').mockImplementation(() => undefined)
+    const extractor = new ZipExtractor(undefined, openArchive)
+
+    let thrown: unknown
+    try {
+      extractor.testPassword(zipPath, password)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(String(thrown)).not.toContain(password)
+    expect(String((thrown as Error).cause)).not.toContain(password)
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(password)
+  })
+})
+
+describe('ZipExtractor.extract', () => {
+  it('rejects case-insensitive flattened basename collisions before writing any output', async () => {
+    const dir = makeTempDir()
+    const zipPath = join(dir, 'duplicate-basename.zip')
+    const targetDir = makeTempDir()
+    const zip = new AdmZip()
+    zip.addFile('case-a/sample.json', Buffer.from('{"case":"a"}'))
+    zip.addFile('case-b/SAMPLE.JSON', Buffer.from('{"case":"b"}'))
+    zip.writeZip(zipPath)
+
+    const extractor = new ZipExtractor()
+    const result = await extractor.extract(zipPath, targetDir)
+
+    expect(result.extractedFiles).toEqual([])
+    expect(result.errors.join(' ')).toMatch(/duplicate.*basename/i)
+    expect(readdirSync(targetDir)).toEqual([])
+  })
+
+  it('redacts the supplied password from per-entry extraction errors', async () => {
+    const password = 'sentinel-extraction-password'
+    const getData = vi.fn(() => {
+      throw new Error(`decryption failed for ${password}`)
+    })
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'secret.json', encrypted: true, declaredSize: 2, getData }
+    ])
+    const targetDir = makeTempDir()
+    const extractor = new ZipExtractor(undefined, openArchive)
+
+    const result = await extractor.extract(zipPath, targetDir, password)
+
+    expect(result.errors).toHaveLength(1)
+    expect(JSON.stringify(result)).not.toContain(password)
+    expect(readdirSync(targetDir)).toEqual([])
   })
 })

--- a/tests/main/import/ZipExtractor.test.ts
+++ b/tests/main/import/ZipExtractor.test.ts
@@ -25,7 +25,7 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
 import AdmZip from 'adm-zip'
 import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { basename, dirname, join } from 'path'
 import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
 import { ZipExtractor } from '../../../src/main/import/ZipExtractor'
@@ -155,7 +155,10 @@ function zipCryptoDecryptByte(keys: Uint32Array): number {
  */
 function zipCryptoEncrypt(data: Buffer, crc: number, password: string): Buffer {
   const { keys, update } = makeZipCryptoKeys(password)
-  const header = Buffer.from(randomBytes(12))
+  // Deterministic salt bytes keep the wrong-password regression stable. With
+  // random bytes, ZipCrypto's one-byte verifier has a 1/256 chance of accepting
+  // the wrong password and failing later as CRC corruption instead.
+  const header = Buffer.alloc(12)
   header[11] = (crc >>> 24) & 0xff
 
   const out = Buffer.alloc(12 + data.length)
@@ -526,6 +529,125 @@ describe('ZipExtractor.testPassword', () => {
 })
 
 describe('ZipExtractor.extract', () => {
+  it('rejects a declared entry size above the extraction limit before decoding', async () => {
+    const getData = vi.fn(() => Buffer.alloc(5))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'large.json', encrypted: false, declaredSize: 5, getData }
+    ])
+    const targetDir = makeTempDir()
+    const extractor = new ZipExtractor(
+      { maxEntryUncompressedBytes: 4, maxTotalUncompressedBytes: 10 },
+      openArchive
+    )
+
+    const result = await extractor.extract(zipPath, targetDir)
+
+    expect(result.errors.join(' ')).toMatch(/limit/i)
+    expect(result.extractedFiles).toEqual([])
+    expect(getData).not.toHaveBeenCalled()
+    expect(readdirSync(targetDir)).toEqual([])
+  })
+
+  it('rejects decoded entry data above the extraction limit before writing', async () => {
+    const getData = vi.fn(() => Buffer.alloc(5))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'lying-header.json', encrypted: false, declaredSize: 1, getData }
+    ])
+    const targetDir = makeTempDir()
+    const extractor = new ZipExtractor(
+      { maxEntryUncompressedBytes: 4, maxTotalUncompressedBytes: 10 },
+      openArchive
+    )
+
+    const result = await extractor.extract(zipPath, targetDir)
+
+    expect(result.errors.join(' ')).toMatch(/limit/i)
+    expect(result.extractedFiles).toEqual([])
+    expect(getData).toHaveBeenCalledOnce()
+    expect(readdirSync(targetDir)).toEqual([])
+  })
+
+  it('rejects a cumulative declared extraction size before decoding any entry', async () => {
+    const firstRead = vi.fn(() => Buffer.alloc(4))
+    const secondRead = vi.fn(() => Buffer.alloc(4))
+    const { zipPath, openArchive } = makeStubArchive([
+      { entryName: 'first.json', encrypted: false, declaredSize: 4, getData: firstRead },
+      { entryName: 'second.json', encrypted: false, declaredSize: 4, getData: secondRead }
+    ])
+    const targetDir = makeTempDir()
+    const extractor = new ZipExtractor(
+      { maxEntryUncompressedBytes: 5, maxTotalUncompressedBytes: 6 },
+      openArchive
+    )
+
+    const result = await extractor.extract(zipPath, targetDir)
+
+    expect(result.errors.join(' ')).toMatch(/total limit/i)
+    expect(result.extractedFiles).toEqual([])
+    expect(firstRead).not.toHaveBeenCalled()
+    expect(secondRead).not.toHaveBeenCalled()
+    expect(readdirSync(targetDir)).toEqual([])
+  })
+
+  it('rejects cumulative decoded extraction data before writing the overflowing entry', async () => {
+    const thirdRead = vi.fn(() => Buffer.alloc(1, 3))
+    const { zipPath, openArchive } = makeStubArchive([
+      {
+        entryName: 'first.json',
+        encrypted: false,
+        declaredSize: 1,
+        getData: () => Buffer.alloc(4, 1)
+      },
+      {
+        entryName: 'second.json',
+        encrypted: false,
+        declaredSize: 1,
+        getData: () => Buffer.alloc(4, 2)
+      },
+      {
+        entryName: 'third.json',
+        encrypted: false,
+        declaredSize: 1,
+        getData: thirdRead
+      }
+    ])
+    const targetDir = makeTempDir()
+    const extractor = new ZipExtractor(
+      { maxEntryUncompressedBytes: 5, maxTotalUncompressedBytes: 6 },
+      openArchive
+    )
+
+    const result = await extractor.extract(zipPath, targetDir)
+
+    expect(result.errors.join(' ')).toMatch(/total limit/i)
+    expect(result.extractedFiles).toHaveLength(1)
+    expect(basename(result.extractedFiles[0])).toBe('first.json')
+    expect(thirdRead).not.toHaveBeenCalled()
+  })
+
+  it('isolates Unicode caseless-equivalent basenames without changing their basenames', async () => {
+    const dir = makeTempDir()
+    const zipPath = join(dir, 'unicode-basename.zip')
+    const targetDir = makeTempDir()
+    const zip = new AdmZip()
+    zip.addFile('case-a/FUSS.json', Buffer.from('{"case":"ascii"}'))
+    zip.addFile('case-b/Fu\u00df.JSON', Buffer.from('{"case":"unicode"}'))
+    zip.writeZip(zipPath)
+
+    const result = await new ZipExtractor().extract(zipPath, targetDir)
+
+    expect(result.errors).toEqual([])
+    expect(result.extractedFiles.map((path) => basename(path))).toEqual([
+      'FUSS.json',
+      'Fu\u00df.JSON'
+    ])
+    expect(new Set(result.extractedFiles.map((path) => dirname(path))).size).toBe(2)
+    expect(result.extractedFiles.map((path) => readFileSync(path, 'utf8'))).toEqual([
+      '{"case":"ascii"}',
+      '{"case":"unicode"}'
+    ])
+  })
+
   it('rejects case-insensitive flattened basename collisions before writing any output', async () => {
     const dir = makeTempDir()
     const zipPath = join(dir, 'duplicate-basename.zip')

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -1,0 +1,156 @@
+/**
+ * batch-import IPC handler tests.
+ *
+ * Covers the two batch-import.ts catch sites from finding C8 / Codex F-05:
+ * - `selectFolder`: a directory-read failure must surface as a structured
+ *   IPC error, not masquerade as an empty folder (`[]`).
+ * - `selectZip` (bonus, same citation): a dialog/settings failure must
+ *   surface as an error, not masquerade as "user cancelled" (`null`).
+ *
+ * `batch-import-logic` is mocked because these two handlers don't delegate
+ * to it for the behavior under test — that module has its own dedicated
+ * tests (tests/main/handlers/batch-import-logic.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isIpcError } from '../../../../src/shared/types/errors'
+
+const { showOpenDialog, readdir, loadSettings, saveSettings } = vi.hoisted(() => ({
+  showOpenDialog: vi.fn(),
+  readdir: vi.fn(),
+  loadSettings: vi.fn(),
+  saveSettings: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog }
+}))
+
+vi.mock('fs/promises', () => ({
+  readdir
+}))
+
+vi.mock('../../../../src/main/ipc/utils/settings-io', () => ({
+  loadSettings,
+  saveSettings
+}))
+
+vi.mock('../../../../src/main/ipc/utils/safeEmit', () => ({
+  safeEmit: vi.fn()
+}))
+
+vi.mock('../../../../src/main/ipc/handlers/batch-import-logic', () => ({
+  checkDuplicateFiles: vi.fn(),
+  startBatchImport: vi.fn(),
+  cancelBatchImport: vi.fn(),
+  testZipPassword: vi.fn(),
+  extractZip: vi.fn(),
+  cleanupZipTemp: vi.fn()
+}))
+
+vi.mock('../../../../src/main/import', () => ({
+  ZipExtractor: class {
+    isEncrypted(): boolean {
+      return false
+    }
+  }
+}))
+
+import { registerBatchImportHandlers } from '../../../../src/main/ipc/handlers/batch-import'
+
+type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+function makeIpcMain(): { handle: ReturnType<typeof vi.fn> } {
+  return { handle: vi.fn() }
+}
+
+function getHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string
+): HandlerCallback {
+  const call = ipcMain.handle.mock.calls.find(([c]) => c === channel) as
+    [string, HandlerCallback] | undefined
+  if (!call) throw new Error(`Handler for ${channel} not registered`)
+  return call[1]
+}
+
+async function invokeHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  const handler = getHandler(ipcMain, channel)
+  return handler({}, ...args)
+}
+
+describe('batch-import IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    loadSettings.mockResolvedValue({})
+    saveSettings.mockResolvedValue(undefined)
+  })
+
+  describe('batch-import:selectFolder', () => {
+    it('surfaces a directory-read failure as a structured error, not an empty folder', async () => {
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/data/import'] })
+      readdir.mockRejectedValue(new Error('EACCES: permission denied'))
+
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:selectFolder')
+
+      expect(isIpcError(result)).toBe(true)
+      expect(result).not.toEqual([])
+    })
+
+    it('preserves the legitimate outcome: user cancelling the dialog still returns []', async () => {
+      showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:selectFolder')
+
+      expect(result).toEqual([])
+      expect(readdir).not.toHaveBeenCalled()
+    })
+
+    it('preserves the legitimate outcome: a genuinely empty folder returns []', async () => {
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/data/empty'] })
+      readdir.mockResolvedValue([])
+
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:selectFolder')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('batch-import:selectZip', () => {
+    it('surfaces a settings/dialog failure as a structured error, not "user cancelled"', async () => {
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/data/archive.zip'] })
+      saveSettings.mockRejectedValue(new Error('ENOSPC: no space left on device'))
+
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:selectZip')
+
+      expect(isIpcError(result)).toBe(true)
+      expect(result).not.toBeNull()
+    })
+
+    it('preserves the legitimate outcome: user cancelling the dialog still returns null', async () => {
+      showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:selectZip')
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -14,11 +14,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { isIpcError } from '../../../../src/shared/types/errors'
 
-const { showOpenDialog, readdir, loadSettings, saveSettings } = vi.hoisted(() => ({
+const { showOpenDialog, readdir, loadSettings, saveSettings, cleanupZipTemp } = vi.hoisted(() => ({
   showOpenDialog: vi.fn(),
   readdir: vi.fn(),
   loadSettings: vi.fn(),
-  saveSettings: vi.fn()
+  saveSettings: vi.fn(),
+  cleanupZipTemp: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -44,7 +45,7 @@ vi.mock('../../../../src/main/ipc/handlers/batch-import-logic', () => ({
   cancelBatchImport: vi.fn(),
   testZipPassword: vi.fn(),
   extractZip: vi.fn(),
-  cleanupZipTemp: vi.fn()
+  cleanupZipTemp
 }))
 
 vi.mock('../../../../src/main/import', () => ({
@@ -151,6 +152,32 @@ describe('batch-import IPC handlers', () => {
       const result = await invokeHandler(ipcMain, 'batch-import:selectZip')
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('batch-import:cleanupZipTemp', () => {
+    it('passes extraction-scoped cleanup authority to the logic layer', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:cleanupZipTemp',
+        '11111111-1111-4111-8111-111111111111'
+      )
+
+      expect(isIpcError(result)).toBe(false)
+      expect(cleanupZipTemp).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111')
+    })
+
+    it('rejects missing cleanup authority instead of performing global cleanup', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers({ ipcMain, getDb: vi.fn() } as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:cleanupZipTemp')
+
+      expect(isIpcError(result)).toBe(true)
+      expect(cleanupZipTemp).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/main/storage/postgres-cohort-repository.test.ts
+++ b/tests/main/storage/postgres-cohort-repository.test.ts
@@ -194,6 +194,29 @@ describe('PostgresCohortRepository', () => {
     expect(dataParams).toEqual(['1', 200, 100, 'GRCh37', 10, 0])
   })
 
+  it('propagates the error instead of silently running unfiltered when panel interval resolution fails', async () => {
+    // Clinical-safety guarantee: a panel IS active (active_panel_ids is
+    // non-empty) but the interval computation itself throws. The cohort
+    // query must reject (surface the failure) rather than silently fall
+    // back to an unfiltered result set — see PostgresCohortRepository's
+    // resolvePanelParams for the contract this mirrors from panelIntervalHelper.ts.
+    const query = vi.fn().mockResolvedValueOnce({ rows: [{ chr: '1' }] })
+    const resolveIntervals = vi
+      .fn()
+      .mockRejectedValue(new Error('Simulated panel interval computation failure'))
+    const repository = new PostgresCohortRepository({ query } as never, 'public', resolveIntervals)
+
+    await expect(
+      repository.queryVariants({
+        active_panel_ids: [3, 4],
+        panel_padding_bp: 7500,
+        genome_build: 'GRCh37',
+        limit: 10,
+        offset: 0
+      })
+    ).rejects.toThrow('Simulated panel interval computation failure')
+  })
+
   it('resolves active panels from PostgreSQL panel genes through gene reference coordinates', async () => {
     geneReferenceMocks.getCoordinatesForGenes.mockReturnValue(
       new Map([

--- a/tests/main/workers/db-worker-dispatch.test.ts
+++ b/tests/main/workers/db-worker-dispatch.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import Database from 'better-sqlite3-multiple-ciphers'
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
 import { initializeSchema } from '../../../src/main/database/schema'
@@ -137,6 +137,50 @@ describe('db-worker-dispatch', () => {
       params: [{ limit: 25, offset: 0 }]
     })
     expect(result).toBeDefined()
+  })
+
+  // ── Panel-interval failure propagation (clinical-safety) ───
+  //
+  // A panel-interval computation failure must make the whole task throw
+  // rather than silently continuing with an unfiltered query — a caught
+  // exception here must never be indistinguishable from "no panel active".
+
+  it('variants:query throws when panel interval computation fails (does not fall back to unfiltered)', () => {
+    const deps = makeDeps()
+    const fakeGeneRefDb = {
+      getCoordinatesForGenes: () => new Map()
+    } as unknown as import('../../../src/main/database/GeneReferenceDb').GeneReferenceDb
+    deps.geneRefDb = fakeGeneRefDb
+    vi.spyOn(deps.repos.panels, 'computeIntervals').mockImplementation(() => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+
+    const filter = { case_id: 0, active_panel_ids: [1] }
+    expect(() =>
+      dispatchTask(deps, {
+        type: 'variants:query',
+        params: [filter, 0, 25, [], false, false]
+      })
+    ).toThrow('Simulated panel interval computation failure')
+  })
+
+  it('cohort:variants throws when panel interval computation fails (does not fall back to unfiltered)', () => {
+    const deps = makeDeps()
+    const fakeGeneRefDb = {
+      getCoordinatesForGenes: () => new Map()
+    } as unknown as import('../../../src/main/database/GeneReferenceDb').GeneReferenceDb
+    deps.geneRefDb = fakeGeneRefDb
+    vi.spyOn(deps.repos.panels, 'computeIntervals').mockImplementation(() => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+
+    const cohortParams = { limit: 25, offset: 0, active_panel_ids: [1] }
+    expect(() =>
+      dispatchTask(deps, {
+        type: 'cohort:variants',
+        params: [cohortParams]
+      })
+    ).toThrow('Simulated panel interval computation failure')
   })
 
   it('cohort:carriers returns empty array for fresh DB', () => {
@@ -376,5 +420,32 @@ describe('resolvePanelIntervalsInPlace', () => {
     expect(filter.active_panel_ids).toBeUndefined()
     expect(filter.panel_padding_bp).toBeUndefined()
     expect(filter.genome_build).toBeUndefined()
+  })
+
+  it('propagates the error when panel interval computation fails instead of dropping the filter silently', () => {
+    const filter: PanelAwareFilter = {
+      active_panel_ids: [1, 2],
+      panel_padding_bp: 5000,
+      genome_build: 'GRCh38',
+      case_id: 1
+    }
+    const repos = createRepositories(db)
+    vi.spyOn(repos.panels, 'computeIntervals').mockImplementation(() => {
+      throw new Error('Simulated panel interval computation failure')
+    })
+    // geneRefDb must be non-null so the function actually attempts the
+    // computation instead of short-circuiting via the "unavailable" no-op path.
+    const fakeGeneRefDb = {
+      getCoordinatesForGenes: () => new Map()
+    } as unknown as import('../../../src/main/database/GeneReferenceDb').GeneReferenceDb
+
+    expect(() => resolvePanelIntervalsInPlace(filter, repos, fakeGeneRefDb, db, 1)).toThrow(
+      'Simulated panel interval computation failure'
+    )
+    // The filter must NOT have been silently downgraded to "no panel restriction":
+    // active_panel_ids should still be present since the fields are only cleaned
+    // up after a successful (or intentionally skipped) computation.
+    expect(filter.active_panel_ids).toEqual([1, 2])
+    expect(filter.panel_intervals).toBeUndefined()
   })
 })

--- a/tests/main/workers/db-worker-dispatch.test.ts
+++ b/tests/main/workers/db-worker-dispatch.test.ts
@@ -396,17 +396,24 @@ describe('resolvePanelIntervalsInPlace', () => {
     expect(filter.genome_build).toBeUndefined()
   })
 
-  it('removes IPC-only fields when geneRefDb is null', () => {
+  it('throws when a panel is active but geneRefDb is null instead of silently dropping the filter', () => {
+    // A non-empty active_panel_ids with a null geneRefDb means the panel
+    // cannot be resolved -- this must surface as an error, not silently
+    // clear the panel fields and let the query run unfiltered (clinical-
+    // safety hazard: a dropped filter must not look identical to "panel
+    // matched everything").
     const filter: PanelAwareFilter = {
       active_panel_ids: [1, 2],
       panel_padding_bp: 3000,
       genome_build: 'GRCh37'
     }
     const repos = createRepositories(db)
-    resolvePanelIntervalsInPlace(filter, repos, null, db)
-    expect(filter.active_panel_ids).toBeUndefined()
-    expect(filter.panel_padding_bp).toBeUndefined()
-    expect(filter.genome_build).toBeUndefined()
+    expect(() => resolvePanelIntervalsInPlace(filter, repos, null, db)).toThrow(
+      /gene reference database is unavailable/i
+    )
+    // The filter must NOT have been silently downgraded to "no panel
+    // restriction" before the throw.
+    expect(filter.active_panel_ids).toEqual([1, 2])
     expect(filter.panel_intervals).toBeUndefined()
   })
 

--- a/tests/renderer/components/ImportWizard.test.ts
+++ b/tests/renderer/components/ImportWizard.test.ts
@@ -7,8 +7,18 @@
  *
  * Also tests cancel behavior and error handling.
  */
-import { describe, it, expect } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { ref, isProxy } from 'vue'
+import ImportWizard from '../../../src/renderer/src/components/import/ImportWizard.vue'
+import ImportSourceSelector from '../../../src/renderer/src/components/import/ImportSourceSelector.vue'
+import { createMockApi, type MockApi } from '../../utils/mock-api'
+
+const vuetify = createVuetify({ components, directives })
 
 /**
  * Simulates Electron's structured clone validation.
@@ -159,5 +169,60 @@ describe('ImportWizard IPC safety', () => {
         'userMessage' in errorResponse ? errorResponse.userMessage : 'Import failed unexpectedly'
       expect(errorMsg).toBe('An unexpected error occurred.')
     })
+  })
+})
+
+describe('ImportWizard ZIP password unlock', () => {
+  let mockApi: MockApi
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockApi = createMockApi()
+    window.api = mockApi as unknown as typeof window.api
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces password-test IPC errors and clears loading', async () => {
+    mockApi.batchImport.selectZip = vi.fn().mockResolvedValue({
+      filePath: '/tmp/corrupt.zip',
+      isEncrypted: true
+    })
+    mockApi.batchImport.testZipPassword = vi.fn().mockResolvedValue({
+      code: 'PARSE_ERROR',
+      message: 'zip central directory missing',
+      userMessage: 'Could not read ZIP archive'
+    })
+
+    const wrapper = mount(ImportWizard, {
+      global: {
+        plugins: [vuetify]
+      },
+      attachTo: document.body
+    })
+    wrapper.vm.show()
+    await flushPromises()
+
+    wrapper.findComponent(ImportSourceSelector).vm.$emit('select', 'zip')
+    await flushPromises()
+
+    const password = document.body.querySelector('input[type="password"]')
+    expect(password).toBeInstanceOf(HTMLInputElement)
+    ;(password as HTMLInputElement).value = 'secret'
+    password!.dispatchEvent(new Event('input', { bubbles: true }))
+    const unlock = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Unlock')
+    )
+    expect(unlock).toBeInstanceOf(HTMLButtonElement)
+    unlock!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    expect(document.body.textContent).toContain('Could not read ZIP archive')
+    expect(document.body.textContent).not.toContain('[object Object]')
+    expect(document.body.querySelector('.v-progress-circular')).toBeNull()
   })
 })

--- a/tests/renderer/components/ImportWizard.test.ts
+++ b/tests/renderer/components/ImportWizard.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { ref, isProxy } from 'vue'
 import ImportWizard from '../../../src/renderer/src/components/import/ImportWizard.vue'
 import ImportSourceSelector from '../../../src/renderer/src/components/import/ImportSourceSelector.vue'
+import BatchReviewPhase from '../../../src/renderer/src/components/batch-import/BatchReviewPhase.vue'
 import { createMockApi, type MockApi } from '../../utils/mock-api'
 
 const vuetify = createVuetify({ components, directives })
@@ -175,6 +176,42 @@ describe('ImportWizard IPC safety', () => {
 describe('ImportWizard ZIP password unlock', () => {
   let mockApi: MockApi
 
+  function mountWizard(): ReturnType<typeof mount> {
+    return mount(ImportWizard, {
+      global: { plugins: [vuetify] },
+      attachTo: document.body
+    })
+  }
+
+  function prepareSuccessfulZipReview(): void {
+    mockApi.batchImport.selectZip = vi.fn().mockResolvedValue({
+      filePath: '/tmp/archive.zip',
+      isEncrypted: false
+    })
+    mockApi.batchImport.extractZip = vi.fn().mockResolvedValue({
+      files: ['/tmp/varlens-zip-entry/case.json'],
+      errors: []
+    })
+    mockApi.batchImport.checkDuplicates = vi.fn().mockResolvedValue({
+      files: [
+        {
+          filePath: '/tmp/varlens-zip-entry/case.json',
+          fileName: 'case.json',
+          caseName: 'case',
+          isDuplicate: false
+        }
+      ],
+      duplicateCount: 0
+    })
+  }
+
+  async function openZipReview(wrapper: ReturnType<typeof mount>): Promise<void> {
+    wrapper.vm.show()
+    await flushPromises()
+    wrapper.findComponent(ImportSourceSelector).vm.$emit('select', 'zip')
+    await flushPromises()
+  }
+
   beforeEach(() => {
     setActivePinia(createPinia())
     mockApi = createMockApi()
@@ -183,6 +220,7 @@ describe('ImportWizard ZIP password unlock', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     document.body.innerHTML = ''
     vi.restoreAllMocks()
   })
@@ -244,5 +282,92 @@ describe('ImportWizard ZIP password unlock', () => {
     await flushPromises()
 
     expect(document.body.textContent).toContain('No importable files found in archive')
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
+  })
+
+  it('cleans extracted ZIP data when the review dialog closes', async () => {
+    prepareSuccessfulZipReview()
+    const wrapper = mountWizard()
+    await openZipReview(wrapper)
+
+    wrapper.findComponent({ name: 'VDialog' }).vm.$emit('update:modelValue', false)
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
+  })
+
+  it('cleans extracted ZIP data when navigating back from review', async () => {
+    prepareSuccessfulZipReview()
+    const wrapper = mountWizard()
+    await openZipReview(wrapper)
+
+    const back = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Back')
+    )
+    expect(back).toBeInstanceOf(HTMLButtonElement)
+    back!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
+  })
+
+  it('cleans an abandoned ZIP extraction before opening a fresh wizard flow', async () => {
+    prepareSuccessfulZipReview()
+    const wrapper = mountWizard()
+    await openZipReview(wrapper)
+
+    wrapper.vm.show()
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
+  })
+
+  it('cleans ZIP data and surfaces an initial duplicate-check failure', async () => {
+    prepareSuccessfulZipReview()
+    mockApi.batchImport.checkDuplicates = vi.fn().mockResolvedValue({
+      code: 'DATABASE_ERROR',
+      message: 'database is locked',
+      userMessage: 'Could not check duplicate cases'
+    })
+    const wrapper = mountWizard()
+
+    await openZipReview(wrapper)
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
+    expect(document.body.textContent).toContain('Could not check duplicate cases')
+  })
+
+  it('invalidates stale review data and surfaces a debounced duplicate-check failure', async () => {
+    vi.useFakeTimers()
+    prepareSuccessfulZipReview()
+    mockApi.batchImport.checkDuplicates = vi
+      .fn()
+      .mockResolvedValueOnce({
+        files: [
+          {
+            filePath: '/tmp/varlens-zip-entry/case.json',
+            fileName: 'case.json',
+            caseName: 'case',
+            isDuplicate: false
+          }
+        ],
+        duplicateCount: 0
+      })
+      .mockResolvedValueOnce({
+        code: 'DATABASE_ERROR',
+        message: 'database is locked',
+        userMessage: 'Could not refresh duplicate cases'
+      })
+    const wrapper = mountWizard()
+    await openZipReview(wrapper)
+
+    wrapper.findComponent(BatchReviewPhase).vm.$emit('update:stripText', '_results')
+    await wrapper.vm.$nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
+    expect(document.body.textContent).toContain('Could not refresh duplicate cases')
+    expect(document.body.textContent).not.toContain('case.json')
   })
 })

--- a/tests/renderer/components/ImportWizard.test.ts
+++ b/tests/renderer/components/ImportWizard.test.ts
@@ -225,4 +225,24 @@ describe('ImportWizard ZIP password unlock', () => {
     expect(document.body.textContent).not.toContain('[object Object]')
     expect(document.body.querySelector('.v-progress-circular')).toBeNull()
   })
+
+  it('surfaces an archive with no importable files instead of silently doing nothing', async () => {
+    mockApi.batchImport.selectZip = vi.fn().mockResolvedValue({
+      filePath: '/tmp/empty.zip',
+      isEncrypted: false
+    })
+    mockApi.batchImport.extractZip = vi.fn().mockResolvedValue({ files: [], errors: [] })
+
+    const wrapper = mount(ImportWizard, {
+      global: { plugins: [vuetify] },
+      attachTo: document.body
+    })
+    wrapper.vm.show()
+    await flushPromises()
+
+    wrapper.findComponent(ImportSourceSelector).vm.$emit('select', 'zip')
+    await flushPromises()
+
+    expect(document.body.textContent).toContain('No importable files found in archive')
+  })
 })

--- a/tests/renderer/components/ImportWizard.test.ts
+++ b/tests/renderer/components/ImportWizard.test.ts
@@ -47,6 +47,17 @@ function assertStructuredCloneable(value: unknown, path = 'root'): void {
   }
 }
 
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe('ImportWizard IPC safety', () => {
   describe('Vue reactive Proxy detection', () => {
     it('should detect that ref<string[]>.value is a Proxy', () => {
@@ -190,7 +201,8 @@ describe('ImportWizard ZIP password unlock', () => {
     })
     mockApi.batchImport.extractZip = vi.fn().mockResolvedValue({
       files: ['/tmp/varlens-zip-entry/case.json'],
-      errors: []
+      errors: [],
+      extractionId: '11111111-1111-4111-8111-111111111111'
     })
     mockApi.batchImport.checkDuplicates = vi.fn().mockResolvedValue({
       files: [
@@ -269,7 +281,11 @@ describe('ImportWizard ZIP password unlock', () => {
       filePath: '/tmp/empty.zip',
       isEncrypted: false
     })
-    mockApi.batchImport.extractZip = vi.fn().mockResolvedValue({ files: [], errors: [] })
+    mockApi.batchImport.extractZip = vi.fn().mockResolvedValue({
+      files: [],
+      errors: [],
+      extractionId: '11111111-1111-4111-8111-111111111111'
+    })
 
     const wrapper = mount(ImportWizard, {
       global: { plugins: [vuetify] },
@@ -369,5 +385,132 @@ describe('ImportWizard ZIP password unlock', () => {
     expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledOnce()
     expect(document.body.textContent).toContain('Could not refresh duplicate cases')
     expect(document.body.textContent).not.toContain('case.json')
+  })
+
+  it('cleans a late stale extraction without replacing the current cleanup authority', async () => {
+    const staleExtraction = deferred<{
+      files: string[]
+      errors: string[]
+      extractionId: string
+    }>()
+    mockApi.batchImport.selectZip = vi.fn().mockResolvedValue({
+      filePath: '/tmp/archive.zip',
+      isEncrypted: false
+    })
+    mockApi.batchImport.extractZip = vi
+      .fn()
+      .mockReturnValueOnce(staleExtraction.promise)
+      .mockResolvedValueOnce({
+        files: ['/tmp/current/case.json'],
+        errors: [],
+        extractionId: '22222222-2222-4222-8222-222222222222'
+      })
+    mockApi.batchImport.checkDuplicates = vi.fn().mockResolvedValue({
+      files: [
+        {
+          filePath: '/tmp/current/case.json',
+          fileName: 'case.json',
+          caseName: 'case',
+          isDuplicate: false
+        }
+      ],
+      duplicateCount: 0
+    })
+    const wrapper = mountWizard()
+
+    wrapper.vm.show()
+    await flushPromises()
+    wrapper.findComponent(ImportSourceSelector).vm.$emit('select', 'zip')
+    await flushPromises()
+    wrapper.vm.show()
+    await flushPromises()
+    wrapper.findComponent(ImportSourceSelector).vm.$emit('select', 'zip')
+    await flushPromises()
+
+    staleExtraction.resolve({
+      files: ['/tmp/stale/case.json'],
+      errors: [],
+      extractionId: '11111111-1111-4111-8111-111111111111'
+    })
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111'
+    )
+
+    wrapper.findComponent({ name: 'VDialog' }).vm.$emit('update:modelValue', false)
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledWith(
+      '22222222-2222-4222-8222-222222222222'
+    )
+  })
+
+  it('waits for the terminal cancelled result before cleaning ZIP data', async () => {
+    prepareSuccessfulZipReview()
+    const completion = deferred<{
+      succeeded: number
+      failed: number
+      skipped: number
+      cancelled: boolean
+      details: []
+    }>()
+    mockApi.batchImport.start = vi.fn().mockReturnValue(completion.promise)
+    mockApi.batchImport.cancel = vi.fn().mockResolvedValue(undefined)
+    const wrapper = mountWizard()
+    await openZipReview(wrapper)
+
+    const start = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Import 1 file')
+    )
+    expect(start).toBeInstanceOf(HTMLButtonElement)
+    start!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    const cancel = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Cancel')
+    )
+    expect(cancel).toBeInstanceOf(HTMLButtonElement)
+    cancel!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    expect(mockApi.batchImport.cancel).toHaveBeenCalledOnce()
+    expect(mockApi.batchImport.cleanupZipTemp).not.toHaveBeenCalled()
+
+    completion.resolve({
+      succeeded: 0,
+      failed: 0,
+      skipped: 0,
+      cancelled: true,
+      details: []
+    })
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111'
+    )
+  })
+
+  it('cleans ZIP data when starting the batch import fails', async () => {
+    prepareSuccessfulZipReview()
+    mockApi.batchImport.start = vi.fn().mockResolvedValue({
+      code: 'UNKNOWN',
+      message: 'worker failed to start',
+      userMessage: 'Could not start import'
+    })
+    const wrapper = mountWizard()
+    await openZipReview(wrapper)
+
+    const start = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Import 1 file')
+    )
+    expect(start).toBeInstanceOf(HTMLButtonElement)
+    start!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111'
+    )
+    expect(document.body.textContent).toContain('Could not start import')
   })
 })

--- a/tests/renderer/composables/useZipImportCleanup.test.ts
+++ b/tests/renderer/composables/useZipImportCleanup.test.ts
@@ -1,0 +1,165 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useZipImportCleanup } from '../../../src/renderer/src/composables/useZipImportCleanup'
+import type { DuplicateCheckResult } from '../../../src/shared/types/api'
+import type { IpcResult } from '../../../src/shared/types/errors'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function createHarness(checkDuplicatesRequest: ReturnType<typeof vi.fn>) {
+  const cleanupRequest = vi.fn(async () => undefined)
+  const importStore = {
+    importError: vi.fn()
+  }
+  const state = {
+    step: ref(2),
+    selectedFilePaths: ref(['/tmp/current.json']),
+    reviewFiles: ref([]),
+    duplicateCount: ref(0),
+    stripText: ref(''),
+    isZipImport: ref(true),
+    zipPath: ref('/tmp/archive.zip'),
+    zipExtractionId: ref('extraction-current'),
+    zipPasswordNeeded: ref(false),
+    zipPassword: ref(''),
+    zipError: ref(''),
+    showZipPassword: ref(false),
+    zipUnlocking: ref(false)
+  }
+  const cleanup = useZipImportCleanup({
+    cleanupRequest,
+    checkDuplicatesRequest,
+    importStore: importStore as never,
+    state
+  })
+  return { cleanup, cleanupRequest, importStore, state }
+}
+
+describe('useZipImportCleanup request ownership', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('ignores an older duplicate response that resolves after a newer response', async () => {
+    vi.useFakeTimers()
+    const first = deferred<IpcResult<DuplicateCheckResult>>()
+    const second = deferred<IpcResult<DuplicateCheckResult>>()
+    const request = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const { cleanup, state } = createHarness(request)
+
+    cleanup.scheduleDuplicateRecheck()
+    await vi.advanceTimersByTimeAsync(300)
+    state.stripText.value = 'new'
+    cleanup.scheduleDuplicateRecheck()
+    await vi.advanceTimersByTimeAsync(300)
+
+    second.resolve({ files: [], duplicateCount: 2 })
+    await second.promise
+    first.resolve({ files: [], duplicateCount: 1 })
+    await first.promise
+    await Promise.resolve()
+
+    expect(state.duplicateCount.value).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it('does not let a stale duplicate failure clean the current extraction', async () => {
+    vi.useFakeTimers()
+    const first = deferred<IpcResult<DuplicateCheckResult>>()
+    const second = deferred<IpcResult<DuplicateCheckResult>>()
+    const request = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const { cleanup, cleanupRequest, state } = createHarness(request)
+
+    cleanup.scheduleDuplicateRecheck()
+    await vi.advanceTimersByTimeAsync(300)
+    state.stripText.value = 'new'
+    cleanup.scheduleDuplicateRecheck()
+    await vi.advanceTimersByTimeAsync(300)
+    second.resolve({ files: [], duplicateCount: 0 })
+    await second.promise
+    first.resolve({ code: 'DATABASE_ERROR', message: 'old request failed' } as never)
+    await first.promise
+    await Promise.resolve()
+
+    expect(cleanupRequest).not.toHaveBeenCalled()
+    expect(state.zipExtractionId.value).toBe('extraction-current')
+    vi.useRealTimers()
+  })
+
+  it('sends the captured extraction ID when abandoning ZIP state', async () => {
+    const { cleanup, cleanupRequest, state } = createHarness(vi.fn())
+
+    cleanup.abandonZipImport('close')
+    await Promise.resolve()
+
+    expect(cleanupRequest).toHaveBeenCalledWith('extraction-current')
+    expect(state.zipExtractionId.value).toBe('')
+  })
+
+  it('retains cleanup authority after a failure so cleanup can be retried', async () => {
+    const { cleanup, cleanupRequest, importStore, state } = createHarness(vi.fn())
+    cleanupRequest.mockResolvedValueOnce({
+      code: 'UNKNOWN',
+      message: 'directory is busy',
+      userMessage: 'Could not clean temporary files'
+    })
+
+    await cleanup.cleanupZipTemp('first attempt')
+
+    expect(state.zipExtractionId.value).toBe('extraction-current')
+    expect(importStore.importError).toHaveBeenCalled()
+
+    await cleanup.cleanupZipTemp('retry')
+
+    expect(cleanupRequest).toHaveBeenCalledTimes(2)
+    expect(state.zipExtractionId.value).toBe('')
+  })
+
+  it('retries failed abandoned-extraction cleanup on the next lifecycle cleanup', async () => {
+    const { cleanup, cleanupRequest } = createHarness(vi.fn())
+    cleanupRequest.mockResolvedValueOnce({
+      code: 'UNKNOWN',
+      message: 'directory is busy',
+      userMessage: 'Could not clean temporary files'
+    })
+
+    cleanup.abandonZipImport('dialog close')
+    await Promise.resolve()
+    await Promise.resolve()
+    await cleanup.cleanupZipTemp('next dialog close')
+
+    expect(cleanupRequest).toHaveBeenNthCalledWith(1, 'extraction-current')
+    expect(cleanupRequest).toHaveBeenNthCalledWith(2, 'extraction-current')
+  })
+
+  it('retries cleanup lost from duplicate-check failure state on the next lifecycle cleanup', async () => {
+    const { cleanup, cleanupRequest, state } = createHarness(vi.fn())
+    cleanupRequest.mockResolvedValueOnce({
+      code: 'UNKNOWN',
+      message: 'directory is busy',
+      userMessage: 'Could not clean temporary files'
+    })
+
+    await cleanup.handleDuplicateCheckFailure(new Error('duplicate check failed'))
+    expect(state.zipExtractionId.value).toBe('')
+
+    await cleanup.cleanupZipTemp('next dialog close')
+
+    expect(cleanupRequest).toHaveBeenNthCalledWith(1, 'extraction-current')
+    expect(cleanupRequest).toHaveBeenNthCalledWith(2, 'extraction-current')
+  })
+})

--- a/tests/shared/ipc/domains/batch-import.test.ts
+++ b/tests/shared/ipc/domains/batch-import.test.ts
@@ -52,7 +52,8 @@ describe('batch-import preload domain behavior', () => {
       })
       .mockResolvedValueOnce({
         files: ['/extracted/file1.json', '/extracted/file2.json'],
-        errors: []
+        errors: [],
+        extractionId: '11111111-1111-4111-8111-111111111111'
       })
       .mockResolvedValueOnce(undefined)
 
@@ -98,7 +99,9 @@ describe('batch-import preload domain behavior', () => {
       errors: []
     })
 
-    await expect(api.cleanupZipTemp()).resolves.toBeUndefined()
+    await expect(
+      api.cleanupZipTemp('11111111-1111-4111-8111-111111111111')
+    ).resolves.toBeUndefined()
 
     expect(invoke).toHaveBeenNthCalledWith(1, 'batch-import:selectFiles')
     expect(invoke).toHaveBeenNthCalledWith(2, 'batch-import:selectFolder')
@@ -129,7 +132,11 @@ describe('batch-import preload domain behavior', () => {
       '/path/to/archive.zip',
       undefined
     )
-    expect(invoke).toHaveBeenNthCalledWith(9, 'batch-import:cleanupZipTemp')
+    expect(invoke).toHaveBeenNthCalledWith(
+      9,
+      'batch-import:cleanupZipTemp',
+      '11111111-1111-4111-8111-111111111111'
+    )
   })
 
   it('preload index preserves batch-import transport results when exposing window.api', async () => {
@@ -187,7 +194,7 @@ describe('batch-import preload domain behavior', () => {
         cancel: () => Promise<unknown>
         selectZip: () => Promise<unknown>
         testZipPassword: (zipPath: string, password: string) => Promise<unknown>
-        cleanupZipTemp: () => Promise<unknown>
+        cleanupZipTemp: (extractionId: string) => Promise<unknown>
       }
     }
 
@@ -206,7 +213,9 @@ describe('batch-import preload domain behavior', () => {
       code: ErrorCode.WRONG_PASSWORD,
       message: 'Password test failed'
     })
-    await expect(api.batchImport.cleanupZipTemp()).resolves.toBeUndefined()
+    await expect(
+      api.batchImport.cleanupZipTemp('11111111-1111-4111-8111-111111111111')
+    ).resolves.toBeUndefined()
 
     expect(invoke).toHaveBeenCalledWith('batch-import:selectFiles')
     expect(invoke).toHaveBeenCalledWith('batch-import:selectFolder')
@@ -214,6 +223,9 @@ describe('batch-import preload domain behavior', () => {
     expect(invoke).toHaveBeenCalledWith('batch-import:cancel')
     expect(invoke).toHaveBeenCalledWith('batch-import:selectZip')
     expect(invoke).toHaveBeenCalledWith('batch-import:testZipPassword', '/archive.zip', 'pwd')
-    expect(invoke).toHaveBeenCalledWith('batch-import:cleanupZipTemp')
+    expect(invoke).toHaveBeenCalledWith(
+      'batch-import:cleanupZipTemp',
+      '11111111-1111-4111-8111-111111111111'
+    )
   })
 })

--- a/tests/utils/mock-api.ts
+++ b/tests/utils/mock-api.ts
@@ -207,7 +207,11 @@ export function createMockApi(): MockApi {
       cancel: vi.fn().mockResolvedValue(undefined),
       selectZip: vi.fn().mockResolvedValue(null),
       testZipPassword: vi.fn().mockResolvedValue({ valid: true }),
-      extractZip: vi.fn().mockResolvedValue([]),
+      extractZip: vi.fn().mockResolvedValue({
+        files: [],
+        errors: [],
+        extractionId: 'mock-extraction-id'
+      }),
       cleanupZipTemp: vi.fn().mockResolvedValue(undefined),
       onProgress: vi.fn(() => vi.fn()), // Returns cleanup function
       onComplete: vi.fn(() => vi.fn()) // Returns cleanup function

--- a/tests/web-gate/dispatcher-adapters-auth-import.test.ts
+++ b/tests/web-gate/dispatcher-adapters-auth-import.test.ts
@@ -393,7 +393,7 @@ describe('web dispatcher adapters: auth and import', () => {
         request as never,
         reply as never,
         deps
-      )) as { files: string[]; errors: string[] }
+      )) as { files: string[]; errors: string[]; extractionId: string }
 
       expect(reply.code).not.toHaveBeenCalledWith(403)
       expect(result.errors).toEqual([])

--- a/tests/web-gate/parity/data-manifest-parity-support.ts
+++ b/tests/web-gate/parity/data-manifest-parity-support.ts
@@ -283,7 +283,7 @@ async function runZipImport(
   fixture: ManifestFixture
 ): Promise<ScenarioSnapshot> {
   const target = fixture.varlensTarget!
-  const extracted = await call<{ files: string[]; errors: string[] }>(
+  const extracted = await call<{ files: string[]; errors: string[]; extractionId: string }>(
     'batch-import',
     'extractZip',
     [repoPath(target.artifact!)]
@@ -305,7 +305,7 @@ async function runZipImport(
       variants.push(...normalizeRows(queryAll))
     }
   } finally {
-    await call<void>('batch-import', 'cleanupZipTemp', [])
+    await call<void>('batch-import', 'cleanupZipTemp', [extracted.extractionId])
   }
 
   variants.sort((a, b) => variantIdentity(a).localeCompare(variantIdentity(b)))

--- a/tests/web-gate/parity/ipc/batch-import.ts
+++ b/tests/web-gate/parity/ipc/batch-import.ts
@@ -3,12 +3,12 @@ import { basenames, zipBatchPath, type IpcScenario } from './shared'
 export const batchImportScenario: IpcScenario = {
   area: 'batch-import',
   run: async (ctx) => {
-    const extracted = await ctx.call<{ files: string[]; errors: string[] }>(
-      'batchImport',
-      'extractZip',
-      [zipBatchPath()]
-    )
-    await ctx.call('batchImport', 'cleanupZipTemp')
+    const extracted = await ctx.call<{
+      files: string[]
+      errors: string[]
+      extractionId: string
+    }>('batchImport', 'extractZip', [zipBatchPath()])
+    await ctx.call('batchImport', 'cleanupZipTemp', [extracted.extractionId])
     return [{ errors: extracted.errors, files: basenames(extracted.files) }]
   }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,23 @@
 {
   "compilerOptions": {
     "target": "ES2020",
+    // Explicit `lib` = the default ES2020 target's implied set (es2020, dom,
+    // webworker.importscripts, scripthost, dom.iterable, dom.asynciterable —
+    // see `lib.es2020.full.d.ts`) plus `ES2022.Error`. That one addition is
+    // purely additive (adds `Error`'s `cause` option/property typings, which
+    // Node 24 already supports at runtime); it does not change emitted JS
+    // syntax and does not remove anything the default target-implied set had.
+    // Needed so `new Error(msg, { cause })` type-checks, which ESLint 10's
+    // `preserve-caught-error` rule requires when re-throwing from a catch.
+    "lib": [
+      "ES2020",
+      "DOM",
+      "WebWorker.ImportScripts",
+      "ScriptHost",
+      "DOM.Iterable",
+      "DOM.AsyncIterable",
+      "ES2022.Error"
+    ],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary

Eliminates **silent-failure degradation** (findings C2 + C8): code paths that swallowed an error and quietly returned a degraded or fake-success result. Main-process IPC handlers now let genuine failures throw (so `wrapHandler` surfaces a structured error) while preserving legitimate benign outcomes.

**PR-B** of the staged security & bug remediation.

## What changed

**Panel-filter safety (C2 — clinical):** a panel-interval computation failure used to return `undefined`, which callers treated as "no filter" → the variant query silently ran **unfiltered**, returning more variants than the active gene panel intends. Now a genuine computation failure propagates on all three code paths that had the bug — `panelIntervalHelper.ts`, `db-worker-dispatch.ts` (the production worker-pool path), and `PostgresCohortRepository.ts` — while "no panel configured" still runs unfiltered correctly. Cohort parity: covered on case + cohort paths across SQLite main-thread, SQLite worker-pool, and Postgres. Also closes the `geneRefDb === null` variant (a gene-ref DB open failure with an active panel now throws instead of silently dropping the panel).

**Batch-import (C8):** a DB error looked like "no duplicates", a corrupt zip like "wrong password", a folder-read error like "empty folder", and a failed extraction like a valid 0-file result. Now genuine failures throw and benign outcomes are preserved:
- `checkDuplicateFiles` DB error → throws (≠ "no duplicates")
- `testZipPassword` → distinguishes a real wrong password (returns `false`) from a corrupt archive / corrupt *unencrypted* entry (throws), via the entry encryption flag
- `selectFolder` read failure → throws (≠ empty folder)
- `extractZip` → throws when extraction yielded 0 files but produced errors, while preserving a genuinely empty archive and partial-success

## Reviews

- **Codex-high (per-diff, whole-branch gate):** initial NO-GO caught 3 blocking defects the per-task reviews missed (the `geneRefDb`-null panel drop; corrupt-unencrypted-zip looking like wrong-password; zero-file-with-errors returning as success) — all fixed — then **GO**, no remaining blockers.
- Per-task reviews: both tasks approved (the batch-import reviewer traced the full renderer consumption chain).

## Verification

- `make ci` green: **3918 passing**, 0 failures; `make typecheck`/`lint-check`/`format-check` clean.
- **Caveat:** `make agent-check` fails only on the pre-existing `postgres baseline: 21/21` debt (unrelated to this PR).

## Follow-ups (tracked, out of scope)

- Type `batch-import` `selectFolder`/`selectFiles` as `IpcResult<string[]>` + unwrap at the renderer call sites; wrap `ImportWizard`'s `stripText` watch handler; delete the orphaned/dead `BatchImportDialog.vue`.

Part of the security & bug remediation series (PR-A #306 merged/open; PRs C–I to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmqdEMGjqVhTX8EKr6QxoH
