### PR TITLE
fix(import): VCF annotation & mapping correctness (C3, C5, C6) [PR-C]

### DIFF
--- a/src/main/import/vcf/VcfMapper.ts
+++ b/src/main/import/vcf/VcfMapper.ts
@@ -75,12 +75,17 @@ export function mapVcfRecord(
     if (!isStructural && shouldSkipGenotype(gtFieldValue)) continue
 
     // Parse full genotype data (with altAlleleIndex=1 since already split)
-    const genotype = parseGenotype(sampleValues, rec.format, 1)
+    const genotype = parseGenotype(
+      sampleValues,
+      rec.format,
+      1,
+      header.formatDefs.get('AD')?.number ?? 'R'
+    )
 
     // Step 3: Parse annotation (CSQ or ANN)
     // altIdx is 0-based across splitRecords; VEP's ALLELE_NUM is 1-based.
     const altAllele = rec.alt[0]
-    const annotation = parseAnnotation(rec.info, header, altAllele, rec.ref, altIdx + 1)
+    const annotation = parseAnnotation(rec.info, header, altAllele, rec.ref, altIdx + 1, record.alt)
 
     // Step 4: Apply INFO field registry
     const infoResult = applyInfoFieldRegistry(rec.info, registry, annotation)

--- a/src/main/import/vcf/VcfMapper.ts
+++ b/src/main/import/vcf/VcfMapper.ts
@@ -78,8 +78,9 @@ export function mapVcfRecord(
     const genotype = parseGenotype(sampleValues, rec.format, 1)
 
     // Step 3: Parse annotation (CSQ or ANN)
+    // altIdx is 0-based across splitRecords; VEP's ALLELE_NUM is 1-based.
     const altAllele = rec.alt[0]
-    const annotation = parseAnnotation(rec.info, header, altAllele, rec.ref)
+    const annotation = parseAnnotation(rec.info, header, altAllele, rec.ref, altIdx + 1)
 
     // Step 4: Apply INFO field registry
     const infoResult = applyInfoFieldRegistry(rec.info, registry, annotation)

--- a/src/main/import/vcf/info-field-registry.ts
+++ b/src/main/import/vcf/info-field-registry.ts
@@ -13,7 +13,7 @@ const ANNOTATION_INFO_IDS = new Set(['CSQ', 'ANN'])
 /** Default registry covering common annotation pipelines */
 export const DEFAULT_INFO_FIELD_MAPPINGS: InfoFieldMapping[] = [
   {
-    infoIds: ['gnomADe_AF', 'gnomADg_AF', 'gnomAD_AF', 'AF'],
+    infoIds: ['gnomADe_AF', 'gnomADg_AF', 'gnomAD_AF'],
     column: 'gnomad_af',
     type: 'float',
     csqField: 'gnomADe_AF',

--- a/src/main/import/vcf/vcf-allele-splitter.ts
+++ b/src/main/import/vcf/vcf-allele-splitter.ts
@@ -13,7 +13,8 @@ function normalizeVectorToken(value: string | undefined): string {
 
 /**
  * Split a multi-allelic VcfRawRecord into one record per ALT allele.
- * Single-allelic records pass through unchanged (returned as a one-element array).
+ * Single-allelic records are also normalized so Number=A/R FORMAT vectors
+ * have the same biallelic representation as split multi-allelic records.
  *
  * @param record - Raw VCF record (may have multiple ALT alleles)
  * @param infoDefs - INFO field definitions from VCF header (for Number semantics)
@@ -25,11 +26,6 @@ export function splitMultiAllelic(
   infoDefs: Map<string, InfoFieldDef>,
   formatDefs: Map<string, FormatFieldDef>
 ): VcfRawRecord[] {
-  // Single-allelic: pass through
-  if (record.alt.length <= 1) {
-    return [record]
-  }
-
   const results: VcfRawRecord[] = []
 
   for (let altIdx = 0; altIdx < record.alt.length; altIdx++) {

--- a/src/main/import/vcf/vcf-allele-splitter.ts
+++ b/src/main/import/vcf/vcf-allele-splitter.ts
@@ -70,11 +70,7 @@ function splitInfoFields(
       case 'A': {
         // Per-ALT allele — select value at altIdx
         const parts = value.split(',')
-        if (altIdx < parts.length) {
-          result.set(key, parts[altIdx])
-        } else {
-          result.set(key, value)
-        }
+        result.set(key, parts[altIdx] ?? '.')
         break
       }
 
@@ -84,7 +80,7 @@ function splitInfoFields(
         if (parts.length > altIdx + 1) {
           result.set(key, `${parts[0]},${parts[altIdx + 1]}`)
         } else {
-          result.set(key, value)
+          result.set(key, `${parts[0] ?? '.'},.`)
         }
         break
       }
@@ -146,13 +142,17 @@ function splitSampleFields(
         const parts = values[fIdx].split(',')
         if (parts.length > altIdx + 1) {
           newValues[fIdx] = `${parts[0]},${parts[altIdx + 1]}`
+        } else {
+          newValues[fIdx] = `${parts[0] ?? '.'},.`
         }
       } else if (number === 'A') {
         // Per-ALT — select value at altIdx
         const parts = values[fIdx].split(',')
-        if (altIdx < parts.length) {
-          newValues[fIdx] = parts[altIdx]
-        }
+        const selected = parts[altIdx] ?? '.'
+        // Genotype parsing consumes AD as a biallelic REF,ALT pair. A
+        // non-standard Number=A AD has no reference depth, so retain the ALT
+        // depth explicitly while marking REF missing.
+        newValues[fIdx] = field === 'AD' ? `.,${selected}` : selected
       }
       // Number=1, 0, ., G: keep as-is
     }

--- a/src/main/import/vcf/vcf-allele-splitter.ts
+++ b/src/main/import/vcf/vcf-allele-splitter.ts
@@ -7,6 +7,10 @@
 
 import type { VcfRawRecord, InfoFieldDef, FormatFieldDef } from './types'
 
+function normalizeVectorToken(value: string | undefined): string {
+  return value === undefined || value === '' ? '.' : value
+}
+
 /**
  * Split a multi-allelic VcfRawRecord into one record per ALT allele.
  * Single-allelic records pass through unchanged (returned as a one-element array).
@@ -70,7 +74,7 @@ function splitInfoFields(
       case 'A': {
         // Per-ALT allele — select value at altIdx
         const parts = value.split(',')
-        result.set(key, parts[altIdx] ?? '.')
+        result.set(key, normalizeVectorToken(parts[altIdx]))
         break
       }
 
@@ -78,9 +82,12 @@ function splitInfoFields(
         // Per-allele (REF + ALTs) — keep REF (index 0) + current ALT
         const parts = value.split(',')
         if (parts.length > altIdx + 1) {
-          result.set(key, `${parts[0]},${parts[altIdx + 1]}`)
+          result.set(
+            key,
+            `${normalizeVectorToken(parts[0])},${normalizeVectorToken(parts[altIdx + 1])}`
+          )
         } else {
-          result.set(key, `${parts[0] ?? '.'},.`)
+          result.set(key, `${normalizeVectorToken(parts[0])},.`)
         }
         break
       }
@@ -124,7 +131,7 @@ function splitSampleFields(
       }
 
       const def = formatDefs.get(field)
-      let number = def?.number ?? '.'
+      const number = def?.number ?? (field === 'AD' ? 'R' : '.')
 
       // AD (allele depths) is conventionally Number=R (one value per allele,
       // REF included). Some VCFs omit the ##FORMAT=<ID=AD,...> header line
@@ -132,23 +139,21 @@ function splitSampleFields(
       // leaves the full multi-allele AD unreduced. Downstream genotype
       // parsing assumes an already-split, biallelic AD (it reads index 1 for
       // "this" ALT's depth), so default AD to Number=R when its def is
-      // missing or its declared Number isn't already R/A.
-      if (field === 'AD' && number !== 'R' && number !== 'A') {
-        number = 'R'
-      }
+      // missing. Explicit header declarations remain authoritative.
 
       if (number === 'R') {
         // Per-allele (REF + ALTs) — keep REF + current ALT
         const parts = values[fIdx].split(',')
         if (parts.length > altIdx + 1) {
-          newValues[fIdx] = `${parts[0]},${parts[altIdx + 1]}`
+          newValues[fIdx] =
+            `${normalizeVectorToken(parts[0])},${normalizeVectorToken(parts[altIdx + 1])}`
         } else {
-          newValues[fIdx] = `${parts[0] ?? '.'},.`
+          newValues[fIdx] = `${normalizeVectorToken(parts[0])},.`
         }
       } else if (number === 'A') {
         // Per-ALT — select value at altIdx
         const parts = values[fIdx].split(',')
-        const selected = parts[altIdx] ?? '.'
+        const selected = normalizeVectorToken(parts[altIdx])
         // Genotype parsing consumes AD as a biallelic REF,ALT pair. A
         // non-standard Number=A AD has no reference depth, so retain the ALT
         // depth explicitly while marking REF missing.

--- a/src/main/import/vcf/vcf-allele-splitter.ts
+++ b/src/main/import/vcf/vcf-allele-splitter.ts
@@ -128,7 +128,18 @@ function splitSampleFields(
       }
 
       const def = formatDefs.get(field)
-      const number = def?.number ?? '.'
+      let number = def?.number ?? '.'
+
+      // AD (allele depths) is conventionally Number=R (one value per allele,
+      // REF included). Some VCFs omit the ##FORMAT=<ID=AD,...> header line
+      // entirely, which otherwise falls through to "keep as-is" below and
+      // leaves the full multi-allele AD unreduced. Downstream genotype
+      // parsing assumes an already-split, biallelic AD (it reads index 1 for
+      // "this" ALT's depth), so default AD to Number=R when its def is
+      // missing or its declared Number isn't already R/A.
+      if (field === 'AD' && number !== 'R' && number !== 'A') {
+        number = 'R'
+      }
 
       if (number === 'R') {
         // Per-allele (REF + ALTs) — keep REF + current ALT

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -196,12 +196,22 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
     parsed.push({ parts, allele })
   }
 
-  // Filter by allele. Unlike VEP CSQ, SnpEff's ANN field 0 is always the real ALT
-  // sequence (never "-" and never an index), so deletions disambiguate by exact
-  // sequence match. The "-" shortcut in matchesAllele exists only for VEP's
-  // lossy deletion notation and must never fire here — otherwise a malformed or
-  // unexpected "-" block could cross-match any shorter ALT at a multi-deletion site.
-  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref, false))
+  // Filter by allele. Unlike VEP CSQ, SnpEff's ANN field 0 is always the literal
+  // raw VCF ALT string — confirmed against real SnpEff output in
+  // tests/test-data/vcf/edge-cases.snpeff.vcf.gz and single-sample.snpeff.vcf.gz,
+  // e.g. REF=C ALT=CT,CTT emits ANN=CT|...,CTT|... and REF=T ALT=TTATC emits
+  // ANN=TTATC|..., never a VEP-style "inserted bases only" suffix. So ANN alleles
+  // disambiguate by exact sequence match only. Both VEP heuristics in
+  // matchesAllele must be disabled here:
+  //   - the "-" deletion shortcut (allowDeletionDash) — SnpEff never emits "-",
+  //     so a literal "-" block must not cross-match a shorter ALT.
+  //   - the insertion-suffix heuristic (allowInsertionSuffix), i.e.
+  //     `annAllele === altAllele.substring(1)` — this exists only to match VEP's
+  //     "inserted bases only" notation. Left enabled for ANN, it lets a block
+  //     for one split ALT cross-attach to an unrelated, longer split ALT that
+  //     happens to share a suffix (e.g. REF=A ALT=AT,T: the T block's allele
+  //     "T" equals "AT".substring(1), wrongly attaching it to the AT split).
+  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref, false, false))
 
   if (filtered.length === 0) return emptyResult()
 
@@ -254,7 +264,8 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
 /**
  * Check if an annotation allele matches the target ALT allele.
  * VEP CSQ uses the VCF ALT bases for SNVs, "-" for deletions, inserted bases for insertions.
- * SnpEff ANN uses the full ALT allele string (real sequence, never "-").
+ * SnpEff ANN uses the full raw ALT allele string exactly as written in the VCF ALT
+ * column (real sequence, never "-", never an inserted-bases-only suffix).
  *
  * @param allowDeletionDash - Whether the VEP "-" deletion shortcut may fire. VEP's
  *   Allele field is lossy ("-" for every deletion ALT at a multi-allelic site), so
@@ -262,18 +273,30 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
  *   ALLELE_NUM disambiguation isn't available. SnpEff ANN callers must pass
  *   `false` — ANN's allele field is always a concrete sequence, so a literal "-"
  *   there is never a real allele and must not cross-match a shorter ALT.
+ * @param allowInsertionSuffix - Whether the VEP "inserted bases only" heuristic
+ *   (`annAllele === altAllele.substring(1)`) may fire. VEP's Allele field for an
+ *   insertion is the inserted bases only (ALT minus the shared first base), so
+ *   this is a safe heuristic only for VEP CSQ. SnpEff ANN callers must pass
+ *   `false` — ANN's allele field is always the full raw ALT string, so this
+ *   substring heuristic is not just unnecessary but actively wrong: at a mixed
+ *   multi-allelic site (e.g. REF=A ALT=AT,T) it makes the shorter split's ANN
+ *   block ("T") falsely match the longer split's ALT ("AT"), since
+ *   "AT".substring(1) === "T".
  */
 function matchesAllele(
   annAllele: string,
   altAllele: string,
   ref: string,
-  allowDeletionDash: boolean = true
+  allowDeletionDash: boolean = true,
+  allowInsertionSuffix: boolean = true
 ): boolean {
   if (annAllele === altAllele) return true
   // VEP deletion notation: "-" only matches when ALT is actually shorter than REF
   if (allowDeletionDash && annAllele === '-' && altAllele.length < ref.length) return true
   // VEP insertion: the annotation Allele is the inserted bases (ALT minus first base)
-  if (altAllele.length > 1 && annAllele === altAllele.substring(1)) return true
+  if (allowInsertionSuffix && altAllele.length > 1 && annAllele === altAllele.substring(1)) {
+    return true
+  }
   return false
 }
 

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -27,6 +27,8 @@ const IMPACT_ORDER: Record<string, number> = {
  * @param alleleIndex - 1-based index of altAllele among the original ALT list
  *   (matches VEP CSQ's ALLELE_NUM). Required to disambiguate multi-allelic
  *   deletion sites, where VEP emits "-" for every deletion ALT.
+ * @param originalAltAlleles - All ALT alleles before splitting. Used to reject
+ *   lossy CSQ allele heuristics that match more than one ALT.
  * @returns Annotation result with selected transcript and all transcripts
  */
 export function parseAnnotation(
@@ -34,10 +36,11 @@ export function parseAnnotation(
   header: VcfHeader,
   altAllele: string,
   ref?: string,
-  alleleIndex?: number
+  alleleIndex?: number,
+  originalAltAlleles: string[] = [altAllele]
 ): AnnotationResult {
   if (header.annotationType === 'csq' && header.csqFields !== null) {
-    return parseCsq(info, header.csqFields, altAllele, ref ?? '', alleleIndex)
+    return parseCsq(info, header.csqFields, altAllele, ref ?? '', alleleIndex, originalAltAlleles)
   }
 
   if (header.annotationType === 'ann') {
@@ -59,7 +62,8 @@ function parseCsq(
   csqFieldNames: string[],
   altAllele: string,
   ref: string,
-  alleleIndex?: number
+  alleleIndex: number | undefined,
+  originalAltAlleles: string[]
 ): AnnotationResult {
   const csqRaw = info.get('CSQ')
   if (csqRaw == null || csqRaw === '') return emptyResult()
@@ -100,7 +104,11 @@ function parseCsq(
       const parsedAlleleNum = Number(alleleNumStr)
       return Number.isSafeInteger(parsedAlleleNum) && parsedAlleleNum === alleleIndex
     }
-    return matchesAllele(t.allele, altAllele, ref)
+    if (!matchesAllele(t.allele, altAllele, ref)) return false
+    const matchingAltCount = originalAltAlleles.filter((candidate) =>
+      matchesAllele(t.allele, candidate, ref)
+    ).length
+    return matchingAltCount === 1
   })
 
   if (filtered.length === 0) return emptyResult()

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -87,8 +87,13 @@ function parseCsq(
   // so at a multi-deletion multi-allelic site the Allele/length heuristic alone
   // cannot tell two deletions apart. When the CSQ config declares ALLELE_NUM
   // (the 1-based index of the ALT this block annotates), prefer it — it is the
-  // only reliable discriminator for that case. Fall back to the Allele-string
-  // heuristic when ALLELE_NUM isn't configured, or is missing on a given block.
+  // only reliable discriminator for that case. Fall back to the full Allele-string
+  // heuristic (including the "-" deletion shortcut) only when ALLELE_NUM isn't
+  // configured at all. When ALLELE_NUM *is* configured but a given block's value
+  // is missing/empty, we're in disambiguation mode without a discriminator for
+  // that block — route it through the dash-disabled path so a "-" block can't
+  // guess and cross-contaminate every deletion split, while a block with a
+  // concrete Allele sequence still matches its own allele by exact match.
   const hasAlleleNumField = csqFieldNames.includes('ALLELE_NUM')
   const filtered = parsed.filter((t) => {
     if (hasAlleleNumField && alleleIndex !== undefined) {
@@ -96,6 +101,7 @@ function parseCsq(
       if (alleleNumStr !== undefined) {
         return parseInt(alleleNumStr, 10) === alleleIndex
       }
+      return matchesAllele(t.allele, altAllele, ref, false)
     }
     return matchesAllele(t.allele, altAllele, ref)
   })

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -24,16 +24,20 @@ const IMPACT_ORDER: Record<string, number> = {
  * @param header - Parsed VCF header with annotation type info
  * @param altAllele - The ALT allele to filter annotations for
  * @param ref - The REF allele (used to disambiguate deletion matching)
+ * @param alleleIndex - 1-based index of altAllele among the original ALT list
+ *   (matches VEP CSQ's ALLELE_NUM). Required to disambiguate multi-allelic
+ *   deletion sites, where VEP emits "-" for every deletion ALT.
  * @returns Annotation result with selected transcript and all transcripts
  */
 export function parseAnnotation(
   info: Map<string, string>,
   header: VcfHeader,
   altAllele: string,
-  ref?: string
+  ref?: string,
+  alleleIndex?: number
 ): AnnotationResult {
   if (header.annotationType === 'csq' && header.csqFields !== null) {
-    return parseCsq(info, header.csqFields, altAllele, ref ?? '')
+    return parseCsq(info, header.csqFields, altAllele, ref ?? '', alleleIndex)
   }
 
   if (header.annotationType === 'ann') {
@@ -54,7 +58,8 @@ function parseCsq(
   info: Map<string, string>,
   csqFieldNames: string[],
   altAllele: string,
-  ref: string
+  ref: string,
+  alleleIndex?: number
 ): AnnotationResult {
   const csqRaw = info.get('CSQ')
   if (csqRaw == null || csqRaw === '') return emptyResult()
@@ -78,8 +83,22 @@ function parseCsq(
     parsed.push({ fields, allele })
   }
 
-  // Filter by allele: VEP uses the ALT base for SNVs, "-" for deletions, inserted seq for insertions
-  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref))
+  // Filter by allele. VEP's Allele field is "-" for every deletion ALT at a site,
+  // so at a multi-deletion multi-allelic site the Allele/length heuristic alone
+  // cannot tell two deletions apart. When the CSQ config declares ALLELE_NUM
+  // (the 1-based index of the ALT this block annotates), prefer it — it is the
+  // only reliable discriminator for that case. Fall back to the Allele-string
+  // heuristic when ALLELE_NUM isn't configured, or is missing on a given block.
+  const hasAlleleNumField = csqFieldNames.includes('ALLELE_NUM')
+  const filtered = parsed.filter((t) => {
+    if (hasAlleleNumField && alleleIndex !== undefined) {
+      const alleleNumStr = t.fields.get('ALLELE_NUM')
+      if (alleleNumStr !== undefined) {
+        return parseInt(alleleNumStr, 10) === alleleIndex
+      }
+    }
+    return matchesAllele(t.allele, altAllele, ref)
+  })
 
   if (filtered.length === 0) return emptyResult()
 
@@ -171,8 +190,12 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
     parsed.push({ parts, allele })
   }
 
-  // Filter by allele
-  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref))
+  // Filter by allele. Unlike VEP CSQ, SnpEff's ANN field 0 is always the real ALT
+  // sequence (never "-" and never an index), so deletions disambiguate by exact
+  // sequence match. The "-" shortcut in matchesAllele exists only for VEP's
+  // lossy deletion notation and must never fire here — otherwise a malformed or
+  // unexpected "-" block could cross-match any shorter ALT at a multi-deletion site.
+  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref, false))
 
   if (filtered.length === 0) return emptyResult()
 
@@ -225,12 +248,24 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
 /**
  * Check if an annotation allele matches the target ALT allele.
  * VEP CSQ uses the VCF ALT bases for SNVs, "-" for deletions, inserted bases for insertions.
- * SnpEff ANN uses the full ALT allele string.
+ * SnpEff ANN uses the full ALT allele string (real sequence, never "-").
+ *
+ * @param allowDeletionDash - Whether the VEP "-" deletion shortcut may fire. VEP's
+ *   Allele field is lossy ("-" for every deletion ALT at a multi-allelic site), so
+ *   this is only a safe heuristic for VEP CSQ, and only as a fallback when
+ *   ALLELE_NUM disambiguation isn't available. SnpEff ANN callers must pass
+ *   `false` — ANN's allele field is always a concrete sequence, so a literal "-"
+ *   there is never a real allele and must not cross-match a shorter ALT.
  */
-function matchesAllele(annAllele: string, altAllele: string, ref: string): boolean {
+function matchesAllele(
+  annAllele: string,
+  altAllele: string,
+  ref: string,
+  allowDeletionDash: boolean = true
+): boolean {
   if (annAllele === altAllele) return true
   // VEP deletion notation: "-" only matches when ALT is actually shorter than REF
-  if (annAllele === '-' && altAllele.length < ref.length) return true
+  if (allowDeletionDash && annAllele === '-' && altAllele.length < ref.length) return true
   // VEP insertion: the annotation Allele is the inserted bases (ALT minus first base)
   if (altAllele.length > 1 && annAllele === altAllele.substring(1)) return true
   return false

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -44,7 +44,7 @@ export function parseAnnotation(
   }
 
   if (header.annotationType === 'ann') {
-    return parseAnn(info, altAllele, ref ?? '')
+    return parseAnn(info, altAllele, originalAltAlleles)
   }
 
   return emptyResult()
@@ -187,7 +187,11 @@ interface AnnTranscript {
   allele: string
 }
 
-function parseAnn(info: Map<string, string>, altAllele: string, ref: string): AnnotationResult {
+function parseAnn(
+  info: Map<string, string>,
+  altAllele: string,
+  originalAltAlleles: string[]
+): AnnotationResult {
   const annRaw = info.get('ANN')
   if (annRaw == null || annRaw === '') return emptyResult()
 
@@ -201,13 +205,12 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
     parsed.push({ parts, allele })
   }
 
-  // Filter by allele. Unlike VEP CSQ, SnpEff's ANN field 0 is always the literal
-  // raw VCF ALT string — confirmed against real SnpEff output in
-  // tests/test-data/vcf/edge-cases.snpeff.vcf.gz and single-sample.snpeff.vcf.gz,
-  // e.g. REF=C ALT=CT,CTT emits ANN=CT|...,CTT|... and REF=T ALT=TTATC emits
-  // ANN=TTATC|..., never a VEP-style "inserted bases only" suffix. So ANN alleles
-  // disambiguate by exact sequence match only. Both VEP heuristics in
-  // matchesAllele must be disabled here:
+  // Ordinary SnpEff ANN field 0 values are the literal raw VCF ALT string.
+  // The ANN standard also defines compound values whose leading component is
+  // the annotated ALT: cancer comparisons use ALT-REFERENCE (e.g. G-C), and
+  // compound annotations use ALT-chr:pos_REF>ALT. Match that leading component
+  // exactly against one original ALT; never apply VEP's deletion/insertion
+  // heuristics here:
   //   - the "-" deletion shortcut (allowDeletionDash) — SnpEff never emits "-",
   //     so a literal "-" block must not cross-match a shorter ALT.
   //   - the insertion-suffix heuristic (allowInsertionSuffix), i.e.
@@ -216,7 +219,11 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
   //     for one split ALT cross-attach to an unrelated, longer split ALT that
   //     happens to share a suffix (e.g. REF=A ALT=AT,T: the T block's allele
   //     "T" equals "AT".substring(1), wrongly attaching it to the AT split).
-  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref, false, false))
+  const filtered = parsed.filter((t) => {
+    const leadingAlt = t.allele.split('-', 1)[0]
+    if (leadingAlt !== altAllele) return false
+    return originalAltAlleles.filter((candidate) => candidate === leadingAlt).length === 1
+  })
 
   if (filtered.length === 0) return emptyResult()
 

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -87,21 +87,18 @@ function parseCsq(
   // so at a multi-deletion multi-allelic site the Allele/length heuristic alone
   // cannot tell two deletions apart. When the CSQ config declares ALLELE_NUM
   // (the 1-based index of the ALT this block annotates), prefer it — it is the
-  // only reliable discriminator for that case. Fall back to the full Allele-string
-  // heuristic (including the "-" deletion shortcut) only when ALLELE_NUM isn't
-  // configured at all. When ALLELE_NUM *is* configured but a given block's value
-  // is missing/empty, we're in disambiguation mode without a discriminator for
-  // that block — route it through the dash-disabled path so a "-" block can't
-  // guess and cross-contaminate every deletion split, while a block with a
-  // concrete Allele sequence still matches its own allele by exact match.
+  // only reliable discriminator for that case. Fall back to Allele-string
+  // heuristics only when ALLELE_NUM is absent from the header entirely. Once
+  // declared, a block with a missing or malformed value is unsafe to attach:
+  // partial fallback can cross-match another ALT at a mixed multi-allelic site.
   const hasAlleleNumField = csqFieldNames.includes('ALLELE_NUM')
   const filtered = parsed.filter((t) => {
-    if (hasAlleleNumField && alleleIndex !== undefined) {
+    if (hasAlleleNumField) {
+      if (alleleIndex === undefined) return false
       const alleleNumStr = t.fields.get('ALLELE_NUM')
-      if (alleleNumStr !== undefined) {
-        return parseInt(alleleNumStr, 10) === alleleIndex
-      }
-      return matchesAllele(t.allele, altAllele, ref, false)
+      if (alleleNumStr === undefined || !/^[1-9]\d*$/.test(alleleNumStr)) return false
+      const parsedAlleleNum = Number(alleleNumStr)
+      return Number.isSafeInteger(parsedAlleleNum) && parsedAlleleNum === alleleIndex
     }
     return matchesAllele(t.allele, altAllele, ref)
   })

--- a/src/main/import/vcf/vcf-genotype-parser.ts
+++ b/src/main/import/vcf/vcf-genotype-parser.ts
@@ -49,7 +49,7 @@ export function parseGenotype(
       const adParts = adStr.split(',')
       if (adParts.length >= 2) {
         const refVal = parseInt(adParts[0], 10)
-        const altVal = parseInt(adParts[altAlleleIndex] || adParts[1], 10)
+        const altVal = parseInt(adParts[altAlleleIndex] ?? '', 10)
         adRef = isNaN(refVal) ? null : refVal
         adAlt = isNaN(altVal) ? null : altVal
       }

--- a/src/main/import/vcf/vcf-genotype-parser.ts
+++ b/src/main/import/vcf/vcf-genotype-parser.ts
@@ -13,12 +13,15 @@ import type { GenotypeData } from './types'
  * @param sampleValues - Colon-split values for one sample (e.g. ["0/1", "99", "45", "22,23"])
  * @param formatFields - FORMAT field order (e.g. ["GT", "GQ", "DP", "AD"])
  * @param altAlleleIndex - 1-based index of ALT allele for multi-allelic AD extraction (default 1)
+ * @param adNumber - Header-declared Number for AD. Only A/R vectors have
+ *   allele-depth semantics; missing declarations default to conventional R.
  * @returns Parsed genotype data
  */
 export function parseGenotype(
   sampleValues: string[],
   formatFields: string[],
-  altAlleleIndex: number = 1
+  altAlleleIndex: number = 1,
+  adNumber: string = 'R'
 ): GenotypeData {
   // Build index map for FORMAT fields
   const fieldIndex = new Map<string, number>()
@@ -43,15 +46,17 @@ export function parseGenotype(
   let adRef: number | null = null
   let adAlt: number | null = null
 
-  if (adIdx !== undefined && adIdx < sampleValues.length) {
+  if (
+    (adNumber === 'A' || adNumber === 'R') &&
+    adIdx !== undefined &&
+    adIdx < sampleValues.length
+  ) {
     const adStr = sampleValues[adIdx]
     if (adStr !== '.' && adStr !== '') {
       const adParts = adStr.split(',')
       if (adParts.length >= 2) {
-        const refVal = parseInt(adParts[0], 10)
-        const altVal = parseInt(adParts[altAlleleIndex] ?? '', 10)
-        adRef = isNaN(refVal) ? null : refVal
-        adAlt = isNaN(altVal) ? null : altVal
+        adRef = parseNonNegativeInteger(adParts[0])
+        adAlt = parseNonNegativeInteger(adParts[altAlleleIndex] ?? '')
       }
     }
   }
@@ -76,6 +81,11 @@ function parseIntField(fieldIdx: number | undefined, sampleValues: string[]): nu
   if (fieldIdx === undefined || fieldIdx >= sampleValues.length) return null
   const val = sampleValues[fieldIdx]
   if (val === '.' || val === '') return null
-  const parsed = parseInt(val, 10)
-  return isNaN(parsed) ? null : parsed
+  return parseNonNegativeInteger(val)
+}
+
+function parseNonNegativeInteger(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) ? parsed : null
 }

--- a/tests/main/import/vcf/info-field-registry.test.ts
+++ b/tests/main/import/vcf/info-field-registry.test.ts
@@ -95,6 +95,52 @@ describe('info-field-registry', () => {
     expect(result.mappedValues.has('gnomad_af')).toBe(false)
   })
 
+  it('does not map plain AF (caller VAF) to gnomad_af — it is not a gnomAD population frequency', () => {
+    const info = new Map([['AF', '0.3']])
+    const annotation: AnnotationResult = {
+      geneSymbol: null,
+      consequence: null,
+      impact: null,
+      transcript: null,
+      cdna: null,
+      aaChange: null,
+      gnomadAf: null,
+      cadd: null,
+      clinvar: null,
+      transcripts: []
+    }
+
+    const result = applyInfoFieldRegistry(info, DEFAULT_INFO_FIELD_MAPPINGS, annotation)
+
+    expect(result.mappedValues.has('gnomad_af')).toBe(false)
+    expect(result.infoJson).not.toBeNull()
+    expect(result.infoJson!['AF']).toBe('0.3')
+  })
+
+  it('keeps the real gnomAD value when both a gnomAD field and plain AF are present', () => {
+    const info = new Map([
+      ['gnomAD_AF', '0.001'],
+      ['AF', '0.3']
+    ])
+    const annotation: AnnotationResult = {
+      geneSymbol: null,
+      consequence: null,
+      impact: null,
+      transcript: null,
+      cdna: null,
+      aaChange: null,
+      gnomadAf: null,
+      cadd: null,
+      clinvar: null,
+      transcripts: []
+    }
+
+    const result = applyInfoFieldRegistry(info, DEFAULT_INFO_FIELD_MAPPINGS, annotation)
+
+    expect(result.mappedValues.get('gnomad_af')).toBeCloseTo(0.001, 6)
+    expect(result.infoJson!['AF']).toBe('0.3')
+  })
+
   it('unmapped INFO fields go to info_json', () => {
     const info = new Map([
       ['gnomADe_AF', '0.001'], // mapped

--- a/tests/main/import/vcf/vcf-allele-splitter.test.ts
+++ b/tests/main/import/vcf/vcf-allele-splitter.test.ts
@@ -138,6 +138,33 @@ describe('vcf-allele-splitter', () => {
     expect(results[1].info.get('MLEAC')).toBe('20,.')
   })
 
+  it('normalizes empty Number=A/R INFO tokens to missing values', () => {
+    const defs = makeInfoDefs([
+      { id: 'AF', number: 'A', type: 'Float' },
+      { id: 'MLEAC', number: 'R', type: 'Integer' }
+    ])
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 202,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 95,
+      filter: 'PASS',
+      info: new Map([
+        ['AF', '0.1,'],
+        ['MLEAC', ',4']
+      ]),
+      format: ['GT'],
+      samples: new Map([['S1', ['0/2']]])
+    }
+
+    const results = splitMultiAllelic(record, defs, formatDefs)
+    expect(results[0].info.get('MLEAC')).toBe('.,4')
+    expect(results[1].info.get('AF')).toBe('.')
+    expect(results[1].info.get('MLEAC')).toBe('.,.')
+  })
+
   it('remaps GT for multi-allelic splits', () => {
     const record: VcfRawRecord = {
       chrom: 'chr22',
@@ -263,6 +290,55 @@ describe('vcf-allele-splitter', () => {
     const results = splitMultiAllelic(record, infoDefs, numberAFormats)
     expect(results[0].samples.get('S1')![1]).toBe('.,3')
     expect(results[1].samples.get('S1')![1]).toBe('.,7')
+  })
+
+  it('respects an explicit non-allelic AD Number declaration', () => {
+    const fixedPairFormats = makeFormatDefs([
+      { id: 'GT', number: '1', type: 'String' },
+      { id: 'AD', number: '2', type: 'Integer' }
+    ])
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 303,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'AD'],
+      samples: new Map([['S1', ['0/2', '10,7']]])
+    }
+
+    const results = splitMultiAllelic(record, infoDefs, fixedPairFormats)
+    expect(results[0].samples.get('S1')![1]).toBe('10,7')
+    expect(results[1].samples.get('S1')![1]).toBe('10,7')
+  })
+
+  it('normalizes empty AD tokens for Number=R and Number=A', () => {
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 304,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'AD'],
+      samples: new Map([['S1', ['0/2', '10,']]])
+    }
+
+    const numberRResults = splitMultiAllelic(record, infoDefs, formatDefs)
+    expect(numberRResults[0].samples.get('S1')![1]).toBe('10,.')
+    expect(numberRResults[1].samples.get('S1')![1]).toBe('10,.')
+
+    const numberAFormats = makeFormatDefs([
+      { id: 'GT', number: '1', type: 'String' },
+      { id: 'AD', number: 'A', type: 'Integer' }
+    ])
+    const numberAResults = splitMultiAllelic(record, infoDefs, numberAFormats)
+    expect(numberAResults[1].samples.get('S1')![1]).toBe('.,.')
   })
 
   it('handles triallelic with three ALT alleles', () => {

--- a/tests/main/import/vcf/vcf-allele-splitter.test.ts
+++ b/tests/main/import/vcf/vcf-allele-splitter.test.ts
@@ -112,6 +112,32 @@ describe('vcf-allele-splitter', () => {
     expect(r2.info.get('AC')).toBe('10') // Number=A: select index 1
   })
 
+  it('marks missing Number=A/R INFO values instead of copying another allele', () => {
+    const defs = makeInfoDefs([
+      { id: 'AF', number: 'A', type: 'Float' },
+      { id: 'MLEAC', number: 'R', type: 'Integer' }
+    ])
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 201,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 95,
+      filter: 'PASS',
+      info: new Map([
+        ['AF', '0.1'],
+        ['MLEAC', '20,4']
+      ]),
+      format: ['GT'],
+      samples: new Map([['S1', ['0/2']]])
+    }
+
+    const results = splitMultiAllelic(record, defs, formatDefs)
+    expect(results[1].info.get('AF')).toBe('.')
+    expect(results[1].info.get('MLEAC')).toBe('20,.')
+  })
+
   it('remaps GT for multi-allelic splits', () => {
     const record: VcfRawRecord = {
       chrom: 'chr22',
@@ -196,6 +222,47 @@ describe('vcf-allele-splitter', () => {
     // Split for ALT=T (altIdx=1): AD should be ref,alt2 = 10,7 — NOT 10,3
     // (the bug reused ALT#1's depth for every subsequent split allele).
     expect(results[1].samples.get('S1')![3]).toBe('10,7')
+  })
+
+  it('marks a missing target AD depth as missing instead of retaining another allele depth', () => {
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 301,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'AD'],
+      samples: new Map([['S1', ['0/2', '10,3']]])
+    }
+
+    const results = splitMultiAllelic(record, infoDefs, formatDefs)
+    expect(results[1].samples.get('S1')![1]).toBe('10,.')
+  })
+
+  it('normalizes Number=A AD to a biallelic missing-ref shape', () => {
+    const numberAFormats = makeFormatDefs([
+      { id: 'GT', number: '1', type: 'String' },
+      { id: 'AD', number: 'A', type: 'Integer' }
+    ])
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 302,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'AD'],
+      samples: new Map([['S1', ['0/2', '3,7']]])
+    }
+
+    const results = splitMultiAllelic(record, infoDefs, numberAFormats)
+    expect(results[0].samples.get('S1')![1]).toBe('.,3')
+    expect(results[1].samples.get('S1')![1]).toBe('.,7')
   })
 
   it('handles triallelic with three ALT alleles', () => {

--- a/tests/main/import/vcf/vcf-allele-splitter.test.ts
+++ b/tests/main/import/vcf/vcf-allele-splitter.test.ts
@@ -251,6 +251,28 @@ describe('vcf-allele-splitter', () => {
     expect(results[1].samples.get('S1')![3]).toBe('10,7')
   })
 
+  it('normalizes single-allelic Number=A AD into a missing-ref ALT pair', () => {
+    const altAdDefs = makeFormatDefs([
+      { id: 'GT', number: '1', type: 'String' },
+      { id: 'AD', number: 'A', type: 'Integer' }
+    ])
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 304,
+      id: null,
+      ref: 'A',
+      alt: ['G'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'AD'],
+      samples: new Map([['S1', ['0/1', '7']]])
+    }
+
+    const results = splitMultiAllelic(record, infoDefs, altAdDefs)
+    expect(results[0].samples.get('S1')![1]).toBe('.,7')
+  })
+
   it('marks a missing target AD depth as missing instead of retaining another allele depth', () => {
     const record: VcfRawRecord = {
       chrom: 'chr22',

--- a/tests/main/import/vcf/vcf-allele-splitter.test.ts
+++ b/tests/main/import/vcf/vcf-allele-splitter.test.ts
@@ -166,6 +166,38 @@ describe('vcf-allele-splitter', () => {
     expect(results[1].samples.get('S1')![3]).toBe('25,5')
   })
 
+  it('defaults AD to Number=R when the header def is missing (no ##FORMAT AD line)', () => {
+    // Simulates a VCF whose header omits ##FORMAT=<ID=AD,Number=R,...> for AD.
+    const formatDefsNoAD = makeFormatDefs([
+      { id: 'GT', number: '1', type: 'String' },
+      { id: 'GQ', number: '1', type: 'Integer' },
+      { id: 'DP', number: '1', type: 'Integer' }
+      // No AD entry at all — formatDefs.get('AD') will be undefined
+    ])
+
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 300,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'GQ', 'DP', 'AD'],
+      samples: new Map([['S1', ['0/2', '90', '48', '10,3,7']]])
+    }
+
+    const results = splitMultiAllelic(record, infoDefs, formatDefsNoAD)
+
+    // Split for ALT=G (altIdx=0): AD should be ref,alt1 = 10,3
+    expect(results[0].samples.get('S1')![3]).toBe('10,3')
+
+    // Split for ALT=T (altIdx=1): AD should be ref,alt2 = 10,7 — NOT 10,3
+    // (the bug reused ALT#1's depth for every subsequent split allele).
+    expect(results[1].samples.get('S1')![3]).toBe('10,7')
+  })
+
   it('handles triallelic with three ALT alleles', () => {
     const record: VcfRawRecord = {
       chrom: 'chr1',

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -163,7 +163,7 @@ describe('vcf-annotation-parser', () => {
       expect(result.transcripts).toHaveLength(1)
     })
 
-    it('does not cross-contaminate multi-deletion splits when a block\'s ALLELE_NUM is declared but empty', () => {
+    it("does not cross-contaminate multi-deletion splits when a block's ALLELE_NUM is declared but empty", () => {
       // REF=CAT, ALT=C,CA — same two-deletion site as above, but block 2 (GENE2)
       // has NO ALLELE_NUM value even though the CSQ header declares the field.
       // Falling back to the lossy "-"/length heuristic here would let GENE2
@@ -272,7 +272,7 @@ describe('vcf-annotation-parser', () => {
       expect(resultAllele2.transcript).toBe('T2')
     })
 
-    it('does not cross-attach a shorter split\'s ANN block via the VEP insertion-suffix heuristic', () => {
+    it("does not cross-attach a shorter split's ANN block via the VEP insertion-suffix heuristic", () => {
       // REF=A, ALT=AT,T — a mixed insertion/SNV multi-allelic site. SnpEff's ANN
       // allele field is always the full raw ALT string (confirmed against real
       // SnpEff output, e.g. tests/test-data/vcf/single-sample.snpeff.vcf.gz

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -162,6 +162,48 @@ describe('vcf-annotation-parser', () => {
       expect(result.geneSymbol).toBe('GENE1')
       expect(result.transcripts).toHaveLength(1)
     })
+
+    it('does not cross-contaminate multi-deletion splits when a block\'s ALLELE_NUM is declared but empty', () => {
+      // REF=CAT, ALT=C,CA — same two-deletion site as above, but block 2 (GENE2)
+      // has NO ALLELE_NUM value even though the CSQ header declares the field.
+      // Falling back to the lossy "-"/length heuristic here would let GENE2
+      // cross-match BOTH split records (VEP emits "-" for every deletion ALT).
+      // Correct behavior: without ALLELE_NUM to disambiguate, a "-" block must
+      // not guess — it must match neither split, while GENE1 (which does carry
+      // ALLELE_NUM=1) still matches only its own allele.
+      const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
+      const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
+      const info = new Map([
+        ['CSQ', '-|frameshift_variant|HIGH|GENE1|T1|1,-|inframe_deletion|MODERATE|GENE2|T2|']
+      ])
+
+      // Split record for ALT index 1 (C): GENE1 matches via its explicit
+      // ALLELE_NUM=1; GENE2 (no ALLELE_NUM) must NOT cross-attach.
+      const resultAllele1 = parseAnnotation(info, alleleNumHeader, 'C', 'CAT', 1)
+      expect(resultAllele1.transcripts).toHaveLength(1)
+      expect(resultAllele1.geneSymbol).toBe('GENE1')
+
+      // Split record for ALT index 2 (CA): GENE1 is excluded (ALLELE_NUM=1 !== 2)
+      // and GENE2 must ALSO be excluded — it cannot be disambiguated, so it must
+      // match nothing rather than guessing via the dash/length heuristic.
+      const resultAllele2 = parseAnnotation(info, alleleNumHeader, 'CA', 'CAT', 2)
+      expect(resultAllele2.transcripts).toHaveLength(0)
+      expect(resultAllele2.geneSymbol).toBeNull()
+    })
+
+    it('still matches a block by exact sequence when ALLELE_NUM is declared but empty and Allele is concrete', () => {
+      // Unlike the lossy "-" deletion notation, a concrete Allele sequence (e.g.
+      // an insertion's inserted bases) is unambiguous on its own — it should
+      // still match its own ALT via the exact-sequence/insertion heuristic even
+      // without ALLELE_NUM to help disambiguate.
+      const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
+      const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
+      const info = new Map([['CSQ', 'TT|frameshift_variant|HIGH|GENE3|T3|']])
+
+      const result = parseAnnotation(info, alleleNumHeader, 'ATT', 'A', 1)
+      expect(result.transcripts).toHaveLength(1)
+      expect(result.geneSymbol).toBe('GENE3')
+    })
   })
 
   describe('ANN parsing', () => {

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -272,6 +272,36 @@ describe('vcf-annotation-parser', () => {
       expect(resultAllele2.transcript).toBe('T2')
     })
 
+    it('does not cross-attach a shorter split\'s ANN block via the VEP insertion-suffix heuristic', () => {
+      // REF=A, ALT=AT,T — a mixed insertion/SNV multi-allelic site. SnpEff's ANN
+      // allele field is always the full raw ALT string (confirmed against real
+      // SnpEff output, e.g. tests/test-data/vcf/single-sample.snpeff.vcf.gz
+      // REF=T ALT=TTATC -> ANN=TTATC|...), so "AT" and "T" disambiguate by exact
+      // match. VEP's "inserted bases only" heuristic ("AT".substring(1) === "T")
+      // must NOT apply to ANN — otherwise the T block would falsely cross-attach
+      // to the AT split.
+      const info = new Map([
+        [
+          'ANN',
+          'AT|frameshift_variant|HIGH|GENE_AT|E1|transcript|T1|protein_coding|1/1|c.1_2insT|p.X1fs|||||,' +
+            'T|missense_variant|MODERATE|GENE_T|E2|transcript|T2|protein_coding|1/1|c.1A>T|p.X1Y|||||'
+        ]
+      ])
+
+      // Split record for ALT=AT must match ONLY the GENE_AT/T1 block.
+      const resultAt = parseAnnotation(info, header, 'AT', 'A')
+      expect(resultAt.transcripts).toHaveLength(1)
+      expect(resultAt.geneSymbol).toBe('GENE_AT')
+      expect(resultAt.transcript).toBe('T1')
+
+      // Split record for ALT=T must match ONLY the GENE_T/T2 block — it must NOT
+      // also pick up the AT block via the substring(1) cross-match.
+      const resultT = parseAnnotation(info, header, 'T', 'A')
+      expect(resultT.transcripts).toHaveLength(1)
+      expect(resultT.geneSymbol).toBe('GENE_T')
+      expect(resultT.transcript).toBe('T2')
+    })
+
     it('handles compound annotations (frameshift&splice_region)', () => {
       const info = new Map([
         [

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -204,12 +204,25 @@ describe('vcf-annotation-parser', () => {
       expect(result.geneSymbol).toBeNull()
     })
 
-    it('rejects a partially numeric ALLELE_NUM instead of accepting parseInt prefix data', () => {
+    it.each(['', '0', '-1', '01', '+1', ' 1', '1 ', '1junk', '9007199254740992'])(
+      'rejects malformed ALLELE_NUM %j',
+      (alleleNum) => {
+        const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
+        const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
+        const info = new Map([['CSQ', `G|missense_variant|MODERATE|GENE4|T4|${alleleNum}`]])
+
+        const result = parseAnnotation(info, alleleNumHeader, 'G', 'A', 1)
+        expect(result.transcripts).toHaveLength(0)
+        expect(result.geneSymbol).toBeNull()
+      }
+    )
+
+    it('rejects ALLELE_NUM annotations when the caller omits the allele index', () => {
       const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
       const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
-      const info = new Map([['CSQ', 'G|missense_variant|MODERATE|GENE4|T4|1junk']])
+      const info = new Map([['CSQ', 'G|missense_variant|MODERATE|GENE4|T4|1']])
 
-      const result = parseAnnotation(info, alleleNumHeader, 'G', 'A', 1)
+      const result = parseAnnotation(info, alleleNumHeader, 'G', 'A')
       expect(result.transcripts).toHaveLength(0)
       expect(result.geneSymbol).toBeNull()
     })

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -163,6 +163,23 @@ describe('vcf-annotation-parser', () => {
       expect(result.transcripts).toHaveLength(1)
     })
 
+    it('fails closed when a CSQ allele heuristic matches multiple original ALT alleles', () => {
+      const info = new Map([
+        [
+          'CSQ',
+          '-|frameshift_variant|HIGH|GENE1|E1|Transcript|T1|protein_coding||||||||||||||||,-|inframe_deletion|MODERATE|GENE2|E2|Transcript|T2|protein_coding||||||||||||||||'
+        ]
+      ])
+
+      const first = parseAnnotation(info, header, 'C', 'CAT', 1, ['C', 'CA'])
+      const second = parseAnnotation(info, header, 'CA', 'CAT', 2, ['C', 'CA'])
+
+      expect(first.transcripts).toHaveLength(0)
+      expect(second.transcripts).toHaveLength(0)
+      expect(first.geneSymbol).toBeNull()
+      expect(second.geneSymbol).toBeNull()
+    })
+
     it("does not cross-contaminate multi-deletion splits when a block's ALLELE_NUM is declared but empty", () => {
       // REF=CAT, ALT=C,CA — same two-deletion site as above, but block 2 (GENE2)
       // has NO ALLELE_NUM value even though the CSQ header declares the field.

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -267,6 +267,25 @@ describe('vcf-annotation-parser', () => {
       expect(result.transcripts).toHaveLength(1)
     })
 
+    it.each([
+      ['G-C', 'G'],
+      ['C-chr1:123456_A>T', 'C']
+    ])('matches standard compound ANN allele %s to its leading ALT %s', (annAllele, alt) => {
+      const info = new Map([
+        [
+          'ANN',
+          `${annAllele}|missense_variant|MODERATE|GENE1|E1|transcript|T1|protein_coding||||||||`
+        ]
+      ])
+
+      const matched = parseAnnotation(info, header, alt, 'A', 1, [alt, 'T'])
+      const other = parseAnnotation(info, header, 'T', 'A', 2, [alt, 'T'])
+
+      expect(matched.transcripts).toHaveLength(1)
+      expect(matched.geneSymbol).toBe('GENE1')
+      expect(other.transcripts).toHaveLength(0)
+    })
+
     it('handles multi-annotation ANN with allele filtering', () => {
       const info = new Map([
         [

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -191,18 +191,27 @@ describe('vcf-annotation-parser', () => {
       expect(resultAllele2.geneSymbol).toBeNull()
     })
 
-    it('still matches a block by exact sequence when ALLELE_NUM is declared but empty and Allele is concrete', () => {
-      // Unlike the lossy "-" deletion notation, a concrete Allele sequence (e.g.
-      // an insertion's inserted bases) is unambiguous on its own — it should
-      // still match its own ALT via the exact-sequence/insertion heuristic even
-      // without ALLELE_NUM to help disambiguate.
+    it('does not use allele heuristics when ALLELE_NUM is declared but empty', () => {
+      // Once the header declares ALLELE_NUM, it is the authoritative mapping.
+      // Falling back for just one malformed block can cross-attach an inserted-
+      // bases suffix to another ALT at a mixed multi-allelic site.
       const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
       const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
       const info = new Map([['CSQ', 'TT|frameshift_variant|HIGH|GENE3|T3|']])
 
       const result = parseAnnotation(info, alleleNumHeader, 'ATT', 'A', 1)
-      expect(result.transcripts).toHaveLength(1)
-      expect(result.geneSymbol).toBe('GENE3')
+      expect(result.transcripts).toHaveLength(0)
+      expect(result.geneSymbol).toBeNull()
+    })
+
+    it('rejects a partially numeric ALLELE_NUM instead of accepting parseInt prefix data', () => {
+      const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
+      const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
+      const info = new Map([['CSQ', 'G|missense_variant|MODERATE|GENE4|T4|1junk']])
+
+      const result = parseAnnotation(info, alleleNumHeader, 'G', 'A', 1)
+      expect(result.transcripts).toHaveLength(0)
+      expect(result.geneSymbol).toBeNull()
     })
   })
 

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -124,6 +124,44 @@ describe('vcf-annotation-parser', () => {
       expect(result.transcript).toBe('T2')
       expect(result.impact).toBe('HIGH')
     })
+
+    it('disambiguates multi-allelic deletions via ALLELE_NUM when both use "-" notation', () => {
+      // REF=CAT, ALT=C,CA — a two-deletion multi-allelic site. VEP emits "-" for
+      // BOTH deletion ALTs, so the Allele-string heuristic alone cannot tell them
+      // apart. ALLELE_NUM (1-based index of the ALT this block annotates) must
+      // disambiguate: block 1 belongs to ALT index 1 (C), block 2 to ALT index 2 (CA).
+      const fields = ['Allele', 'Consequence', 'IMPACT', 'SYMBOL', 'Feature', 'ALLELE_NUM']
+      const alleleNumHeader = makeHeader({ annotationType: 'csq', csqFields: fields })
+      const info = new Map([
+        ['CSQ', '-|frameshift_variant|HIGH|GENE1|T1|1,-|inframe_deletion|MODERATE|GENE2|T2|2']
+      ])
+
+      // Split record for ALT index 1 (C) must get ONLY the GENE1/T1 annotation.
+      const resultAllele1 = parseAnnotation(info, alleleNumHeader, 'C', 'CAT', 1)
+      expect(resultAllele1.transcripts).toHaveLength(1)
+      expect(resultAllele1.geneSymbol).toBe('GENE1')
+      expect(resultAllele1.consequence).toBe('frameshift_variant')
+      expect(resultAllele1.transcript).toBe('T1')
+
+      // Split record for ALT index 2 (CA) must get ONLY the GENE2/T2 annotation.
+      const resultAllele2 = parseAnnotation(info, alleleNumHeader, 'CA', 'CAT', 2)
+      expect(resultAllele2.transcripts).toHaveLength(1)
+      expect(resultAllele2.geneSymbol).toBe('GENE2')
+      expect(resultAllele2.consequence).toBe('inframe_deletion')
+      expect(resultAllele2.transcript).toBe('T2')
+    })
+
+    it('falls back to the Allele/length heuristic when ALLELE_NUM is absent from the CSQ config', () => {
+      // Same csqFields as the main describe block (no ALLELE_NUM) — single-deletion
+      // site, so the "-" shortcut alone is unambiguous and must still work.
+      const info = new Map([
+        ['CSQ', '-|frameshift_variant|HIGH|GENE1|E1|Transcript|T1|protein_coding||||||||||||||||']
+      ])
+
+      const result = parseAnnotation(info, header, 'C', 'CAT')
+      expect(result.geneSymbol).toBe('GENE1')
+      expect(result.transcripts).toHaveLength(1)
+    })
   })
 
   describe('ANN parsing', () => {
@@ -162,6 +200,34 @@ describe('vcf-annotation-parser', () => {
       // MODERATE should be selected over MODIFIER
       expect(result.transcript).toBe('T1')
       expect(result.geneSymbol).toBe('LZTR1')
+    })
+
+    it('disambiguates multi-allelic deletions by exact sequence, never via the "-" shortcut', () => {
+      // REF=CAT, ALT=C,CA. Unlike VEP, SnpEff's ANN allele field (index 0) always
+      // carries the real ALT sequence, so C and CA disambiguate by exact match.
+      // A third, pathological block using literal "-" (as VEP would) proves the
+      // "-"/length shortcut is disabled for ANN — it must never cross-match a
+      // real deletion allele just because it's shorter than REF.
+      const info = new Map([
+        [
+          'ANN',
+          'C|frameshift_variant|HIGH|GENE1|E1|transcript|T1|protein_coding|1/1|c.1_2del|p.X1fs|||||,' +
+            'CA|inframe_deletion|MODERATE|GENE2|E2|transcript|T2|protein_coding|1/1|c.2del|p.X2del|||||,' +
+            '-|intergenic_region|MODIFIER|GENE3|E3|transcript|T3|protein_coding|||||||||'
+        ]
+      ])
+
+      // Split record for ALT=C must match ONLY the GENE1/T1 block by exact sequence.
+      const resultAllele1 = parseAnnotation(info, header, 'C', 'CAT')
+      expect(resultAllele1.transcripts).toHaveLength(1)
+      expect(resultAllele1.geneSymbol).toBe('GENE1')
+      expect(resultAllele1.transcript).toBe('T1')
+
+      // Split record for ALT=CA must match ONLY the GENE2/T2 block.
+      const resultAllele2 = parseAnnotation(info, header, 'CA', 'CAT')
+      expect(resultAllele2.transcripts).toHaveLength(1)
+      expect(resultAllele2.geneSymbol).toBe('GENE2')
+      expect(resultAllele2.transcript).toBe('T2')
     })
 
     it('handles compound annotations (frameshift&splice_region)', () => {

--- a/tests/main/import/vcf/vcf-genotype-parser.test.ts
+++ b/tests/main/import/vcf/vcf-genotype-parser.test.ts
@@ -115,4 +115,12 @@ describe('vcf-genotype-parser', () => {
     expect(gt.adAlt).toBe(24)
     expect(gt.ab).toBeCloseTo(0.5, 4)
   })
+
+  it('does not reuse ALT 1 depth when the requested ALT depth is missing', () => {
+    const gt = parseGenotype(['0/2', '90', '13', '10,3'], FORMAT, 2)
+
+    expect(gt.adRef).toBe(10)
+    expect(gt.adAlt).toBeNull()
+    expect(gt.ab).toBeNull()
+  })
 })

--- a/tests/main/import/vcf/vcf-genotype-parser.test.ts
+++ b/tests/main/import/vcf/vcf-genotype-parser.test.ts
@@ -123,4 +123,20 @@ describe('vcf-genotype-parser', () => {
     expect(gt.adAlt).toBeNull()
     expect(gt.ab).toBeNull()
   })
+
+  it('rejects malformed AD tokens instead of accepting numeric prefixes', () => {
+    const gt = parseGenotype(['0/1', '90', '13', '10junk,7junk'], FORMAT)
+
+    expect(gt.adRef).toBeNull()
+    expect(gt.adAlt).toBeNull()
+    expect(gt.ab).toBeNull()
+  })
+
+  it('does not interpret an explicit non-A/R AD vector as REF and ALT depths', () => {
+    const gt = parseGenotype(['0/1', '90', '17', '10,7'], FORMAT, 1, '2')
+
+    expect(gt.adRef).toBeNull()
+    expect(gt.adAlt).toBeNull()
+    expect(gt.ab).toBeNull()
+  })
 })

--- a/tests/main/import/vcf/vcf-mapper.test.ts
+++ b/tests/main/import/vcf/vcf-mapper.test.ts
@@ -194,7 +194,10 @@ describe('VcfMapper', () => {
       ...header,
       formatDefs: new Map([
         ['GT', { id: 'GT', number: '1', type: 'String' as const, description: 'Genotype' }],
-        ['GQ', { id: 'GQ', number: '1', type: 'Integer' as const, description: 'Genotype Quality' }],
+        [
+          'GQ',
+          { id: 'GQ', number: '1', type: 'Integer' as const, description: 'Genotype Quality' }
+        ],
         ['DP', { id: 'DP', number: '1', type: 'Integer' as const, description: 'Read Depth' }]
         // No AD def — the VCF omits ##FORMAT=<ID=AD,Number=R,...>
       ])

--- a/tests/main/import/vcf/vcf-mapper.test.ts
+++ b/tests/main/import/vcf/vcf-mapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { mapVcfRecord } from '../../../../src/main/import/vcf/VcfMapper'
+import { parseVcfHeaderFromLines } from '../../../../src/main/import/vcf/vcf-header-parser'
 import type { VcfRawRecord, VcfHeader } from '../../../../src/main/import/vcf/types'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../../../../src/main/import/vcf/info-field-registry'
 
@@ -225,6 +226,50 @@ describe('VcfMapper', () => {
     // Must be ALT#2's own depth (7), not ALT#1's depth (3) reused via a hardcoded index.
     expect(results[0].ad_alt).toBe(7)
     expect(results[0].ab).toBeCloseTo(7 / 17, 4)
+  })
+
+  it('maps ALLELE_NUM annotations and AD through the parsed-header multi-allelic path', () => {
+    const parsedHeader = parseVcfHeaderFromLines([
+      '##fileformat=VCFv4.2',
+      '##INFO=<ID=CSQ,Number=.,Type=String,Description="VEP Format: Allele|Consequence|IMPACT|SYMBOL|Feature|ALLELE_NUM">',
+      '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+      '##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths">',
+      '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005'
+    ])
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 20006000,
+      id: null,
+      ref: 'CAT',
+      alt: ['C', 'CA'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map([
+        ['CSQ', '-|frameshift_variant|HIGH|GENE1|T1|1,-|inframe_deletion|MODERATE|GENE2|T2|2']
+      ]),
+      format: ['GT', 'AD'],
+      samples: new Map([['HG005', ['1/2', '5,7,11']]])
+    }
+
+    const results = mapVcfRecord(record, parsedHeader, 'HG005', DEFAULT_INFO_FIELD_MAPPINGS)
+
+    expect(results).toHaveLength(2)
+    expect(results[0]).toMatchObject({
+      alt: 'C',
+      gene_symbol: 'GENE1',
+      func: 'frameshift_variant',
+      gt_num: '1/.',
+      ad_ref: 5,
+      ad_alt: 7
+    })
+    expect(results[1]).toMatchObject({
+      alt: 'CA',
+      gene_symbol: 'GENE2',
+      func: 'inframe_deletion',
+      gt_num: './1',
+      ad_ref: 5,
+      ad_alt: 11
+    })
   })
 
   it('maps ANN-annotated variant with standalone INFO fields', () => {

--- a/tests/main/import/vcf/vcf-mapper.test.ts
+++ b/tests/main/import/vcf/vcf-mapper.test.ts
@@ -256,6 +256,11 @@ describe('VcfMapper', () => {
     expect(v.chr).toBe('chr22')
     expect(v.gt_num).toBe('0/1')
     expect(v.gene_symbol).toBeNull()
-    expect(v.gnomad_af).toBeCloseTo(0.1, 4) // mapped from AF via registry
+    // Plain AF is the caller's sample allele frequency, not a gnomAD population
+    // frequency — it must not be mapped to gnomad_af, but it must still be
+    // preserved in info_json rather than silently dropped.
+    expect(v.gnomad_af).toBeNull()
+    expect(v.info_json).not.toBeNull()
+    expect(JSON.parse(v.info_json!)['AF']).toBe('0.1')
   })
 })

--- a/tests/main/import/vcf/vcf-mapper.test.ts
+++ b/tests/main/import/vcf/vcf-mapper.test.ts
@@ -228,6 +228,35 @@ describe('VcfMapper', () => {
     expect(results[0].ab).toBeCloseTo(7 / 17, 4)
   })
 
+  it('does not derive allele depths from an explicitly non-allelic AD vector', () => {
+    const fixedAdHeader: VcfHeader = {
+      ...header,
+      formatDefs: new Map(header.formatDefs).set('AD', {
+        id: 'AD',
+        number: '2',
+        type: 'Integer',
+        description: 'Caller-specific fixed pair, not REF plus ALTs'
+      })
+    }
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 20005500,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'AD'],
+      samples: new Map([['HG005', ['0/2', '10,7']]])
+    }
+
+    const results = mapVcfRecord(record, fixedAdHeader, 'HG005', DEFAULT_INFO_FIELD_MAPPINGS)
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({ alt: 'T', ad_ref: null, ad_alt: null, ab: null })
+  })
+
   it('maps ALLELE_NUM annotations and AD through the parsed-header multi-allelic path', () => {
     const parsedHeader = parseVcfHeaderFromLines([
       '##fileformat=VCFv4.2',

--- a/tests/main/import/vcf/vcf-mapper.test.ts
+++ b/tests/main/import/vcf/vcf-mapper.test.ts
@@ -189,6 +189,41 @@ describe('VcfMapper', () => {
     expect(resultsHG006[0].alt).toBe('T')
   })
 
+  it('assigns each split ALT its own AD depth when the AD header lacks Number=R', () => {
+    const headerNoAdDef: VcfHeader = {
+      ...header,
+      formatDefs: new Map([
+        ['GT', { id: 'GT', number: '1', type: 'String' as const, description: 'Genotype' }],
+        ['GQ', { id: 'GQ', number: '1', type: 'Integer' as const, description: 'Genotype Quality' }],
+        ['DP', { id: 'DP', number: '1', type: 'Integer' as const, description: 'Read Depth' }]
+        // No AD def — the VCF omits ##FORMAT=<ID=AD,Number=R,...>
+      ])
+    }
+
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 20005000,
+      id: null,
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 90,
+      filter: 'PASS',
+      info: new Map(),
+      format: ['GT', 'GQ', 'DP', 'AD'],
+      samples: new Map([['HG005', ['0/2', '90', '48', '10,3,7']]])
+    }
+
+    // HG005 carries genotype 0/2 -> only the second ALT (T, altIdx=1) is relevant
+    const results = mapVcfRecord(record, headerNoAdDef, 'HG005', DEFAULT_INFO_FIELD_MAPPINGS)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].alt).toBe('T')
+    expect(results[0].ad_ref).toBe(10)
+    // Must be ALT#2's own depth (7), not ALT#1's depth (3) reused via a hardcoded index.
+    expect(results[0].ad_alt).toBe(7)
+    expect(results[0].ab).toBeCloseTo(7 / 17, 4)
+  })
+
   it('maps ANN-annotated variant with standalone INFO fields', () => {
     const annHeader: VcfHeader = {
       ...header,


### PR DESCRIPTION
## Summary

Fixes three VCF-import annotation/mapping correctness bugs (findings C3, C5, C6). All are silent data-correctness issues that could mislead a clinician.

**PR-C** of the staged security & bug remediation.

## What changed

- **`AF` no longer mapped to `gnomad_af` (C3).** Plain `AF` in a VCF is the caller's observed ALT allele frequency in the sample (DeepVariant/DRAGEN/GATK/bcftools), not a gnomAD population frequency. For non-VEP VCFs this silently stored the sample VAF in `gnomad_af`, making "gnomAD AF < 0.001" rarity filters clinically misleading. `AF` now falls through to `info_json`; real gnomAD fields are unaffected.

- **Multi-allelic deletion/insertion annotations disambiguated per format (C5).** `matchesAllele`'s VEP heuristics (`-` deletion, `substring(1)` insertion) cross-attached the wrong allele's annotation at multi-allelic sites. Now:
  - **VEP CSQ:** when `ALLELE_NUM` is present, blocks are filtered by the 1-based ALT index (threaded from `VcfMapper` as `altIdx+1`, verified correct); the `-`/length heuristic remains only as a fallback when `ALLELE_NUM` is absent from the config. A per-block empty `ALLELE_NUM` routes through exact-only matching (no lossy cross-match).
  - **SnpEff ANN:** exact raw-ALT-sequence matching only — both the deletion-dash and insertion-suffix heuristics are disabled (verified against real fixtures that SnpEff's `ANN` Allele field is always the literal ALT).

- **`AD` alt-depth split fixed when the `AD` header lacks `Number=R` (C6).** Previously the full multi-allele `AD` was kept and the 2nd+ ALT split records read the *first* ALT's depth. Now a missing/`.`-Number `AD` is treated as `Number=R` and each split record reads its own allele's depth (`AD[altIdx+1]`), so `ad_alt`/`ab` are correct.

## Reviews

- **Codex-high (per-diff whole-branch gate):** two NO-GO rounds caught real defects the per-task reviews missed — a per-block empty-`ALLELE_NUM` fallback that reintroduced cross-contamination, and the SnpEff insertion-suffix heuristic still firing on `ANN` — both fixed — then **GO**. Codex also independently confirmed the `altIdx+1` (ALLELE_NUM) and `AD[altIdx+1]` index math and the `consequence`=IMPACT / `func`=SO-term mapping.
- Per-task reviews approved each fix (one independently reverted-and-reran to confirm the tests are load-bearing).

## Verification

- `make test` (`--project main`): **2804 passing**, 0 failures; `make typecheck` clean.
- New regression fixtures: VEP two-deletion with `ALLELE_NUM`, VEP mixed present/empty `ALLELE_NUM`, SnpEff two-deletion by sequence, SnpEff `REF=A ALT=AT,T` insertion cross-attach, multi-allelic `AD` without `Number=R`.

Part of the security & bug remediation series (PR-A #306, PR-B #307; PRs D–I to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmqdEMGjqVhTX8EKr6QxoH
