### PR TITLE
fix(db): canonical transcript impact/SO model + two-engine denormalization (C4) [PR-D]

### DIFF
--- a/.planning/plans/2026-07-13-pr309-transcript-correctness.md
+++ b/.planning/plans/2026-07-13-pr309-transcript-correctness.md
@@ -1,0 +1,71 @@
+# PR309 Transcript Correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate transcript semantic mismatches across VCF/JSON import, legacy migration, transcript switching, and renderer ordering.
+
+**Architecture:** Centralize IMPACT/SO repair in the shared transcript canonicalizer. Keep format-specific annotation ranking in the VCF parser, and mirror explicit-null denormalization plus selected-row migration recovery across SQLite and PostgreSQL.
+
+**Tech Stack:** TypeScript 6, Vitest, SQLite, PostgreSQL, Vue renderer utilities.
+
+---
+
+### Task 1: Canonicalization and import validation
+
+**Files:**
+- Modify: `src/shared/types/transcript.ts`
+- Modify: `src/main/import/transforms/FieldMapper.ts`
+- Test: `tests/main/import/ObjectFormatMapper.test.ts`
+- Test: `tests/main/import/FieldMapper.test.ts`
+
+- [ ] Add failing tests proving swapped `{ consequence: SO, func: IMPACT }` becomes `{ consequence: IMPACT, func: SO }` and unknown columnar IMPACT becomes `null`.
+- [ ] Run the two test files and confirm the expected assertion failures.
+- [ ] Update `canonicalizeTranscriptSemantics` to detect IMPACT in either input and update `FieldMapper` to canonicalize its mapped IMPACT/FUNC pair.
+- [ ] Run the two test files and confirm they pass.
+
+### Task 2: Highest-impact VCF transcript rows
+
+**Files:**
+- Modify: `src/main/import/vcf/vcf-annotation-parser.ts`
+- Test: `tests/main/import/vcf/vcf-annotation-parser.test.ts`
+
+- [ ] Add failing CSQ and ANN tests with duplicate feature IDs whose later annotation has higher impact.
+- [ ] Run the parser test and confirm selected transcript rows disagree with the parent before the fix.
+- [ ] Rank annotations per transcript using the existing CSQ/ANN scoring functions before constructing each row.
+- [ ] Run the parser test and confirm parent and selected transcript semantics agree.
+
+### Task 3: Legacy impact recovery and explicit-null switching
+
+**Files:**
+- Modify: `src/main/database/migrations.ts`
+- Modify: `src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql`
+- Modify: `src/main/database/TranscriptRepository.ts`
+- Modify: `src/main/storage/postgres/PostgresTranscriptsRepository.ts`
+- Test: `tests/main/database/migrations.test.ts`
+- Test: `tests/main/storage/postgres-migration-definitions.test.ts`
+- Test: `tests/main/storage/transcript-switch-denormalization.test.ts`
+- Test: `tests/main/storage/postgres-transcripts-repository.test.ts`
+
+- [ ] Add failing migration tests proving the selected matching legacy transcript recovers parent IMPACT while non-selected/nonmatching rows remain null.
+- [ ] Add failing switch tests proving an impact-unknown target clears the parent consequence on both repository paths.
+- [ ] Run the focused migration/storage tests and confirm expected failures.
+- [ ] Change migrations to preserve original SO in `func` and conditionally recover selected matching IMPACT; make both repositories always set consequence, including null.
+- [ ] Run the focused migration/storage tests and confirm they pass.
+
+### Task 4: DB-only renderer severity
+
+**Files:**
+- Modify: `src/renderer/src/utils/mergeTranscripts.ts`
+- Test: `tests/renderer/utils/mergeTranscripts.test.ts`
+
+- [ ] Add a failing test proving DB-only HIGH sorts before DB-only MODERATE.
+- [ ] Run the test and confirm alphabetical ordering causes failure.
+- [ ] Initialize unified DB rows with `impact` from canonical `db.consequence`.
+- [ ] Run the renderer utility test and confirm it passes.
+
+### Task 5: Verification and commit
+
+- [ ] Run all focused suites touched above.
+- [ ] Run `make typecheck`, `make agent-check`, and `make ci`.
+- [ ] Inspect `git diff --check` and the final diff.
+- [ ] Commit with `fix(import): close transcript semantic edge cases`.

--- a/.planning/specs/2026-07-13-pr309-transcript-correctness-design.md
+++ b/.planning/specs/2026-07-13-pr309-transcript-correctness-design.md
@@ -1,0 +1,21 @@
+# PR309 Transcript Correctness Follow-up Design
+
+## Goal
+
+Close the five adversarial review findings while preserving the canonical model: `consequence` is an IMPACT enum and `func` is a Sequence Ontology term.
+
+## Design
+
+- Extend the shared transcript semantic canonicalizer so an IMPACT found in either input field is retained, an SO term is retained in `func`, and invalid/nonrecoverable impact becomes `null`.
+- In the VCF annotation parser, select the highest-ranked annotation independently for each transcript before constructing transcript rows. Parent selection and per-transcript selection use the same format-specific ranking.
+- In SQLite and PostgreSQL migrations, preserve the legacy SO term in `func` and recover impact only for the selected row whose transcript matches the parent variant and whose parent consequence is a valid IMPACT enum.
+- Transcript switches atomically write every denormalized field, including `consequence = null` when impact is unavailable. This prevents rows assembled from two different selected transcripts.
+- Columnar JSON mapping validates IMPACT through the shared canonicalizer. Renderer merge rows expose DB `consequence` as their sortable impact.
+
+## Error handling and compatibility
+
+Unknown impact values fail closed to `null`; they are never copied into `consequence`. Existing SO terms are preserved when possible. Both storage engines implement identical migration and switch semantics inside existing transactions.
+
+## Verification
+
+Each finding receives a regression test that is observed failing before the implementation change. Focused import, migration, storage, and renderer suites run after each fix, followed by typecheck, agent-check, and the repository CI gate.

--- a/scripts/postgres/init-db/12-phase7-variants.sql
+++ b/scripts/postgres/init-db/12-phase7-variants.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS variant_transcripts (
   transcript_id TEXT NOT NULL,
   gene_symbol TEXT,
   consequence TEXT,
+  func TEXT,
   cdna TEXT,
   aa_change TEXT,
   hpo_sim_score DOUBLE PRECISION,

--- a/src/main/database/TranscriptRepository.ts
+++ b/src/main/database/TranscriptRepository.ts
@@ -1,5 +1,9 @@
 import { BaseRepository } from './BaseRepository'
-import type { TranscriptAnnotation, TranscriptInsertRow } from '../../shared/types/transcript'
+import {
+  isTranscriptImpact,
+  type TranscriptAnnotation,
+  type TranscriptInsertRow
+} from '../../shared/types/transcript'
 
 export class TranscriptRepository extends BaseRepository {
   getVariantTranscripts(variantId: number): TranscriptAnnotation[] {
@@ -93,20 +97,27 @@ export class TranscriptRepository extends BaseRepository {
           .where('transcript_id', '=', transcriptId)
       )!
 
+      const canonicalImpact = isTranscriptImpact(transcript.consequence)
+        ? transcript.consequence
+        : undefined
+      const canonicalFunc =
+        canonicalImpact === undefined
+          ? (transcript.func ?? transcript.consequence)
+          : transcript.func
+
+      const denormalized = {
+        transcript: transcriptId,
+        gene_symbol: transcript.gene_symbol,
+        func: canonicalFunc,
+        cdna: transcript.cdna,
+        aa_change: transcript.aa_change,
+        hpo_sim_score: transcript.hpo_sim_score,
+        moi: transcript.moi,
+        ...(canonicalImpact === undefined ? {} : { consequence: canonicalImpact })
+      }
+
       this.execRun(
-        this.kysely
-          .updateTable('variants')
-          .set({
-            transcript: transcriptId,
-            gene_symbol: transcript.gene_symbol,
-            consequence: transcript.consequence,
-            func: transcript.func,
-            cdna: transcript.cdna,
-            aa_change: transcript.aa_change,
-            hpo_sim_score: transcript.hpo_sim_score,
-            moi: transcript.moi
-          })
-          .where('id', '=', variantId)
+        this.kysely.updateTable('variants').set(denormalized).where('id', '=', variantId)
       )
     })
   }

--- a/src/main/database/TranscriptRepository.ts
+++ b/src/main/database/TranscriptRepository.ts
@@ -72,6 +72,7 @@ export class TranscriptRepository extends BaseRepository {
       const transcript = this.execFirst<{
         gene_symbol: string | null
         consequence: string | null
+        func: string | null
         cdna: string | null
         aa_change: string | null
         hpo_sim_score: number | null
@@ -79,7 +80,15 @@ export class TranscriptRepository extends BaseRepository {
       }>(
         this.kysely
           .selectFrom('variant_transcripts')
-          .select(['gene_symbol', 'consequence', 'cdna', 'aa_change', 'hpo_sim_score', 'moi'])
+          .select([
+            'gene_symbol',
+            'consequence',
+            'func',
+            'cdna',
+            'aa_change',
+            'hpo_sim_score',
+            'moi'
+          ])
           .where('variant_id', '=', variantId)
           .where('transcript_id', '=', transcriptId)
       )!
@@ -91,6 +100,7 @@ export class TranscriptRepository extends BaseRepository {
             transcript: transcriptId,
             gene_symbol: transcript.gene_symbol,
             consequence: transcript.consequence,
+            func: transcript.func,
             cdna: transcript.cdna,
             aa_change: transcript.aa_change,
             hpo_sim_score: transcript.hpo_sim_score,

--- a/src/main/database/TranscriptRepository.ts
+++ b/src/main/database/TranscriptRepository.ts
@@ -1,6 +1,6 @@
 import { BaseRepository } from './BaseRepository'
 import {
-  isTranscriptImpact,
+  canonicalizeTranscriptSemantics,
   type TranscriptAnnotation,
   type TranscriptInsertRow
 } from '../../shared/types/transcript'
@@ -97,23 +97,17 @@ export class TranscriptRepository extends BaseRepository {
           .where('transcript_id', '=', transcriptId)
       )!
 
-      const canonicalImpact = isTranscriptImpact(transcript.consequence)
-        ? transcript.consequence
-        : undefined
-      const canonicalFunc =
-        canonicalImpact === undefined
-          ? (transcript.func ?? transcript.consequence)
-          : transcript.func
+      const semantics = canonicalizeTranscriptSemantics(transcript.consequence, transcript.func)
 
       const denormalized = {
         transcript: transcriptId,
         gene_symbol: transcript.gene_symbol,
-        func: canonicalFunc,
+        consequence: semantics.consequence,
+        func: semantics.func,
         cdna: transcript.cdna,
         aa_change: transcript.aa_change,
         hpo_sim_score: transcript.hpo_sim_score,
-        moi: transcript.moi,
-        ...(canonicalImpact === undefined ? {} : { consequence: canonicalImpact })
+        moi: transcript.moi
       }
 
       this.execRun(

--- a/src/main/database/TranscriptRepository.ts
+++ b/src/main/database/TranscriptRepository.ts
@@ -9,6 +9,7 @@ export class TranscriptRepository extends BaseRepository {
       transcript_id: string
       gene_symbol: string | null
       consequence: string | null
+      func: string | null
       cdna: string | null
       aa_change: string | null
       hpo_sim_score: number | null
@@ -25,6 +26,7 @@ export class TranscriptRepository extends BaseRepository {
           'transcript_id',
           'gene_symbol',
           'consequence',
+          'func',
           'cdna',
           'aa_change',
           'hpo_sim_score',
@@ -109,6 +111,7 @@ export class TranscriptRepository extends BaseRepository {
             transcript_id: transcript.transcript_id,
             gene_symbol: transcript.gene_symbol,
             consequence: transcript.consequence,
+            func: transcript.func,
             cdna: transcript.cdna,
             aa_change: transcript.aa_change,
             hpo_sim_score: transcript.hpo_sim_score,

--- a/src/main/database/VariantRepository.ts
+++ b/src/main/database/VariantRepository.ts
@@ -122,7 +122,6 @@ export class VariantRepository extends BaseRepository {
           )
 
           const variantId = result.lastInsertRowid as number
-
           if (v._transcripts !== undefined && v._transcripts.length > 0) {
             for (const t of v._transcripts) {
               this.execRun(

--- a/src/main/database/VariantRepository.ts
+++ b/src/main/database/VariantRepository.ts
@@ -131,6 +131,7 @@ export class VariantRepository extends BaseRepository {
                   transcript_id: t.transcript_id,
                   gene_symbol: t.gene_symbol,
                   consequence: t.consequence,
+                  func: t.func,
                   cdna: t.cdna,
                   aa_change: t.aa_change,
                   hpo_sim_score: t.hpo_sim_score,

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -1792,17 +1792,14 @@ export function runMigrations(db: Database.Database): void {
   // = IMPACT and variant_transcripts.func = SO term on every path, matching
   // the variants table's existing convention.
   //
-  // Backfill: additive only, no data mutation. Legacy rows are NOT rewritten:
+  // Backfill without guessing an impact:
   //   - JSON-imported rows already have the correct IMPACT in `consequence`;
   //     the original per-transcript SO term was discarded at import time and
   //     cannot be recovered from the database alone, so `func` stays NULL.
-  //   - VCF-imported rows keep their historically mislabeled `consequence`
-  //     (which actually holds an SO term, not an IMPACT level). Inferring the
-  //     correct IMPACT from a bare SO term would require embedding a static
-  //     VEP/SnpEff severity-ranking table as a guess — explicitly out of
-  //     scope ("do NOT guess an impact you can't derive"). `func` stays NULL
-  //     for these rows too. A full re-import of the affected case corrects
-  //     both columns going forward.
+  //   - A non-enum `consequence` is provably not an IMPACT value. Preserve it
+  //     as the SO term in `func` and clear `consequence`; do not guess an
+  //     unavailable impact. Repository writeback preserves the parent impact
+  //     when the selected transcript has no known impact.
   if (currentVersion < 32) {
     const vtCols = db.prepare('PRAGMA table_info(variant_transcripts)').all() as {
       name: string
@@ -1810,6 +1807,13 @@ export function runMigrations(db: Database.Database): void {
     if (!vtCols.some((c) => c.name === 'func')) {
       db.exec('ALTER TABLE variant_transcripts ADD COLUMN func TEXT')
     }
+    db.exec(`
+      UPDATE variant_transcripts
+         SET func = consequence,
+             consequence = NULL
+       WHERE consequence IS NOT NULL
+         AND consequence NOT IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
+    `)
     db.exec('PRAGMA user_version = 32')
   }
 }

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -43,6 +43,10 @@ import { BUILT_IN_SHORTLIST_PRESETS } from './built-in-shortlist-presets'
  * - 26: v0.55.0 FTS5 virtual tables for variant_sv + variant_str (multi-variant filter/sort/search)
  * - 27: filter_presets.kind discriminator + built-in shortlist preset seeds (unified Shortlist tab)
  * - 28: idx_variants_case_type for case_id-first cohort scans
+ * - 29: covering index on variants(chr, pos, ref, alt)
+ * - 30: end_pos on cohort_variant_summary for SV/CNV interval-overlap
+ * - 31: projects registry
+ * - 32: variant_transcripts.func — canonical transcript impact/SO model (D1)
  *
  * @param db - better-sqlite3-multiple-ciphers Database instance
  */
@@ -1773,5 +1777,39 @@ export function runMigrations(db: Database.Database): void {
         VALUES (1, 'default', 'main');
     `)
     db.exec('PRAGMA user_version = 31')
+  }
+
+  // ── Migration v32: canonical transcript impact/SO model (D1) ──
+  //
+  // variant_transcripts.consequence is conflated: JSON import writes the
+  // IMPACT level there (correct per the variants.consequence/variants.func
+  // convention), but VCF import (VEP CSQ / SnpEff ANN) writes the raw
+  // Sequence Ontology term instead — corrupting impact/rarity filters once
+  // the transcript-switch denormalization copies it onto variants.consequence.
+  //
+  // Fix: add a `func` column mirroring variants.func, and fix every import
+  // path (this migration + application code) so variant_transcripts.consequence
+  // = IMPACT and variant_transcripts.func = SO term on every path, matching
+  // the variants table's existing convention.
+  //
+  // Backfill: additive only, no data mutation. Legacy rows are NOT rewritten:
+  //   - JSON-imported rows already have the correct IMPACT in `consequence`;
+  //     the original per-transcript SO term was discarded at import time and
+  //     cannot be recovered from the database alone, so `func` stays NULL.
+  //   - VCF-imported rows keep their historically mislabeled `consequence`
+  //     (which actually holds an SO term, not an IMPACT level). Inferring the
+  //     correct IMPACT from a bare SO term would require embedding a static
+  //     VEP/SnpEff severity-ranking table as a guess — explicitly out of
+  //     scope ("do NOT guess an impact you can't derive"). `func` stays NULL
+  //     for these rows too. A full re-import of the affected case corrects
+  //     both columns going forward.
+  if (currentVersion < 32) {
+    const vtCols = db.prepare('PRAGMA table_info(variant_transcripts)').all() as {
+      name: string
+    }[]
+    if (!vtCols.some((c) => c.name === 'func')) {
+      db.exec('ALTER TABLE variant_transcripts ADD COLUMN func TEXT')
+    }
+    db.exec('PRAGMA user_version = 32')
   }
 }

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -1793,9 +1793,9 @@ export function runMigrations(db: Database.Database): void {
   // the variants table's existing convention.
   //
   // Backfill without guessing an impact:
-  //   - JSON-imported rows already have the correct IMPACT in `consequence`;
-  //     the original per-transcript SO term was discarded at import time and
-  //     cannot be recovered from the database alone, so `func` stays NULL.
+  //   - JSON-imported rows already have the correct IMPACT in `consequence`.
+  //     Recover `func` for the selected row when the parent still names that
+  //     transcript and retains its SO term; other unavailable terms stay NULL.
   //   - A non-enum `consequence` is provably not an IMPACT value. Preserve it
   //     as the SO term in `func`. For the selected transcript only, recover the
   //     parent IMPACT when the parent names that same transcript; all other
@@ -1808,6 +1808,25 @@ export function runMigrations(db: Database.Database): void {
       db.exec('ALTER TABLE variant_transcripts ADD COLUMN func TEXT')
     }
     db.exec(`
+      UPDATE variant_transcripts AS vt
+         SET func = (
+           SELECT v.func
+             FROM variants AS v
+            WHERE v.id = vt.variant_id
+              AND v.transcript = vt.transcript_id
+              AND v.func IS NOT NULL
+         )
+       WHERE vt.func IS NULL
+         AND vt.is_selected = 1
+         AND vt.consequence IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
+         AND EXISTS (
+           SELECT 1
+             FROM variants AS v
+            WHERE v.id = vt.variant_id
+              AND v.transcript = vt.transcript_id
+              AND v.func IS NOT NULL
+         );
+
       UPDATE variant_transcripts AS vt
          SET func = vt.consequence,
              consequence = CASE

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -1797,9 +1797,9 @@ export function runMigrations(db: Database.Database): void {
   //     the original per-transcript SO term was discarded at import time and
   //     cannot be recovered from the database alone, so `func` stays NULL.
   //   - A non-enum `consequence` is provably not an IMPACT value. Preserve it
-  //     as the SO term in `func` and clear `consequence`; do not guess an
-  //     unavailable impact. Repository writeback preserves the parent impact
-  //     when the selected transcript has no known impact.
+  //     as the SO term in `func`. For the selected transcript only, recover the
+  //     parent IMPACT when the parent names that same transcript; all other
+  //     unavailable impacts stay NULL.
   if (currentVersion < 32) {
     const vtCols = db.prepare('PRAGMA table_info(variant_transcripts)').all() as {
       name: string
@@ -1808,11 +1808,20 @@ export function runMigrations(db: Database.Database): void {
       db.exec('ALTER TABLE variant_transcripts ADD COLUMN func TEXT')
     }
     db.exec(`
-      UPDATE variant_transcripts
-         SET func = consequence,
-             consequence = NULL
-       WHERE consequence IS NOT NULL
-         AND consequence NOT IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
+      UPDATE variant_transcripts AS vt
+         SET func = vt.consequence,
+             consequence = CASE
+               WHEN vt.is_selected = 1 THEN (
+                 SELECT v.consequence
+                   FROM variants AS v
+                  WHERE v.id = vt.variant_id
+                    AND v.transcript = vt.transcript_id
+                    AND v.consequence IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
+               )
+               ELSE NULL
+             END
+       WHERE vt.consequence IS NOT NULL
+         AND vt.consequence NOT IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
     `)
     db.exec('PRAGMA user_version = 32')
   }

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS variant_transcripts (
   transcript_id TEXT NOT NULL,
   gene_symbol TEXT,
   consequence TEXT,
+  func TEXT,
   cdna TEXT,
   aa_change TEXT,
   hpo_sim_score REAL,

--- a/src/main/import/transforms/FieldMapper.ts
+++ b/src/main/import/transforms/FieldMapper.ts
@@ -254,6 +254,7 @@ export class FieldMapper extends Transform {
           string | null,
         consequence: this.extractValue(row, this.cols.IMPACT, i, true, IMPACT_DICTIONARY) as
           string | null,
+        func: this.extractValue(row, this.cols.FUNC, i, false) as string | null,
         cdna: this.extractValue(row, this.cols.CDNA, i, false) as string | null,
         aa_change: this.extractValue(row, this.cols.AA_CHANGE, i, false) as string | null,
         hpo_sim_score: this.extractNumericFromDict(

--- a/src/main/import/transforms/FieldMapper.ts
+++ b/src/main/import/transforms/FieldMapper.ts
@@ -9,6 +9,7 @@ import {
 } from '../config/fieldMapping'
 import type { RawVariantRow } from '../types'
 import type { TranscriptInsertRow } from '../../../shared/types/transcript'
+import { canonicalizeTranscriptSemantics } from '../../../shared/types/transcript'
 
 type MappedVariant = Omit<Variant, 'id' | 'case_id'>
 
@@ -40,6 +41,11 @@ export class FieldMapper extends Transform {
     try {
       const row = chunk.value
       const selectedTranscript = (row[this.cols.SELECTED_TRANSCRIPT] as number) ?? 0
+      const semantics = canonicalizeTranscriptSemantics(
+        this.extractValue(row, this.cols.IMPACT, selectedTranscript, true, IMPACT_DICTIONARY) as
+          string | null,
+        this.extractValue(row, this.cols.FUNC, selectedTranscript, false) as string | null
+      )
 
       const mapped: MappedVariant = {
         chr: this.extractValue(row, this.cols.CHR, selectedTranscript, false) as string,
@@ -60,13 +66,7 @@ export class FieldMapper extends Transform {
           false,
           undefined
         ) as string | null,
-        consequence: this.extractValue(
-          row,
-          this.cols.IMPACT,
-          selectedTranscript,
-          true,
-          IMPACT_DICTIONARY
-        ) as string | null,
+        consequence: semantics.consequence,
         gnomad_af: this.extractValue(row, this.cols.GNOMAD_AF, selectedTranscript, false) as
           number | null,
         cadd: this.extractValue(row, this.cols.CADD, selectedTranscript, false) as number | null,
@@ -74,7 +74,7 @@ export class FieldMapper extends Transform {
           string | null,
         gt_num: this.extractValue(row, this.cols.GT_NUM, selectedTranscript, false) as
           string | null,
-        func: this.extractValue(row, this.cols.FUNC, selectedTranscript, false) as string | null,
+        func: semantics.func,
         qual: this.extractValue(row, this.cols.QUAL, selectedTranscript, false) as number | null,
         hpo_sim_score: this.extractNumericFromDict(
           row,
@@ -248,13 +248,16 @@ export class FieldMapper extends Transform {
       if (transcriptId === null || seen.has(transcriptId)) continue
       seen.add(transcriptId)
 
+      const semantics = canonicalizeTranscriptSemantics(
+        this.extractValue(row, this.cols.IMPACT, i, true, IMPACT_DICTIONARY) as string | null,
+        this.extractValue(row, this.cols.FUNC, i, false) as string | null
+      )
       transcripts.push({
         transcript_id: transcriptId,
         gene_symbol: this.extractValue(row, this.cols.GENE, i, true, this.dictionaries.gene) as
           string | null,
-        consequence: this.extractValue(row, this.cols.IMPACT, i, true, IMPACT_DICTIONARY) as
-          string | null,
-        func: this.extractValue(row, this.cols.FUNC, i, false) as string | null,
+        consequence: semantics.consequence,
+        func: semantics.func,
         cdna: this.extractValue(row, this.cols.CDNA, i, false) as string | null,
         aa_change: this.extractValue(row, this.cols.AA_CHANGE, i, false) as string | null,
         hpo_sim_score: this.extractNumericFromDict(

--- a/src/main/import/transforms/ObjectFormatMapper.ts
+++ b/src/main/import/transforms/ObjectFormatMapper.ts
@@ -144,6 +144,7 @@ export class ObjectFormatMapper extends Transform {
             transcript_id: mapped.transcript,
             gene_symbol: mapped.gene_symbol,
             consequence: mapped.consequence,
+            func: mapped.func,
             cdna: mapped.cdna,
             aa_change: mapped.aa_change,
             hpo_sim_score: mapped.hpo_sim_score,

--- a/src/main/import/transforms/ObjectFormatMapper.ts
+++ b/src/main/import/transforms/ObjectFormatMapper.ts
@@ -1,6 +1,7 @@
 import { Transform, TransformCallback } from 'node:stream'
 import type { Variant } from '../../database/types'
 import type { TranscriptInsertRow } from '../../../shared/types/transcript'
+import { canonicalizeTranscriptSemantics } from '../../../shared/types/transcript'
 
 type MappedVariant = Omit<Variant, 'id' | 'case_id'>
 
@@ -108,6 +109,10 @@ export class ObjectFormatMapper extends Transform {
         }
       }
 
+      const semantics = canonicalizeTranscriptSemantics(
+        normalizeString(variant.consequence),
+        normalizeString(variant.func)
+      )
       const mapped: MappedVariant = {
         chr: normalizeString(variant.chr) ?? '',
         pos: normalizeNumber(variant.pos) ?? 0,
@@ -115,12 +120,12 @@ export class ObjectFormatMapper extends Transform {
         alt: normalizeString(variant.alt) ?? '',
         gene_symbol: normalizeString(variant.gene_symbol),
         omim_mim_number: normalizeString(variant.omim_mim_number),
-        consequence: normalizeString(variant.consequence),
+        consequence: semantics.consequence,
         gnomad_af: normalizeNumber(variant.gnomad_af),
         cadd: normalizeNumber(variant.cadd),
         clinvar: normalizeString(variant.clinvar),
         gt_num: normalizeString(variant.gt_num),
-        func: normalizeString(variant.func),
+        func: semantics.func,
         qual: normalizeNumber(variant.qual),
         hpo_sim_score: normalizeNumber(variant.hpo_sim_score),
         transcript: normalizeString(variant.transcript),

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -92,7 +92,9 @@ function parseCsq(
       transcriptMap.set(tid, {
         transcript_id: tid,
         gene_symbol: t.fields.get('SYMBOL') ?? null,
-        consequence: t.fields.get('Consequence') ?? null,
+        // Canonical model: consequence = IMPACT level, func = SO term.
+        consequence: t.fields.get('IMPACT') ?? null,
+        func: t.fields.get('Consequence') ?? null,
         cdna: t.fields.get('HGVSc') ?? null,
         aa_change: t.fields.get('HGVSp') ?? null,
         hpo_sim_score: null,
@@ -185,7 +187,9 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
       transcriptMap.set(tid, {
         transcript_id: tid,
         gene_symbol: t.parts[ANN_GENE_NAME] ?? null,
-        consequence: t.parts[ANN_ANNOTATION] ?? null,
+        // Canonical model: consequence = IMPACT level, func = SO term.
+        consequence: t.parts[ANN_IMPACT] ?? null,
+        func: t.parts[ANN_ANNOTATION] ?? null,
         cdna: t.parts[ANN_HGVSC] ?? null,
         aa_change: t.parts[ANN_HGVSP] ?? null,
         hpo_sim_score: null,

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -6,7 +6,10 @@
  */
 
 import type { VcfHeader, AnnotationResult } from './types'
-import type { TranscriptInsertRow } from '../../../shared/types/transcript'
+import {
+  canonicalizeTranscriptSemantics,
+  type TranscriptInsertRow
+} from '../../../shared/types/transcript'
 
 /** Impact severity order for transcript selection */
 const IMPACT_ORDER: Record<string, number> = {
@@ -89,12 +92,16 @@ function parseCsq(
   for (const t of filtered) {
     const tid = t.fields.get('Feature') ?? ''
     if (!transcriptMap.has(tid)) {
+      const semantics = canonicalizeTranscriptSemantics(
+        t.fields.get('IMPACT') ?? null,
+        t.fields.get('Consequence') ?? null
+      )
       transcriptMap.set(tid, {
         transcript_id: tid,
         gene_symbol: t.fields.get('SYMBOL') ?? null,
         // Canonical model: consequence = IMPACT level, func = SO term.
-        consequence: t.fields.get('IMPACT') ?? null,
-        func: t.fields.get('Consequence') ?? null,
+        consequence: semantics.consequence,
+        func: semantics.func,
         cdna: t.fields.get('HGVSc') ?? null,
         aa_change: t.fields.get('HGVSp') ?? null,
         hpo_sim_score: null,
@@ -114,6 +121,10 @@ function parseCsq(
   }
 
   const best = bestIdx >= 0 ? filtered[bestIdx] : null
+  const bestSemantics = canonicalizeTranscriptSemantics(
+    best?.fields.get('IMPACT') ?? null,
+    best?.fields.get('Consequence') ?? null
+  )
 
   // Parse numeric fields from the best transcript
   const gnomadAfStr = best?.fields.get('gnomADe_AF') ?? best?.fields.get('gnomADg_AF') ?? null
@@ -123,7 +134,7 @@ function parseCsq(
   return {
     geneSymbol: best?.fields.get('SYMBOL') ?? null,
     consequence: best?.fields.get('Consequence') ?? null,
-    impact: best?.fields.get('IMPACT') ?? null,
+    impact: bestSemantics.consequence,
     transcript: best?.fields.get('Feature') ?? null,
     cdna: best?.fields.get('HGVSc') ?? null,
     aaChange: best?.fields.get('HGVSp') ?? null,
@@ -184,12 +195,16 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
   for (const t of filtered) {
     const tid = t.parts[ANN_FEATURE_ID] ?? ''
     if (!transcriptMap.has(tid)) {
+      const semantics = canonicalizeTranscriptSemantics(
+        t.parts[ANN_IMPACT] ?? null,
+        t.parts[ANN_ANNOTATION] ?? null
+      )
       transcriptMap.set(tid, {
         transcript_id: tid,
         gene_symbol: t.parts[ANN_GENE_NAME] ?? null,
         // Canonical model: consequence = IMPACT level, func = SO term.
-        consequence: t.parts[ANN_IMPACT] ?? null,
-        func: t.parts[ANN_ANNOTATION] ?? null,
+        consequence: semantics.consequence,
+        func: semantics.func,
         cdna: t.parts[ANN_HGVSC] ?? null,
         aa_change: t.parts[ANN_HGVSP] ?? null,
         hpo_sim_score: null,
@@ -209,11 +224,15 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
   }
 
   const best = bestIdx >= 0 ? filtered[bestIdx] : null
+  const bestSemantics = canonicalizeTranscriptSemantics(
+    best?.parts[ANN_IMPACT] ?? null,
+    best?.parts[ANN_ANNOTATION] ?? null
+  )
 
   return {
     geneSymbol: best?.parts[ANN_GENE_NAME] ?? null,
     consequence: best?.parts[ANN_ANNOTATION] ?? null,
-    impact: best?.parts[ANN_IMPACT] ?? null,
+    impact: bestSemantics.consequence,
     transcript: best?.parts[ANN_FEATURE_ID] ?? null,
     cdna: best?.parts[ANN_HGVSC] ?? null,
     aaChange: best?.parts[ANN_HGVSP] ?? null,

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -88,29 +88,32 @@ function parseCsq(
 
   // Build TranscriptInsertRows, deduplicating by transcript_id
   // (same transcript can appear multiple times with different consequences)
-  const transcriptMap = new Map<string, TranscriptInsertRow>()
+  const transcriptMap = new Map<string, CsqTranscript>()
   for (const t of filtered) {
     const tid = t.fields.get('Feature') ?? ''
-    if (!transcriptMap.has(tid)) {
-      const semantics = canonicalizeTranscriptSemantics(
-        t.fields.get('IMPACT') ?? null,
-        t.fields.get('Consequence') ?? null
-      )
-      transcriptMap.set(tid, {
-        transcript_id: tid,
-        gene_symbol: t.fields.get('SYMBOL') ?? null,
-        // Canonical model: consequence = IMPACT level, func = SO term.
-        consequence: semantics.consequence,
-        func: semantics.func,
-        cdna: t.fields.get('HGVSc') ?? null,
-        aa_change: t.fields.get('HGVSp') ?? null,
-        hpo_sim_score: null,
-        moi: null,
-        is_selected: 0
-      })
+    const existing = transcriptMap.get(tid)
+    if (existing === undefined || selectBestTranscript([existing, t]) === 1) {
+      transcriptMap.set(tid, t)
     }
   }
-  const transcripts = Array.from(transcriptMap.values())
+  const transcripts: TranscriptInsertRow[] = Array.from(transcriptMap.values()).map((t) => {
+    const semantics = canonicalizeTranscriptSemantics(
+      t.fields.get('IMPACT') ?? null,
+      t.fields.get('Consequence') ?? null
+    )
+    return {
+      transcript_id: t.fields.get('Feature') ?? '',
+      gene_symbol: t.fields.get('SYMBOL') ?? null,
+      // Canonical model: consequence = IMPACT level, func = SO term.
+      consequence: semantics.consequence,
+      func: semantics.func,
+      cdna: t.fields.get('HGVSc') ?? null,
+      aa_change: t.fields.get('HGVSp') ?? null,
+      hpo_sim_score: null,
+      moi: null,
+      is_selected: 0
+    }
+  })
 
   // Select best transcript
   const bestIdx = selectBestTranscript(filtered)
@@ -191,29 +194,32 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
 
   // Build TranscriptInsertRows, deduplicating by transcript_id
   // (same transcript can appear multiple times with different consequences)
-  const transcriptMap = new Map<string, TranscriptInsertRow>()
+  const transcriptMap = new Map<string, AnnTranscript>()
   for (const t of filtered) {
     const tid = t.parts[ANN_FEATURE_ID] ?? ''
-    if (!transcriptMap.has(tid)) {
-      const semantics = canonicalizeTranscriptSemantics(
-        t.parts[ANN_IMPACT] ?? null,
-        t.parts[ANN_ANNOTATION] ?? null
-      )
-      transcriptMap.set(tid, {
-        transcript_id: tid,
-        gene_symbol: t.parts[ANN_GENE_NAME] ?? null,
-        // Canonical model: consequence = IMPACT level, func = SO term.
-        consequence: semantics.consequence,
-        func: semantics.func,
-        cdna: t.parts[ANN_HGVSC] ?? null,
-        aa_change: t.parts[ANN_HGVSP] ?? null,
-        hpo_sim_score: null,
-        moi: null,
-        is_selected: 0
-      })
+    const existing = transcriptMap.get(tid)
+    if (existing === undefined || selectBestTranscriptAnn([existing, t]) === 1) {
+      transcriptMap.set(tid, t)
     }
   }
-  const transcripts = Array.from(transcriptMap.values())
+  const transcripts: TranscriptInsertRow[] = Array.from(transcriptMap.values()).map((t) => {
+    const semantics = canonicalizeTranscriptSemantics(
+      t.parts[ANN_IMPACT] ?? null,
+      t.parts[ANN_ANNOTATION] ?? null
+    )
+    return {
+      transcript_id: t.parts[ANN_FEATURE_ID] ?? '',
+      gene_symbol: t.parts[ANN_GENE_NAME] ?? null,
+      // Canonical model: consequence = IMPACT level, func = SO term.
+      consequence: semantics.consequence,
+      func: semantics.func,
+      cdna: t.parts[ANN_HGVSC] ?? null,
+      aa_change: t.parts[ANN_HGVSP] ?? null,
+      hpo_sim_score: null,
+      moi: null,
+      is_selected: 0
+    }
+  })
 
   // Select best transcript
   const bestIdx = selectBestTranscriptAnn(filtered)

--- a/src/main/storage/postgres/PostgresJsonImportRepository.ts
+++ b/src/main/storage/postgres/PostgresJsonImportRepository.ts
@@ -58,6 +58,7 @@ const TRANSCRIPT_RECORDSET_TYPES: Record<string, string> = {
   transcript_id: 'text',
   gene_symbol: 'text',
   consequence: 'text',
+  func: 'text',
   cdna: 'text',
   aa_change: 'text',
   hpo_sim_score: 'double precision',

--- a/src/main/storage/postgres/PostgresTranscriptsRepository.ts
+++ b/src/main/storage/postgres/PostgresTranscriptsRepository.ts
@@ -29,7 +29,7 @@ function toNullableBoolean(value: unknown): boolean | null {
 }
 
 const transcriptColumns = `
-  id, variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+  id, variant_id, transcript_id, gene_symbol, consequence, func, cdna, aa_change,
   hpo_sim_score, moi, is_selected, is_mane_select, is_canonical
 `
 
@@ -86,9 +86,9 @@ export class PostgresTranscriptsRepository {
       await client.query('BEGIN')
       await client.query(
         `INSERT INTO ${this.schemaName}.variant_transcripts
-           (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+           (variant_id, transcript_id, gene_symbol, consequence, func, cdna, aa_change,
             hpo_sim_score, moi, is_selected, is_mane_select, is_canonical)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0, NULL, NULL)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, NULL, NULL)
          ON CONFLICT (variant_id, transcript_id)
          DO NOTHING`,
         [
@@ -96,6 +96,7 @@ export class PostgresTranscriptsRepository {
           transcript.transcript_id,
           transcript.gene_symbol,
           transcript.consequence,
+          transcript.func,
           transcript.cdna,
           transcript.aa_change,
           transcript.hpo_sim_score,
@@ -179,6 +180,7 @@ export class PostgresTranscriptsRepository {
       transcript_id: row.transcript_id as string,
       gene_symbol: (row.gene_symbol as string | null) ?? null,
       consequence: (row.consequence as string | null) ?? null,
+      func: (row.func as string | null) ?? null,
       cdna: (row.cdna as string | null) ?? null,
       aa_change: (row.aa_change as string | null) ?? null,
       hpo_sim_score: (row.hpo_sim_score as number | null) ?? null,

--- a/src/main/storage/postgres/PostgresTranscriptsRepository.ts
+++ b/src/main/storage/postgres/PostgresTranscriptsRepository.ts
@@ -148,16 +148,18 @@ export class PostgresTranscriptsRepository {
           SET transcript = $2,
               gene_symbol = $3,
               consequence = $4,
-              cdna = $5,
-              aa_change = $6,
-              hpo_sim_score = $7,
-              moi = $8
+              func = $5,
+              cdna = $6,
+              aa_change = $7,
+              hpo_sim_score = $8,
+              moi = $9
         WHERE id = $1`,
       [
         variantId,
         transcript.transcript_id,
         transcript.gene_symbol,
         transcript.consequence,
+        transcript.func,
         transcript.cdna,
         transcript.aa_change,
         transcript.hpo_sim_score,

--- a/src/main/storage/postgres/PostgresTranscriptsRepository.ts
+++ b/src/main/storage/postgres/PostgresTranscriptsRepository.ts
@@ -1,7 +1,7 @@
 import type { Pool, PoolClient } from 'pg'
 
 import {
-  isTranscriptImpact,
+  canonicalizeTranscriptSemantics,
   type TranscriptAnnotation,
   type TranscriptInsertRow
 } from '../../../shared/types/transcript'
@@ -147,19 +147,16 @@ export class PostgresTranscriptsRepository {
     variantId: number,
     transcript: Record<string, unknown>
   ): Promise<void> {
-    const canonicalImpact = isTranscriptImpact(transcript.consequence)
-      ? transcript.consequence
-      : null
-    const canonicalFunc =
-      canonicalImpact === null
-        ? (transcript.func ?? transcript.consequence ?? null)
-        : (transcript.func ?? null)
+    const semantics = canonicalizeTranscriptSemantics(
+      (transcript.consequence as string | null | undefined) ?? null,
+      (transcript.func as string | null | undefined) ?? null
+    )
 
     await client.query(
       `UPDATE ${this.schemaName}.variants
           SET transcript = $2,
               gene_symbol = $3,
-              consequence = COALESCE($4, consequence),
+              consequence = $4,
               func = $5,
               cdna = $6,
               aa_change = $7,
@@ -170,8 +167,8 @@ export class PostgresTranscriptsRepository {
         variantId,
         transcript.transcript_id,
         transcript.gene_symbol,
-        canonicalImpact,
-        canonicalFunc,
+        semantics.consequence,
+        semantics.func,
         transcript.cdna,
         transcript.aa_change,
         transcript.hpo_sim_score,

--- a/src/main/storage/postgres/PostgresTranscriptsRepository.ts
+++ b/src/main/storage/postgres/PostgresTranscriptsRepository.ts
@@ -1,6 +1,10 @@
 import type { Pool, PoolClient } from 'pg'
 
-import type { TranscriptAnnotation, TranscriptInsertRow } from '../../../shared/types/transcript'
+import {
+  isTranscriptImpact,
+  type TranscriptAnnotation,
+  type TranscriptInsertRow
+} from '../../../shared/types/transcript'
 import { quoteIdentifier } from './identifiers'
 
 type QueryablePool = Pick<Pool, 'query'> & Partial<Pick<Pool, 'connect'>>
@@ -143,11 +147,19 @@ export class PostgresTranscriptsRepository {
     variantId: number,
     transcript: Record<string, unknown>
   ): Promise<void> {
+    const canonicalImpact = isTranscriptImpact(transcript.consequence)
+      ? transcript.consequence
+      : null
+    const canonicalFunc =
+      canonicalImpact === null
+        ? (transcript.func ?? transcript.consequence ?? null)
+        : (transcript.func ?? null)
+
     await client.query(
       `UPDATE ${this.schemaName}.variants
           SET transcript = $2,
               gene_symbol = $3,
-              consequence = $4,
+              consequence = COALESCE($4, consequence),
               func = $5,
               cdna = $6,
               aa_change = $7,
@@ -158,8 +170,8 @@ export class PostgresTranscriptsRepository {
         variantId,
         transcript.transcript_id,
         transcript.gene_symbol,
-        transcript.consequence,
-        transcript.func,
+        canonicalImpact,
+        canonicalFunc,
         transcript.cdna,
         transcript.aa_change,
         transcript.hpo_sim_score,

--- a/src/main/storage/postgres/migrations/definitions.ts
+++ b/src/main/storage/postgres/migrations/definitions.ts
@@ -68,6 +68,11 @@ const MIGRATION_FILES: readonly MigrationFile[] = [
     version: '0013',
     name: 'central_audit_schema',
     fileName: '0013_central_audit_schema.sql'
+  },
+  {
+    version: '0014',
+    name: 'variant_transcripts_func',
+    fileName: '0014_variant_transcripts_func.sql'
   }
 ]
 

--- a/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
+++ b/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
@@ -9,16 +9,12 @@
 -- variants table's existing consequence/func convention. Application code
 -- now writes consequence = IMPACT, func = SO term on every import path.
 --
--- Additive only — no data mutation. Legacy rows are NOT rewritten:
+-- Backfill without guessing an impact:
 --   - JSON-imported rows already have the correct IMPACT in `consequence`;
 --     the original per-transcript SO term was discarded at import time and
 --     is not recoverable from the database alone, so `func` stays NULL.
---   - VCF-imported rows keep their historically mislabeled `consequence`
---     (actually an SO term, not an IMPACT level). Inferring the correct
---     IMPACT from a bare SO term would require a static VEP/SnpEff
---     severity-ranking table as a guess, which is out of scope. `func`
---     stays NULL for these rows too. A full re-import of the affected case
---     corrects both columns going forward.
+--   - A non-enum `consequence` is provably not an IMPACT. Preserve it as the
+--     SO term in `func` and clear `consequence`; do not invent an impact.
 --
 -- "__schema__" is the migration-runner template placeholder (see
 -- 0001_create_cases.sql). IF NOT EXISTS makes the ALTER itself replay-safe;
@@ -27,3 +23,9 @@
 
 ALTER TABLE "__schema__"."variant_transcripts"
   ADD COLUMN IF NOT EXISTS func TEXT;
+
+UPDATE "__schema__"."variant_transcripts"
+   SET func = consequence,
+       consequence = NULL
+ WHERE consequence IS NOT NULL
+   AND consequence NOT IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER');

--- a/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
+++ b/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
@@ -10,9 +10,9 @@
 -- now writes consequence = IMPACT, func = SO term on every import path.
 --
 -- Backfill without guessing an impact:
---   - JSON-imported rows already have the correct IMPACT in `consequence`;
---     the original per-transcript SO term was discarded at import time and
---     is not recoverable from the database alone, so `func` stays NULL.
+--   - JSON-imported rows already have the correct IMPACT in `consequence`.
+--     Recover `func` for the selected row when the parent still names that
+--     transcript and retains its SO term; other unavailable terms stay NULL.
 --   - A non-enum `consequence` is provably not an IMPACT. Preserve it as the
 --     SO term in `func`. Recover the parent IMPACT only for the selected row
 --     when the parent names that same transcript; otherwise leave it NULL.
@@ -24,6 +24,16 @@
 
 ALTER TABLE "__schema__"."variant_transcripts"
   ADD COLUMN IF NOT EXISTS func TEXT;
+
+UPDATE "__schema__"."variant_transcripts" AS vt
+   SET func = v.func
+  FROM "__schema__"."variants" AS v
+ WHERE v.id = vt.variant_id
+   AND vt.func IS NULL
+   AND vt.is_selected = 1
+   AND vt.consequence IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
+   AND v.transcript = vt.transcript_id
+   AND v.func IS NOT NULL;
 
 UPDATE "__schema__"."variant_transcripts" AS vt
    SET func = vt.consequence,

--- a/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
+++ b/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
@@ -1,0 +1,29 @@
+-- D1 (2026-07-06 security-and-bug remediation): canonical transcript
+-- impact/SO model. variant_transcripts.consequence was conflated — JSON
+-- import wrote the IMPACT level (correct), but VCF import (VEP CSQ / SnpEff
+-- ANN) wrote the raw Sequence Ontology term instead, corrupting
+-- impact/rarity filters once the transcript-switch denormalization copies
+-- it onto variants.consequence.
+--
+-- Fix: add `func` mirroring variants.func (the SO term), matching the
+-- variants table's existing consequence/func convention. Application code
+-- now writes consequence = IMPACT, func = SO term on every import path.
+--
+-- Additive only — no data mutation. Legacy rows are NOT rewritten:
+--   - JSON-imported rows already have the correct IMPACT in `consequence`;
+--     the original per-transcript SO term was discarded at import time and
+--     is not recoverable from the database alone, so `func` stays NULL.
+--   - VCF-imported rows keep their historically mislabeled `consequence`
+--     (actually an SO term, not an IMPACT level). Inferring the correct
+--     IMPACT from a bare SO term would require a static VEP/SnpEff
+--     severity-ranking table as a guess, which is out of scope. `func`
+--     stays NULL for these rows too. A full re-import of the affected case
+--     corrects both columns going forward.
+--
+-- "__schema__" is the migration-runner template placeholder (see
+-- 0001_create_cases.sql). IF NOT EXISTS makes the ALTER itself replay-safe;
+-- the migration runner's schema_migrations ledger already guarantees this
+-- file is applied at most once per schema.
+
+ALTER TABLE "__schema__"."variant_transcripts"
+  ADD COLUMN IF NOT EXISTS func TEXT;

--- a/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
+++ b/src/main/storage/postgres/migrations/sql/0014_variant_transcripts_func.sql
@@ -14,7 +14,8 @@
 --     the original per-transcript SO term was discarded at import time and
 --     is not recoverable from the database alone, so `func` stays NULL.
 --   - A non-enum `consequence` is provably not an IMPACT. Preserve it as the
---     SO term in `func` and clear `consequence`; do not invent an impact.
+--     SO term in `func`. Recover the parent IMPACT only for the selected row
+--     when the parent names that same transcript; otherwise leave it NULL.
 --
 -- "__schema__" is the migration-runner template placeholder (see
 -- 0001_create_cases.sql). IF NOT EXISTS makes the ALTER itself replay-safe;
@@ -24,8 +25,15 @@
 ALTER TABLE "__schema__"."variant_transcripts"
   ADD COLUMN IF NOT EXISTS func TEXT;
 
-UPDATE "__schema__"."variant_transcripts"
-   SET func = consequence,
-       consequence = NULL
- WHERE consequence IS NOT NULL
-   AND consequence NOT IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER');
+UPDATE "__schema__"."variant_transcripts" AS vt
+   SET func = vt.consequence,
+       consequence = CASE
+         WHEN vt.is_selected = 1 AND v.transcript = vt.transcript_id
+           AND v.consequence IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER')
+         THEN v.consequence
+         ELSE NULL
+       END
+  FROM "__schema__"."variants" AS v
+ WHERE v.id = vt.variant_id
+   AND vt.consequence IS NOT NULL
+   AND vt.consequence NOT IN ('HIGH', 'MODERATE', 'LOW', 'MODIFIER');

--- a/src/main/storage/postgres/postgres-import-columns.ts
+++ b/src/main/storage/postgres/postgres-import-columns.ts
@@ -55,6 +55,7 @@ export const VARIANT_TRANSCRIPT_COLUMNS = [
   'transcript_id',
   'gene_symbol',
   'consequence',
+  'func',
   'cdna',
   'aa_change',
   'hpo_sim_score',
@@ -156,8 +157,9 @@ export const VARIANT_STR_COPY_COLUMNS = VARIANT_STR_COLUMNS
 // using encodeBoolean would throw because the encoder is strict.
 //
 // Where a column name appears in multiple tables (e.g. `gene_symbol`,
-// `consequence`, `cdna`, `aa_change`, `hpo_sim_score`, `moi`, `variant_id`),
-// the type is identical across tables, so a single shared entry is correct.
+// `consequence`, `func`, `cdna`, `aa_change`, `hpo_sim_score`, `moi`,
+// `variant_id`), the type is identical across tables, so a single shared
+// entry is correct.
 // ---------------------------------------------------------------------------
 
 export const VARIANT_COLUMN_ENCODERS: Record<string, CopyColumnEncoder> = {

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -87,8 +87,8 @@ export function prepareStatements(db: DatabaseType) {
 
   const insertTranscriptStmt = db.prepare(`
     INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol,
-      consequence, cdna, aa_change, hpo_sim_score, moi, is_selected)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      consequence, func, cdna, aa_change, hpo_sim_score, moi, is_selected)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   const insertCaseStmt = db.prepare(`
@@ -161,6 +161,7 @@ export function prepareStatements(db: DatabaseType) {
             t.transcript_id,
             t.gene_symbol,
             t.consequence,
+            t.func,
             t.cdna,
             t.aa_change,
             t.hpo_sim_score,

--- a/src/renderer/src/components/TranscriptSection.vue
+++ b/src/renderer/src/components/TranscriptSection.vue
@@ -142,6 +142,7 @@ function vepToInsertRow(vep: VepTranscriptConsequence): TranscriptInsertRow {
     transcript_id: normalizeTranscriptId(vep.transcript_id),
     gene_symbol: vep.gene_symbol ?? null,
     consequence: vep.impact ?? null,
+    func: vep.consequence_terms.length > 0 ? vep.consequence_terms.join(', ') : null,
     cdna: null,
     aa_change: null,
     hpo_sim_score: null,

--- a/src/renderer/src/components/TranscriptSection.vue
+++ b/src/renderer/src/components/TranscriptSection.vue
@@ -127,7 +127,16 @@ function vepSourceColor(vepSource: string | null): string {
   return 'grey'
 }
 
+/**
+ * SO term (e.g. "missense_variant") shown as the consequence chip's tooltip.
+ * Prefers the canonical `func` field (populated for both DB- and VEP-sourced
+ * rows); falls back to `consequence_terms` for defense-in-depth in case a
+ * caller only populated the latter.
+ */
 function consequenceTooltip(row: UnifiedTranscriptRow): string | null {
+  if (row.func !== null && row.func.length > 0) {
+    return row.func
+  }
   if (row.consequence_terms !== null && row.consequence_terms.length > 0) {
     return row.consequence_terms.join(', ')
   }

--- a/src/renderer/src/utils/mergeTranscripts.ts
+++ b/src/renderer/src/utils/mergeTranscripts.ts
@@ -3,7 +3,7 @@
  * into a unified list with provenance tracking.
  */
 
-import type { TranscriptAnnotation } from '../../../shared/types/transcript'
+import { isTranscriptImpact, type TranscriptAnnotation } from '../../../shared/types/transcript'
 import type { VepTranscriptConsequence } from '../../../shared/types/vep'
 
 /** Where a transcript row came from */
@@ -81,7 +81,7 @@ export function mergeTranscripts(
       original_id: db.transcript_id,
       gene_symbol: db.gene_symbol,
       consequence: db.consequence,
-      impact: null,
+      impact: isTranscriptImpact(db.consequence) ? db.consequence : null,
       func: db.func,
       consequence_terms: null,
       cdna: db.cdna,

--- a/src/renderer/src/utils/mergeTranscripts.ts
+++ b/src/renderer/src/utils/mergeTranscripts.ts
@@ -18,6 +18,8 @@ export interface UnifiedTranscriptRow {
   gene_symbol: string | null
   consequence: string | null
   impact: string | null
+  /** Sequence Ontology term (missense_variant, stop_gained, ...), joined if multiple. */
+  func: string | null
   consequence_terms: string[] | null
   cdna: string | null
   aa_change: string | null
@@ -80,6 +82,7 @@ export function mergeTranscripts(
       gene_symbol: db.gene_symbol,
       consequence: db.consequence,
       impact: null,
+      func: db.func,
       consequence_terms: null,
       cdna: db.cdna,
       aa_change: db.aa_change,
@@ -106,6 +109,8 @@ export function mergeTranscripts(
       existing.vep_source = vep.source ?? null
       existing.impact = vep.impact ?? null
       existing.consequence_terms = vep.consequence_terms ?? null
+      existing.func =
+        vep.consequence_terms.length > 0 ? vep.consequence_terms.join(', ') : existing.func
       existing.biotype = vep.biotype ?? null
       // Fill in MANE/canonical from VEP if DB didn't have them
       if (existing.is_mane_select === null && vep.mane_select !== undefined) {
@@ -122,6 +127,7 @@ export function mergeTranscripts(
         gene_symbol: vep.gene_symbol ?? null,
         consequence: vep.impact ?? null,
         impact: vep.impact ?? null,
+        func: vep.consequence_terms.length > 0 ? vep.consequence_terms.join(', ') : null,
         consequence_terms: vep.consequence_terms ?? null,
         cdna: null,
         aa_change: null,

--- a/src/shared/api/schemas/transcripts.ts
+++ b/src/shared/api/schemas/transcripts.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { TRANSCRIPT_IMPACT_VALUES } from '../../types/transcript'
 
 export const TranscriptVariantIdSchema = z.number().int().positive()
 export const TranscriptIdSchema = z.string().min(1)
@@ -6,7 +7,7 @@ export const TranscriptIdSchema = z.string().min(1)
 export const TranscriptInsertRowSchema = z.object({
   transcript_id: z.string().min(1),
   gene_symbol: z.string().nullable(),
-  consequence: z.string().nullable(),
+  consequence: z.enum(TRANSCRIPT_IMPACT_VALUES).nullable(),
   func: z.string().nullable(),
   cdna: z.string().nullable(),
   aa_change: z.string().nullable(),

--- a/src/shared/api/schemas/transcripts.ts
+++ b/src/shared/api/schemas/transcripts.ts
@@ -7,6 +7,7 @@ export const TranscriptInsertRowSchema = z.object({
   transcript_id: z.string().min(1),
   gene_symbol: z.string().nullable(),
   consequence: z.string().nullable(),
+  func: z.string().nullable(),
   cdna: z.string().nullable(),
   aa_change: z.string().nullable(),
   hpo_sim_score: z.number().nullable(),

--- a/src/shared/types/database-schema.ts
+++ b/src/shared/types/database-schema.ts
@@ -64,6 +64,7 @@ export interface VariantTranscriptsTable {
   transcript_id: string
   gene_symbol: string | null
   consequence: string | null
+  func: string | null
   cdna: string | null
   aa_change: string | null
   hpo_sim_score: number | null

--- a/src/shared/types/import-worker.ts
+++ b/src/shared/types/import-worker.ts
@@ -70,6 +70,7 @@ export const TRANSCRIPT_INSERT_COLUMNS = [
   'transcript_id',
   'gene_symbol',
   'consequence',
+  'func',
   'cdna',
   'aa_change',
   'hpo_sim_score',

--- a/src/shared/types/transcript.ts
+++ b/src/shared/types/transcript.ts
@@ -1,3 +1,14 @@
+export const TRANSCRIPT_IMPACT_VALUES = ['HIGH', 'MODERATE', 'LOW', 'MODIFIER'] as const
+
+export function isTranscriptImpact(
+  value: unknown
+): value is (typeof TRANSCRIPT_IMPACT_VALUES)[number] {
+  return (
+    typeof value === 'string' &&
+    TRANSCRIPT_IMPACT_VALUES.includes(value as (typeof TRANSCRIPT_IMPACT_VALUES)[number])
+  )
+}
+
 /**
  * TranscriptAnnotation — full row from variant_transcripts table.
  * Returned by getVariantTranscripts() to the renderer.

--- a/src/shared/types/transcript.ts
+++ b/src/shared/types/transcript.ts
@@ -9,6 +9,15 @@ export function isTranscriptImpact(
   )
 }
 
+/** Canonicalize imported IMPACT/SO fields without discarding a legacy SO value. */
+export function canonicalizeTranscriptSemantics(
+  consequence: string | null,
+  func: string | null
+): { consequence: (typeof TRANSCRIPT_IMPACT_VALUES)[number] | null; func: string | null } {
+  if (isTranscriptImpact(consequence)) return { consequence, func }
+  return { consequence: null, func: func ?? consequence }
+}
+
 /**
  * TranscriptAnnotation — full row from variant_transcripts table.
  * Returned by getVariantTranscripts() to the renderer.

--- a/src/shared/types/transcript.ts
+++ b/src/shared/types/transcript.ts
@@ -14,8 +14,19 @@ export function canonicalizeTranscriptSemantics(
   consequence: string | null,
   func: string | null
 ): { consequence: (typeof TRANSCRIPT_IMPACT_VALUES)[number] | null; func: string | null } {
-  if (isTranscriptImpact(consequence)) return { consequence, func }
-  return { consequence: null, func: func ?? consequence }
+  const canonicalImpact = isTranscriptImpact(consequence)
+    ? consequence
+    : isTranscriptImpact(func)
+      ? func
+      : null
+  const canonicalFunc =
+    func !== null && !isTranscriptImpact(func)
+      ? func
+      : consequence !== null && !isTranscriptImpact(consequence)
+        ? consequence
+        : null
+
+  return { consequence: canonicalImpact, func: canonicalFunc }
 }
 
 /**

--- a/src/shared/types/transcript.ts
+++ b/src/shared/types/transcript.ts
@@ -7,7 +7,10 @@ export interface TranscriptAnnotation {
   variant_id: number
   transcript_id: string
   gene_symbol: string | null
+  /** IMPACT level (HIGH/MODERATE/LOW/MODIFIER) — same convention as variants.consequence. */
   consequence: string | null
+  /** Sequence Ontology term (missense_variant, stop_gained, ...) — same convention as variants.func. */
+  func: string | null
   cdna: string | null
   aa_change: string | null
   hpo_sim_score: number | null
@@ -24,7 +27,10 @@ export interface TranscriptAnnotation {
 export interface TranscriptInsertRow {
   transcript_id: string
   gene_symbol: string | null
+  /** IMPACT level (HIGH/MODERATE/LOW/MODIFIER) — same convention as variants.consequence. */
   consequence: string | null
+  /** Sequence Ontology term (missense_variant, stop_gained, ...) — same convention as variants.func. */
+  func: string | null
   cdna: string | null
   aa_change: string | null
   hpo_sim_score: number | null

--- a/tests/main/database/FilterPresetRepository.test.ts
+++ b/tests/main/database/FilterPresetRepository.test.ts
@@ -30,7 +30,7 @@ describe('migration v15 - filter_presets', () => {
 
   it('sets user_version to latest', () => {
     const version = db.pragma('user_version', { simple: true })
-    expect(version).toBe(31)
+    expect(version).toBe(32)
   })
 
   it('creates unique index on name', () => {

--- a/tests/main/database/PanelRepository.test.ts
+++ b/tests/main/database/PanelRepository.test.ts
@@ -54,7 +54,7 @@ describe('PanelRepository', () => {
 
     it('sets user_version to latest', () => {
       const version = db.pragma('user_version', { simple: true })
-      expect(version).toBe(31)
+      expect(version).toBe(32)
     })
   })
 

--- a/tests/main/database/migration-v13.test.ts
+++ b/tests/main/database/migration-v13.test.ts
@@ -67,6 +67,6 @@ describe('Migration v13-v14: cohort summary tables', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const version = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(version.user_version).toBe(31)
+    expect(version.user_version).toBe(32)
   })
 })

--- a/tests/main/database/migration-v8.test.ts
+++ b/tests/main/database/migration-v8.test.ts
@@ -40,6 +40,6 @@ describe('Migration v8: age and date_of_birth', () => {
 
   it('sets schema version to latest after all migrations', () => {
     const result = db.pragma('user_version') as Array<{ user_version: number }>
-    expect(result[0].user_version).toBe(31)
+    expect(result[0].user_version).toBe(32)
   })
 })

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -1389,6 +1389,7 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
         ref TEXT NOT NULL,
         alt TEXT NOT NULL,
         consequence TEXT,
+        func TEXT,
         transcript TEXT,
         FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE
       );
@@ -1437,6 +1438,20 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
        VALUES (?, ?, ?, ?, ?)`
     ).run(variantId, 'NM_IMPACT.1', 'LEGACYGENE', 'HIGH', 0)
 
+    const jsonVariantId = db
+      .prepare(
+        `INSERT INTO variants (case_id, chr, pos, ref, alt, consequence, func, transcript)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(caseId, '1', 101, 'C', 'T', 'LOW', 'synonymous_variant', 'NM_JSON.1')
+      .lastInsertRowid as number
+    // Pre-v32 JSON rows retained the selected parent transcript's SO term on
+    // variants.func even though variant_transcripts had nowhere to store it.
+    db.prepare(
+      `INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol, consequence, is_selected)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(jsonVariantId, 'NM_JSON.1', 'JSONGENE', 'LOW', 1)
+
     runMigrations(db)
 
     const columns = db.prepare(`PRAGMA table_info(variant_transcripts)`).all() as Array<{
@@ -1471,6 +1486,16 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
         func: 'missense_variant'
       }
     ])
+
+    expect(
+      db
+        .prepare(
+          `SELECT consequence, func
+             FROM variant_transcripts
+            WHERE variant_id = ? AND transcript_id = ?`
+        )
+        .get(jsonVariantId, 'NM_JSON.1')
+    ).toEqual({ consequence: 'LOW', func: 'synonymous_variant' })
 
     expect(db.pragma('user_version', { simple: true })).toBe(32)
   })

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -1365,7 +1365,7 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
     expect(db.pragma('user_version', { simple: true })).toBe(32)
   })
 
-  it('additive backfill: existing rows survive the ALTER with func defaulting to NULL', () => {
+  it('canonicalizes legacy SO terms without guessing an unavailable impact', () => {
     // Hand-build the pre-v32 `variant_transcripts` shape (no `func` column) —
     // deliberately bypassing initializeSchema(), which already bakes `func`
     // into the CREATE TABLE for brand-new databases — so this test genuinely
@@ -1420,12 +1420,17 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
       .prepare(`INSERT INTO variants (case_id, chr, pos, ref, alt) VALUES (?, ?, ?, ?, ?)`)
       .run(caseId, '1', 100, 'A', 'G').lastInsertRowid as number
     // Seeded the way the pre-fix VCF import path actually wrote rows: an SO
-    // term mislabeled into `consequence` (the bug this task fixes going
-    // forward). The migration must NOT rewrite or corrupt this legacy value.
+    // term mislabeled into `consequence`. The migration can identify that it
+    // is not an IMPACT value without guessing which impact it should have.
     db.prepare(
       `INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol, consequence, is_selected)
        VALUES (?, ?, ?, ?, ?)`
     ).run(variantId, 'NM_LEGACY.1', 'LEGACYGENE', 'missense_variant', 1)
+
+    db.prepare(
+      `INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol, consequence, is_selected)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(variantId, 'NM_IMPACT.1', 'LEGACYGENE', 'HIGH', 0)
 
     runMigrations(db)
 
@@ -1434,24 +1439,33 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
     }>
     expect(columns.some((c) => c.name === 'func')).toBe(true)
 
-    const row = db
+    const rows = db
       .prepare(
-        `SELECT transcript_id, gene_symbol, consequence, func FROM variant_transcripts WHERE variant_id = ?`
+        `SELECT transcript_id, gene_symbol, consequence, func
+           FROM variant_transcripts
+          WHERE variant_id = ?
+          ORDER BY transcript_id`
       )
-      .get(variantId) as {
+      .all(variantId) as Array<{
       transcript_id: string
       gene_symbol: string
       consequence: string | null
       func: string | null
-    }
-    // Legacy row survives untouched: consequence keeps its historically
-    // mislabeled value (an SO term, not IMPACT) and func is NULL because it
-    // cannot be safely derived from the DB alone (documented in the v32
-    // migration comment) — leaving it null is acceptable, corrupting is not.
-    expect(row.transcript_id).toBe('NM_LEGACY.1')
-    expect(row.gene_symbol).toBe('LEGACYGENE')
-    expect(row.consequence).toBe('missense_variant')
-    expect(row.func).toBeNull()
+    }>
+    expect(rows).toEqual([
+      {
+        transcript_id: 'NM_IMPACT.1',
+        gene_symbol: 'LEGACYGENE',
+        consequence: 'HIGH',
+        func: null
+      },
+      {
+        transcript_id: 'NM_LEGACY.1',
+        gene_symbol: 'LEGACYGENE',
+        consequence: null,
+        func: 'missense_variant'
+      }
+    ])
 
     expect(db.pragma('user_version', { simple: true })).toBe(32)
   })

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -1388,6 +1388,8 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
         pos INTEGER NOT NULL,
         ref TEXT NOT NULL,
         alt TEXT NOT NULL,
+        consequence TEXT,
+        transcript TEXT,
         FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE
       );
       CREATE TABLE variant_transcripts (
@@ -1417,8 +1419,11 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
       )
       .run('legacy-case', '/legacy.vcf', 100, Date.now()).lastInsertRowid as number
     const variantId = db
-      .prepare(`INSERT INTO variants (case_id, chr, pos, ref, alt) VALUES (?, ?, ?, ?, ?)`)
-      .run(caseId, '1', 100, 'A', 'G').lastInsertRowid as number
+      .prepare(
+        `INSERT INTO variants (case_id, chr, pos, ref, alt, consequence, transcript)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(caseId, '1', 100, 'A', 'G', 'MODERATE', 'NM_LEGACY.1').lastInsertRowid as number
     // Seeded the way the pre-fix VCF import path actually wrote rows: an SO
     // term mislabeled into `consequence`. The migration can identify that it
     // is not an IMPACT value without guessing which impact it should have.
@@ -1462,7 +1467,7 @@ describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO mod
       {
         transcript_id: 'NM_LEGACY.1',
         gene_symbol: 'LEGACYGENE',
-        consequence: null,
+        consequence: 'MODERATE',
         func: 'missense_variant'
       }
     ])

--- a/tests/main/database/migrations.test.ts
+++ b/tests/main/database/migrations.test.ts
@@ -131,7 +131,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(31)
+      expect(versionResult.user_version).toBe(32)
 
       service.close()
 
@@ -141,7 +141,7 @@ describe('Schema Migrations', () => {
       const versionAfterReopen = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionAfterReopen.user_version).toBe(31)
+      expect(versionAfterReopen.user_version).toBe(32)
 
       service.close()
     })
@@ -468,7 +468,7 @@ describe('Schema Migrations', () => {
       let versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(31)
+      expect(versionResult.user_version).toBe(32)
 
       service.close()
 
@@ -488,7 +488,7 @@ describe('Schema Migrations', () => {
       versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(31)
+      expect(versionResult.user_version).toBe(32)
 
       service.close()
     })
@@ -522,7 +522,7 @@ describe('Schema Migrations', () => {
       const versionResult = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(versionResult.user_version).toBe(31)
+      expect(versionResult.user_version).toBe(32)
 
       service.close()
     })
@@ -760,7 +760,7 @@ describe('Schema Migrations', () => {
       const version = service.database.prepare('PRAGMA user_version').get() as {
         user_version: number
       }
-      expect(version.user_version).toBe(31)
+      expect(version.user_version).toBe(32)
 
       service.close()
     })
@@ -801,7 +801,7 @@ describe('Schema Migrations', () => {
 
       // Verify user_version = latest (v15 + v16 + v17 + v18 + … + v28 + v29 all run)
       const version = db.pragma('user_version', { simple: true }) as number
-      expect(version).toBe(31)
+      expect(version).toBe(32)
 
       service.close()
     })
@@ -1257,9 +1257,9 @@ describe('migration v27 — filter_presets.kind + shortlist seeds', () => {
     expect(idx).toBeTruthy()
   })
 
-  it('PRAGMA user_version = 31 after migration', () => {
+  it('PRAGMA user_version = 32 after migration', () => {
     const v = db.pragma('user_version', { simple: true })
-    expect(v).toBe(31)
+    expect(v).toBe(32)
   })
 })
 
@@ -1314,7 +1314,7 @@ describe('migration v31 — projects registry (D5)', () => {
     }
     expect(row).toEqual({ id: 1, name: 'default', schema_name: 'main' })
 
-    expect(db.pragma('user_version', { simple: true })).toBe(31)
+    expect(db.pragma('user_version', { simple: true })).toBe(32)
   })
 
   it('SQLite v31: re-running migrations is idempotent (single default row)', () => {
@@ -1325,6 +1325,134 @@ describe('migration v31 — projects registry (D5)', () => {
 
     const count = db.prepare(`SELECT COUNT(*) AS c FROM projects`).get() as { c: number }
     expect(count.c).toBe(1)
-    expect(db.pragma('user_version', { simple: true })).toBe(31)
+    expect(db.pragma('user_version', { simple: true })).toBe(32)
+  })
+})
+
+describe('migration v32 — variant_transcripts.func (D1 canonical impact/SO model)', () => {
+  let db: Database.Database
+
+  afterEach(() => {
+    db.close()
+  })
+
+  it('adds a nullable func column to variant_transcripts', () => {
+    db = new Database(':memory:')
+    initializeSchema(db)
+    runMigrations(db)
+
+    const columns = db.prepare(`PRAGMA table_info(variant_transcripts)`).all() as Array<{
+      name: string
+      notnull: number
+    }>
+    const funcCol = columns.find((c) => c.name === 'func')
+    expect(funcCol).toBeDefined()
+    expect(funcCol!.notnull).toBe(0)
+
+    expect(db.pragma('user_version', { simple: true })).toBe(32)
+  })
+
+  it('is idempotent — re-running migrations does not throw or duplicate the column', () => {
+    db = new Database(':memory:')
+    initializeSchema(db)
+    runMigrations(db)
+    expect(() => runMigrations(db)).not.toThrow()
+
+    const columns = db.prepare(`PRAGMA table_info(variant_transcripts)`).all() as Array<{
+      name: string
+    }>
+    expect(columns.filter((c) => c.name === 'func')).toHaveLength(1)
+    expect(db.pragma('user_version', { simple: true })).toBe(32)
+  })
+
+  it('additive backfill: existing rows survive the ALTER with func defaulting to NULL', () => {
+    // Hand-build the pre-v32 `variant_transcripts` shape (no `func` column) —
+    // deliberately bypassing initializeSchema(), which already bakes `func`
+    // into the CREATE TABLE for brand-new databases — so this test genuinely
+    // exercises the v32 ALTER TABLE branch against a legacy table, the way a
+    // real upgrade from an installed pre-D1 database would.
+    db = new Database(':memory:')
+    db.exec(`
+      CREATE TABLE cases (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE,
+        file_path TEXT NOT NULL,
+        file_size INTEGER NOT NULL,
+        variant_count INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      );
+      CREATE TABLE variants (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        case_id INTEGER NOT NULL,
+        chr TEXT NOT NULL,
+        pos INTEGER NOT NULL,
+        ref TEXT NOT NULL,
+        alt TEXT NOT NULL,
+        FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE
+      );
+      CREATE TABLE variant_transcripts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        variant_id INTEGER NOT NULL,
+        transcript_id TEXT NOT NULL,
+        gene_symbol TEXT,
+        consequence TEXT,
+        cdna TEXT,
+        aa_change TEXT,
+        hpo_sim_score REAL,
+        moi TEXT,
+        is_selected INTEGER NOT NULL DEFAULT 0,
+        is_mane_select INTEGER,
+        is_canonical INTEGER,
+        FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE,
+        UNIQUE(variant_id, transcript_id)
+      );
+    `)
+    // Every earlier migration (v1-v31) is a no-op once user_version is
+    // already at 31, so this jumps straight to the v32 block under test.
+    db.exec('PRAGMA user_version = 31')
+
+    const caseId = db
+      .prepare(
+        `INSERT INTO cases (name, file_path, file_size, variant_count, created_at) VALUES (?, ?, ?, 0, ?)`
+      )
+      .run('legacy-case', '/legacy.vcf', 100, Date.now()).lastInsertRowid as number
+    const variantId = db
+      .prepare(`INSERT INTO variants (case_id, chr, pos, ref, alt) VALUES (?, ?, ?, ?, ?)`)
+      .run(caseId, '1', 100, 'A', 'G').lastInsertRowid as number
+    // Seeded the way the pre-fix VCF import path actually wrote rows: an SO
+    // term mislabeled into `consequence` (the bug this task fixes going
+    // forward). The migration must NOT rewrite or corrupt this legacy value.
+    db.prepare(
+      `INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol, consequence, is_selected)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(variantId, 'NM_LEGACY.1', 'LEGACYGENE', 'missense_variant', 1)
+
+    runMigrations(db)
+
+    const columns = db.prepare(`PRAGMA table_info(variant_transcripts)`).all() as Array<{
+      name: string
+    }>
+    expect(columns.some((c) => c.name === 'func')).toBe(true)
+
+    const row = db
+      .prepare(
+        `SELECT transcript_id, gene_symbol, consequence, func FROM variant_transcripts WHERE variant_id = ?`
+      )
+      .get(variantId) as {
+      transcript_id: string
+      gene_symbol: string
+      consequence: string | null
+      func: string | null
+    }
+    // Legacy row survives untouched: consequence keeps its historically
+    // mislabeled value (an SO term, not IMPACT) and func is NULL because it
+    // cannot be safely derived from the DB alone (documented in the v32
+    // migration comment) — leaving it null is acceptable, corrupting is not.
+    expect(row.transcript_id).toBe('NM_LEGACY.1')
+    expect(row.gene_symbol).toBe('LEGACYGENE')
+    expect(row.consequence).toBe('missense_variant')
+    expect(row.func).toBeNull()
+
+    expect(db.pragma('user_version', { simple: true })).toBe(32)
   })
 })

--- a/tests/main/database/transcripts-insert.test.ts
+++ b/tests/main/database/transcripts-insert.test.ts
@@ -47,7 +47,8 @@ describe('insertVariantsBatch with transcripts', () => {
           {
             transcript_id: 'NM_007294.4',
             gene_symbol: 'BRCA1',
-            consequence: 'missense_variant',
+            consequence: 'MODERATE',
+            func: 'missense_variant',
             cdna: 'c.123A>G',
             aa_change: 'p.His41Arg',
             hpo_sim_score: null,
@@ -57,7 +58,8 @@ describe('insertVariantsBatch with transcripts', () => {
           {
             transcript_id: 'NM_007299.4',
             gene_symbol: 'BRCA1',
-            consequence: 'synonymous_variant',
+            consequence: 'LOW',
+            func: 'synonymous_variant',
             cdna: 'c.456C>T',
             aa_change: null,
             hpo_sim_score: null,
@@ -77,8 +79,13 @@ describe('insertVariantsBatch with transcripts', () => {
     expect(txRows).toHaveLength(2)
     expect(txRows[0].transcript_id).toBe('NM_007294.4')
     expect(txRows[0].is_selected).toBe(1)
+    // Canonical model (D1): consequence = IMPACT, func = SO term.
+    expect(txRows[0].consequence).toBe('MODERATE')
+    expect(txRows[0].func).toBe('missense_variant')
     expect(txRows[1].transcript_id).toBe('NM_007299.4')
     expect(txRows[1].is_selected).toBe(0)
+    expect(txRows[1].consequence).toBe('LOW')
+    expect(txRows[1].func).toBe('synonymous_variant')
   })
 
   it('should work without _transcripts (backwards compatible)', () => {

--- a/tests/main/database/transcripts.test.ts
+++ b/tests/main/database/transcripts.test.ts
@@ -12,12 +12,12 @@ function makeVariant(overrides: Partial<VariantInsert> = {}): VariantInsert {
     alt: 'G',
     gene_symbol: 'BRCA1',
     omim_mim_number: null,
-    consequence: 'missense_variant',
+    consequence: 'MODERATE',
     gnomad_af: 0.001,
     cadd: 28,
     clinvar: null,
     gt_num: '0/1',
-    func: null,
+    func: 'missense_variant',
     qual: 30,
     hpo_sim_score: null,
     transcript: 'NM_007294.4',
@@ -44,13 +44,14 @@ describe('DatabaseService transcript methods', () => {
 
     // Insert multiple transcript rows for testing
     const insertTx = db.database.prepare(`
-      INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change, hpo_sim_score, moi, is_selected)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO variant_transcripts (variant_id, transcript_id, gene_symbol, consequence, func, cdna, aa_change, hpo_sim_score, moi, is_selected)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
     insertTx.run(
       variantId,
       'NM_007294.4',
       'BRCA1',
+      'MODERATE',
       'missense_variant',
       'c.123A>G',
       'p.His41Arg',
@@ -62,6 +63,7 @@ describe('DatabaseService transcript methods', () => {
       variantId,
       'NM_007299.4',
       'BRCA1',
+      'LOW',
       'synonymous_variant',
       'c.456C>T',
       null,
@@ -73,6 +75,7 @@ describe('DatabaseService transcript methods', () => {
       variantId,
       'NR_027676.2',
       'BRCA1',
+      'MODIFIER',
       'non_coding_transcript_variant',
       null,
       null,
@@ -127,7 +130,8 @@ describe('DatabaseService transcript methods', () => {
       const variants = db.variants.getVariants({ case_id: caseId }, 10)
       const v = variants.data[0]
       expect(v.transcript).toBe('NM_007299.4')
-      expect(v.consequence).toBe('synonymous_variant')
+      expect(v.consequence).toBe('LOW')
+      expect(v.func).toBe('synonymous_variant')
       expect(v.cdna).toBe('c.456C>T')
       expect(v.aa_change).toBeNull()
     })

--- a/tests/main/database/vcf-migration.test.ts
+++ b/tests/main/database/vcf-migration.test.ts
@@ -46,14 +46,14 @@ describe('Migration v23: VCF import columns', () => {
   it('sets user_version to latest', () => {
     runMigrations(db)
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(31)
+    expect(result.user_version).toBe(32)
   })
 
   it('is idempotent — running migrations twice does not fail', () => {
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
     const result = db.prepare('PRAGMA user_version').get() as { user_version: number }
-    expect(result.user_version).toBe(31)
+    expect(result.user_version).toBe(32)
   })
 
   it('new variant columns are nullable and default to NULL', () => {

--- a/tests/main/handlers/transcripts-handlers.test.ts
+++ b/tests/main/handlers/transcripts-handlers.test.ts
@@ -69,4 +69,42 @@ describe('transcript PostgreSQL executor routing', () => {
       params: [9, transcript]
     })
   })
+
+  it('rejects a non-IMPACT consequence before it reaches a write executor', async () => {
+    const writeExecute = vi.fn()
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler)
+      })
+    }
+    const { registerTranscriptHandlers } =
+      await import('../../../src/main/ipc/handlers/transcripts')
+
+    registerTranscriptHandlers({
+      ipcMain: ipcMain as never,
+      getDb: vi.fn() as never,
+      getDbManager: (() => ({
+        getCurrentSession: () => ({
+          capabilities: { backend: 'postgres' },
+          getWriteExecutor: () => ({ execute: writeExecute })
+        })
+      })) as never
+    })
+
+    const result = await handlers.get('transcripts:insertAndSwitch')!(undefined, 9, {
+      transcript_id: 'NM_BAD.1',
+      gene_symbol: 'BRCA2',
+      consequence: 'stop_gained',
+      func: 'stop_gained',
+      cdna: null,
+      aa_change: null,
+      hpo_sim_score: null,
+      moi: null,
+      is_selected: 0
+    })
+
+    expect(result).toMatchObject({ code: 'UNKNOWN', message: 'Invalid parameters' })
+    expect(writeExecute).not.toHaveBeenCalled()
+  })
 })

--- a/tests/main/handlers/transcripts-handlers.test.ts
+++ b/tests/main/handlers/transcripts-handlers.test.ts
@@ -27,6 +27,7 @@ describe('transcript PostgreSQL executor routing', () => {
       transcript_id: 'NM_000059.4',
       gene_symbol: 'BRCA2',
       consequence: 'HIGH',
+      func: 'missense_variant',
       cdna: 'c.1A>G',
       aa_change: 'p.M1V',
       hpo_sim_score: 0.8,

--- a/tests/main/import/FieldMapper.test.ts
+++ b/tests/main/import/FieldMapper.test.ts
@@ -371,6 +371,23 @@ describe('FieldMapper', () => {
       expect(transcripts[1].consequence).toBe('MODERATE')
     })
 
+    it('extracts the per-transcript func (SO term) from the FUNC column', async () => {
+      const row = createTestRow({
+        1: 0,
+        28: ['1', '2'], // Transcript IDs
+        20: ['missense_variant', 'synonymous_variant'] // FUNC (SO term), per-transcript
+      })
+
+      const results = await runTransform([row])
+      const variant = results[0] as Record<string, unknown>
+      const transcripts = variant._transcripts as Record<string, unknown>[]
+
+      // func = SO term (raw, no dictionary), matching the same per-transcript
+      // index as consequence/cdna/aa_change — NOT the IMPACT dictionary value.
+      expect(transcripts[0].func).toBe('missense_variant')
+      expect(transcripts[1].func).toBe('synonymous_variant')
+    })
+
     it('should emit single transcript for non-array columns', async () => {
       const row = createTestRow({
         1: 0,

--- a/tests/main/import/FieldMapper.test.ts
+++ b/tests/main/import/FieldMapper.test.ts
@@ -388,6 +388,25 @@ describe('FieldMapper', () => {
       expect(transcripts[1].func).toBe('synonymous_variant')
     })
 
+    it('rejects unknown IMPACT codes for the parent and transcript rows', async () => {
+      const row = createTestRow({
+        21: ['99'],
+        20: ['missense_variant'],
+        28: ['1']
+      })
+
+      const results = await runTransform([row])
+      const variant = results[0] as Record<string, unknown>
+      const transcripts = variant._transcripts as Record<string, unknown>[]
+
+      expect(variant.consequence).toBeNull()
+      expect(variant.func).toBe('missense_variant')
+      expect(transcripts[0]).toMatchObject({
+        consequence: null,
+        func: 'missense_variant'
+      })
+    })
+
     it('should emit single transcript for non-array columns', async () => {
       const row = createTestRow({
         1: 0,

--- a/tests/main/import/ObjectFormatMapper.test.ts
+++ b/tests/main/import/ObjectFormatMapper.test.ts
@@ -58,4 +58,25 @@ describe('ObjectFormatMapper transcript output', () => {
     const v = results[0] as Record<string, unknown>
     expect(v._transcripts).toBeUndefined()
   })
+
+  it('keeps non-IMPACT legacy consequence text out of consequence', async () => {
+    const [mapped] = await runObjectTransform([
+      {
+        chr: '1',
+        pos: 100,
+        ref: 'A',
+        alt: 'G',
+        consequence: 'missense_variant',
+        transcript: 'NM_1'
+      }
+    ])
+
+    const variant = mapped as Record<string, unknown>
+    expect(variant.consequence).toBeNull()
+    expect(variant.func).toBe('missense_variant')
+    expect((variant._transcripts as Record<string, unknown>[])[0]).toMatchObject({
+      consequence: null,
+      func: 'missense_variant'
+    })
+  })
 })

--- a/tests/main/import/ObjectFormatMapper.test.ts
+++ b/tests/main/import/ObjectFormatMapper.test.ts
@@ -79,4 +79,26 @@ describe('ObjectFormatMapper transcript output', () => {
       func: 'missense_variant'
     })
   })
+
+  it('repairs swapped legacy consequence and func fields without losing either value', async () => {
+    const [mapped] = await runObjectTransform([
+      {
+        chr: '1',
+        pos: 100,
+        ref: 'A',
+        alt: 'G',
+        consequence: 'missense_variant',
+        func: 'MODERATE',
+        transcript: 'NM_1'
+      }
+    ])
+
+    const variant = mapped as Record<string, unknown>
+    expect(variant.consequence).toBe('MODERATE')
+    expect(variant.func).toBe('missense_variant')
+    expect((variant._transcripts as Record<string, unknown>[])[0]).toMatchObject({
+      consequence: 'MODERATE',
+      func: 'missense_variant'
+    })
+  })
 })

--- a/tests/main/import/ObjectFormatMapper.test.ts
+++ b/tests/main/import/ObjectFormatMapper.test.ts
@@ -31,7 +31,8 @@ describe('ObjectFormatMapper transcript output', () => {
         ref: 'A',
         alt: 'G',
         gene_symbol: 'BRCA1',
-        consequence: 'missense_variant',
+        consequence: 'MODERATE',
+        func: 'missense_variant',
         transcript: 'NM_007294.4',
         cdna: 'c.123A>G',
         aa_change: 'p.His41Arg',
@@ -45,6 +46,10 @@ describe('ObjectFormatMapper transcript output', () => {
     expect(transcripts[0].transcript_id).toBe('NM_007294.4')
     expect(transcripts[0].is_selected).toBe(1)
     expect(transcripts[0].gene_symbol).toBe('BRCA1')
+    // Canonical model (D1): consequence = IMPACT, func = SO term, both
+    // passed through from the top-level mapped variant onto the transcript row.
+    expect(transcripts[0].consequence).toBe('MODERATE')
+    expect(transcripts[0].func).toBe('missense_variant')
   })
 
   it('should NOT emit _transcripts when transcript is null', async () => {

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -147,6 +147,27 @@ describe('vcf-annotation-parser', () => {
       expect(result.transcript).toBe('T2')
       expect(result.impact).toBe('HIGH')
     })
+
+    it('retains the highest-impact CSQ block when one transcript appears more than once', () => {
+      const info = new Map([
+        [
+          'CSQ',
+          'G|upstream_gene_variant|MODIFIER|GENE1|E1|Transcript|T1|protein_coding||||||||||||||||,G|stop_gained|HIGH|GENE1|E1|Transcript|T1|protein_coding||||||||||||||||'
+        ]
+      ])
+
+      const result = parseAnnotation(info, header, 'G')
+
+      expect(result).toMatchObject({ impact: 'HIGH', consequence: 'stop_gained', transcript: 'T1' })
+      expect(result.transcripts).toEqual([
+        expect.objectContaining({
+          transcript_id: 'T1',
+          consequence: 'HIGH',
+          func: 'stop_gained',
+          is_selected: 1
+        })
+      ])
+    })
   })
 
   describe('ANN parsing', () => {
@@ -202,6 +223,28 @@ describe('vcf-annotation-parser', () => {
 
       expect(result.consequence).toBe('frameshift_variant&splice_region_variant')
       expect(result.impact).toBe('HIGH')
+    })
+
+    it('retains the highest-impact ANN block when one transcript appears more than once', () => {
+      const info = new Map([
+        [
+          'ANN',
+          'G|upstream_gene_variant|MODIFIER|GENE1|E1|transcript|T1|protein_coding||||||||,' +
+            'G|stop_gained|HIGH|GENE1|E1|transcript|T1|protein_coding||||||||'
+        ]
+      ])
+
+      const result = parseAnnotation(info, header, 'G')
+
+      expect(result).toMatchObject({ impact: 'HIGH', consequence: 'stop_gained', transcript: 'T1' })
+      expect(result.transcripts).toEqual([
+        expect.objectContaining({
+          transcript_id: 'T1',
+          consequence: 'HIGH',
+          func: 'stop_gained',
+          is_selected: 1
+        })
+      ])
     })
   })
 

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -75,6 +75,24 @@ describe('vcf-annotation-parser', () => {
       expect(result.transcripts[0].func).toBe('synonymous_variant')
     })
 
+    it('rejects a non-enum IMPACT while preserving its SO consequence', () => {
+      const info = new Map([
+        [
+          'CSQ',
+          'T|synonymous_variant|SEVERE|COMT|ENSG1|Transcript|ENST1|protein_coding||||||||||YES||||||'
+        ]
+      ])
+
+      const result = parseAnnotation(info, header, 'T')
+
+      expect(result.impact).toBeNull()
+      expect(result.consequence).toBe('synonymous_variant')
+      expect(result.transcripts[0]).toMatchObject({
+        consequence: null,
+        func: 'synonymous_variant'
+      })
+    })
+
     it('selects MANE Select transcript over others', () => {
       // First transcript is MANE_SELECT + CANONICAL, second is not
       const info = new Map([

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -68,6 +68,11 @@ describe('vcf-annotation-parser', () => {
       expect(result.clinvar).toBeNull() // empty field
       expect(result.transcripts).toHaveLength(1)
       expect(result.transcripts[0].is_selected).toBe(1)
+      // Canonical model (issue C4/F-02): per-transcript `consequence` must be
+      // the IMPACT level, and the new `func` column must carry the SO term —
+      // the same split already used on the top-level `variants` row.
+      expect(result.transcripts[0].consequence).toBe('LOW')
+      expect(result.transcripts[0].func).toBe('synonymous_variant')
     })
 
     it('selects MANE Select transcript over others', () => {
@@ -146,6 +151,9 @@ describe('vcf-annotation-parser', () => {
       expect(result.cdna).toBe('c.310T>C')
       expect(result.aaChange).toBe('p.Ser104Pro')
       expect(result.transcripts).toHaveLength(1)
+      // Canonical model: per-transcript `consequence` = IMPACT, `func` = SO term.
+      expect(result.transcripts[0].consequence).toBe('MODERATE')
+      expect(result.transcripts[0].func).toBe('missense_variant')
     })
 
     it('handles multi-annotation ANN with allele filtering', () => {

--- a/tests/main/import/vcf/vcf-worker-integration.test.ts
+++ b/tests/main/import/vcf/vcf-worker-integration.test.ts
@@ -88,6 +88,24 @@ describe('VCF import worker integration', () => {
     // Check that at least one is_selected = 1
     const selectedCount = transcripts.filter((t) => t.is_selected === 1).length
     expect(selectedCount).toBeGreaterThan(0)
+
+    // Canonical model (D1 / issue C4 / Codex F-02): every transcript row's
+    // `consequence` must be an IMPACT level (or null), never the raw SO term,
+    // and `func` (when populated) must be the SO term the VEP CSQ annotation
+    // carried — exercised end-to-end through the real VcfStrategy import path
+    // (not a unit-level parser call), so a missed column-list update or a
+    // reverted field swap fails loudly here.
+    const IMPACT_LEVELS = new Set(['HIGH', 'MODERATE', 'LOW', 'MODIFIER'])
+    for (const t of transcripts) {
+      if (t.consequence !== null) {
+        expect(IMPACT_LEVELS.has(t.consequence as string)).toBe(true)
+      }
+    }
+    const withFunc = transcripts.filter((t) => t.func !== null)
+    expect(withFunc.length).toBeGreaterThan(0)
+    for (const t of withFunc) {
+      expect(IMPACT_LEVELS.has(t.func as string)).toBe(false)
+    }
   })
 
   it('handles cancellation via AbortSignal', async () => {

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -91,6 +91,8 @@ describe('Postgres migration definitions', () => {
     expect(transcriptFuncMigration?.name).toBe('variant_transcripts_func')
     expect(transcriptFuncMigration?.sql).toContain('ALTER TABLE "__schema__"."variant_transcripts"')
     expect(transcriptFuncMigration?.sql).toContain('ADD COLUMN IF NOT EXISTS func TEXT')
+    expect(transcriptFuncMigration?.sql).toContain('SET func = v.func')
+    expect(transcriptFuncMigration?.sql).toContain('v.func IS NOT NULL')
     expect(transcriptFuncMigration?.sql).toContain(
       'vt.is_selected = 1 AND v.transcript = vt.transcript_id'
     )

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -4,7 +4,7 @@ import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migratio
 
 describe('Postgres migration definitions', () => {
   it('loads the PostgreSQL migrations with SQL and sha256 checksums', () => {
-    expect(POSTGRES_MIGRATIONS).toHaveLength(13)
+    expect(POSTGRES_MIGRATIONS).toHaveLength(14)
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.version)).toEqual([
       '0001',
       '0002',
@@ -18,7 +18,8 @@ describe('Postgres migration definitions', () => {
       '0010',
       '0011',
       '0012',
-      '0013'
+      '0013',
+      '0014'
     ])
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.name)).toEqual([
       'create_cases',
@@ -33,7 +34,8 @@ describe('Postgres migration definitions', () => {
       'cohort_summary',
       'projects_registry',
       'extend_audit_contract',
-      'central_audit_schema'
+      'central_audit_schema',
+      'variant_transcripts_func'
     ])
 
     for (const migration of POSTGRES_MIGRATIONS) {
@@ -82,5 +84,12 @@ describe('Postgres migration definitions', () => {
     expect(centralAuditMigration?.sql).toContain('BEFORE TRUNCATE ON varlens_audit."audit_log"')
     expect(centralAuditMigration?.sql).toContain(`to_regclass('"__schema__"."audit_log"')`)
     expect(centralAuditMigration?.sql).toContain('DROP TABLE "__schema__"."audit_log"')
+
+    const transcriptFuncMigration = POSTGRES_MIGRATIONS.find(
+      (migration) => migration.version === '0014'
+    )
+    expect(transcriptFuncMigration?.name).toBe('variant_transcripts_func')
+    expect(transcriptFuncMigration?.sql).toContain('ALTER TABLE "__schema__"."variant_transcripts"')
+    expect(transcriptFuncMigration?.sql).toContain('ADD COLUMN IF NOT EXISTS func TEXT')
   })
 })

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -91,5 +91,9 @@ describe('Postgres migration definitions', () => {
     expect(transcriptFuncMigration?.name).toBe('variant_transcripts_func')
     expect(transcriptFuncMigration?.sql).toContain('ALTER TABLE "__schema__"."variant_transcripts"')
     expect(transcriptFuncMigration?.sql).toContain('ADD COLUMN IF NOT EXISTS func TEXT')
+    expect(transcriptFuncMigration?.sql).toContain(
+      'vt.is_selected = 1 AND v.transcript = vt.transcript_id'
+    )
+    expect(transcriptFuncMigration?.sql).toContain('FROM "__schema__"."variants" AS v')
   })
 })

--- a/tests/main/storage/postgres-migrations-idempotent.test.ts
+++ b/tests/main/storage/postgres-migrations-idempotent.test.ts
@@ -121,9 +121,40 @@ describe.skipIf(!RUN)('Postgres migrations: real-instance idempotency', () => {
        VALUES ('star', 'variant_annotation', '1:100:A:G', '{"starred":1}', 'legacy-user')`
     )
 
+    const throughCentral = POSTGRES_MIGRATIONS.filter((m) => m.version < '0014')
+    const centralResult = await new PostgresMigrationRunner(pool, schema, throughCentral).migrate()
+    expect(centralResult.applied).toContain('0013')
+
+    const caseResult = await probeClient.query<{ id: string }>(
+      `INSERT INTO "${schema}".cases
+        (name, file_path, file_size, variant_count, created_at)
+       VALUES ('legacy-json-case', '/legacy.json', 100, 1, 0)
+       RETURNING id`
+    )
+    const variantResult = await probeClient.query<{ id: string }>(
+      `INSERT INTO "${schema}".variants
+        (case_id, chr, pos, ref, alt, consequence, func, transcript)
+       VALUES ($1, '1', 101, 'C', 'T', 'LOW', 'synonymous_variant', 'NM_JSON.1')
+       RETURNING id`,
+      [caseResult.rows[0].id]
+    )
+    await probeClient.query(
+      `INSERT INTO "${schema}".variant_transcripts
+        (variant_id, transcript_id, consequence, is_selected)
+       VALUES ($1, 'NM_JSON.1', 'LOW', 1)`,
+      [variantResult.rows[0].id]
+    )
+
     const result = await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
-    expect(result.applied.length).toBeGreaterThan(0)
-    expect(result.applied).toContain('0013')
+    expect(result.applied).toEqual(['0014'])
+
+    const migratedTranscript = await probeClient.query<{ consequence: string; func: string }>(
+      `SELECT consequence, func
+         FROM "${schema}".variant_transcripts
+        WHERE variant_id = $1`,
+      [variantResult.rows[0].id]
+    )
+    expect(migratedTranscript.rows).toEqual([{ consequence: 'LOW', func: 'synonymous_variant' }])
 
     const snapshot = await captureSchema(probeClient, schema)
     expect(snapshot.tables.length).toBeGreaterThan(0)

--- a/tests/main/storage/postgres-transcripts-repository.test.ts
+++ b/tests/main/storage/postgres-transcripts-repository.test.ts
@@ -134,6 +134,43 @@ describe('PostgresTranscriptsRepository', () => {
     expect(release).toHaveBeenCalledOnce()
   })
 
+  it('clears the parent impact when the selected transcript impact is unavailable', async () => {
+    const release = vi.fn()
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            transcript_id: 'NM_LEGACY.1',
+            gene_symbol: 'LEGACY',
+            consequence: null,
+            func: 'stop_gained',
+            cdna: null,
+            aa_change: null,
+            hpo_sim_score: null,
+            moi: null
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+    const pool = { connect: vi.fn(async () => ({ query, release })) }
+    const repository = new PostgresTranscriptsRepository(pool as never, 'case_schema')
+
+    await repository.switchSelectedTranscript(9, 'NM_LEGACY.1')
+
+    const updateSql = query.mock.calls[3][0] as string
+    expect(updateSql).toContain('consequence = $4')
+    expect(updateSql).not.toContain('COALESCE($4, consequence)')
+    expect(query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('UPDATE "case_schema".variants'),
+      [9, 'NM_LEGACY.1', 'LEGACY', null, 'stop_gained', null, null, null, null]
+    )
+  })
+
   it('inserts missing transcripts without overwriting existing rows and then switches selection', async () => {
     const transcript = {
       transcript_id: 'NM_000059.4',

--- a/tests/main/storage/postgres-transcripts-repository.test.ts
+++ b/tests/main/storage/postgres-transcripts-repository.test.ts
@@ -101,6 +101,7 @@ describe('PostgresTranscriptsRepository', () => {
             transcript_id: 'NM_000059.4',
             gene_symbol: 'BRCA2',
             consequence: 'HIGH',
+            func: 'stop_gained',
             cdna: 'c.1A>G',
             aa_change: 'p.M1V',
             hpo_sim_score: 0.8,
@@ -127,7 +128,7 @@ describe('PostgresTranscriptsRepository', () => {
     expect(query).toHaveBeenNthCalledWith(
       4,
       expect.stringContaining('UPDATE "case_schema".variants'),
-      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'c.1A>G', 'p.M1V', 0.8, 'AD']
+      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'stop_gained', 'c.1A>G', 'p.M1V', 0.8, 'AD']
     )
     expect(query).toHaveBeenNthCalledWith(5, 'COMMIT')
     expect(release).toHaveBeenCalledOnce()
@@ -157,6 +158,7 @@ describe('PostgresTranscriptsRepository', () => {
             transcript_id: 'NM_000059.4',
             gene_symbol: 'BRCA2',
             consequence: 'HIGH',
+            func: 'missense_variant',
             cdna: 'c.1A>G',
             aa_change: 'p.M1V',
             hpo_sim_score: 0.8,
@@ -193,7 +195,7 @@ describe('PostgresTranscriptsRepository', () => {
     expect(query).toHaveBeenNthCalledWith(
       5,
       expect.stringContaining('UPDATE "case_schema".variants'),
-      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'c.1A>G', 'p.M1V', 0.8, 'AD']
+      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'missense_variant', 'c.1A>G', 'p.M1V', 0.8, 'AD']
     )
     expect(query).toHaveBeenNthCalledWith(6, 'COMMIT')
     expect(release).toHaveBeenCalledOnce()

--- a/tests/main/storage/postgres-transcripts-repository.test.ts
+++ b/tests/main/storage/postgres-transcripts-repository.test.ts
@@ -13,6 +13,7 @@ describe('PostgresTranscriptsRepository', () => {
             transcript_id: 'NM_000059.4',
             gene_symbol: 'BRCA2',
             consequence: 'HIGH',
+            func: 'stop_gained',
             cdna: null,
             aa_change: null,
             hpo_sim_score: null,
@@ -33,6 +34,7 @@ describe('PostgresTranscriptsRepository', () => {
         transcript_id: 'NM_000059.4',
         gene_symbol: 'BRCA2',
         consequence: 'HIGH',
+        func: 'stop_gained',
         cdna: null,
         aa_change: null,
         hpo_sim_score: null,
@@ -54,6 +56,7 @@ describe('PostgresTranscriptsRepository', () => {
             transcript_id: 'NM_007294.4',
             gene_symbol: 'BRCA1',
             consequence: 'MODERATE',
+            func: 'missense_variant',
             cdna: null,
             aa_change: null,
             hpo_sim_score: null,
@@ -74,6 +77,7 @@ describe('PostgresTranscriptsRepository', () => {
         transcript_id: 'NM_007294.4',
         gene_symbol: 'BRCA1',
         consequence: 'MODERATE',
+        func: 'missense_variant',
         cdna: null,
         aa_change: null,
         hpo_sim_score: null,
@@ -134,6 +138,7 @@ describe('PostgresTranscriptsRepository', () => {
       transcript_id: 'NM_000059.4',
       gene_symbol: 'BRCA2',
       consequence: 'HIGH',
+      func: 'missense_variant',
       cdna: 'c.1A>G',
       aa_change: 'p.M1V',
       hpo_sim_score: 0.8,
@@ -174,7 +179,7 @@ describe('PostgresTranscriptsRepository', () => {
     expect(query).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('ON CONFLICT (variant_id, transcript_id)\n         DO NOTHING'),
-      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'c.1A>G', 'p.M1V', 0.8, 'AD']
+      [9, 'NM_000059.4', 'BRCA2', 'HIGH', 'missense_variant', 'c.1A>G', 'p.M1V', 0.8, 'AD']
     )
     expect(query).toHaveBeenNthCalledWith(
       3,

--- a/tests/main/storage/transcript-switch-denormalization.test.ts
+++ b/tests/main/storage/transcript-switch-denormalization.test.ts
@@ -3,9 +3,17 @@
  *
  * Issue #207: switching the selected transcript must update the denormalized
  * transcript columns on the parent `variants` row (transcript, gene_symbol,
- * consequence, cdna, aa_change, hpo_sim_score, moi), not just flip
+ * consequence, func, cdna, aa_change, hpo_sim_score, moi), not just flip
  * `variant_transcripts.is_selected`. The Postgres backend originally missed the
  * parent-row update; PR #214 fixed it inside `PostgresTranscriptsRepository`.
+ *
+ * Follow-up (D1/D2): `variant_transcripts.consequence` is the IMPACT level
+ * (HIGH/MODERATE/LOW/MODIFIER) and `variant_transcripts.func` is the Sequence
+ * Ontology term (missense_variant, stop_gained, ...) — same convention as
+ * `variants.consequence` / `variants.func`. The denorm writeback originally
+ * copied `consequence` but not `func`, so `variants.func` went stale on a
+ * transcript switch. `func` must now be copied too, without crossing the two
+ * columns.
  *
  * Existing coverage stops short of a real engine:
  *   - postgres-transcripts-repository.test.ts mocks the `pg` client and only
@@ -49,11 +57,12 @@ const PG_URL =
   process.env.VARLENS_PG_URL ??
   'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
 
-/** The seven denormalized transcript columns mirrored onto `variants`. */
+/** The eight denormalized transcript columns mirrored onto `variants`. */
 interface DenormFields {
   transcript: string | null
   gene_symbol: string | null
   consequence: string | null
+  func: string | null
   cdna: string | null
   aa_change: string | null
   hpo_sim_score: number | null
@@ -64,7 +73,10 @@ interface DenormFields {
 interface TranscriptFixture {
   transcript_id: string
   gene_symbol: string
+  /** IMPACT level (HIGH/MODERATE/LOW/MODIFIER) — must land in variants.consequence. */
   consequence: string
+  /** Sequence Ontology term — must land in variants.func, never in variants.consequence. */
+  func: string
   cdna: string
   aa_change: string | null
   hpo_sim_score: number
@@ -75,7 +87,8 @@ interface TranscriptFixture {
 const TRANSCRIPT_A: TranscriptFixture = {
   transcript_id: 'NM_AAA.1',
   gene_symbol: 'GENEA',
-  consequence: 'missense_variant',
+  consequence: 'MODERATE',
+  func: 'missense_variant',
   cdna: 'c.1A>G',
   aa_change: 'p.Met1Val',
   hpo_sim_score: 0.1,
@@ -85,7 +98,8 @@ const TRANSCRIPT_A: TranscriptFixture = {
 const TRANSCRIPT_B: TranscriptFixture = {
   transcript_id: 'NM_BBB.2',
   gene_symbol: 'GENEB',
-  consequence: 'stop_gained',
+  consequence: 'HIGH',
+  func: 'stop_gained',
   cdna: 'c.2C>T',
   aa_change: 'p.Gln2Ter',
   hpo_sim_score: 0.9,
@@ -110,6 +124,7 @@ function denormOf(t: TranscriptFixture): DenormFields {
     transcript: t.transcript_id,
     gene_symbol: t.gene_symbol,
     consequence: t.consequence,
+    func: t.func,
     cdna: t.cdna,
     aa_change: t.aa_change,
     hpo_sim_score: t.hpo_sim_score,
@@ -122,6 +137,7 @@ function denormOfInsert(t: TranscriptInsertRow): DenormFields {
     transcript: t.transcript_id,
     gene_symbol: t.gene_symbol,
     consequence: t.consequence,
+    func: t.func,
     cdna: t.cdna,
     aa_change: t.aa_change,
     hpo_sim_score: t.hpo_sim_score,
@@ -156,7 +172,7 @@ function variantSeed(): Omit<Variant, 'id' | 'case_id'> {
     cadd: 28,
     clinvar: null,
     gt_num: '0/1',
-    func: null,
+    func: TRANSCRIPT_A.func,
     qual: 30,
     hpo_sim_score: TRANSCRIPT_A.hpo_sim_score,
     transcript: TRANSCRIPT_A.transcript_id,
@@ -175,9 +191,9 @@ async function setupSqlite(): Promise<BackendHarness> {
   let seedCounter = 0
   const insertTranscript = db.database.prepare(
     `INSERT INTO variant_transcripts
-       (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+       (variant_id, transcript_id, gene_symbol, consequence, func, cdna, aa_change,
         hpo_sim_score, moi, is_selected)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
 
   return {
@@ -196,6 +212,7 @@ async function setupSqlite(): Promise<BackendHarness> {
           t.transcript_id,
           t.gene_symbol,
           t.consequence,
+          t.func,
           t.cdna,
           t.aa_change,
           t.hpo_sim_score,
@@ -208,7 +225,7 @@ async function setupSqlite(): Promise<BackendHarness> {
     readVariantDenorm: async (variantId: number) => {
       const row = db.database
         .prepare(
-          `SELECT transcript, gene_symbol, consequence, cdna, aa_change, hpo_sim_score, moi
+          `SELECT transcript, gene_symbol, consequence, func, cdna, aa_change, hpo_sim_score, moi
              FROM variants WHERE id = ?`
         )
         .get(variantId) as DenormFields
@@ -264,9 +281,9 @@ async function setupPostgres(): Promise<BackendHarness> {
       const seed = variantSeed()
       const variantRes = await client.query(
         `INSERT INTO "${schema}".variants
-           (case_id, chr, pos, ref, alt, gene_symbol, consequence,
+           (case_id, chr, pos, ref, alt, gene_symbol, consequence, func,
             hpo_sim_score, transcript, cdna, aa_change, moi)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id`,
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id`,
         [
           caseId,
           seed.chr,
@@ -275,6 +292,7 @@ async function setupPostgres(): Promise<BackendHarness> {
           seed.alt,
           seed.gene_symbol,
           seed.consequence,
+          seed.func,
           seed.hpo_sim_score,
           seed.transcript,
           seed.cdna,
@@ -290,14 +308,15 @@ async function setupPostgres(): Promise<BackendHarness> {
       ] as const) {
         await client.query(
           `INSERT INTO "${schema}".variant_transcripts
-             (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change,
+             (variant_id, transcript_id, gene_symbol, consequence, func, cdna, aa_change,
               hpo_sim_score, moi, is_selected)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
           [
             variantId,
             t.transcript_id,
             t.gene_symbol,
             t.consequence,
+            t.func,
             t.cdna,
             t.aa_change,
             t.hpo_sim_score,
@@ -310,7 +329,7 @@ async function setupPostgres(): Promise<BackendHarness> {
     },
     readVariantDenorm: async (variantId: number) => {
       const res = await client.query(
-        `SELECT transcript, gene_symbol, consequence, cdna, aa_change, hpo_sim_score, moi
+        `SELECT transcript, gene_symbol, consequence, func, cdna, aa_change, hpo_sim_score, moi
            FROM "${schema}".variants WHERE id = $1`,
         [variantId]
       )
@@ -319,6 +338,7 @@ async function setupPostgres(): Promise<BackendHarness> {
         transcript: r.transcript,
         gene_symbol: r.gene_symbol,
         consequence: r.consequence,
+        func: r.func,
         cdna: r.cdna,
         aa_change: r.aa_change,
         hpo_sim_score: r.hpo_sim_score === null ? null : Number(r.hpo_sim_score),

--- a/tests/main/storage/transcript-switch-denormalization.test.ts
+++ b/tests/main/storage/transcript-switch-denormalization.test.ts
@@ -96,7 +96,8 @@ const TRANSCRIPT_B: TranscriptFixture = {
 const TRANSCRIPT_C: TranscriptInsertRow = {
   transcript_id: 'ENST_CCC.1',
   gene_symbol: 'GENEC',
-  consequence: 'splice_acceptor_variant',
+  consequence: 'HIGH',
+  func: 'splice_acceptor_variant',
   cdna: 'c.3-1G>A',
   aa_change: null,
   hpo_sim_score: 0.55,

--- a/tests/main/storage/transcript-switch-denormalization.test.ts
+++ b/tests/main/storage/transcript-switch-denormalization.test.ts
@@ -119,6 +119,17 @@ const TRANSCRIPT_C: TranscriptInsertRow = {
   is_selected: 1
 }
 
+const LEGACY_TRANSCRIPT: TranscriptFixture = {
+  transcript_id: 'NM_LEGACY.1',
+  gene_symbol: 'LEGACY',
+  consequence: 'stop_gained',
+  func: 'stop_gained',
+  cdna: 'c.4C>T',
+  aa_change: 'p.Gln2Ter',
+  hpo_sim_score: 0.4,
+  moi: 'AD'
+}
+
 function denormOf(t: TranscriptFixture): DenormFields {
   return {
     transcript: t.transcript_id,
@@ -149,6 +160,8 @@ interface BackendHarness {
   session: StorageSession
   /** Insert a fresh case + variant (carrying A's values) + transcripts A (selected) and B. */
   seedVariantWithTranscripts: () => Promise<number>
+  /** Add a pre-migration row whose SO term is still stored in consequence. */
+  addLegacyTranscript: (variantId: number) => Promise<void>
   readVariantDenorm: (variantId: number) => Promise<DenormFields>
   cleanup: () => Promise<void>
 }
@@ -221,6 +234,20 @@ async function setupSqlite(): Promise<BackendHarness> {
         )
       }
       return variantId
+    },
+    addLegacyTranscript: async (variantId: number) => {
+      insertTranscript.run(
+        variantId,
+        LEGACY_TRANSCRIPT.transcript_id,
+        LEGACY_TRANSCRIPT.gene_symbol,
+        LEGACY_TRANSCRIPT.consequence,
+        null,
+        LEGACY_TRANSCRIPT.cdna,
+        LEGACY_TRANSCRIPT.aa_change,
+        LEGACY_TRANSCRIPT.hpo_sim_score,
+        LEGACY_TRANSCRIPT.moi,
+        0
+      )
     },
     readVariantDenorm: async (variantId: number) => {
       const row = db.database
@@ -327,6 +354,26 @@ async function setupPostgres(): Promise<BackendHarness> {
       }
       return variantId
     },
+    addLegacyTranscript: async (variantId: number) => {
+      await client.query(
+        `INSERT INTO "${schema}".variant_transcripts
+           (variant_id, transcript_id, gene_symbol, consequence, func, cdna, aa_change,
+            hpo_sim_score, moi, is_selected)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          variantId,
+          LEGACY_TRANSCRIPT.transcript_id,
+          LEGACY_TRANSCRIPT.gene_symbol,
+          LEGACY_TRANSCRIPT.consequence,
+          null,
+          LEGACY_TRANSCRIPT.cdna,
+          LEGACY_TRANSCRIPT.aa_change,
+          LEGACY_TRANSCRIPT.hpo_sim_score,
+          LEGACY_TRANSCRIPT.moi,
+          0
+        ]
+      )
+    },
     readVariantDenorm: async (variantId: number) => {
       const res = await client.query(
         `SELECT transcript, gene_symbol, consequence, func, cdna, aa_change, hpo_sim_score, moi
@@ -395,6 +442,27 @@ describe.each(fixtures)('transcript-switch denormalization — $name', ({ setup 
     })
 
     expect(await h.readVariantDenorm(variantId)).toEqual(denormOfInsert(TRANSCRIPT_C))
+  })
+
+  it('never writes a legacy SO term into variants.consequence', async () => {
+    const variantId = await h.seedVariantWithTranscripts()
+    await h.addLegacyTranscript(variantId)
+
+    await h.session.getWriteExecutor().execute({
+      type: 'transcripts:switch',
+      params: [variantId, LEGACY_TRANSCRIPT.transcript_id]
+    })
+
+    expect(await h.readVariantDenorm(variantId)).toEqual({
+      transcript: LEGACY_TRANSCRIPT.transcript_id,
+      gene_symbol: LEGACY_TRANSCRIPT.gene_symbol,
+      consequence: TRANSCRIPT_A.consequence,
+      func: LEGACY_TRANSCRIPT.func,
+      cdna: LEGACY_TRANSCRIPT.cdna,
+      aa_change: LEGACY_TRANSCRIPT.aa_change,
+      hpo_sim_score: LEGACY_TRANSCRIPT.hpo_sim_score,
+      moi: LEGACY_TRANSCRIPT.moi
+    })
   })
 })
 

--- a/tests/main/storage/transcript-switch-denormalization.test.ts
+++ b/tests/main/storage/transcript-switch-denormalization.test.ts
@@ -444,7 +444,7 @@ describe.each(fixtures)('transcript-switch denormalization — $name', ({ setup 
     expect(await h.readVariantDenorm(variantId)).toEqual(denormOfInsert(TRANSCRIPT_C))
   })
 
-  it('never writes a legacy SO term into variants.consequence', async () => {
+  it('clears stale parent impact when the selected legacy transcript has no recoverable impact', async () => {
     const variantId = await h.seedVariantWithTranscripts()
     await h.addLegacyTranscript(variantId)
 
@@ -456,7 +456,7 @@ describe.each(fixtures)('transcript-switch denormalization — $name', ({ setup 
     expect(await h.readVariantDenorm(variantId)).toEqual({
       transcript: LEGACY_TRANSCRIPT.transcript_id,
       gene_symbol: LEGACY_TRANSCRIPT.gene_symbol,
-      consequence: TRANSCRIPT_A.consequence,
+      consequence: null,
       func: LEGACY_TRANSCRIPT.func,
       cdna: LEGACY_TRANSCRIPT.cdna,
       aa_change: LEGACY_TRANSCRIPT.aa_change,

--- a/tests/renderer/components/TranscriptSection.test.ts
+++ b/tests/renderer/components/TranscriptSection.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Component tests for TranscriptSection.vue — the shared transcript table used by
+ * both the case view and the cohort view (`mode: 'case' | 'cohort'`).
+ *
+ * Post-D1/D2, `variant_transcripts.consequence` holds the canonical IMPACT level
+ * (HIGH/MODERATE/LOW/MODIFIER) for ALL import paths (VCF and JSON), and
+ * `variant_transcripts.func` holds the Sequence Ontology term. These tests lock
+ * down that:
+ *   1. The impact chip colors correctly off the canonical `consequence` field for
+ *      DB-imported rows (case mode) regardless of import source.
+ *   2. The SO term (`func`) is surfaced to the user (via the consequence tooltip),
+ *      not silently dropped.
+ *   3. Cohort mode (VEP-sourced rows only — DB transcripts never populate; see
+ *      VariantDetailsPanel.vue passing `variant-id: null` in cohort mode) renders
+ *      identical chip + func semantics via the same shared component.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import TranscriptSection from '../../../src/renderer/src/components/TranscriptSection.vue'
+import { createMockApi } from '../../utils/mock-api'
+import type { TranscriptAnnotation } from '../../../src/shared/types/transcript'
+import type { VepTranscriptConsequence } from '../../../src/shared/types/vep'
+
+const vuetify = createVuetify({ components, directives })
+
+/** Minimal DB transcript row (shape returned by transcripts:list for both VCF- and JSON-imported cases). */
+function makeDbTranscript(overrides: Partial<TranscriptAnnotation> = {}): TranscriptAnnotation {
+  return {
+    id: 1,
+    variant_id: 1,
+    transcript_id: 'ENST00000357654',
+    gene_symbol: 'BRCA1',
+    consequence: 'MODERATE',
+    func: 'missense_variant',
+    cdna: 'c.123A>G',
+    aa_change: 'p.Arg41Gly',
+    hpo_sim_score: null,
+    moi: null,
+    is_selected: true,
+    is_mane_select: null,
+    is_canonical: null,
+    ...overrides
+  }
+}
+
+/** Minimal VEP transcript consequence (cohort mode's only transcript source). */
+function makeVepTranscript(
+  overrides: Partial<VepTranscriptConsequence> = {}
+): VepTranscriptConsequence {
+  return {
+    transcript_id: 'ENST00000222222',
+    gene_symbol: 'BRCA1',
+    consequence_terms: ['missense_variant'],
+    impact: 'MODERATE',
+    ...overrides
+  }
+}
+
+describe('TranscriptSection', () => {
+  beforeEach(() => {
+    window.api = createMockApi()
+  })
+
+  async function mountCase(dbRows: TranscriptAnnotation[]) {
+    window.api.transcripts.list.mockResolvedValue(dbRows)
+    const wrapper = mount(TranscriptSection, {
+      props: {
+        variantId: 1,
+        vepTranscripts: [],
+        vepLoading: false,
+        mode: 'case' as const
+      },
+      global: { plugins: [vuetify] }
+    })
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  function mountCohort(vepRows: VepTranscriptConsequence[]) {
+    return mount(TranscriptSection, {
+      props: {
+        variantId: null,
+        vepTranscripts: vepRows,
+        vepLoading: false,
+        mode: 'cohort' as const
+      },
+      global: { plugins: [vuetify] }
+    })
+  }
+
+  it('colors the impact chip from the canonical IMPACT field for a DB-imported transcript row', async () => {
+    const wrapper = await mountCase([makeDbTranscript({ consequence: 'MODERATE' })])
+
+    const chip = wrapper.findAll('.v-chip').find((c) => c.text() === 'MODERATE')
+    expect(chip?.exists()).toBe(true)
+    expect(chip!.classes()).toContain('text-warning')
+  })
+
+  it('surfaces the func (SO term) for a DB-imported transcript row via the consequence tooltip', async () => {
+    const wrapper = await mountCase([
+      makeDbTranscript({ consequence: 'MODERATE', func: 'missense_variant' })
+    ])
+
+    const tooltip = wrapper.findComponent({ name: 'VTooltip' })
+    expect(tooltip.exists()).toBe(true)
+    expect(tooltip.props('text')).toBe('missense_variant')
+  })
+
+  it('renders identical chip + func semantics for a HIGH-impact DB row (import source agnostic)', async () => {
+    const wrapper = await mountCase([
+      makeDbTranscript({ consequence: 'HIGH', func: 'stop_gained' })
+    ])
+
+    const chip = wrapper.findAll('.v-chip').find((c) => c.text() === 'HIGH')
+    expect(chip?.exists()).toBe(true)
+    expect(chip!.classes()).toContain('text-error')
+
+    const tooltip = wrapper.findComponent({ name: 'VTooltip' })
+    expect(tooltip.props('text')).toBe('stop_gained')
+  })
+
+  it('does not lose information when func is null (no tooltip text, chip still colors)', async () => {
+    const wrapper = await mountCase([makeDbTranscript({ consequence: 'LOW', func: null })])
+
+    const chip = wrapper.findAll('.v-chip').find((c) => c.text() === 'LOW')
+    expect(chip?.exists()).toBe(true)
+    expect(chip!.classes()).toContain('text-info')
+  })
+
+  it('cohort mode (VEP-sourced row) renders identical chip + func semantics as case mode', () => {
+    const wrapper = mountCohort([
+      makeVepTranscript({ impact: 'MODERATE', consequence_terms: ['missense_variant'] })
+    ])
+
+    const chip = wrapper.findAll('.v-chip').find((c) => c.text() === 'MODERATE')
+    expect(chip?.exists()).toBe(true)
+    expect(chip!.classes()).toContain('text-warning')
+
+    const tooltip = wrapper.findComponent({ name: 'VTooltip' })
+    expect(tooltip.props('text')).toBe('missense_variant')
+  })
+})

--- a/tests/renderer/utils/mergeTranscripts.test.ts
+++ b/tests/renderer/utils/mergeTranscripts.test.ts
@@ -251,6 +251,18 @@ describe('mergeTranscripts', () => {
       expect(result.map((r) => r.impact)).toEqual(['HIGH', 'MODERATE', 'LOW', 'MODIFIER'])
     })
 
+    it('sorts DB-only rows by their canonical consequence impact', () => {
+      const db = [
+        makeDbRow({ id: 1, transcript_id: 'A_MODERATE', consequence: 'MODERATE' }),
+        makeDbRow({ id: 2, transcript_id: 'Z_HIGH', consequence: 'HIGH' })
+      ]
+
+      const result = mergeTranscripts(db, [])
+
+      expect(result.map((row) => row.transcript_id)).toEqual(['Z_HIGH', 'A_MODERATE'])
+      expect(result.map((row) => row.impact)).toEqual(['HIGH', 'MODERATE'])
+    })
+
     it('sorts alphabetically by transcript_id as tiebreaker', () => {
       const vep = [
         makeVepRow({ transcript_id: 'ENST00000333333.1', impact: 'MODERATE' }),

--- a/tests/renderer/utils/mergeTranscripts.test.ts
+++ b/tests/renderer/utils/mergeTranscripts.test.ts
@@ -14,6 +14,7 @@ function makeDbRow(overrides: Partial<TranscriptAnnotation> = {}): TranscriptAnn
     transcript_id: 'ENST00000357654',
     gene_symbol: 'BRCA1',
     consequence: 'MODERATE',
+    func: 'missense_variant',
     cdna: 'c.123A>G',
     aa_change: 'p.Arg41Gly',
     hpo_sim_score: null,
@@ -115,6 +116,65 @@ describe('mergeTranscripts', () => {
     expect(result[0].biotype).toBe('protein_coding')
     expect(result[0]._dbRow).toBe(db[0])
     expect(result[0]._vepRow).toBe(vep[0])
+  })
+
+  describe('func (SO term) propagation', () => {
+    it('surfaces the DB row func (SO term) for a DB-only ("imported") row', () => {
+      const db = [makeDbRow({ consequence: 'MODERATE', func: 'missense_variant' })]
+      const result = mergeTranscripts(db, [])
+
+      expect(result[0].consequence).toBe('MODERATE')
+      expect(result[0].func).toBe('missense_variant')
+    })
+
+    it('does not lose information: func stays null (not dropped) when the DB row has none', () => {
+      const db = [makeDbRow({ func: null })]
+      const result = mergeTranscripts(db, [])
+
+      expect(result[0].func).toBeNull()
+    })
+
+    it('joins VEP consequence_terms into func for a VEP-only row', () => {
+      const vep = [makeVepRow({ consequence_terms: ['missense_variant', 'splice_region_variant'] })]
+      const result = mergeTranscripts([], vep)
+
+      expect(result[0].func).toBe('missense_variant, splice_region_variant')
+    })
+
+    it('sets func to null for a VEP-only row with no consequence_terms', () => {
+      const vep = [makeVepRow({ consequence_terms: [] })]
+      const result = mergeTranscripts([], vep)
+
+      expect(result[0].func).toBeNull()
+    })
+
+    it('overwrites DB func with fresh VEP consequence_terms on merge ("both")', () => {
+      const db = [makeDbRow({ transcript_id: 'ENST00000357654', func: 'missense_variant' })]
+      const vep = [
+        makeVepRow({
+          transcript_id: 'ENST00000357654.9',
+          consequence_terms: ['missense_variant', 'NMD_transcript_variant']
+        })
+      ]
+      const result = mergeTranscripts(db, vep)
+
+      expect(result[0].source).toBe('both')
+      expect(result[0].func).toBe('missense_variant, NMD_transcript_variant')
+    })
+
+    it('preserves DB func on merge when VEP provides no consequence_terms', () => {
+      const db = [makeDbRow({ transcript_id: 'ENST00000357654', func: 'missense_variant' })]
+      const vep = [
+        makeVepRow({
+          transcript_id: 'ENST00000357654.9',
+          consequence_terms: []
+        })
+      ]
+      const result = mergeTranscripts(db, vep)
+
+      expect(result[0].source).toBe('both')
+      expect(result[0].func).toBe('missense_variant')
+    })
   })
 
   it('matches version-stripped IDs (ENST00000357654.9 ≈ ENST00000357654)', () => {

--- a/tests/web-gate/dispatcher-adapters-core.test.ts
+++ b/tests/web-gate/dispatcher-adapters-core.test.ts
@@ -175,6 +175,7 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
       transcript_id: 'NM_000059.4',
       gene_symbol: 'BRCA2',
       consequence: 'HIGH',
+      func: 'missense_variant',
       cdna: 'c.1A>G',
       aa_change: 'p.M1V',
       hpo_sim_score: 0.8,

--- a/tests/web-gate/parity/ipc/transcripts.ts
+++ b/tests/web-gate/parity/ipc/transcripts.ts
@@ -8,7 +8,8 @@ export const transcriptsScenario: IpcScenario = {
       {
         transcript_id: 'ENST_PARITY_000001',
         gene_symbol: 'COMT',
-        consequence: 'stop_gained',
+        consequence: 'HIGH',
+        func: 'stop_gained',
         cdna: 'c.493G>A',
         aa_change: 'p.Glu165Ter',
         hpo_sim_score: 0.87,


### PR DESCRIPTION
## Summary

Fixes the transcript impact/SO conflation (finding C4 / Codex F-02) — a **live data-corruption bug**: VCF import stored the Sequence-Ontology term in `variant_transcripts.consequence` (which must be the IMPACT level), and the transcript-switch denormalization copies that column onto `variants.consequence`. So switching the selected transcript on a VCF-imported variant wrote an SO term into the main IMPACT field that impact/rarity filters depend on.

**PR-D** of the staged security & bug remediation. Highest-risk PR (schema migration + two-engine denormalization).

## ⚠️ Merge-ordering note

The Postgres migration is numbered **`0014`**, which collides with an unrelated `hosted_user_private_db` migration on the unmerged sibling branch `web/11-hosted-db-foundation`. Whichever of the two merges **second** must be renumbered, or the migration checksum ledger will reject it. On this branch `0014` is the correct next sequential number.

## What changed

**Canonical model (D1):** added a `func` column to `variant_transcripts` (SO term) via an additive, idempotent, version-tracked migration on **both** SQLite (v32) and Postgres (0014). All five import paths (VEP CSQ, SnpEff ANN, JSON columnar, JSON object, VEP enrichment) now write `consequence`=IMPACT + `func`=SO term — matching the `variants` table convention. Updated **14** hard-coded transcript column-list artifacts (schema, worker INSERT, shared types, Zod, Postgres `_COLUMNS`/`_COPY_COLUMNS` + encoders, both import repos). Legacy rows keep `func` NULL (safe; a re-import fully corrects them). The Postgres COPY/jsonb paths are name-driven off a single column constant, so ordinal drift is structurally impossible.

**Denormalization writeback (D2):** the transcript-switch writeback now copies `func` too, on **both** engines (SQLite `TranscriptRepository` + Postgres `PostgresTranscriptsRepository`), keeping `impact→variants.consequence` and `SO→variants.func` uncrossed. Verified via the issue-207 two-engine harness.

**UI (D3):** the transcript impact chip now colors correctly for VCF rows (it keys off `consequence`=IMPACT post-D1), and the SO term (`func`) is surfaced in the consequence tooltip. Cohort parity by construction — `TranscriptSection` is a single shared component with no case/cohort mode-branching on the chip.

## Reviews

- **Codex-high (whole-branch gate):** **GO** — independently confirmed every Postgres column list has `func` at the correct ordinal, COPY uses explicit column names (no physical-order shift), all import paths write the right columns, and both denorm writebacks copy impact/SO uncrossed.
- Per-task reviews: D1 reviewed on Opus (column-count/order safety verified by construction); D2 and D3 reviewers independently reran the two-engine harness / reverted-and-reran the UI test.

## Verification

- SQLite `make test` (`--project main`): **2798 passing**.
- Postgres: migration + COPY path verified on the live `varlens-postgres-1` container; the issue-207 denormalization harness green on **both** SQLite and Postgres (`VARLENS_RUN_POSTGRES_E2E=1`).
- `make typecheck` clean.

## Follow-ups (tracked, non-blocking)

- Test-hygiene: a few older fixtures still seed pre-D1 SO-in-`consequence` values / omit `func` (`transcripts.test.ts:47`, `streaming-import.test.ts:89`, `postgres-vcf-import-repository.copy.test.ts:485`) — not production paths, but weaken regression signal.

Part of the security & bug remediation series (PR-A #306, PR-B #307, PR-C #308; PRs E–I to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmqdEMGjqVhTX8EKr6QxoH
