### PR TITLE
fix(import): VCF POS/QUAL validation + capped-reader DoS hardening (C7) [PR-E]

### DIFF
--- a/.planning/plans/2026-07-13-pr310-final-blocker-fixes.md
+++ b/.planning/plans/2026-07-13-pr310-final-blocker-fixes.md
@@ -1,0 +1,63 @@
+# PR310 Final Blocker Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept legitimate high-ratio cohort VCFs while retaining bounded gzip protection, and stream BED rows atomically into both storage backends without full-array materialization.
+
+**Architecture:** Add a bounded VCF-prefix/sample-count classifier to the decompression stream policy. Move BED file consumption behind a storage task carrying file path and strictness so each backend owns a single transaction and bounded insert chunks.
+
+**Tech Stack:** TypeScript 6, Node streams/zlib/readline, better-sqlite3, PostgreSQL `pg`, Vitest
+
+---
+
+### Task 1: VCF-aware gzip ratio regression
+
+**Files:**
+- Modify: `tests/main/import/stream-utils-caps.test.ts`
+- Modify: `src/main/import/stream-utils.ts`
+
+- [x] Add a test that builds a valid 500-sample, >64 MiB VCF gzip and consumes it through `createCappedLineStream` with production defaults; assert every line is accepted.
+- [x] Run the focused test and confirm it fails with `DecompressionRatioExceededError`.
+- [x] Add a bounded prefix classifier and sample-aware VCF allowance, based on the configured stream ratio and capped by a hard maximum.
+- [x] Add a short-line non-VCF gzip bomb test and assert ratio rejection before the absolute cap.
+- [x] Run `npx vitest run tests/main/import/stream-utils-caps.test.ts`; require both acceptance and rejection tests to pass.
+
+### Task 2: Streaming BED storage contract tests
+
+**Files:**
+- Modify: `src/main/storage/write-executor.ts`
+- Modify: `tests/main/storage/postgres-panels-repository.test.ts`
+- Modify: `tests/main/database/GeneListRepository.test.ts`
+- Modify: representative desktop/web handler tests
+
+- [x] Change failing handler tests to require `region-files:importBed` tasks with `[fileId, filePath, { rejectMalformedRows }]`, never `entries[]`.
+- [x] Add PostgreSQL tests with a BED file larger than one chunk; assert bounded `UNNEST` calls, exact count/total bases, one transaction, and rollback on parser failure.
+- [x] Add SQLite repository tests for streamed import, exact metadata, rollback preserving prior rows, and concurrent imports without leaked staging tables.
+- [x] Run focused tests and confirm failures are contract/implementation failures, not fixture errors.
+
+### Task 3: Implement backend-owned streaming BED persistence
+
+**Files:**
+- Modify: `src/main/database/GeneListRepository.ts`
+- Modify: `src/main/storage/postgres/PostgresPanelsRepository.ts`
+- Modify: `src/main/storage/sqlite/SqliteWriteExecutor.ts`
+- Modify: `src/main/storage/postgres/PostgresWriteExecutor.ts`
+- Modify: `src/main/storage/write-executor.ts`
+- Modify: `src/main/ipc/handlers/gene-lists.ts`
+- Modify: `src/web/server/routes/region-files.ts`
+
+- [x] Define a path/policy write task and route it through both executors.
+- [x] Implement SQLite bounded staging chunks with a reusable statement, bounded parser, safe metadata accumulation, and a short atomic replacement transaction.
+- [x] Implement one-transaction PostgreSQL streaming insert with fixed-size arrays, bounded parser, safe metadata accumulation, and rollback.
+- [x] Remove handler `collectBedEntries` arrays while preserving desktop path validation and web upload ownership.
+- [x] Run all focused desktop/web/repository tests and require green.
+
+### Task 4: Verification and commit
+
+**Files:**
+- Verify all modified source, tests, spec, and plan.
+
+- [x] Run focused import, storage, desktop handler, and web route tests.
+- [x] Run `make typecheck`, `make lint-check`, `make format-check`, and `make agent-check`.
+- [x] Run `git diff --check` and inspect the branch/worktree diff and status.
+- [x] Commit with `fix(import): stream BED persistence and tune gzip guards`.

--- a/.planning/plans/2026-07-13-pr310-final-hardening.md
+++ b/.planning/plans/2026-07-13-pr310-final-hardening.md
@@ -1,0 +1,70 @@
+# PR 310 Final Import Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the final PR310 denial-of-service and malformed-record blockers without rejecting legitimate WGS imports or weakening path authority.
+
+**Architecture:** Add a shared gzip expansion-ratio monitor alongside the existing byte and line caps. Bound valid BED objects at the shared streaming reader, retain filter interval merging, route web BED imports through that reader, and chunk PostgreSQL persistence. Tighten VCF parsing at the source so unsafe POS and malformed non-dot QUAL become reasoned skips in every importer.
+
+**Tech Stack:** TypeScript 6, Node streams/zlib, Electron workers, PostgreSQL, SQLite, Vitest
+
+---
+
+### Task 1: Practical gzip expansion guard
+
+**Files:**
+- Modify: `tests/main/import/stream-utils-caps.test.ts`
+- Modify: `src/main/import/stream-utils.ts`
+
+- [x] Add failing tests proving a highly compressible gzip is rejected by a ratio override before the large decompressed-byte cap, while a gzip below the ratio and the ratio-check floor are accepted.
+- [x] Run `npx vitest run tests/main/import/stream-utils-caps.test.ts` and confirm the new ratio tests fail.
+- [x] Add `DecompressionRatioExceededError` and a gzip-only transform that rejects after output exceeds both a 64 MiB floor and 100 times the consumed compressed bytes. This leaves almost 4x headroom over the most compressible shipped VCF fixture while retaining the 256 GiB worker-capable total budget. Add test-only option overrides.
+- [x] Re-run the focused test and require success.
+
+### Task 2: Bounded BED collection and web streaming
+
+**Files:**
+- Modify: `tests/main/import/vcf/bed-filter.test.ts`
+- Modify: `tests/web-gate/dispatcher-adapters-assets-annotations-export.test.ts`
+- Modify: `src/main/import/vcf/bed-reader.ts`
+- Modify: `src/main/import/vcf/bed-filter.ts`
+- Modify: `src/web/server/routes/region-files.ts`
+
+- [x] Add failing tests for the one-million-entry guard through a small override, safe BED coordinates, gzip/resource rejection in the web adapter, strict malformed-row behavior on web, and successful staged gzip BED streaming.
+- [x] Run both focused test files and confirm the new cases fail.
+- [x] Add `BedEntryLimitExceededError`, safe-integer validation, an optional entry-limit override, and optional strict malformed-row rejection to the shared async BED reader. Keep desktop filtering permissive for malformed rows and keep `BedFilter`'s per-chromosome sort/merge behavior.
+- [x] Replace the web route's `readFile`/split path with the shared capped reader while preserving upload-reference resolution and raw server-path rejection.
+- [x] Re-run the focused desktop and web tests and require success.
+
+### Task 3: Chunk region persistence
+
+**Files:**
+- Modify: `tests/main/storage/postgres-panels-repository.test.ts`
+- Modify: `src/main/storage/postgres/PostgresPanelsRepository.ts`
+
+- [x] Add a failing repository test with more than one 10,000-row logical chunk and assert multiple bounded `UNNEST` inserts plus one transactional metadata update.
+- [x] Run `npx vitest run tests/main/storage/postgres-panels-repository.test.ts` and confirm the new assertion fails.
+- [x] Slice entries into 10,000-row chunks before constructing PostgreSQL parameter arrays, accumulating counts and total bases without allocating arrays for the entire BED at once.
+- [x] Re-run the focused repository test and require success.
+
+### Task 4: Exact VCF numeric validation
+
+**Files:**
+- Modify: `tests/main/import/vcf/vcf-line-parser.test.ts`
+- Modify: representative worker/strategy tests that assert counted skip reasons
+- Modify: `src/main/import/vcf/vcf-line-parser.ts`
+
+- [x] Change/add failing tests proving POS above `Number.MAX_SAFE_INTEGER` is rejected with a reason, malformed finite-looking/non-finite non-dot QUAL returns `null` with a QUAL reason, dot QUAL remains a valid missing value, and strategy/worker skip counters receive the QUAL rejection.
+- [x] Run the focused parser and import tests and confirm the new expectations fail.
+- [x] Parse digit-only POS with `Number()` and require a positive safe integer. For QUAL, accept only dot or a finite number matching the complete numeric grammar; otherwise invoke `onSkip` and reject the row.
+- [x] Re-run the focused tests and require success.
+
+### Task 5: Final verification and commit
+
+**Files:**
+- Verify all modified source, tests, and this plan.
+
+- [x] Run combined focused desktop and web tests.
+- [x] Run `make typecheck`, `make lint-check`, `make format-check`, and `make agent-check`.
+- [x] Run `make ci` and `VARLENS_WEB=1 make ci` on the final snapshot.
+- [x] Inspect the diff and source sizes, commit with a Conventional Commit message, keep the worktree, and do not push.

--- a/.planning/plans/2026-07-13-pr310-wgs-safe-import-fixes.md
+++ b/.planning/plans/2026-07-13-pr310-wgs-safe-import-fixes.md
@@ -1,0 +1,42 @@
+# PR310 WGS-Safe Import Hardening Plan
+
+**Goal:** Preserve bounded WGS imports and file-atomic visibility while closing parser amplification and multi-file cancellation gaps.
+
+**Architecture:** Use bounded streaming/scanning at parser boundaries, hidden PostgreSQL base tables with per-batch production commits and a ready-only visibility boundary, and a dedicated SQLite append connection with operation-scoped cancellation.
+
+### Task 1: Parser and diagnostic budgets
+
+- [x] Add red tests for unbounded JSON keys, high-sample selected-column parsing, annotation/allele amplification, structural expansion, valid high-ratio VCFs, and bounded BED errors.
+- [x] Implement bounded JSON key/token/depth accounting.
+- [x] Resolve the selected VCF sample once and avoid cohort-width row allocation.
+- [x] Add high-sample-safe header scanning and a bounded all-samples compatibility path.
+- [x] Group annotations once, map selected alleles, and enforce aggregate work/output budgets.
+- [x] Run the focused parser/import tests and type checking.
+- [x] Checkpoint as `474e1fde`.
+
+### Task 2: PostgreSQL WGS-safe provisional imports
+
+- [x] Change tests to require commit boundaries between staging batches and no production case on late failure.
+- [x] Add durable provisional case status, watermark, and ready-only case/variant views.
+- [x] COPY each bounded batch directly to production base tables inside its own transaction.
+- [x] Add a schema-scoped advisory lock before recovery and hold it for the full import.
+- [x] Delete current-file rows in bounded watermark-scoped chunks after failure/cancellation.
+- [x] Recover interrupted provisional cases before starting a new locked import.
+- [x] Flip visibility only in the final consistent bookkeeping transaction.
+- [x] Preserve final synchronous bookkeeping and cohort-summary behavior.
+- [x] Run the full PostgreSQL worker/repository/integration test cluster.
+
+### Task 3: SQLite transaction isolation and cancellation
+
+- [x] Add a regression test proving the main connection is outside the append transaction and cancellation rolls back inserted batches.
+- [x] Move appended-file writes to a dedicated encrypted worker-style SQLite connection.
+- [x] Add abort checks around row parsing, batch flush, and commit.
+- [x] Keep multi-file cancellation reachable across nested first-file and append phases.
+- [x] Run all SQLite executor, handler, database, and append tests.
+
+### Task 4: Verification and checkpoint
+
+- [x] Run focused import, worker, executor, database, and handler tests.
+- [x] Run `make ci` and every `make ci-full` component because workers and IPC lifecycle changed.
+- [x] Run `make agent-check`, formatting, and `git diff --check`.
+- [ ] Commit the storage/cancellation redesign on the PR310 branch.

--- a/.planning/specs/2026-07-13-pr310-final-blocker-design.md
+++ b/.planning/specs/2026-07-13-pr310-final-blocker-design.md
@@ -1,0 +1,25 @@
+# PR310 Final Blocker Design
+
+## Goal
+
+Close the two remaining import hardening blockers without rejecting supported high-sample-count VCFs or retaining a full BED object graph in Electron/web memory.
+
+## Gzip resource control
+
+The absolute decompressed-byte and line-length caps remain mandatory for every input. The ratio guard becomes format-aware rather than treating a compression ratio as proof of hostility. A small prefix inspector identifies VCF input and reads the `#CHROM` sample count without buffering data lines. VCF streams receive a bounded sample-aware ratio allowance because repeated genotype columns legitimately compress far beyond 100x; non-VCF JSON/BED retains the conservative default. Focused callers can configure the base ratio through the existing stream option, while a hard upper bound prevents the sample count from silently disabling the guard.
+
+Acceptance is locked by a production-default stream test using a valid 500-sample VCF whose decompressed size exceeds the 64 MiB ratio floor, plus a many-short-line gzip bomb that is rejected before the absolute decompressed cap.
+
+## BED persistence
+
+BED parsing and persistence become a storage-owned operation. Desktop and web handlers pass only the authorized path, file ID, and malformed-row policy. PostgreSQL opens one transaction, consumes the shared bounded `readBedEntries` async iterable in fixed-size chunks, updates count/total-base metadata, and commits. SQLite streams into uniquely named bounded staging chunks, then performs a short transaction that atomically replaces the visible rows and metadata. A parse/insert failure leaves or rolls back to the prior region file.
+
+The storage write contract therefore carries a path and policy rather than `entries[]`. No handler, executor task, or repository owns a million-entry array. PostgreSQL uses bounded `UNNEST` arrays per chunk; SQLite prepares and reuses one insert statement for bounded staging chunks and deletes the staging table after either success or failure.
+
+## Security and errors
+
+Desktop path authority stays at the IPC boundary; web upload references remain user-scoped and resolve to their staged server path before storage runs. Parsers retain safe-integer and decompressed-size validation. Transaction rollback is mandatory on malformed strict web rows, resource-limit failures, and database insert failures.
+
+## Verification
+
+Tests cover VCF high-ratio acceptance and bomb rejection, bounded chunk sizes, both backend transaction commit/rollback, desktop and web task shapes, path authority, type checking, lint, formatting, and agent-health gates.

--- a/.planning/specs/2026-07-13-pr310-wgs-safe-import-design.md
+++ b/.planning/specs/2026-07-13-pr310-wgs-safe-import-design.md
@@ -1,0 +1,45 @@
+# PR310 WGS-Safe Import Hardening Design
+
+## Goal
+
+Close the final import denial-of-service and atomicity blockers without reintroducing the PostgreSQL GIAB WGS memory failure or rejecting legitimate large cohorts.
+
+## Parser budgets
+
+JSON format detection streams keys without retaining an unbounded key array. Independent budgets cover token count, nesting depth, top-level key count, key bytes, and individual key length before format selection.
+
+VCF production paths resolve the selected sample column once from the header and scan only that column on each data row. Headers accept cohorts above 10,000 samples but use a 100,000-sample token budget and a scanner rather than an unbounded split. The legacy all-samples row API has the same explicit compatibility limit. FORMAT cardinality remains bounded per sample, while cohort width does not multiply FORMAT allocation.
+
+Multi-allelic mapping groups annotations by allele in one pass, maps only alleles carried by the selected sample for non-structural records, and rejects aggregate annotation-match and expansion-work budgets before multiplicative allocation. BED diagnostics include only a bounded preview and the original line length.
+
+Once VCF structure is established, gzip protection relies on absolute decompressed-byte, header-byte, line-length, and parser-work limits. A fixed compression-ratio cutoff is not applied to valid cohort VCFs because legitimate repeated genotype columns can exceed it.
+
+## PostgreSQL provisional visibility
+
+A WGS file never remains inside one transaction across all batches. Migration 0014 renames the physical case and variant tables to `cases_all` and `variants_all`, then exposes ready-only `cases` and `variants` views. Existing read repositories therefore share one visibility boundary: provisional cases and their committed variants do not appear in case lists, aggregates, cohort queries, annotations, or variant reads.
+
+The import worker reserves a unique case name in `cases_all` with `import_status = 'importing'`. Each bounded mapped batch is copied directly to `variants_all` and its extension tables in an independent transaction. The case stores the maximum pre-file variant ID as a durable watermark; a failed append deletes only IDs above that watermark in 10,000-row transactions. A new failed case is deleted after its rows drain, while an existing case returns to `ready`. Startup recovery applies the same bounded cleanup to interrupted provisional cases.
+
+A schema-scoped PostgreSQL advisory lock is held by the import connection before recovery and for the full operation. This prevents another Electron/web/process worker from reclaiming a live import. Cancellation is checked between every committed batch and before the final transaction.
+
+The final synchronous transaction writes provenance, refreshes the authoritative count/frequency/cohort-summary state, flips the case to `ready`, and commits atomically. It performs no WGS-scale variant copy or duplicate generated-column computation; PostgreSQL MVCC keeps the previous ready snapshot visible until every derived structure and the case publish together. If the final `COMMIT` result is ambiguous, the worker never runs destructive cleanup: either PostgreSQL committed the ready case, or the still-hidden import is reclaimed idempotently by the next advisory-lock owner.
+
+The public `cases` and `variants` names remain automatically updatable views. Ordinary lifecycle INSERT/UPDATE/DELETE operations therefore retain their existing contracts; import-only code addresses the hidden physical tables explicitly.
+
+## SQLite append isolation and cancellation
+
+Additional files use a dedicated SQLite connection opened from the database path and encryption key. `BEGIN IMMEDIATE` is held only on that connection while bounded batches are parsed and inserted. Unrelated main-connection writes can no longer join or be rolled back by the append transaction. Cancellation is represented by an `AbortSignal`, checked before rows, flushes, and commit; cancellation rolls back the isolated connection.
+
+The IPC layer keeps a cancellation operation reachable for the full single- or multi-file lifetime. Nested first-file imports restore the enclosing cancellation owner when they finish. PostgreSQL cancellation reaches its worker client; SQLite cancellation both cancels the first-file worker and aborts append parsing.
+
+## Acceptance
+
+- A late PostgreSQL VCF failure after committed production batches leaves no visible case or variants.
+- Consecutive WGS batches contain a commit boundary and cancellation checkpoint.
+- A failed second PostgreSQL file leaves the first file intact and removes only IDs above its durable watermark.
+- Ready-only views hide provisional rows from raw case and variant aggregate paths.
+- A second PostgreSQL process cannot recover a live import because the schema advisory lock fails closed.
+- Ordinary writes through the ready-only views remain functional, and no generated column is supplied by the COPY path.
+- SQLite append cancellation rolls back the current file and the main database connection is never inside the append transaction.
+- Multi-file cancellation remains reachable through `cancelImport` on both backends.
+- Parser regression tests cover large valid cohorts and adversarial key, annotation, ALT/sample, FORMAT, gzip, and BED inputs.

--- a/src/main/database/DatabaseService.ts
+++ b/src/main/database/DatabaseService.ts
@@ -281,6 +281,23 @@ export class DatabaseService {
   }
 
   /**
+   * Keep one SQLite transaction open across a bounded async producer.
+   * Nested repository transactions become savepoints under better-sqlite3,
+   * so streamed batches remain memory-bounded while the whole file is atomic.
+   */
+  async runAsyncTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      const result = await fn()
+      this.db.exec('COMMIT')
+      return result
+    } catch (error) {
+      if (this.db.inTransaction) this.db.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  /**
    * Check if this database is encrypted
    */
   isEncrypted(): boolean {

--- a/src/main/database/DatabaseService.ts
+++ b/src/main/database/DatabaseService.ts
@@ -281,23 +281,6 @@ export class DatabaseService {
   }
 
   /**
-   * Keep one SQLite transaction open across a bounded async producer.
-   * Nested repository transactions become savepoints under better-sqlite3,
-   * so streamed batches remain memory-bounded while the whole file is atomic.
-   */
-  async runAsyncTransaction<T>(fn: () => Promise<T>): Promise<T> {
-    this.db.exec('BEGIN IMMEDIATE')
-    try {
-      const result = await fn()
-      this.db.exec('COMMIT')
-      return result
-    } catch (error) {
-      if (this.db.inTransaction) this.db.exec('ROLLBACK')
-      throw error
-    }
-  }
-
-  /**
    * Check if this database is encrypted
    */
   isEncrypted(): boolean {

--- a/src/main/database/GeneListRepository.ts
+++ b/src/main/database/GeneListRepository.ts
@@ -1,5 +1,13 @@
+import { randomUUID } from 'node:crypto'
+
 import { BaseRepository } from './BaseRepository'
 import type { GeneList, GeneListWithCount, RegionFile } from './types'
+import { TransactionError } from './errors'
+import { MAX_BED_FILTER_DECOMPRESSED_BYTES } from '../import/vcf/bed-filter'
+import { readBedEntries, type BedEntry, type BedReaderOptions } from '../import/vcf/bed-reader'
+import { resolveMaxDecompressedBytes } from '../import/stream-utils'
+
+export const SQLITE_REGION_FILE_INSERT_CHUNK_SIZE = 10_000
 
 export class GeneListRepository extends BaseRepository {
   // ============================================================
@@ -115,37 +123,103 @@ export class GeneListRepository extends BaseRepository {
     this.execRun(this.kysely.deleteFrom('region_files').where('id', '=', id))
   }
 
-  importBedEntries(
+  async importBedFile(
     fileId: number,
-    entries: Array<{ chr: string; start: number; end: number; label?: string }>
+    filePath: string,
+    options: BedReaderOptions = {}
+  ): Promise<RegionFile> {
+    const stagingTable = `region_file_import_${randomUUID().replace(/-/gu, '')}`
+    this.db.exec(
+      `CREATE TABLE "${stagingTable}" (
+        chr TEXT NOT NULL,
+        start_pos INTEGER NOT NULL,
+        end_pos INTEGER NOT NULL,
+        label TEXT
+      )`
+    )
+    try {
+      const insertEntry = this.db.prepare(
+        `INSERT INTO "${stagingTable}" (chr, start_pos, end_pos, label) VALUES (?, ?, ?, ?)`
+      )
+      const insertChunk = this.db.transaction((entries: BedEntry[]) => {
+        for (const entry of entries) {
+          insertEntry.run(entry.chr, entry.start, entry.end, entry.label ?? null)
+        }
+      })
+      const persistChunk = (entries: BedEntry[]): void => {
+        try {
+          insertChunk(entries)
+        } catch (error) {
+          throw asTransactionError(error)
+        }
+      }
+      const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
+      let regionCount = 0
+      let totalBases = 0
+      let chunk: BedEntry[] = []
+      for await (const entry of readBedEntries(filePath, maxBytes, options)) {
+        chunk.push(entry)
+        regionCount += 1
+        totalBases = addSafeBaseCount(totalBases, entry.end - entry.start)
+        if (chunk.length === SQLITE_REGION_FILE_INSERT_CHUNK_SIZE) {
+          persistChunk(chunk)
+          chunk = []
+        }
+      }
+      if (chunk.length > 0) persistChunk(chunk)
+
+      return this.replaceRegionFileEntries(fileId, stagingTable, regionCount, totalBases)
+    } finally {
+      this.db.exec(`DROP TABLE IF EXISTS "${stagingTable}"`)
+    }
+  }
+
+  private replaceRegionFileEntries(
+    fileId: number,
+    stagingTable: string,
+    regionCount: number,
+    totalBases: number
   ): RegionFile {
-    return this.runTransaction(() => {
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
       this.execRun(
         this.kysely.deleteFrom('region_file_entries').where('region_file_id', '=', fileId)
       )
-      let totalBases = 0
-      for (const e of entries) {
-        this.execRun(
-          this.kysely.insertInto('region_file_entries').values({
-            region_file_id: fileId,
-            chr: e.chr,
-            start_pos: e.start,
-            end_pos: e.end,
-            label: e.label ?? null
-          })
+      this.db
+        .prepare(
+          `INSERT INTO region_file_entries
+            (region_file_id, chr, start_pos, end_pos, label)
+           SELECT ?, chr, start_pos, end_pos, label FROM "${stagingTable}"`
         )
-        totalBases += e.end - e.start
-      }
+        .run(fileId)
       this.execRun(
         this.kysely
           .updateTable('region_files')
-          .set({ region_count: entries.length, total_bases: totalBases, updated_at: Date.now() })
+          .set({ region_count: regionCount, total_bases: totalBases, updated_at: Date.now() })
           .where('id', '=', fileId)
       )
-
-      return this.execFirst<RegionFile>(
+      const result = this.execFirst<RegionFile>(
         this.kysely.selectFrom('region_files').selectAll().where('id', '=', fileId)
       ) as RegionFile
-    })
+      this.db.exec('COMMIT')
+      return result
+    } catch (error) {
+      if (this.db.inTransaction) this.db.exec('ROLLBACK')
+      throw asTransactionError(error)
+    }
   }
+}
+
+function addSafeBaseCount(total: number, increment: number): number {
+  const next = total + increment
+  if (!Number.isSafeInteger(next)) {
+    throw new RangeError('BED total base count exceeds the safe integer range')
+  }
+  return next
+}
+
+function asTransactionError(error: unknown): TransactionError {
+  return error instanceof TransactionError
+    ? error
+    : new TransactionError('Transaction failed', error instanceof Error ? error : undefined)
 }

--- a/src/main/import/format-detection.ts
+++ b/src/main/import/format-detection.ts
@@ -2,6 +2,7 @@ import { createInterface } from 'node:readline'
 import { parser } from 'stream-json'
 import { pick } from 'stream-json/filters/pick.js'
 import { streamArray } from 'stream-json/streamers/stream-array.js'
+import { createJsonRecordBudget } from './json-resource-budget'
 import { compose, type Readable } from 'node:stream'
 import type { FileFormat, FormatInfo } from './strategies/ImportStrategy'
 import { createCappedLineStream, createDecompressedStream } from './stream-utils'
@@ -258,6 +259,7 @@ export async function createDataPipeline(filePath: string): Promise<{
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: 'variants' }),
+        createJsonRecordBudget(),
         streamArray.asStream()
       )
       break
@@ -268,6 +270,7 @@ export async function createDataPipeline(filePath: string): Promise<{
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: samplePath }),
+        createJsonRecordBudget(),
         streamArray.asStream()
       )
       break
@@ -280,6 +283,7 @@ export async function createDataPipeline(filePath: string): Promise<{
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: dataPath }),
+        createJsonRecordBudget(),
         streamArray.asStream()
       )
       break

--- a/src/main/import/format-detection.ts
+++ b/src/main/import/format-detection.ts
@@ -1,53 +1,36 @@
-import { createReadStream } from 'node:fs'
-import { createGunzip } from 'node:zlib'
 import { createInterface } from 'node:readline'
 import { parser } from 'stream-json'
 import { pick } from 'stream-json/filters/pick.js'
 import { streamArray } from 'stream-json/streamers/stream-array.js'
-import type { Readable } from 'node:stream'
+import { compose, type Readable } from 'node:stream'
 import type { FileFormat, FormatInfo } from './strategies/ImportStrategy'
-import { createDecompressedStream, isGzipped } from './stream-utils'
+import { createCappedLineStream, createDecompressedStream } from './stream-utils'
 
 /**
  * Check if a file is a VCF file by reading the first line.
  * VCF files start with "##fileformat=VCFv4"
  */
 async function isVcfFile(filePath: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const raw = createReadStream(filePath, { start: 0, end: 1024 })
-    const stream = isGzipped(filePath) ? raw.pipe(createGunzip()) : raw
-
+  return new Promise((resolve, reject) => {
+    const { stream } = createCappedLineStream(filePath)
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
-    let resolved = false
+    let settled = false
+
+    const settle = (result: boolean, error?: Error): void => {
+      if (settled) return
+      settled = true
+      rl.close()
+      stream.destroy()
+      if (error !== undefined) reject(error)
+      else resolve(result)
+    }
 
     rl.on('line', (line: string) => {
-      if (!resolved) {
-        resolved = true
-        rl.close()
-        resolve(line.startsWith('##fileformat=VCFv'))
-      }
+      settle(line.startsWith('##fileformat=VCFv'))
     })
-
-    rl.on('close', () => {
-      if (!resolved) {
-        resolved = true
-        resolve(false)
-      }
-    })
-
-    rl.on('error', () => {
-      if (!resolved) {
-        resolved = true
-        resolve(false)
-      }
-    })
-
-    stream.on('error', () => {
-      if (!resolved) {
-        resolved = true
-        resolve(false)
-      }
-    })
+    rl.on('close', () => settle(false))
+    rl.on('error', (error) => settle(false, error))
+    stream.on('error', (error) => settle(false, error))
   })
 }
 
@@ -78,14 +61,13 @@ export async function detectFormat(filePath: string): Promise<FormatInfo> {
     }
   }
   return new Promise((resolve, reject) => {
-    const stream = createDecompressedStream(filePath).pipe(parser.asStream())
+    const stream = compose(createDecompressedStream(filePath), parser.asStream())
 
     const topLevelKeys: string[] = []
     let depth = 0
     let resolved = false
 
     const cleanup = (): void => {
-      stream.removeAllListeners()
       stream.destroy()
     }
 
@@ -199,7 +181,7 @@ export async function detectFormat(filePath: string): Promise<FormatInfo> {
  */
 export async function extractFirstSampleId(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const stream = createDecompressedStream(filePath).pipe(parser.asStream())
+    const stream = compose(createDecompressedStream(filePath), parser.asStream())
 
     let inSamples = false
     let sampleId: string | null = null
@@ -207,7 +189,6 @@ export async function extractFirstSampleId(filePath: string): Promise<string> {
     let resolved = false
 
     const cleanup = (): void => {
-      stream.removeAllListeners()
       stream.destroy()
     }
 
@@ -269,35 +250,38 @@ export async function createDataPipeline(filePath: string): Promise<{
   stream: Readable
 }> {
   const formatInfo = await detectFormat(filePath)
-  const decompressed = createDecompressedStream(filePath)
-  const jsonParser = parser.asStream()
-
   let stream: Readable
 
   switch (formatInfo.format) {
     case 'simple':
-      stream = decompressed
-        .pipe(jsonParser)
-        .pipe(pick.asStream({ filter: 'variants' }))
-        .pipe(streamArray.asStream())
+      stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: 'variants' }),
+        streamArray.asStream()
+      )
       break
 
     case 'object': {
       const samplePath = `samples.${formatInfo.caseKey}.variants`
-      stream = decompressed
-        .pipe(jsonParser)
-        .pipe(pick.asStream({ filter: samplePath }))
-        .pipe(streamArray.asStream())
+      stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: samplePath }),
+        streamArray.asStream()
+      )
       break
     }
 
     case 'columnar': {
       const wrapped = formatInfo.wrapped !== false
       const dataPath = wrapped ? `${formatInfo.caseKey}.data` : 'data'
-      stream = decompressed
-        .pipe(jsonParser)
-        .pipe(pick.asStream({ filter: dataPath }))
-        .pipe(streamArray.asStream())
+      stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: dataPath }),
+        streamArray.asStream()
+      )
       break
     }
 

--- a/src/main/import/format-detection.ts
+++ b/src/main/import/format-detection.ts
@@ -7,6 +7,24 @@ import { compose, type Readable } from 'node:stream'
 import type { FileFormat, FormatInfo } from './strategies/ImportStrategy'
 import { createCappedLineStream, createDecompressedStream } from './stream-utils'
 
+const MAX_FORMAT_DETECTION_TOP_LEVEL_KEYS = 4_096
+const MAX_FORMAT_DETECTION_TOP_LEVEL_KEY_BYTES = 1024 * 1024
+const MAX_FORMAT_DETECTION_KEY_BYTES = 16 * 1024
+const MAX_FORMAT_DETECTION_TOKENS = 250_000
+const MAX_FORMAT_DETECTION_DEPTH = 64
+
+interface JsonToken {
+  name?: string
+  value?: unknown
+}
+
+export class FormatDetectionLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FormatDetectionLimitError'
+  }
+}
+
 /**
  * Check if a file is a VCF file by reading the first line.
  * VCF files start with "##fileformat=VCFv4"
@@ -62,11 +80,23 @@ export async function detectFormat(filePath: string): Promise<FormatInfo> {
     }
   }
   return new Promise((resolve, reject) => {
-    const stream = compose(createDecompressedStream(filePath), parser.asStream())
+    const stream = compose(
+      createDecompressedStream(filePath),
+      parser.asStream({ packKeys: false, packStrings: false, packNumbers: false })
+    )
 
-    const topLevelKeys: string[] = []
+    let firstTopLevelKey = ''
+    let topLevelKeyCount = 0
+    let topLevelKeyBytes = 0
+    let hasVariants = false
+    let hasMetadata = false
+    let hasSamples = false
+    let hasData = false
+    let hasHeader = false
     let depth = 0
     let resolved = false
+    let tokenCount = 0
+    const keyReader = new BoundedJsonKeyReader()
 
     const cleanup = (): void => {
       stream.destroy()
@@ -88,12 +118,61 @@ export async function detectFormat(filePath: string): Promise<FormatInfo> {
 
     let pendingDataKey = false
 
-    stream.on('data', (data: { name?: string; value?: unknown }) => {
+    const processTopLevelKey = (key: string): void => {
+      topLevelKeyCount += 1
+      topLevelKeyBytes += Buffer.byteLength(key, 'utf8')
+      if (
+        topLevelKeyCount > MAX_FORMAT_DETECTION_TOP_LEVEL_KEYS ||
+        topLevelKeyBytes > MAX_FORMAT_DETECTION_TOP_LEVEL_KEY_BYTES
+      ) {
+        throw new FormatDetectionLimitError(
+          'JSON format detection exceeded its top-level keys budget'
+        )
+      }
+      if (topLevelKeyCount === 1) firstTopLevelKey = key
+      hasVariants ||= key === 'variants'
+      hasMetadata ||= key === 'metadata'
+      hasSamples ||= key === 'samples'
+      hasData ||= key === 'data'
+      hasHeader ||= key === 'header'
+
+      if (hasVariants) {
+        resolveFormat('simple', 'variants')
+        return
+      }
+      if (hasMetadata && hasSamples) {
+        resolved = true
+        cleanup()
+        extractFirstSampleId(filePath)
+          .then((sampleId) => resolve({ format: 'object', caseKey: sampleId }))
+          .catch(reject)
+        return
+      }
+      if (hasData && hasHeader) {
+        resolved = true
+        cleanup()
+        resolve({ format: 'columnar', caseKey: '', wrapped: false })
+        return
+      }
+      if (firstTopLevelKey === 'data' && topLevelKeyCount === 1) pendingDataKey = true
+    }
+
+    stream.on('data', (data: JsonToken) => {
       if (resolved) return
+
+      tokenCount += 1
+      if (tokenCount > MAX_FORMAT_DETECTION_TOKENS) {
+        rejectFormat(new FormatDetectionLimitError('JSON format detection token budget exceeded'))
+        return
+      }
 
       // Track depth
       if (data.name === 'startObject' || data.name === 'startArray') {
         depth++
+        if (depth > MAX_FORMAT_DETECTION_DEPTH) {
+          rejectFormat(new FormatDetectionLimitError('JSON format detection depth budget exceeded'))
+          return
+        }
       } else if (data.name === 'endObject' || data.name === 'endArray') {
         depth--
       }
@@ -112,64 +191,35 @@ export async function detectFormat(filePath: string): Promise<FormatInfo> {
         // startObject means wrapped columnar — fall through to normal detection
       }
 
-      // Collect top-level keys
-      if (data.name === 'keyValue' && depth === 1) {
-        topLevelKeys.push(String(data.value))
-
-        // Check for simple format
-        if (topLevelKeys.includes('variants')) {
-          resolveFormat('simple', 'variants')
-          return
-        }
-
-        // Check for object format markers
-        if (topLevelKeys.includes('metadata') && topLevelKeys.includes('samples')) {
-          resolved = true
-          cleanup()
-          extractFirstSampleId(filePath)
-            .then((sampleId) => {
-              resolve({ format: 'object', caseKey: sampleId })
-            })
-            .catch(reject)
-          return
-        }
-
-        // Check for unwrapped columnar: data + header both seen at top level
-        if (topLevelKeys.includes('data') && topLevelKeys.includes('header')) {
-          resolved = true
-          cleanup()
-          resolve({ format: 'columnar', caseKey: '', wrapped: false })
-          return
-        }
-
-        // If 'data' is the first key, defer resolution until we see the value type
-        if (topLevelKeys[0] === 'data' && topLevelKeys.length === 1) {
-          pendingDataKey = true
-        }
+      try {
+        const key = keyReader.consume(data, depth)
+        if (key !== null && key.depth === 1) processTopLevelKey(key.value)
+      } catch (error) {
+        rejectFormat(error as Error)
       }
     })
 
     stream.on('end', () => {
       if (resolved) return
 
-      if (topLevelKeys.length === 0) {
+      if (topLevelKeyCount === 0) {
         rejectFormat(new Error('Could not detect file format: no top-level keys found'))
         return
       }
 
-      if (topLevelKeys.includes('variants')) {
+      if (hasVariants) {
         resolveFormat('simple', 'variants')
-      } else if (topLevelKeys.includes('metadata') || topLevelKeys.includes('samples')) {
+      } else if (hasMetadata || hasSamples) {
         resolved = true
         extractFirstSampleId(filePath)
           .then((sampleId) => {
             resolve({ format: 'object', caseKey: sampleId })
           })
           .catch(reject)
-      } else if (topLevelKeys.includes('data') && topLevelKeys.includes('header')) {
+      } else if (hasData && hasHeader) {
         resolve({ format: 'columnar', caseKey: '', wrapped: false })
       } else {
-        resolveFormat('columnar', topLevelKeys[0])
+        resolveFormat('columnar', firstTopLevelKey)
       }
     })
 
@@ -182,35 +232,58 @@ export async function detectFormat(filePath: string): Promise<FormatInfo> {
  */
 export async function extractFirstSampleId(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const stream = compose(createDecompressedStream(filePath), parser.asStream())
+    const stream = compose(
+      createDecompressedStream(filePath),
+      parser.asStream({ packKeys: false, packStrings: false, packNumbers: false })
+    )
 
     let inSamples = false
     let sampleId: string | null = null
     let depth = 0
     let resolved = false
+    let tokenCount = 0
+    const keyReader = new BoundedJsonKeyReader()
 
     const cleanup = (): void => {
       stream.destroy()
     }
 
-    stream.on('data', (data: { name?: string; value?: unknown }) => {
+    stream.on('data', (data: JsonToken) => {
       if (resolved) return
+
+      tokenCount += 1
+      if (tokenCount > MAX_FORMAT_DETECTION_TOKENS) {
+        resolved = true
+        cleanup()
+        reject(new FormatDetectionLimitError('JSON sample detection token budget exceeded'))
+        return
+      }
 
       if (data.name === 'startObject' || data.name === 'startArray') {
         depth++
+        if (depth > MAX_FORMAT_DETECTION_DEPTH) {
+          resolved = true
+          cleanup()
+          reject(new FormatDetectionLimitError('JSON sample detection depth budget exceeded'))
+          return
+        }
       } else if (data.name === 'endObject' || data.name === 'endArray') {
         depth--
       }
 
-      if (data.name === 'keyValue' && depth === 1 && data.value === 'samples') {
-        inSamples = true
-      }
-
-      if (inSamples && data.name === 'keyValue' && depth === 2 && sampleId === null) {
-        sampleId = String(data.value)
+      try {
+        const key = keyReader.consume(data, depth)
+        if (key?.depth === 1 && key.value === 'samples') inSamples = true
+        else if (inSamples && key?.depth === 2 && sampleId === null) {
+          sampleId = key.value
+          resolved = true
+          cleanup()
+          resolve(sampleId)
+        }
+      } catch (error) {
         resolved = true
         cleanup()
-        resolve(sampleId)
+        reject(error)
       }
     })
 
@@ -232,6 +305,41 @@ export async function extractFirstSampleId(filePath: string): Promise<string> {
       reject(err)
     })
   })
+}
+
+class BoundedJsonKeyReader {
+  private active = false
+  private depth = 0
+  private bytes = 0
+  private chunks: string[] = []
+
+  consume(token: JsonToken, currentDepth: number): { value: string; depth: number } | null {
+    if (token.name === 'startKey') {
+      this.active = true
+      this.depth = currentDepth
+      this.bytes = 0
+      this.chunks = []
+      return null
+    }
+    if (this.active && token.name === 'stringChunk') {
+      const chunk = String(token.value ?? '')
+      this.bytes += Buffer.byteLength(chunk, 'utf8')
+      if (this.bytes > MAX_FORMAT_DETECTION_KEY_BYTES) {
+        throw new FormatDetectionLimitError(
+          `JSON format detection key exceeds ${MAX_FORMAT_DETECTION_KEY_BYTES} bytes`
+        )
+      }
+      this.chunks.push(chunk)
+      return null
+    }
+    if (this.active && token.name === 'endKey') {
+      const result = { value: this.chunks.join(''), depth: this.depth }
+      this.active = false
+      this.chunks = []
+      return result
+    }
+    return null
+  }
 }
 
 /**

--- a/src/main/import/gzip-ratio-policy.ts
+++ b/src/main/import/gzip-ratio-policy.ts
@@ -9,6 +9,7 @@ export const DEFAULT_MAX_GZIP_COMPRESSION_RATIO = 100
  * independent absolute decompressed-byte cap is reached.
  */
 export const MAX_VCF_GZIP_COMPRESSION_RATIO = 1000
+export const MAX_GZIP_FORMAT_INSPECTION_BYTES = 4096
 
 /**
  * Incrementally identifies a VCF and counts samples from its #CHROM header.
@@ -22,7 +23,13 @@ export class GzipRatioPolicy {
   private firstLine = true
   private vcf = false
   private sampleCount = 0
+  private vcfHeaderTabs: number | null = null
+  private vcfDataShapeValidated = false
   private inspectionComplete = false
+  private firstLineBytes = 0
+  private fixedFieldMask = 0
+  private posDigitsOnly = true
+  private posHasNonZeroDigit = false
 
   constructor(private readonly baseRatio: number) {}
 
@@ -34,21 +41,39 @@ export class GzipRatioPolicy {
         this.atLineStart = false
         this.linePrefix = ''
         this.lineTabs = 0
+        this.fixedFieldMask = 0
+        this.posDigitsOnly = true
+        this.posHasNonZeroDigit = false
+      }
+      if (this.firstLine) {
+        this.firstLineBytes += 1
+        if (this.firstLineBytes > MAX_GZIP_FORMAT_INSPECTION_BYTES) {
+          this.inspectionComplete = true
+          return
+        }
       }
       if (this.linePrefix.length < 24 && byte !== 0x0a && byte !== 0x0d) {
         this.linePrefix += String.fromCharCode(byte)
       }
-      if (byte === 0x09) this.lineTabs += 1
+      if (byte === 0x09) {
+        this.lineTabs += 1
+      } else if (byte !== 0x0a && byte !== 0x0d) {
+        if (this.lineTabs < 8) this.fixedFieldMask |= 1 << this.lineTabs
+        if (this.lineTabs === 1) {
+          this.posDigitsOnly &&= byte >= 0x30 && byte <= 0x39
+          this.posHasNonZeroDigit ||= byte >= 0x31 && byte <= 0x39
+        }
+      }
       if (byte !== 0x0a) continue
 
       if (this.firstLine) {
         this.vcf = this.linePrefix.startsWith('##fileformat=VCFv')
         this.firstLine = false
         this.inspectionComplete = !this.vcf
-      } else if (this.vcf && this.linePrefix.startsWith('#CHROM\t')) {
-        // Nine fixed/FORMAT columns produce eight tabs before sample columns.
-        this.sampleCount = Math.max(0, this.lineTabs - 8)
-        this.inspectionComplete = true
+      } else if (this.vcfHeaderTabs === null) {
+        this.observeVcfHeaderLine()
+      } else {
+        this.observeVcfDataLine()
       }
       if (this.inspectionComplete) return
       this.atLineStart = true
@@ -56,7 +81,39 @@ export class GzipRatioPolicy {
   }
 
   maxRatio(): number {
-    if (!this.vcf) return this.baseRatio
+    if (!this.vcf || !this.vcfDataShapeValidated) return this.baseRatio
     return Math.min(MAX_VCF_GZIP_COMPRESSION_RATIO, this.baseRatio + this.sampleCount)
+  }
+
+  private observeVcfHeaderLine(): void {
+    if (!this.linePrefix.startsWith('#CHROM\t')) return
+    // Eight mandatory site columns produce seven tabs. FORMAT is the ninth
+    // column, so each tab beyond eight represents one declared sample.
+    if (this.lineTabs < 7) {
+      this.revokeVcfAllowance()
+      return
+    }
+    this.vcfHeaderTabs = this.lineTabs
+    this.sampleCount = Math.max(0, this.lineTabs - 8)
+  }
+
+  private observeVcfDataLine(): void {
+    if (
+      this.linePrefix === '' ||
+      this.linePrefix.startsWith('#') ||
+      this.lineTabs !== this.vcfHeaderTabs ||
+      (this.fixedFieldMask & 0b0001_1011) !== 0b0001_1011 ||
+      !this.posDigitsOnly ||
+      !this.posHasNonZeroDigit
+    ) {
+      this.revokeVcfAllowance()
+      return
+    }
+    this.vcfDataShapeValidated = true
+  }
+
+  private revokeVcfAllowance(): void {
+    this.vcfDataShapeValidated = false
+    this.inspectionComplete = true
   }
 }

--- a/src/main/import/gzip-ratio-policy.ts
+++ b/src/main/import/gzip-ratio-policy.ts
@@ -1,0 +1,62 @@
+/** Default gzip expansion ratio for JSON, BED, and small-sample VCF input. */
+export const DEFAULT_MAX_GZIP_COMPRESSION_RATIO = 100
+
+/**
+ * Hard upper bound for sample-aware VCF expansion. Large joint-called VCFs
+ * contain thousands of repeated genotype columns and legitimately compress
+ * far beyond the generic 100x ceiling. A 1000x ceiling accepts those files
+ * while still requiring one compressed byte per 1000 output bytes before the
+ * independent absolute decompressed-byte cap is reached.
+ */
+export const MAX_VCF_GZIP_COMPRESSION_RATIO = 1000
+
+/**
+ * Incrementally identifies a VCF and counts samples from its #CHROM header.
+ * It retains only short line prefixes and tab counts, never a full header or
+ * data line, so the policy itself cannot become a new buffering sink.
+ */
+export class GzipRatioPolicy {
+  private atLineStart = true
+  private linePrefix = ''
+  private lineTabs = 0
+  private firstLine = true
+  private vcf = false
+  private sampleCount = 0
+  private inspectionComplete = false
+
+  constructor(private readonly baseRatio: number) {}
+
+  observe(chunk: Buffer): void {
+    if (this.inspectionComplete) return
+
+    for (const byte of chunk) {
+      if (this.atLineStart) {
+        this.atLineStart = false
+        this.linePrefix = ''
+        this.lineTabs = 0
+      }
+      if (this.linePrefix.length < 24 && byte !== 0x0a && byte !== 0x0d) {
+        this.linePrefix += String.fromCharCode(byte)
+      }
+      if (byte === 0x09) this.lineTabs += 1
+      if (byte !== 0x0a) continue
+
+      if (this.firstLine) {
+        this.vcf = this.linePrefix.startsWith('##fileformat=VCFv')
+        this.firstLine = false
+        this.inspectionComplete = !this.vcf
+      } else if (this.vcf && this.linePrefix.startsWith('#CHROM\t')) {
+        // Nine fixed/FORMAT columns produce eight tabs before sample columns.
+        this.sampleCount = Math.max(0, this.lineTabs - 8)
+        this.inspectionComplete = true
+      }
+      if (this.inspectionComplete) return
+      this.atLineStart = true
+    }
+  }
+
+  maxRatio(): number {
+    if (!this.vcf) return this.baseRatio
+    return Math.min(MAX_VCF_GZIP_COMPRESSION_RATIO, this.baseRatio + this.sampleCount)
+  }
+}

--- a/src/main/import/gzip-ratio-policy.ts
+++ b/src/main/import/gzip-ratio-policy.ts
@@ -1,14 +1,6 @@
 /** Default gzip expansion ratio for JSON, BED, and small-sample VCF input. */
 export const DEFAULT_MAX_GZIP_COMPRESSION_RATIO = 100
 
-/**
- * Hard upper bound for sample-aware VCF expansion. Large joint-called VCFs
- * contain thousands of repeated genotype columns and legitimately compress
- * far beyond the generic 100x ceiling. A 1000x ceiling accepts those files
- * while still requiring one compressed byte per 1000 output bytes before the
- * independent absolute decompressed-byte cap is reached.
- */
-export const MAX_VCF_GZIP_COMPRESSION_RATIO = 1000
 export const MAX_GZIP_FORMAT_INSPECTION_BYTES = 4096
 
 /**
@@ -22,7 +14,6 @@ export class GzipRatioPolicy {
   private lineTabs = 0
   private firstLine = true
   private vcf = false
-  private sampleCount = 0
   private vcfHeaderTabs: number | null = null
   private vcfDataShapeValidated = false
   private inspectionComplete = false
@@ -82,7 +73,11 @@ export class GzipRatioPolicy {
 
   maxRatio(): number {
     if (!this.vcf || !this.vcfDataShapeValidated) return this.baseRatio
-    return Math.min(MAX_VCF_GZIP_COMPRESSION_RATIO, this.baseRatio + this.sampleCount)
+    // Compression ratio cannot distinguish a valid, highly repetitive cohort
+    // VCF from a bomb. Once the magic/header/first-row shape is established,
+    // the independent absolute decompressed-byte, line, header, record and
+    // expansion-work budgets own resource control without false rejection.
+    return Number.POSITIVE_INFINITY
   }
 
   private observeVcfHeaderLine(): void {
@@ -94,7 +89,6 @@ export class GzipRatioPolicy {
       return
     }
     this.vcfHeaderTabs = this.lineTabs
-    this.sampleCount = Math.max(0, this.lineTabs - 8)
   }
 
   private observeVcfDataLine(): void {

--- a/src/main/import/json-resource-budget.ts
+++ b/src/main/import/json-resource-budget.ts
@@ -1,0 +1,142 @@
+import { Transform, type TransformCallback } from 'node:stream'
+
+export const MAX_JSON_RECORD_BYTES = 1024 * 1024
+export const MAX_JSON_RECORD_TOKENS = 50_000
+export const MAX_JSON_RECORD_CONTAINER_ENTRIES = 10_000
+export const MAX_JSON_RECORD_DEPTH = 64
+
+interface JsonToken {
+  name: string
+  value?: string
+}
+
+export class JsonRecordLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'JsonRecordLimitError'
+  }
+}
+
+/**
+ * Reject oversized array elements before stream-json's streamArray materializes
+ * them into JavaScript objects. The transform is placed after `pick`, where the
+ * selected value must be the array consumed by streamArray.
+ */
+export class JsonRecordBudgetTransform extends Transform {
+  private rootStarted = false
+  private depth = 0
+  private inRecord = false
+  private recordBytes = 0
+  private recordTokens = 0
+  private recordContainerEntries = 0
+  private readonly containers: Array<'array' | 'object'> = []
+
+  constructor() {
+    super({ objectMode: true })
+  }
+
+  override _transform(token: JsonToken, _encoding: BufferEncoding, callback: TransformCallback) {
+    try {
+      this.inspectToken(token)
+      callback(null, token)
+    } catch (error) {
+      callback(error as Error)
+    }
+  }
+
+  private inspectToken(token: JsonToken): void {
+    if (!this.rootStarted) {
+      if (token.name !== 'startArray') {
+        throw new JsonRecordLimitError('Selected JSON import value must be an array')
+      }
+      this.rootStarted = true
+      this.depth = 1
+      this.containers.push('array')
+      return
+    }
+
+    if (!this.inRecord && this.depth === 1 && token.name !== 'endArray') {
+      this.inRecord = true
+      this.recordBytes = 0
+      this.recordTokens = 0
+      this.recordContainerEntries = 0
+    }
+
+    if (this.inRecord) {
+      this.recordTokens += 1
+      if (this.recordTokens > MAX_JSON_RECORD_TOKENS) {
+        throw new JsonRecordLimitError(
+          `JSON import record exceeds ${MAX_JSON_RECORD_TOKENS} tokens`
+        )
+      }
+      if (token.name === 'stringChunk' || token.name === 'numberChunk') {
+        this.recordBytes += Buffer.byteLength(token.value ?? '', 'utf8')
+        if (this.recordBytes > MAX_JSON_RECORD_BYTES) {
+          throw new JsonRecordLimitError(
+            `JSON import record exceeds ${MAX_JSON_RECORD_BYTES} encoded bytes`
+          )
+        }
+      }
+      if (
+        token.name === 'keyValue' ||
+        (this.containers.length > 1 &&
+          this.containers[this.containers.length - 1] === 'array' &&
+          isJsonValueStart(token.name))
+      ) {
+        this.recordContainerEntries += 1
+        if (this.recordContainerEntries > MAX_JSON_RECORD_CONTAINER_ENTRIES) {
+          throw new JsonRecordLimitError(
+            `JSON import record exceeds ${MAX_JSON_RECORD_CONTAINER_ENTRIES} container entries`
+          )
+        }
+      }
+    }
+
+    if (token.name === 'startObject' || token.name === 'startArray') {
+      this.depth += 1
+      this.containers.push(token.name === 'startArray' ? 'array' : 'object')
+      if (this.inRecord && this.depth - 1 > MAX_JSON_RECORD_DEPTH) {
+        throw new JsonRecordLimitError(
+          `JSON import record exceeds nesting depth ${MAX_JSON_RECORD_DEPTH}`
+        )
+      }
+      return
+    }
+
+    if (token.name === 'endObject' || token.name === 'endArray') {
+      this.depth -= 1
+      this.containers.pop()
+      if (this.depth < 0) throw new JsonRecordLimitError('Malformed JSON token nesting')
+      if (this.inRecord && this.depth === 1) this.inRecord = false
+      return
+    }
+
+    if (
+      this.inRecord &&
+      this.depth === 1 &&
+      (token.name === 'stringValue' ||
+        token.name === 'numberValue' ||
+        token.name === 'nullValue' ||
+        token.name === 'trueValue' ||
+        token.name === 'falseValue')
+    ) {
+      this.inRecord = false
+    }
+  }
+}
+
+function isJsonValueStart(tokenName: string): boolean {
+  return (
+    tokenName === 'startObject' ||
+    tokenName === 'startArray' ||
+    tokenName === 'startString' ||
+    tokenName === 'startNumber' ||
+    tokenName === 'nullValue' ||
+    tokenName === 'trueValue' ||
+    tokenName === 'falseValue'
+  )
+}
+
+export function createJsonRecordBudget(): JsonRecordBudgetTransform {
+  return new JsonRecordBudgetTransform()
+}

--- a/src/main/import/strategies/ColumnarStrategy.ts
+++ b/src/main/import/strategies/ColumnarStrategy.ts
@@ -10,6 +10,7 @@ import type { ImportOptions, ImportResult, DataDictionaries } from '../types'
 import type { ImportStrategy, FormatInfo, StrategyContext } from './ImportStrategy'
 import { importRegistry } from './StrategyRegistry'
 import { createDecompressedStream } from '../stream-utils'
+import { createJsonRecordBudget } from '../json-resource-budget'
 
 /** Result of parsing the header: dictionaries + dynamic column positions */
 interface HeaderInfo {
@@ -75,6 +76,7 @@ export class ColumnarStrategy implements ImportStrategy {
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: dataPath }),
+        createJsonRecordBudget(),
         streamArray.asStream(),
         fieldMapper,
         batchAccumulator
@@ -121,6 +123,7 @@ export class ColumnarStrategy implements ImportStrategy {
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: headerPath }),
+        createJsonRecordBudget(),
         streamArray.asStream()
       )
 

--- a/src/main/import/strategies/ColumnarStrategy.ts
+++ b/src/main/import/strategies/ColumnarStrategy.ts
@@ -1,3 +1,4 @@
+import { compose } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { parser } from 'stream-json'
 import { pick } from 'stream-json/filters/pick.js'
@@ -116,13 +117,14 @@ export class ColumnarStrategy implements ImportStrategy {
       const fieldsToExtract = new Set(['Gene', 'Transcript', 'HpoSimScore', 'MoI'])
       let resolved = false
 
-      const stream = createDecompressedStream(filePath)
-        .pipe(parser.asStream())
-        .pipe(pick.asStream({ filter: headerPath }))
-        .pipe(streamArray.asStream())
+      const stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: headerPath }),
+        streamArray.asStream()
+      )
 
       const cleanup = (): void => {
-        stream.removeAllListeners()
         stream.destroy()
       }
 

--- a/src/main/import/strategies/ObjectStrategy.ts
+++ b/src/main/import/strategies/ObjectStrategy.ts
@@ -8,6 +8,7 @@ import type { ImportOptions, ImportResult } from '../types'
 import type { ImportStrategy, FormatInfo, StrategyContext } from './ImportStrategy'
 import { importRegistry } from './StrategyRegistry'
 import { createDecompressedStream } from '../stream-utils'
+import { createJsonRecordBudget } from '../json-resource-budget'
 
 /**
  * Strategy for object format: { "metadata": {...}, "samples": { "<sampleId>": { "variants": [...] } } }
@@ -54,6 +55,7 @@ export class ObjectStrategy implements ImportStrategy {
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: `samples.${formatInfo.caseKey}.variants` }),
+        createJsonRecordBudget(),
         streamArray.asStream(),
         objectMapper,
         batchAccumulator

--- a/src/main/import/strategies/SimpleStrategy.ts
+++ b/src/main/import/strategies/SimpleStrategy.ts
@@ -8,6 +8,7 @@ import type { ImportOptions, ImportResult } from '../types'
 import type { ImportStrategy, FormatInfo, StrategyContext } from './ImportStrategy'
 import { importRegistry } from './StrategyRegistry'
 import { createDecompressedStream } from '../stream-utils'
+import { createJsonRecordBudget } from '../json-resource-budget'
 
 /**
  * Strategy for simple format: { "person_id": ..., "variants": [...] }
@@ -50,6 +51,7 @@ export class SimpleStrategy implements ImportStrategy {
       createDecompressedStream(filePath),
       parser.asStream(),
       pick.asStream({ filter: 'variants' }),
+      createJsonRecordBudget(),
       streamArray.asStream(),
       objectMapper,
       batchAccumulator

--- a/src/main/import/stream-utils.ts
+++ b/src/main/import/stream-utils.ts
@@ -1,6 +1,7 @@
-import { createReadStream, openSync, readSync, closeSync } from 'node:fs'
-import { createGunzip } from 'node:zlib'
-import type { Readable } from 'node:stream'
+import { createReadStream, openSync, readSync, closeSync, readFileSync, statSync } from 'node:fs'
+import { createGunzip, gunzipSync } from 'node:zlib'
+import { compose, Transform } from 'node:stream'
+import type { Readable, TransformCallback } from 'node:stream'
 
 /** Gzip magic number: first two bytes of any gzip file */
 const GZIP_MAGIC = Buffer.from([0x1f, 0x8b])
@@ -29,4 +30,236 @@ export function createDecompressedStream(filePath: string): Readable {
     return raw.pipe(createGunzip())
   }
   return raw
+}
+
+// -----------------------------------------------------------------------------
+// DoS caps for line-oriented VCF/BED consumers (full import, preview, header
+// parsing, BED filtering). Two independent guards, layered because they
+// defend against two different attack shapes:
+//
+//   1. MAX_LINE_BYTES — a single pathological line. `readline` (and any
+//      full-file read) must buffer an entire line before anyone can inspect
+//      it, so a byte-count guard applied *while streaming* is the only thing
+//      that can stop a multi-GB single-line file from ever being held in
+//      memory as one string/buffer.
+//   2. MAX_DECOMPRESSED_BYTES — the total bytes produced by decompression
+//      (or read from a plain file), which defeats a gzip "bomb" (a tiny
+//      .vcf.gz/.bed.gz that inflates to many GB) regardless of how many
+//      lines it contains.
+//
+// Rationale for the values chosen:
+//   - MAX_LINE_BYTES (64 MiB): real-world heavily annotated VCF lines (many
+//     ALT alleles x deep VEP CSQ / SnpEff ANN annotation, e.g. gnomAD-scale
+//     multi-allelic sites) still land in the tens-of-KB to low-single-digit
+//     MB range. 64 MiB leaves roughly 50-100x headroom over any legitimate
+//     line while remaining three orders of magnitude below a "multi-GB
+//     line" attack. This is the always-on guard — it is intentionally NOT
+//     configurable, because a fixed byte ceiling is the only thing that
+//     reliably stops a giant single line no matter how the total-byte
+//     budget below is tuned for a given deployment.
+//   - MAX_DECOMPRESSED_BYTES (256 GiB default): single-sample WGS VCFs
+//     commonly decompress to 10-60 GB; joint-genotyped multi-sample cohort
+//     VCFs can run substantially larger still. A single fixed cap cannot
+//     both reject a bomb quickly *and* never reject a legitimate large
+//     cohort file, so this cap is intentionally generous and overridable
+//     via the VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES environment variable
+//     (bytes) for sites importing genuinely larger joint-called cohorts.
+//     It still bounds the worst case: a decompression bomb that would
+//     otherwise inflate without limit is stopped once it crosses this
+//     ceiling, rather than running until the process OOMs or hangs
+//     indefinitely.
+// -----------------------------------------------------------------------------
+
+/** Always-on per-line byte cap — see rationale above. Not configurable. */
+export const MAX_LINE_BYTES = 64 * 1024 * 1024 // 64 MiB
+
+/** Default total decompressed-byte cap — see rationale above. */
+export const DEFAULT_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024 * 1024 // 256 GiB
+
+/** Environment variable that overrides DEFAULT_MAX_DECOMPRESSED_BYTES, in bytes. */
+const MAX_DECOMPRESSED_BYTES_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+
+/**
+ * Resolve the effective total decompressed-byte cap: an explicit override
+ * (used by tests / advanced call sites) wins, then the environment variable
+ * override (for operators importing genuinely larger joint-called cohorts),
+ * then the documented default.
+ */
+export function resolveMaxDecompressedBytes(override?: number): number {
+  if (override !== undefined) return override
+  const envValue = process.env[MAX_DECOMPRESSED_BYTES_ENV_VAR]
+  if (envValue !== undefined) {
+    const parsed = Number(envValue)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_MAX_DECOMPRESSED_BYTES
+}
+
+/** Thrown when a single line exceeds MAX_LINE_BYTES. */
+export class LineTooLongError extends Error {
+  constructor(maxLineBytes: number) {
+    super(
+      `Refusing to read a line longer than ${maxLineBytes} bytes (suspected malformed or hostile input)`
+    )
+    this.name = 'LineTooLongError'
+  }
+}
+
+/** Thrown when total decompressed bytes exceed the configured cap. */
+export class DecompressedSizeExceededError extends Error {
+  constructor(maxBytes: number) {
+    super(
+      `Refusing to decompress more than ${maxBytes} bytes from a single file (suspected decompression bomb)`
+    )
+    this.name = 'DecompressedSizeExceededError'
+  }
+}
+
+/**
+ * Counts bytes flowing through and errors once `maxBytes` is exceeded.
+ * Defeats a gzip bomb regardless of line structure.
+ */
+class ByteCapTransform extends Transform {
+  private totalBytes = 0
+
+  constructor(private readonly maxBytes: number) {
+    super()
+  }
+
+  override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    this.totalBytes += chunk.length
+    if (this.totalBytes > this.maxBytes) {
+      callback(new DecompressedSizeExceededError(this.maxBytes))
+      return
+    }
+    callback(null, chunk)
+  }
+}
+
+/**
+ * Tracks bytes since the last `\n` seen and errors before a line exceeding
+ * `maxLineBytes` is ever fully buffered by a downstream line reader (e.g.
+ * `readline`). Passes all data through unmodified — this is a monitor, not a
+ * transform of content.
+ */
+class LineLengthCapTransform extends Transform {
+  private currentLineBytes = 0
+
+  constructor(private readonly maxLineBytes: number) {
+    super()
+  }
+
+  override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    let searchStart = 0
+    for (;;) {
+      const newlineIndex = chunk.indexOf(0x0a, searchStart)
+      if (newlineIndex === -1) {
+        this.currentLineBytes += chunk.length - searchStart
+        break
+      }
+      this.currentLineBytes += newlineIndex - searchStart + 1
+      if (this.currentLineBytes > this.maxLineBytes) {
+        callback(new LineTooLongError(this.maxLineBytes))
+        return
+      }
+      this.currentLineBytes = 0
+      searchStart = newlineIndex + 1
+    }
+    if (this.currentLineBytes > this.maxLineBytes) {
+      callback(new LineTooLongError(this.maxLineBytes))
+      return
+    }
+    callback(null, chunk)
+  }
+}
+
+export interface CappedLineStreamOptions {
+  /** Override MAX_LINE_BYTES. Production call sites should not set this. */
+  maxLineBytes?: number
+  /** Override the total decompressed-byte cap (tests, or advanced config). */
+  maxDecompressedBytes?: number
+}
+
+/** Return value of {@link createCappedLineStream}. */
+export interface CappedLineSource {
+  /** Capped, gzip-aware stream — feed this into `readline.createInterface`. */
+  stream: Readable
+  /**
+   * Bytes read so far from the underlying (possibly compressed) file on
+   * disk. Exposed for callers that extrapolate progress from partial reads
+   * (e.g. vcf-preview's line-count estimate) — not itself a DoS guard.
+   */
+  rawBytesRead: () => number
+}
+
+/**
+ * Shared capped reader for VCF/BED line consumers. Auto-detects gzip,
+ * decompresses if needed, and layers both DoS guards (per-line byte cap +
+ * total decompressed-byte cap) on top, so any consumer that builds a
+ * `readline` interface from the returned stream is automatically protected
+ * against a giant single line and a decompression bomb without duplicating
+ * the cap logic per consumer.
+ *
+ * On error, `stream.compose()` destroys every stage of the pipeline
+ * (including the underlying file descriptor), so callers only need a single
+ * 'error' listener on the returned stream.
+ */
+export function createCappedLineStream(
+  filePath: string,
+  options: CappedLineStreamOptions = {}
+): CappedLineSource {
+  const maxLineBytes = options.maxLineBytes ?? MAX_LINE_BYTES
+  const maxDecompressedBytes = resolveMaxDecompressedBytes(options.maxDecompressedBytes)
+
+  const raw = createReadStream(filePath)
+  const gzipped = isGzipped(filePath)
+  const byteCap = new ByteCapTransform(maxDecompressedBytes)
+  const lineCap = new LineLengthCapTransform(maxLineBytes)
+
+  const stream = gzipped
+    ? compose(raw, createGunzip(), byteCap, lineCap)
+    : compose(raw, byteCap, lineCap)
+
+  return { stream, rawBytesRead: () => raw.bytesRead }
+}
+
+/**
+ * Synchronously read an entire file (gzip-aware), bounded by
+ * `maxDecompressedBytes`. Used by consumers whose algorithm needs the whole
+ * file in memory at once (currently: `BedFilter`, whose interval-merging
+ * pass is not naturally streaming). Never allocates a decompressed buffer
+ * larger than the cap: gzip inputs are bounded via zlib's own
+ * `maxOutputLength`, and plain-text inputs are size-checked via `stat`
+ * before ever being read.
+ */
+export function readCappedFileSync(filePath: string, maxDecompressedBytes?: number): string {
+  const maxBytes = resolveMaxDecompressedBytes(maxDecompressedBytes)
+  const gzipped = isGzipped(filePath)
+
+  if (!gzipped) {
+    const { size } = statSync(filePath)
+    if (size > maxBytes) {
+      throw new DecompressedSizeExceededError(maxBytes)
+    }
+    return readFileSync(filePath, 'utf-8')
+  }
+
+  // Cheap pre-check: a compressed file already larger on disk than the cap
+  // has no realistic path to a legitimate, sub-cap decompressed result --
+  // reject before reading it fully into memory.
+  const { size: compressedSize } = statSync(filePath)
+  if (compressedSize > maxBytes) {
+    throw new DecompressedSizeExceededError(maxBytes)
+  }
+
+  const compressed = readFileSync(filePath)
+  try {
+    return gunzipSync(compressed, { maxOutputLength: maxBytes }).toString('utf-8')
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code
+    if (code === 'ERR_BUFFER_TOO_LARGE') {
+      throw new DecompressedSizeExceededError(maxBytes)
+    }
+    throw error
+  }
 }

--- a/src/main/import/stream-utils.ts
+++ b/src/main/import/stream-utils.ts
@@ -1,5 +1,5 @@
-import { createReadStream, openSync, readSync, closeSync, readFileSync, statSync } from 'node:fs'
-import { createGunzip, gunzipSync } from 'node:zlib'
+import { createReadStream, openSync, readSync, closeSync } from 'node:fs'
+import { createGunzip } from 'node:zlib'
 import { compose, Transform } from 'node:stream'
 import type { Readable, TransformCallback } from 'node:stream'
 
@@ -18,18 +18,6 @@ export function isGzipped(filePath: string): boolean {
   } finally {
     closeSync(fd)
   }
-}
-
-/**
- * Create a readable stream that auto-detects gzip compression.
- * Returns a stream of decompressed (or raw) data ready for JSON parsing.
- */
-export function createDecompressedStream(filePath: string): Readable {
-  const raw = createReadStream(filePath)
-  if (isGzipped(filePath)) {
-    return raw.pipe(createGunzip())
-  }
-  return raw
 }
 
 // -----------------------------------------------------------------------------
@@ -78,6 +66,7 @@ export const DEFAULT_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024 * 1024 // 256 Gi
 
 /** Environment variable that overrides DEFAULT_MAX_DECOMPRESSED_BYTES, in bytes. */
 const MAX_DECOMPRESSED_BYTES_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const TEST_MAX_LINE_BYTES_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
 
 /**
  * Resolve the effective total decompressed-byte cap: an explicit override
@@ -93,6 +82,17 @@ export function resolveMaxDecompressedBytes(override?: number): number {
     if (Number.isFinite(parsed) && parsed > 0) return parsed
   }
   return DEFAULT_MAX_DECOMPRESSED_BYTES
+}
+
+function resolveMaxLineBytes(override?: number): number {
+  if (override !== undefined) return override
+  // Keep the security ceiling immutable in production while allowing live
+  // call-path tests to trip it with tiny fixtures instead of 64 MiB strings.
+  if (process.env.NODE_ENV === 'test') {
+    const parsed = Number(process.env[TEST_MAX_LINE_BYTES_ENV_VAR])
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return MAX_LINE_BYTES
 }
 
 /** Thrown when a single line exceeds MAX_LINE_BYTES. */
@@ -134,6 +134,39 @@ class ByteCapTransform extends Transform {
     }
     callback(null, chunk)
   }
+}
+
+function composeCappedDecompressedStream(
+  raw: Readable,
+  gzipped: boolean,
+  maxDecompressedBytes: number,
+  downstream?: Transform
+): Readable {
+  const byteCap = new ByteCapTransform(maxDecompressedBytes)
+  if (downstream !== undefined) {
+    return gzipped
+      ? compose(raw, createGunzip(), byteCap, downstream)
+      : compose(raw, byteCap, downstream)
+  }
+  return gzipped ? compose(raw, createGunzip(), byteCap) : compose(raw, byteCap)
+}
+
+/**
+ * Create a gzip-aware stream with the shared total decompressed-byte guard.
+ * JSON parsers use this directly; line-oriented readers add their independent
+ * per-line guard downstream.
+ */
+export function createDecompressedStream(
+  filePath: string,
+  maxDecompressedBytes?: number
+): Readable {
+  const gzipped = isGzipped(filePath)
+  const raw = createReadStream(filePath)
+  return composeCappedDecompressedStream(
+    raw,
+    gzipped,
+    resolveMaxDecompressedBytes(maxDecompressedBytes)
+  )
 }
 
 /**
@@ -208,58 +241,13 @@ export function createCappedLineStream(
   filePath: string,
   options: CappedLineStreamOptions = {}
 ): CappedLineSource {
-  const maxLineBytes = options.maxLineBytes ?? MAX_LINE_BYTES
+  const maxLineBytes = resolveMaxLineBytes(options.maxLineBytes)
   const maxDecompressedBytes = resolveMaxDecompressedBytes(options.maxDecompressedBytes)
 
-  const raw = createReadStream(filePath)
   const gzipped = isGzipped(filePath)
-  const byteCap = new ByteCapTransform(maxDecompressedBytes)
+  const raw = createReadStream(filePath)
   const lineCap = new LineLengthCapTransform(maxLineBytes)
-
-  const stream = gzipped
-    ? compose(raw, createGunzip(), byteCap, lineCap)
-    : compose(raw, byteCap, lineCap)
+  const stream = composeCappedDecompressedStream(raw, gzipped, maxDecompressedBytes, lineCap)
 
   return { stream, rawBytesRead: () => raw.bytesRead }
-}
-
-/**
- * Synchronously read an entire file (gzip-aware), bounded by
- * `maxDecompressedBytes`. Used by consumers whose algorithm needs the whole
- * file in memory at once (currently: `BedFilter`, whose interval-merging
- * pass is not naturally streaming). Never allocates a decompressed buffer
- * larger than the cap: gzip inputs are bounded via zlib's own
- * `maxOutputLength`, and plain-text inputs are size-checked via `stat`
- * before ever being read.
- */
-export function readCappedFileSync(filePath: string, maxDecompressedBytes?: number): string {
-  const maxBytes = resolveMaxDecompressedBytes(maxDecompressedBytes)
-  const gzipped = isGzipped(filePath)
-
-  if (!gzipped) {
-    const { size } = statSync(filePath)
-    if (size > maxBytes) {
-      throw new DecompressedSizeExceededError(maxBytes)
-    }
-    return readFileSync(filePath, 'utf-8')
-  }
-
-  // Cheap pre-check: a compressed file already larger on disk than the cap
-  // has no realistic path to a legitimate, sub-cap decompressed result --
-  // reject before reading it fully into memory.
-  const { size: compressedSize } = statSync(filePath)
-  if (compressedSize > maxBytes) {
-    throw new DecompressedSizeExceededError(maxBytes)
-  }
-
-  const compressed = readFileSync(filePath)
-  try {
-    return gunzipSync(compressed, { maxOutputLength: maxBytes }).toString('utf-8')
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException)?.code
-    if (code === 'ERR_BUFFER_TOO_LARGE') {
-      throw new DecompressedSizeExceededError(maxBytes)
-    }
-    throw error
-  }
 }

--- a/src/main/import/stream-utils.ts
+++ b/src/main/import/stream-utils.ts
@@ -64,6 +64,18 @@ export const MAX_LINE_BYTES = 64 * 1024 * 1024 // 64 MiB
 /** Default total decompressed-byte cap — see rationale above. */
 export const DEFAULT_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024 * 1024 // 256 GiB
 
+/**
+ * Reject gzip streams expanding beyond this ratio after the safety floor.
+ * The shipped VCF gzip corpus tops out at 25.87x (ordinary single/trio and
+ * annotated fixtures are 7.83x-16.29x), so 100x keeps almost 4x headroom
+ * while stopping highly compressible hostile input far below the 256 GiB
+ * WGS-capable absolute ceiling.
+ */
+export const MAX_GZIP_COMPRESSION_RATIO = 100
+
+/** Avoid false positives for small, legitimately repetitive gzip files. */
+export const MIN_GZIP_RATIO_CHECK_BYTES = 64 * 1024 * 1024 // 64 MiB
+
 /** Environment variable that overrides DEFAULT_MAX_DECOMPRESSED_BYTES, in bytes. */
 const MAX_DECOMPRESSED_BYTES_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 const TEST_MAX_LINE_BYTES_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
@@ -115,6 +127,16 @@ export class DecompressedSizeExceededError extends Error {
   }
 }
 
+/** Thrown when gzip output is implausibly large relative to its compressed file. */
+export class DecompressionRatioExceededError extends Error {
+  constructor(maxRatio: number, minBytes: number) {
+    super(
+      `Refusing to continue gzip expansion beyond ${maxRatio}x after ${minBytes} bytes (suspected decompression bomb)`
+    )
+    this.name = 'DecompressionRatioExceededError'
+  }
+}
+
 /**
  * Counts bytes flowing through and errors once `maxBytes` is exceeded.
  * Defeats a gzip bomb regardless of line structure.
@@ -136,19 +158,56 @@ class ByteCapTransform extends Transform {
   }
 }
 
+class CompressionRatioCapTransform extends Transform {
+  private totalBytes = 0
+
+  constructor(
+    private readonly compressedBytesAccepted: () => number,
+    private readonly maxRatio: number,
+    private readonly minBytes: number
+  ) {
+    super()
+  }
+
+  override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    this.totalBytes += chunk.length
+    const ratio = this.totalBytes / Math.max(this.compressedBytesAccepted(), 1)
+    if (this.totalBytes > this.minBytes && ratio > this.maxRatio) {
+      callback(new DecompressionRatioExceededError(this.maxRatio, this.minBytes))
+      return
+    }
+    callback(null, chunk)
+  }
+}
+
 function composeCappedDecompressedStream(
   raw: Readable,
   gzipped: boolean,
   maxDecompressedBytes: number,
+  maxCompressionRatio: number,
+  minCompressionRatioBytes: number,
   downstream?: Transform
 ): Readable {
   const byteCap = new ByteCapTransform(maxDecompressedBytes)
-  if (downstream !== undefined) {
-    return gzipped
-      ? compose(raw, createGunzip(), byteCap, downstream)
-      : compose(raw, byteCap, downstream)
+  if (gzipped) {
+    const gunzip = createGunzip()
+    // Gunzip.bytesWritten is the compressed input accepted by zlib's engine.
+    // Unlike fs.ReadStream.bytesRead, it excludes filesystem read-ahead and
+    // trailing zero padding after the gzip member, so neither can dilute the
+    // expansion ratio.
+    const ratioCap = new CompressionRatioCapTransform(
+      () => gunzip.bytesWritten,
+      maxCompressionRatio,
+      minCompressionRatioBytes
+    )
+    return downstream !== undefined
+      ? compose(raw, gunzip, ratioCap, byteCap, downstream)
+      : compose(raw, gunzip, ratioCap, byteCap)
   }
-  return gzipped ? compose(raw, createGunzip(), byteCap) : compose(raw, byteCap)
+  if (downstream !== undefined) {
+    return compose(raw, byteCap, downstream)
+  }
+  return compose(raw, byteCap)
 }
 
 /**
@@ -165,7 +224,9 @@ export function createDecompressedStream(
   return composeCappedDecompressedStream(
     raw,
     gzipped,
-    resolveMaxDecompressedBytes(maxDecompressedBytes)
+    resolveMaxDecompressedBytes(maxDecompressedBytes),
+    MAX_GZIP_COMPRESSION_RATIO,
+    MIN_GZIP_RATIO_CHECK_BYTES
   )
 }
 
@@ -211,6 +272,10 @@ export interface CappedLineStreamOptions {
   maxLineBytes?: number
   /** Override the total decompressed-byte cap (tests, or advanced config). */
   maxDecompressedBytes?: number
+  /** Override the gzip expansion ratio. Production call sites should not set this. */
+  maxCompressionRatio?: number
+  /** Override the output floor before ratio checks. Production call sites should not set this. */
+  minCompressionRatioBytes?: number
 }
 
 /** Return value of {@link createCappedLineStream}. */
@@ -243,11 +308,20 @@ export function createCappedLineStream(
 ): CappedLineSource {
   const maxLineBytes = resolveMaxLineBytes(options.maxLineBytes)
   const maxDecompressedBytes = resolveMaxDecompressedBytes(options.maxDecompressedBytes)
+  const maxCompressionRatio = options.maxCompressionRatio ?? MAX_GZIP_COMPRESSION_RATIO
+  const minCompressionRatioBytes = options.minCompressionRatioBytes ?? MIN_GZIP_RATIO_CHECK_BYTES
 
   const gzipped = isGzipped(filePath)
   const raw = createReadStream(filePath)
   const lineCap = new LineLengthCapTransform(maxLineBytes)
-  const stream = composeCappedDecompressedStream(raw, gzipped, maxDecompressedBytes, lineCap)
+  const stream = composeCappedDecompressedStream(
+    raw,
+    gzipped,
+    maxDecompressedBytes,
+    maxCompressionRatio,
+    minCompressionRatioBytes,
+    lineCap
+  )
 
   return { stream, rawBytesRead: () => raw.bytesRead }
 }

--- a/src/main/import/stream-utils.ts
+++ b/src/main/import/stream-utils.ts
@@ -2,6 +2,7 @@ import { createReadStream, openSync, readSync, closeSync } from 'node:fs'
 import { createGunzip } from 'node:zlib'
 import { compose, Transform } from 'node:stream'
 import type { Readable, TransformCallback } from 'node:stream'
+import { DEFAULT_MAX_GZIP_COMPRESSION_RATIO, GzipRatioPolicy } from './gzip-ratio-policy'
 
 /** Gzip magic number: first two bytes of any gzip file */
 const GZIP_MAGIC = Buffer.from([0x1f, 0x8b])
@@ -65,13 +66,13 @@ export const MAX_LINE_BYTES = 64 * 1024 * 1024 // 64 MiB
 export const DEFAULT_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024 * 1024 // 256 GiB
 
 /**
- * Reject gzip streams expanding beyond this ratio after the safety floor.
+ * Generic gzip expansion baseline after the safety floor.
  * The shipped VCF gzip corpus tops out at 25.87x (ordinary single/trio and
  * annotated fixtures are 7.83x-16.29x), so 100x keeps almost 4x headroom
- * while stopping highly compressible hostile input far below the 256 GiB
- * WGS-capable absolute ceiling.
+ * for ordinary input. Joint-called VCFs receive a bounded sample-aware
+ * allowance from GzipRatioPolicy; other formats retain this ceiling.
  */
-export const MAX_GZIP_COMPRESSION_RATIO = 100
+export const MAX_GZIP_COMPRESSION_RATIO = DEFAULT_MAX_GZIP_COMPRESSION_RATIO
 
 /** Avoid false positives for small, legitimately repetitive gzip files. */
 export const MIN_GZIP_RATIO_CHECK_BYTES = 64 * 1024 * 1024 // 64 MiB
@@ -160,20 +161,24 @@ class ByteCapTransform extends Transform {
 
 class CompressionRatioCapTransform extends Transform {
   private totalBytes = 0
+  private readonly policy: GzipRatioPolicy
 
   constructor(
     private readonly compressedBytesAccepted: () => number,
-    private readonly maxRatio: number,
+    maxRatio: number,
     private readonly minBytes: number
   ) {
     super()
+    this.policy = new GzipRatioPolicy(maxRatio)
   }
 
   override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
     this.totalBytes += chunk.length
+    this.policy.observe(chunk)
     const ratio = this.totalBytes / Math.max(this.compressedBytesAccepted(), 1)
-    if (this.totalBytes > this.minBytes && ratio > this.maxRatio) {
-      callback(new DecompressionRatioExceededError(this.maxRatio, this.minBytes))
+    const effectiveMaxRatio = this.policy.maxRatio()
+    if (this.totalBytes > this.minBytes && ratio > effectiveMaxRatio) {
+      callback(new DecompressionRatioExceededError(effectiveMaxRatio, this.minBytes))
       return
     }
     callback(null, chunk)

--- a/src/main/import/stream-utils.ts
+++ b/src/main/import/stream-utils.ts
@@ -69,8 +69,9 @@ export const DEFAULT_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024 * 1024 // 256 Gi
  * Generic gzip expansion baseline after the safety floor.
  * The shipped VCF gzip corpus tops out at 25.87x (ordinary single/trio and
  * annotated fixtures are 7.83x-16.29x), so 100x keeps almost 4x headroom
- * for ordinary input. Joint-called VCFs receive a bounded sample-aware
- * allowance from GzipRatioPolicy; other formats retain this ceiling.
+ * for ordinary input. Structurally validated VCFs rely on the independent
+ * absolute byte/line/header/record budgets because valid joint-called VCFs
+ * can have arbitrarily high repetition; other formats retain this ceiling.
  */
 export const MAX_GZIP_COMPRESSION_RATIO = DEFAULT_MAX_GZIP_COMPRESSION_RATIO
 

--- a/src/main/import/vcf/VcfMapper.ts
+++ b/src/main/import/vcf/VcfMapper.ts
@@ -12,6 +12,7 @@ import { parseGenotype } from './vcf-genotype-parser'
 import { applyInfoFieldRegistry } from './info-field-registry'
 import { detectVariantType } from './variant-type-detector'
 import { extractSvFields, extractCnvFields, extractStrFields } from './extension-parsers'
+import { splitGenotypeAlleles, VcfResourceLimitError } from './vcf-resource-limits'
 
 /** Parse integer from string, returning null for missing/invalid values */
 function parseIntOrNull(val: string | undefined): number | null {
@@ -164,7 +165,8 @@ function shouldSkipGenotype(gt: string): boolean {
   if (gt === '.' || gt === './.' || gt === '.|.') return true
 
   // Split on / or |
-  const alleles = gt.split(/[/|]/)
+  const alleles = splitGenotypeAlleles(gt)
+  if (alleles === null) throw new VcfResourceLimitError('Genotype ploidy exceeds 64 alleles')
 
   // Skip if no allele is "1" (the ALT allele after remapping)
   // This covers ref-hom (0/0), no-call (./.), and partial no-call (0/.)

--- a/src/main/import/vcf/VcfMapper.ts
+++ b/src/main/import/vcf/VcfMapper.ts
@@ -6,13 +6,16 @@
  */
 
 import type { VcfRawRecord, VcfHeader, VcfMappedVariant, InfoFieldMapping } from './types'
-import { splitMultiAllelic } from './vcf-allele-splitter'
-import { parseAnnotation } from './vcf-annotation-parser'
+import { splitAlleleForSample } from './vcf-allele-splitter'
+import { parseAnnotationsForAlleles } from './vcf-annotation-parser'
 import { parseGenotype } from './vcf-genotype-parser'
 import { applyInfoFieldRegistry } from './info-field-registry'
 import { detectVariantType } from './variant-type-detector'
 import { extractSvFields, extractCnvFields, extractStrFields } from './extension-parsers'
 import { splitGenotypeAlleles, VcfResourceLimitError } from './vcf-resource-limits'
+
+const MAX_VCF_EXPANDED_RECORD_BYTES = 64 * 1024 * 1024
+const MAX_VCF_ALLELE_EXPANSION_WORK = 1_000_000
 
 /** Parse integer from string, returning null for missing/invalid values */
 function parseIntOrNull(val: string | undefined): number | null {
@@ -42,45 +45,47 @@ export function mapVcfRecord(
   registry: InfoFieldMapping[],
   callerName: string | null = null
 ): VcfMappedVariant[] {
-  // Step 1: Split multi-allelic into biallelic records
-  const splitRecords = splitMultiAllelic(record, header.infoDefs, header.formatDefs)
-
   const results: VcfMappedVariant[] = []
+  const selectedValues = record.samples.get(sampleName)
+  if (selectedValues === undefined) return results
 
-  for (let altIdx = 0; altIdx < splitRecords.length; altIdx++) {
-    const rec = splitRecords[altIdx]
+  const gtIdx = record.format.indexOf('GT')
+  const rawGt = gtIdx >= 0 && gtIdx < selectedValues.length ? selectedValues[gtIdx] : '.'
+  const carriedAlleles = carriedAltAlleles(rawGt)
+  const targetAltIndexes: number[] = []
 
-    // Step 2: Extract genotype for the selected sample
-    const sampleValues = rec.samples.get(sampleName)
-    if (!sampleValues) continue
-
-    const gtIdx = rec.format.indexOf('GT')
-    const gtFieldValue = gtIdx >= 0 && gtIdx < sampleValues.length ? sampleValues[gtIdx] : '.'
-
-    // Skip if sample does not carry the ALT allele (ref-hom, no-call, or other ALT)
-    // Exception: structural variants (SV/CNV/STR) use caller-specific fields like
-    // CN, VAF, SUPPORT instead of diploid genotypes, so we must NOT filter them by
-    // GT. Structural callers signal their variants in three ways:
-    //   1. Symbolic ALT (<DEL>, <CNV>, <STRn>, ...) — Spectre CNV, Straglr STR
-    //   2. Breakend notation ([/]) — Manta BND records
-    //   3. SVTYPE INFO field — Sniffles2 INS uses sequence ALTs but sets SVTYPE=INS
-    // All three cases must bypass the genotype-skip filter; otherwise Spectre's
-    // `GT=./.` and Sniffles' `GT=./.` on sequence-ALT INSes silently drop the
-    // variant even though the caller reported a finding.
-    const rawAlt = rec.alt[0]
+  for (let altIdx = 0; altIdx < record.alt.length; altIdx++) {
+    const rawAlt = record.alt[altIdx]
     const isStructural =
       rawAlt.startsWith('<') ||
       rawAlt.includes('[') ||
       rawAlt.includes(']') ||
-      rec.info.has('SVTYPE')
-    if (!isStructural && shouldSkipGenotype(gtFieldValue)) continue
+      record.info.has('SVTYPE')
+    if (isStructural || carriedAlleles.has(altIdx + 1)) targetAltIndexes.push(altIdx)
+  }
+
+  assertBoundedExpandedRecord(record, targetAltIndexes.length)
+  assertBoundedAlleleExpansionWork(record, header, targetAltIndexes.length)
+  const annotationByTarget = parseAnnotationsForAlleles(
+    record.info,
+    header,
+    targetAltIndexes.map((index) => record.alt[index]),
+    record.ref
+  )
+
+  for (let targetIndex = 0; targetIndex < targetAltIndexes.length; targetIndex++) {
+    const altIdx = targetAltIndexes[targetIndex]
+    // Build only the one selected sample/ALT view that will be mapped.
+    const rec = splitAlleleForSample(record, header.infoDefs, header.formatDefs, altIdx, sampleName)
+    const sampleValues = rec.samples.get(sampleName)
+    if (sampleValues === undefined) continue
 
     // Parse full genotype data (with altAlleleIndex=1 since already split)
     const genotype = parseGenotype(sampleValues, rec.format, 1)
 
-    // Step 3: Parse annotation (CSQ or ANN)
+    // Step 3: Select the pre-grouped annotation result for this ALT.
     const altAllele = rec.alt[0]
-    const annotation = parseAnnotation(rec.info, header, altAllele, rec.ref)
+    const annotation = annotationByTarget[targetIndex]
 
     // Step 4: Apply INFO field registry
     const infoResult = applyInfoFieldRegistry(rec.info, registry, annotation)
@@ -151,6 +156,46 @@ export function mapVcfRecord(
   return results
 }
 
+function assertBoundedExpandedRecord(record: VcfRawRecord, mappedAltCount: number): void {
+  if (mappedAltCount <= 1) return
+  let retainedInfoBytes = 0
+  for (const [key, value] of record.info) {
+    if (key === 'CSQ' || key === 'ANN') continue
+    retainedInfoBytes += Buffer.byteLength(key, 'utf8') + Buffer.byteLength(value, 'utf8')
+  }
+  const expandedBytes = retainedInfoBytes * mappedAltCount
+  if (!Number.isSafeInteger(expandedBytes) || expandedBytes > MAX_VCF_EXPANDED_RECORD_BYTES) {
+    throw new VcfResourceLimitError(
+      `VCF record expanded output exceeds ${MAX_VCF_EXPANDED_RECORD_BYTES} bytes`
+    )
+  }
+}
+
+function assertBoundedAlleleExpansionWork(
+  record: VcfRawRecord,
+  header: VcfHeader,
+  mappedAltCount: number
+): void {
+  if (mappedAltCount <= 1) return
+  let alleleValuedFields = 0
+  for (const key of record.info.keys()) {
+    const number = header.infoDefs.get(key)?.number
+    if (number === 'A' || number === 'R') alleleValuedFields += 1
+  }
+  for (const key of record.format) {
+    const number = header.formatDefs.get(key)?.number
+    if (number === 'A' || number === 'R') alleleValuedFields += 1
+  }
+  const work =
+    mappedAltCount *
+    (record.info.size + record.format.length + alleleValuedFields * record.alt.length)
+  if (!Number.isSafeInteger(work) || work > MAX_VCF_ALLELE_EXPANSION_WORK) {
+    throw new VcfResourceLimitError(
+      `VCF record allele expansion exceeds work budget ${MAX_VCF_ALLELE_EXPANSION_WORK}`
+    )
+  }
+}
+
 /**
  * Check if a GT field value indicates the sample does NOT carry the ALT allele.
  *
@@ -160,15 +205,15 @@ export function mapVcfRecord(
  * - The GT is ref-homozygous (all alleles are "0")
  * - The GT does not contain "1" at all (sample doesn't carry this specific ALT)
  */
-function shouldSkipGenotype(gt: string): boolean {
-  // No-call shorthand
-  if (gt === '.' || gt === './.' || gt === '.|.') return true
-
-  // Split on / or |
+function carriedAltAlleles(gt: string): Set<number> {
+  const result = new Set<number>()
+  if (gt === '.' || gt === './.' || gt === '.|.') return result
   const alleles = splitGenotypeAlleles(gt)
   if (alleles === null) throw new VcfResourceLimitError('Genotype ploidy exceeds 64 alleles')
-
-  // Skip if no allele is "1" (the ALT allele after remapping)
-  // This covers ref-hom (0/0), no-call (./.), and partial no-call (0/.)
-  return !alleles.includes('1')
+  for (const allele of alleles) {
+    if (!/^\d+$/.test(allele)) continue
+    const value = Number(allele)
+    if (Number.isSafeInteger(value) && value > 0) result.add(value)
+  }
+  return result
 }

--- a/src/main/import/vcf/VcfStrategy.ts
+++ b/src/main/import/vcf/VcfStrategy.ts
@@ -19,6 +19,7 @@ import { detectCaller } from './caller-detector'
 import type { ImportFilters } from './import-filters'
 import { passesPreMappingFilters, passesPostMappingFilters } from './import-filters'
 import { VcfHeaderBudget } from './vcf-header-limits'
+import { VcfResourceLimitError } from './vcf-resource-limits'
 export class VcfStrategy implements ImportStrategy {
   readonly formatId = 'vcf' as const
 
@@ -145,6 +146,7 @@ export class VcfStrategy implements ImportStrategy {
             }
           }
         } catch (lineError) {
+          if (lineError instanceof VcfResourceLimitError) throw lineError
           totalSkipped++
           if (errors.length < 10) {
             errors.push(

--- a/src/main/import/vcf/VcfStrategy.ts
+++ b/src/main/import/vcf/VcfStrategy.ts
@@ -6,10 +6,8 @@
  * annotations and genotypes, then inserts via the existing bulk insert pipeline.
  */
 
-import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
-import { createGunzip } from 'node:zlib'
-import { isGzipped } from '../stream-utils'
+import { createCappedLineStream } from '../stream-utils'
 import type { ImportOptions, ImportResult } from '../types'
 import type { ImportStrategy, FormatInfo, StrategyContext } from '../strategies/ImportStrategy'
 import type { VcfImportOptions, VcfMappedVariant, VcfHeader } from './types'
@@ -37,9 +35,10 @@ export class VcfStrategy implements ImportStrategy {
     const { db, caseId, startTime } = context
     const batchSize = options.batchSize ?? 5000
 
-    // Read file line by line
-    const raw = createReadStream(filePath)
-    const stream = isGzipped(filePath) ? raw.pipe(createGunzip()) : raw
+    // Read file line by line. Shared capped reader guards against a giant
+    // single line and a decompression bomb -- see stream-utils.ts for the
+    // cap rationale.
+    const { stream } = createCappedLineStream(filePath)
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
     const headerLines: string[] = []

--- a/src/main/import/vcf/VcfStrategy.ts
+++ b/src/main/import/vcf/VcfStrategy.ts
@@ -18,6 +18,7 @@ import { DEFAULT_INFO_FIELD_MAPPINGS } from './info-field-registry'
 import { detectCaller } from './caller-detector'
 import type { ImportFilters } from './import-filters'
 import { passesPreMappingFilters, passesPostMappingFilters } from './import-filters'
+import { VcfHeaderBudget } from './vcf-header-limits'
 export class VcfStrategy implements ImportStrategy {
   readonly formatId = 'vcf' as const
 
@@ -39,9 +40,12 @@ export class VcfStrategy implements ImportStrategy {
     // single line and a decompression bomb -- see stream-utils.ts for the
     // cap rationale.
     const { stream } = createCappedLineStream(filePath)
+    stream.on('error', () => undefined)
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
+    rl.on('error', () => undefined)
 
     const headerLines: string[] = []
+    const headerBudget = new VcfHeaderBudget()
     let header: VcfHeader | null = null
     let activeSample = ''
     let totalInserted = 0
@@ -63,6 +67,7 @@ export class VcfStrategy implements ImportStrategy {
 
         // Collect header lines
         if (line.startsWith('#')) {
+          headerBudget.add(line)
           headerLines.push(line)
           continue
         }
@@ -155,6 +160,7 @@ export class VcfStrategy implements ImportStrategy {
         totalInserted += batch.length
       }
     } finally {
+      stream.destroy()
       // Always restore FTS triggers and update case
       db.variants.finishBulkInsert(caseId, totalInserted)
     }

--- a/src/main/import/vcf/VcfStrategy.ts
+++ b/src/main/import/vcf/VcfStrategy.ts
@@ -12,7 +12,11 @@ import type { ImportOptions, ImportResult } from '../types'
 import type { ImportStrategy, FormatInfo, StrategyContext } from '../strategies/ImportStrategy'
 import type { VcfImportOptions, VcfMappedVariant, VcfHeader } from './types'
 import { parseVcfHeaderFromLines } from './vcf-header-parser'
-import { parseVcfLine } from './vcf-line-parser'
+import {
+  parseVcfLine,
+  resolveVcfSelectedSampleColumn,
+  type VcfSelectedSampleColumn
+} from './vcf-line-parser'
 import { mapVcfRecord } from './VcfMapper'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from './info-field-registry'
 import { detectCaller } from './caller-detector'
@@ -49,6 +53,7 @@ export class VcfStrategy implements ImportStrategy {
     const headerBudget = new VcfHeaderBudget()
     let header: VcfHeader | null = null
     let activeSample = ''
+    let activeSampleColumn: VcfSelectedSampleColumn | null = null
     let totalInserted = 0
     let totalSkipped = 0
     const errors: string[] = []
@@ -76,8 +81,11 @@ export class VcfStrategy implements ImportStrategy {
         // Parse header once, on the first data line
         if (header === null) {
           header = parseVcfHeaderFromLines(headerLines)
-          const selectedSample = vcfOptions?.selectedSamples?.[0]
-          activeSample = selectedSample ?? (header.samples.length > 0 ? header.samples[0] : '')
+          activeSampleColumn = resolveVcfSelectedSampleColumn(
+            header.samples,
+            vcfOptions?.selectedSamples?.[0]
+          )
+          activeSample = activeSampleColumn?.name ?? ''
 
           if (activeSample === '') {
             errors.push('No sample found in VCF file')
@@ -90,11 +98,16 @@ export class VcfStrategy implements ImportStrategy {
 
         // Parse the data line
         try {
-          const record = parseVcfLine(line, header.samples, (reason) => {
-            if (errors.length < 10) {
-              errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
-            }
-          })
+          const record = parseVcfLine(
+            line,
+            header.samples,
+            (reason) => {
+              if (errors.length < 10) {
+                errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
+              }
+            },
+            activeSampleColumn ?? undefined
+          )
           if (record === null) {
             totalSkipped++
             continue

--- a/src/main/import/vcf/VcfStrategy.ts
+++ b/src/main/import/vcf/VcfStrategy.ts
@@ -85,7 +85,11 @@ export class VcfStrategy implements ImportStrategy {
 
         // Parse the data line
         try {
-          const record = parseVcfLine(line, header.samples)
+          const record = parseVcfLine(line, header.samples, (reason) => {
+            if (errors.length < 10) {
+              errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
+            }
+          })
           if (record === null) {
             totalSkipped++
             continue

--- a/src/main/import/vcf/bed-filter.ts
+++ b/src/main/import/vcf/bed-filter.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, resolve } from 'path'
-import { readCappedFileSync, resolveMaxDecompressedBytes } from '../stream-utils'
+import { resolveMaxDecompressedBytes } from '../stream-utils'
+import { readBedEntries } from './bed-reader'
 
 export const MAX_BED_FILTER_DECOMPRESSED_BYTES = 256 * 1024 * 1024 // 256 MiB
 
@@ -27,7 +28,7 @@ export class BedFilter {
   }
 
   /** Load intervals from a .bed or .bed.gz file with optional padding */
-  static fromFile(filePath: string, padding: number): BedFilter {
+  static async fromFile(filePath: string, padding: number): Promise<BedFilter> {
     // QW-7 worker-safe defensive check. The full allow-list check happens
     // at the IPC boundary in main; this file is also loaded by worker threads.
     if (!isAbsolute(filePath)) {
@@ -38,31 +39,11 @@ export class BedFilter {
       throw new Error(`BedFilter.fromFile: path must not contain '..' segments: ${filePath}`)
     }
 
-    // Bounded, gzip-aware read: guards against a gzip bomb (a tiny
-    // .bed.gz inflating to many GB) and against an unexpectedly huge plain
-    // .bed file, instead of the previous unbounded gunzipSync(readFileSync())
-    // full-file slurp. See stream-utils.ts for the shared cap rationale.
-    const raw = readCappedFileSync(
-      filePath,
-      Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
-    )
-
     const intervals = new Map<string, Interval[]>()
+    const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
 
-    for (const line of raw.split('\n')) {
-      const trimmed = line.trim()
-      if (
-        !trimmed ||
-        trimmed.startsWith('#') ||
-        trimmed.startsWith('track') ||
-        trimmed.startsWith('browser')
-      ) {
-        continue
-      }
-      const parts = trimmed.split('\t')
-      if (parts.length < 3) continue
-
-      const chr = parts[0]
+    for await (const entry of readBedEntries(filePath, maxBytes)) {
+      const chr = entry.chr
       // BED is 0-based half-open -> convert to 1-based inclusive, then apply padding.
       // Reject malformed rows where columns 2 or 3 don't parse as integers
       // (`Number.isInteger` catches both NaN and fractional values) and skip
@@ -70,10 +51,8 @@ export class BedFilter {
       // a zero-length interval which, after converting to 1-based inclusive
       // via `startRaw + 1`, would produce `start > end` — breaking the
       // binary-search overlap checks silently.
-      const startRaw = parseInt(parts[1], 10)
-      const endRaw = parseInt(parts[2], 10)
-      if (!Number.isInteger(startRaw) || !Number.isInteger(endRaw)) continue
-      if (endRaw <= startRaw) continue
+      const startRaw = entry.start
+      const endRaw = entry.end
 
       const start = Math.max(1, startRaw + 1 - padding)
       const end = endRaw + padding

--- a/src/main/import/vcf/bed-filter.ts
+++ b/src/main/import/vcf/bed-filter.ts
@@ -1,5 +1,7 @@
 import { isAbsolute, resolve } from 'path'
-import { readCappedFileSync } from '../stream-utils'
+import { readCappedFileSync, resolveMaxDecompressedBytes } from '../stream-utils'
+
+export const MAX_BED_FILTER_DECOMPRESSED_BYTES = 256 * 1024 * 1024 // 256 MiB
 
 interface Interval {
   start: number // 1-based inclusive
@@ -40,7 +42,10 @@ export class BedFilter {
     // .bed.gz inflating to many GB) and against an unexpectedly huge plain
     // .bed file, instead of the previous unbounded gunzipSync(readFileSync())
     // full-file slurp. See stream-utils.ts for the shared cap rationale.
-    const raw = readCappedFileSync(filePath)
+    const raw = readCappedFileSync(
+      filePath,
+      Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
+    )
 
     const intervals = new Map<string, Interval[]>()
 

--- a/src/main/import/vcf/bed-filter.ts
+++ b/src/main/import/vcf/bed-filter.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from 'fs'
 import { isAbsolute, resolve } from 'path'
-import { gunzipSync } from 'zlib'
+import { readCappedFileSync } from '../stream-utils'
 
 interface Interval {
   start: number // 1-based inclusive
@@ -37,9 +36,11 @@ export class BedFilter {
       throw new Error(`BedFilter.fromFile: path must not contain '..' segments: ${filePath}`)
     }
 
-    const raw = filePath.endsWith('.gz')
-      ? gunzipSync(readFileSync(filePath)).toString('utf-8')
-      : readFileSync(filePath, 'utf-8')
+    // Bounded, gzip-aware read: guards against a gzip bomb (a tiny
+    // .bed.gz inflating to many GB) and against an unexpectedly huge plain
+    // .bed file, instead of the previous unbounded gunzipSync(readFileSync())
+    // full-file slurp. See stream-utils.ts for the shared cap rationale.
+    const raw = readCappedFileSync(filePath)
 
     const intervals = new Map<string, Interval[]>()
 

--- a/src/main/import/vcf/bed-reader.ts
+++ b/src/main/import/vcf/bed-reader.ts
@@ -28,7 +28,8 @@ export class BedEntryLimitExceededError extends Error {
 
 export class InvalidBedRowError extends Error {
   constructor(line: string) {
-    super(`Invalid BED row: ${line}`)
+    const preview = line.length > 256 ? `${line.slice(0, 256)}…` : line
+    super(`Invalid BED row (${line.length} characters): ${preview}`)
     this.name = 'InvalidBedRowError'
   }
 }

--- a/src/main/import/vcf/bed-reader.ts
+++ b/src/main/import/vcf/bed-reader.ts
@@ -1,0 +1,70 @@
+import { createInterface } from 'node:readline'
+import { statSync } from 'node:fs'
+import { createCappedLineStream, DecompressedSizeExceededError } from '../stream-utils'
+
+export interface BedEntry {
+  chr: string
+  start: number
+  end: number
+  label?: string
+}
+
+function isIgnoredBedLine(line: string): boolean {
+  return (
+    line === '' || line.startsWith('#') || line.startsWith('track') || line.startsWith('browser')
+  )
+}
+
+export function parseBedEntry(line: string): BedEntry | null {
+  const trimmed = line.trim()
+  if (isIgnoredBedLine(trimmed)) return null
+
+  const parts = trimmed.split('\t')
+  if (parts.length < 3) return null
+  if (!/^\d+$/.test(parts[1]) || !/^\d+$/.test(parts[2])) return null
+
+  const start = Number(parts[1])
+  const end = Number(parts[2])
+  if (!Number.isInteger(start) || !Number.isInteger(end) || end <= start) return null
+
+  return {
+    chr: parts[0],
+    start,
+    end,
+    label: parts.length >= 4 ? parts[3] : undefined
+  }
+}
+
+/** Iterate a BED file without materializing its decompressed text. */
+export async function* readBedEntries(
+  filePath: string,
+  maxDecompressedBytes: number
+): AsyncGenerator<BedEntry, void, void> {
+  // Fail synchronously before createReadStream can emit an open error after a
+  // rejected consumer has already settled. The size check also rejects a
+  // plainly oversized BED before reading its sparse/zero-filled contents.
+  if (statSync(filePath).size > maxDecompressedBytes) {
+    throw new DecompressedSizeExceededError(maxDecompressedBytes)
+  }
+  const { stream } = createCappedLineStream(filePath, { maxDecompressedBytes })
+  const lines = createInterface({ input: stream, crlfDelay: Infinity })
+  let streamError: Error | null = null
+
+  const captureStreamError = (error: Error): void => {
+    streamError ??= error
+    lines.close()
+  }
+  stream.on('error', captureStreamError)
+
+  try {
+    for await (const line of lines) {
+      if (streamError !== null) throw streamError
+      const entry = parseBedEntry(line)
+      if (entry !== null) yield entry
+    }
+    if (streamError !== null) throw streamError
+  } finally {
+    lines.close()
+    stream.destroy()
+  }
+}

--- a/src/main/import/vcf/bed-reader.ts
+++ b/src/main/import/vcf/bed-reader.ts
@@ -40,18 +40,19 @@ export interface BedReaderOptions {
   rejectMalformedRows?: boolean
 }
 
-function isIgnoredBedLine(line: string): boolean {
+function isIgnoredBedFirstField(firstField: string | undefined): boolean {
   return (
-    line === '' || line.startsWith('#') || line.startsWith('track') || line.startsWith('browser')
+    firstField === undefined ||
+    firstField.startsWith('#') ||
+    firstField === 'track' ||
+    firstField === 'browser'
   )
 }
 
 export function parseBedEntry(line: string): BedEntry | null {
-  const trimmed = line.trim()
-  if (isIgnoredBedLine(trimmed)) return null
-
-  const parts = trimmed.split(/\s+/u)
-  if (parts.length < 3 || parts[0] === '') return null
+  const parts = scanBedFields(line, 4)
+  if (isIgnoredBedFirstField(parts[0])) return null
+  if (parts.length < 3) return null
   if (!/^\d+$/.test(parts[1]) || !/^\d+$/.test(parts[2])) return null
 
   const start = Number(parts[1])
@@ -64,6 +65,24 @@ export function parseBedEntry(line: string): BedEntry | null {
     end,
     label: parts.length >= 4 ? parts[3] : undefined
   }
+}
+
+/** Read only the BED3/BED4 fields consumed by VarLens; never split a dense remainder. */
+function scanBedFields(line: string, maxFields: number): string[] {
+  const fields: string[] = []
+  let index = 0
+  while (fields.length < maxFields) {
+    while (index < line.length && isBedWhitespace(line.charCodeAt(index))) index += 1
+    if (index === line.length) break
+    const start = index
+    while (index < line.length && !isBedWhitespace(line.charCodeAt(index))) index += 1
+    fields.push(line.slice(start, index))
+  }
+  return fields
+}
+
+function isBedWhitespace(charCode: number): boolean {
+  return charCode === 0x09 || charCode === 0x20 || charCode === 0x0b || charCode === 0x0c
 }
 
 /** Iterate a BED file without materializing its decompressed text. */
@@ -98,7 +117,10 @@ export async function* readBedEntries(
       if (streamError !== null) throw streamError
       const entry = parseBedEntry(line)
       if (entry === null) {
-        if (options.rejectMalformedRows === true && !isIgnoredBedLine(line.trim())) {
+        if (
+          options.rejectMalformedRows === true &&
+          !isIgnoredBedFirstField(scanBedFields(line, 1)[0])
+        ) {
           throw new InvalidBedRowError(line)
         }
         continue

--- a/src/main/import/vcf/bed-reader.ts
+++ b/src/main/import/vcf/bed-reader.ts
@@ -9,6 +9,37 @@ export interface BedEntry {
   label?: string
 }
 
+/**
+ * Intentional object-memory budget for consumers that collect the stream.
+ * One million typical short chromosome/label entries occupy roughly
+ * 100-200 MiB in V8; together with the independent 256 MiB decompressed BED
+ * cap used by production callers, even adversarial retained strings keep the
+ * expected peak below roughly 1 GiB instead of allowing unbounded growth.
+ * The generous count still accommodates large capture/genome interval sets.
+ */
+export const MAX_BED_ENTRIES = 1_000_000
+
+export class BedEntryLimitExceededError extends Error {
+  constructor(maxEntries: number) {
+    super(`Refusing to read more than ${maxEntries} valid BED entries from a single file`)
+    this.name = 'BedEntryLimitExceededError'
+  }
+}
+
+export class InvalidBedRowError extends Error {
+  constructor(line: string) {
+    super(`Invalid BED row: ${line}`)
+    this.name = 'InvalidBedRowError'
+  }
+}
+
+export interface BedReaderOptions {
+  /** Override the production entry cap in focused tests. */
+  maxEntries?: number
+  /** Web region-file import preserves its fail-fast malformed-row behavior. */
+  rejectMalformedRows?: boolean
+}
+
 function isIgnoredBedLine(line: string): boolean {
   return (
     line === '' || line.startsWith('#') || line.startsWith('track') || line.startsWith('browser')
@@ -19,13 +50,13 @@ export function parseBedEntry(line: string): BedEntry | null {
   const trimmed = line.trim()
   if (isIgnoredBedLine(trimmed)) return null
 
-  const parts = trimmed.split('\t')
-  if (parts.length < 3) return null
+  const parts = trimmed.split(/\s+/u)
+  if (parts.length < 3 || parts[0] === '') return null
   if (!/^\d+$/.test(parts[1]) || !/^\d+$/.test(parts[2])) return null
 
   const start = Number(parts[1])
   const end = Number(parts[2])
-  if (!Number.isInteger(start) || !Number.isInteger(end) || end <= start) return null
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || end <= start) return null
 
   return {
     chr: parts[0],
@@ -38,8 +69,13 @@ export function parseBedEntry(line: string): BedEntry | null {
 /** Iterate a BED file without materializing its decompressed text. */
 export async function* readBedEntries(
   filePath: string,
-  maxDecompressedBytes: number
+  maxDecompressedBytes: number,
+  options: BedReaderOptions = {}
 ): AsyncGenerator<BedEntry, void, void> {
+  const maxEntries = options.maxEntries ?? MAX_BED_ENTRIES
+  if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
+    throw new TypeError('BED entry cap must be a positive safe integer')
+  }
   // Fail synchronously before createReadStream can emit an open error after a
   // rejected consumer has already settled. The size check also rejects a
   // plainly oversized BED before reading its sparse/zero-filled contents.
@@ -55,12 +91,21 @@ export async function* readBedEntries(
     lines.close()
   }
   stream.on('error', captureStreamError)
+  let entryCount = 0
 
   try {
     for await (const line of lines) {
       if (streamError !== null) throw streamError
       const entry = parseBedEntry(line)
-      if (entry !== null) yield entry
+      if (entry === null) {
+        if (options.rejectMalformedRows === true && !isIgnoredBedLine(line.trim())) {
+          throw new InvalidBedRowError(line)
+        }
+        continue
+      }
+      entryCount += 1
+      if (entryCount > maxEntries) throw new BedEntryLimitExceededError(maxEntries)
+      yield entry
     }
     if (streamError !== null) throw streamError
   } finally {

--- a/src/main/import/vcf/extension-parsers.ts
+++ b/src/main/import/vcf/extension-parsers.ts
@@ -1,3 +1,5 @@
+import { MAX_VCF_ALT_ALLELES, splitBounded } from './vcf-resource-limits'
+
 export interface SvExtensionRow {
   sv_is_precise: number
   cipos_left: number | null
@@ -61,7 +63,8 @@ function parseFloatOrNull(val: string | undefined): number | null {
 
 function parseCiInterval(val: string | undefined): [number | null, number | null] {
   if (val === undefined || val === '') return [null, null]
-  const parts = val.split(',')
+  const parts = splitBounded(val, ',', MAX_VCF_ALT_ALLELES + 1)
+  if (parts === null) return [null, null]
   if (parts.length !== 2) return [null, null]
   return [parseIntOrNull(parts[0]), parseIntOrNull(parts[1])]
 }
@@ -73,8 +76,12 @@ export function extractSvFields(
   const [ciposL, ciposR] = parseCiInterval(info.get('CIPOS'))
   const [ciendL, ciendR] = parseCiInterval(info.get('CIEND'))
 
-  const prParts = formatRaw.get('PR')?.split(',')
-  const srParts = formatRaw.get('SR')?.split(',')
+  const prValue = formatRaw.get('PR')
+  const srValue = formatRaw.get('SR')
+  const prParts =
+    prValue === undefined ? undefined : splitBounded(prValue, ',', MAX_VCF_ALT_ALLELES + 1)
+  const srParts =
+    srValue === undefined ? undefined : splitBounded(srValue, ',', MAX_VCF_ALT_ALLELES + 1)
 
   return {
     sv_is_precise: info.has('PRECISE') ? 1 : 0,
@@ -90,8 +97,14 @@ export function extractSvFields(
     vaf: parseFloatOrNull(info.get('VAF')),
     dr: parseIntOrNull(formatRaw.get('DR')),
     dv: parseIntOrNull(formatRaw.get('DV')),
-    pe_support: prParts !== undefined && prParts.length >= 2 ? parseIntOrNull(prParts[1]) : null,
-    sr_support: srParts !== undefined && srParts.length >= 2 ? parseIntOrNull(srParts[1]) : null,
+    pe_support:
+      prParts !== undefined && prParts !== null && prParts.length >= 2
+        ? parseIntOrNull(prParts[1])
+        : null,
+    sr_support:
+      srParts !== undefined && srParts !== null && srParts.length >= 2
+        ? parseIntOrNull(srParts[1])
+        : null,
     event_id: info.get('EVENT') ?? null,
     mate_id: info.get('MATEID') ?? null
   }
@@ -107,8 +120,8 @@ export function extractCnvFields(
   let hoAlt: number | null = null
   const hoVal = formatRaw.get('HO')
   if (hoVal !== undefined) {
-    const parts = hoVal.split(',')
-    if (parts.length >= 2) {
+    const parts = splitBounded(hoVal, ',', MAX_VCF_ALT_ALLELES + 1)
+    if (parts !== null && parts.length >= 2) {
       hoRef = parseFloatOrNull(parts[0])
       hoAlt = parseFloatOrNull(parts[1])
     }

--- a/src/main/import/vcf/vcf-allele-splitter.ts
+++ b/src/main/import/vcf/vcf-allele-splitter.ts
@@ -6,6 +6,22 @@
  */
 
 import type { VcfRawRecord, InfoFieldDef, FormatFieldDef } from './types'
+import {
+  MAX_VCF_ALT_ALLELES,
+  splitBounded,
+  splitGenotypeAlleles,
+  VcfResourceLimitError
+} from './vcf-resource-limits'
+
+function splitAlleleValues(value: string): string[] {
+  const parts = splitBounded(value, ',', MAX_VCF_ALT_ALLELES + 1)
+  if (parts === null) {
+    throw new VcfResourceLimitError(
+      `Allele-valued field has more than ${MAX_VCF_ALT_ALLELES + 1} values`
+    )
+  }
+  return parts
+}
 
 /**
  * Split a multi-allelic VcfRawRecord into one record per ALT allele.
@@ -69,7 +85,7 @@ function splitInfoFields(
 
       case 'A': {
         // Per-ALT allele — select value at altIdx
-        const parts = value.split(',')
+        const parts = splitAlleleValues(value)
         if (altIdx < parts.length) {
           result.set(key, parts[altIdx])
         } else {
@@ -80,7 +96,7 @@ function splitInfoFields(
 
       case 'R': {
         // Per-allele (REF + ALTs) — keep REF (index 0) + current ALT
-        const parts = value.split(',')
+        const parts = splitAlleleValues(value)
         if (parts.length > altIdx + 1) {
           result.set(key, `${parts[0]},${parts[altIdx + 1]}`)
         } else {
@@ -132,13 +148,13 @@ function splitSampleFields(
 
       if (number === 'R') {
         // Per-allele (REF + ALTs) — keep REF + current ALT
-        const parts = values[fIdx].split(',')
+        const parts = splitAlleleValues(values[fIdx])
         if (parts.length > altIdx + 1) {
           newValues[fIdx] = `${parts[0]},${parts[altIdx + 1]}`
         }
       } else if (number === 'A') {
         // Per-ALT — select value at altIdx
-        const parts = values[fIdx].split(',')
+        const parts = splitAlleleValues(values[fIdx])
         if (altIdx < parts.length) {
           newValues[fIdx] = parts[altIdx]
         }
@@ -165,7 +181,8 @@ function splitSampleFields(
 function remapGenotype(gt: string, originalAltAllele: number): string {
   // Determine separator
   const separator = gt.includes('|') ? '|' : '/'
-  const alleles = gt.split(/[/|]/)
+  const alleles = splitGenotypeAlleles(gt)
+  if (alleles === null) throw new VcfResourceLimitError('Genotype ploidy exceeds 64 alleles')
 
   const remapped = alleles.map((a) => {
     if (a === '.') return '.'

--- a/src/main/import/vcf/vcf-allele-splitter.ts
+++ b/src/main/import/vcf/vcf-allele-splitter.ts
@@ -64,6 +64,39 @@ export function splitMultiAllelic(
 }
 
 /**
+ * Build one biallelic view for one selected sample. Import mapping uses this
+ * instead of materializing every ALT × every sample clone up front.
+ */
+export function splitAlleleForSample(
+  record: VcfRawRecord,
+  infoDefs: Map<string, InfoFieldDef>,
+  formatDefs: Map<string, FormatFieldDef>,
+  altIdx: number,
+  sampleName: string
+): VcfRawRecord {
+  if (!Number.isSafeInteger(altIdx) || altIdx < 0 || altIdx >= record.alt.length) {
+    throw new RangeError(`ALT index ${altIdx} is outside the VCF record`)
+  }
+  const sampleValues = record.samples.get(sampleName)
+  const samples = new Map<string, string[]>()
+  if (sampleValues !== undefined) {
+    samples.set(sampleName, splitOneSampleFields(record.format, sampleValues, formatDefs, altIdx))
+  }
+  return {
+    chrom: record.chrom,
+    pos: record.pos,
+    id: record.id,
+    ref: record.ref,
+    alt: [record.alt[altIdx]],
+    qual: record.qual,
+    filter: record.filter,
+    info: splitInfoFields(record.info, infoDefs, altIdx),
+    format: record.format,
+    samples
+  }
+}
+
+/**
  * Split INFO fields according to their Number attribute.
  */
 function splitInfoFields(
@@ -129,43 +162,43 @@ function splitSampleFields(
   altIdx: number
 ): Map<string, string[]> {
   const result = new Map<string, string[]>()
-  const originalAltAllele = altIdx + 1 // 1-based allele number in GT
 
   for (const [sampleName, values] of record.samples) {
-    const newValues = [...values]
-
-    for (let fIdx = 0; fIdx < record.format.length; fIdx++) {
-      const field = record.format[fIdx]
-      if (fIdx >= values.length) break
-
-      if (field === 'GT') {
-        newValues[fIdx] = remapGenotype(values[fIdx], originalAltAllele)
-        continue
-      }
-
-      const def = formatDefs.get(field)
-      const number = def?.number ?? '.'
-
-      if (number === 'R') {
-        // Per-allele (REF + ALTs) — keep REF + current ALT
-        const parts = splitAlleleValues(values[fIdx])
-        if (parts.length > altIdx + 1) {
-          newValues[fIdx] = `${parts[0]},${parts[altIdx + 1]}`
-        }
-      } else if (number === 'A') {
-        // Per-ALT — select value at altIdx
-        const parts = splitAlleleValues(values[fIdx])
-        if (altIdx < parts.length) {
-          newValues[fIdx] = parts[altIdx]
-        }
-      }
-      // Number=1, 0, ., G: keep as-is
-    }
-
-    result.set(sampleName, newValues)
+    result.set(sampleName, splitOneSampleFields(record.format, values, formatDefs, altIdx))
   }
 
   return result
+}
+
+function splitOneSampleFields(
+  format: string[],
+  values: string[],
+  formatDefs: Map<string, FormatFieldDef>,
+  altIdx: number
+): string[] {
+  const newValues = [...values]
+  const originalAltAllele = altIdx + 1
+
+  for (let fIdx = 0; fIdx < format.length; fIdx++) {
+    const field = format[fIdx]
+    if (fIdx >= values.length) break
+
+    if (field === 'GT') {
+      newValues[fIdx] = remapGenotype(values[fIdx], originalAltAllele)
+      continue
+    }
+
+    const number = formatDefs.get(field)?.number ?? '.'
+    if (number === 'R') {
+      const parts = splitAlleleValues(values[fIdx])
+      if (parts.length > altIdx + 1) newValues[fIdx] = `${parts[0]},${parts[altIdx + 1]}`
+    } else if (number === 'A') {
+      const parts = splitAlleleValues(values[fIdx])
+      if (altIdx < parts.length) newValues[fIdx] = parts[altIdx]
+    }
+  }
+
+  return newValues
 }
 
 /**

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -7,6 +7,14 @@
 
 import type { VcfHeader, AnnotationResult } from './types'
 import type { TranscriptInsertRow } from '../../../shared/types/transcript'
+import {
+  MAX_VCF_ANNOTATION_CHARS,
+  MAX_VCF_ANNOTATION_FIELDS,
+  MAX_VCF_ANNOTATIONS,
+  MAX_VCF_TOTAL_ANNOTATION_VALUES,
+  splitBounded,
+  VcfResourceLimitError
+} from './vcf-resource-limits'
 
 /** Impact severity order for transcript selection */
 const IMPACT_ORDER: Record<string, number> = {
@@ -58,14 +66,32 @@ function parseCsq(
 ): AnnotationResult {
   const csqRaw = info.get('CSQ')
   if (csqRaw == null || csqRaw === '') return emptyResult()
+  if (csqRaw.length > MAX_VCF_ANNOTATION_CHARS) {
+    throw new VcfResourceLimitError(`CSQ annotation exceeds ${MAX_VCF_ANNOTATION_CHARS} characters`)
+  }
 
   // Split annotations by comma, then each by pipe
-  const annotations = csqRaw.split(',')
+  const annotations = splitBounded(csqRaw, ',', MAX_VCF_ANNOTATIONS)
+  if (annotations === null) {
+    throw new VcfResourceLimitError(`CSQ has more than ${MAX_VCF_ANNOTATIONS} annotations`)
+  }
   const parsed: CsqTranscript[] = []
+  let totalValues = 0
 
   for (const ann of annotations) {
     if (ann === '') continue
-    const parts = ann.split('|')
+    const parts = splitBounded(ann, '|', MAX_VCF_ANNOTATION_FIELDS)
+    if (parts === null) {
+      throw new VcfResourceLimitError(
+        `CSQ annotation has more than ${MAX_VCF_ANNOTATION_FIELDS} fields`
+      )
+    }
+    totalValues += parts.length
+    if (totalValues > MAX_VCF_TOTAL_ANNOTATION_VALUES) {
+      throw new VcfResourceLimitError(
+        `CSQ has more than ${MAX_VCF_TOTAL_ANNOTATION_VALUES} total values`
+      )
+    }
     const fields = new Map<string, string>()
 
     for (let i = 0; i < csqFieldNames.length && i < parts.length; i++) {
@@ -160,13 +186,31 @@ interface AnnTranscript {
 function parseAnn(info: Map<string, string>, altAllele: string, ref: string): AnnotationResult {
   const annRaw = info.get('ANN')
   if (annRaw == null || annRaw === '') return emptyResult()
+  if (annRaw.length > MAX_VCF_ANNOTATION_CHARS) {
+    throw new VcfResourceLimitError(`ANN annotation exceeds ${MAX_VCF_ANNOTATION_CHARS} characters`)
+  }
 
-  const annotations = annRaw.split(',')
+  const annotations = splitBounded(annRaw, ',', MAX_VCF_ANNOTATIONS)
+  if (annotations === null) {
+    throw new VcfResourceLimitError(`ANN has more than ${MAX_VCF_ANNOTATIONS} annotations`)
+  }
   const parsed: AnnTranscript[] = []
+  let totalValues = 0
 
   for (const ann of annotations) {
     if (ann === '') continue
-    const parts = ann.split('|')
+    const parts = splitBounded(ann, '|', MAX_VCF_ANNOTATION_FIELDS)
+    if (parts === null) {
+      throw new VcfResourceLimitError(
+        `ANN annotation has more than ${MAX_VCF_ANNOTATION_FIELDS} fields`
+      )
+    }
+    totalValues += parts.length
+    if (totalValues > MAX_VCF_TOTAL_ANNOTATION_VALUES) {
+      throw new VcfResourceLimitError(
+        `ANN has more than ${MAX_VCF_TOTAL_ANNOTATION_VALUES} total values`
+      )
+    }
     const allele = parts[ANN_ALLELE] ?? ''
     parsed.push({ parts, allele })
   }

--- a/src/main/import/vcf/vcf-annotation-parser.ts
+++ b/src/main/import/vcf/vcf-annotation-parser.ts
@@ -23,6 +23,7 @@ const IMPACT_ORDER: Record<string, number> = {
   LOW: 2,
   MODIFIER: 1
 }
+const MAX_VCF_TOTAL_ANNOTATION_MATCHES = 100_000
 
 /**
  * Parse annotations from VCF INFO fields.
@@ -40,15 +41,29 @@ export function parseAnnotation(
   altAllele: string,
   ref?: string
 ): AnnotationResult {
+  return parseAnnotationsForAlleles(info, header, [altAllele], ref)[0] ?? emptyResult()
+}
+
+/**
+ * Parse one annotation payload once and partition its transcripts across all
+ * ALT alleles. This keeps allocation proportional to the annotation payload
+ * plus matched transcripts instead of reparsing/rebuilding it for every ALT.
+ */
+export function parseAnnotationsForAlleles(
+  info: Map<string, string>,
+  header: VcfHeader,
+  altAlleles: string[],
+  ref = ''
+): AnnotationResult[] {
   if (header.annotationType === 'csq' && header.csqFields !== null) {
-    return parseCsq(info, header.csqFields, altAllele, ref ?? '')
+    return parseCsqForAlleles(info, header.csqFields, altAlleles, ref)
   }
 
   if (header.annotationType === 'ann') {
-    return parseAnn(info, altAllele, ref ?? '')
+    return parseAnnForAlleles(info, altAlleles, ref)
   }
 
-  return emptyResult()
+  return altAlleles.map(() => emptyResult())
 }
 
 // ── CSQ (VEP) Parser ─────────────────────────────────────────
@@ -58,14 +73,14 @@ interface CsqTranscript {
   allele: string
 }
 
-function parseCsq(
+function parseCsqForAlleles(
   info: Map<string, string>,
   csqFieldNames: string[],
-  altAllele: string,
+  altAlleles: string[],
   ref: string
-): AnnotationResult {
+): AnnotationResult[] {
   const csqRaw = info.get('CSQ')
-  if (csqRaw == null || csqRaw === '') return emptyResult()
+  if (csqRaw == null || csqRaw === '') return altAlleles.map(() => emptyResult())
   if (csqRaw.length > MAX_VCF_ANNOTATION_CHARS) {
     throw new VcfResourceLimitError(`CSQ annotation exceeds ${MAX_VCF_ANNOTATION_CHARS} characters`)
   }
@@ -104,9 +119,26 @@ function parseCsq(
     parsed.push({ fields, allele })
   }
 
-  // Filter by allele: VEP uses the ALT base for SNVs, "-" for deletions, inserted seq for insertions
-  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref))
+  // VEP uses the ALT base for SNVs, "-" for deletions, and inserted sequence
+  // for insertions. Partition the already-parsed transcript objects once.
+  const grouped = altAlleles.map(() => [] as CsqTranscript[])
+  const targetIndexes = buildAlleleTargetIndex(altAlleles, ref)
+  let totalMatches = 0
+  for (const transcript of parsed) {
+    for (const index of targetIndexes.get(transcript.allele) ?? []) {
+      totalMatches += 1
+      if (totalMatches > MAX_VCF_TOTAL_ANNOTATION_MATCHES) {
+        throw new VcfResourceLimitError(
+          `CSQ annotation matches exceed ${MAX_VCF_TOTAL_ANNOTATION_MATCHES}`
+        )
+      }
+      grouped[index].push(transcript)
+    }
+  }
+  return grouped.map(buildCsqResult)
+}
 
+function buildCsqResult(filtered: CsqTranscript[]): AnnotationResult {
   if (filtered.length === 0) return emptyResult()
 
   // Build TranscriptInsertRows, deduplicating by transcript_id
@@ -183,9 +215,13 @@ interface AnnTranscript {
   allele: string
 }
 
-function parseAnn(info: Map<string, string>, altAllele: string, ref: string): AnnotationResult {
+function parseAnnForAlleles(
+  info: Map<string, string>,
+  altAlleles: string[],
+  ref: string
+): AnnotationResult[] {
   const annRaw = info.get('ANN')
-  if (annRaw == null || annRaw === '') return emptyResult()
+  if (annRaw == null || annRaw === '') return altAlleles.map(() => emptyResult())
   if (annRaw.length > MAX_VCF_ANNOTATION_CHARS) {
     throw new VcfResourceLimitError(`ANN annotation exceeds ${MAX_VCF_ANNOTATION_CHARS} characters`)
   }
@@ -215,9 +251,24 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
     parsed.push({ parts, allele })
   }
 
-  // Filter by allele
-  const filtered = parsed.filter((t) => matchesAllele(t.allele, altAllele, ref))
+  const grouped = altAlleles.map(() => [] as AnnTranscript[])
+  const targetIndexes = buildAlleleTargetIndex(altAlleles, ref)
+  let totalMatches = 0
+  for (const transcript of parsed) {
+    for (const index of targetIndexes.get(transcript.allele) ?? []) {
+      totalMatches += 1
+      if (totalMatches > MAX_VCF_TOTAL_ANNOTATION_MATCHES) {
+        throw new VcfResourceLimitError(
+          `ANN annotation matches exceed ${MAX_VCF_TOTAL_ANNOTATION_MATCHES}`
+        )
+      }
+      grouped[index].push(transcript)
+    }
+  }
+  return grouped.map(buildAnnResult)
+}
 
+function buildAnnResult(filtered: AnnTranscript[]): AnnotationResult {
   if (filtered.length === 0) return emptyResult()
 
   // Build TranscriptInsertRows, deduplicating by transcript_id
@@ -266,18 +317,22 @@ function parseAnn(info: Map<string, string>, altAllele: string, ref: string): An
 
 // ── Shared helpers ───────────────────────────────────────────
 
-/**
- * Check if an annotation allele matches the target ALT allele.
- * VEP CSQ uses the VCF ALT bases for SNVs, "-" for deletions, inserted bases for insertions.
- * SnpEff ANN uses the full ALT allele string.
- */
-function matchesAllele(annAllele: string, altAllele: string, ref: string): boolean {
-  if (annAllele === altAllele) return true
-  // VEP deletion notation: "-" only matches when ALT is actually shorter than REF
-  if (annAllele === '-' && altAllele.length < ref.length) return true
-  // VEP insertion: the annotation Allele is the inserted bases (ALT minus first base)
-  if (altAllele.length > 1 && annAllele === altAllele.substring(1)) return true
-  return false
+/** Build every accepted annotation spelling once for O(ALT + annotation) grouping. */
+function buildAlleleTargetIndex(altAlleles: string[], ref: string): Map<string, number[]> {
+  const targets = new Map<string, number[]>()
+  const add = (allele: string, index: number): void => {
+    const existing = targets.get(allele)
+    if (existing === undefined) targets.set(allele, [index])
+    else if (existing[existing.length - 1] !== index) existing.push(index)
+  }
+
+  for (let index = 0; index < altAlleles.length; index += 1) {
+    const alt = altAlleles[index]
+    add(alt, index)
+    if (alt.length < ref.length) add('-', index)
+    if (alt.length > 1) add(alt.substring(1), index)
+  }
+  return targets
 }
 
 /**

--- a/src/main/import/vcf/vcf-genotype-parser.ts
+++ b/src/main/import/vcf/vcf-genotype-parser.ts
@@ -6,6 +6,7 @@
  */
 
 import type { GenotypeData } from './types'
+import { MAX_VCF_ALT_ALLELES, splitBounded, VcfResourceLimitError } from './vcf-resource-limits'
 
 /**
  * Parse genotype data from sample values using FORMAT field order.
@@ -46,7 +47,10 @@ export function parseGenotype(
   if (adIdx !== undefined && adIdx < sampleValues.length) {
     const adStr = sampleValues[adIdx]
     if (adStr !== '.' && adStr !== '') {
-      const adParts = adStr.split(',')
+      const adParts = splitBounded(adStr, ',', MAX_VCF_ALT_ALLELES + 1)
+      if (adParts === null) {
+        throw new VcfResourceLimitError(`AD has more than ${MAX_VCF_ALT_ALLELES + 1} allele depths`)
+      }
       if (adParts.length >= 2) {
         const refVal = parseInt(adParts[0], 10)
         const altVal = parseInt(adParts[altAlleleIndex] || adParts[1], 10)

--- a/src/main/import/vcf/vcf-header-limits.ts
+++ b/src/main/import/vcf/vcf-header-limits.ts
@@ -1,0 +1,60 @@
+export const DEFAULT_MAX_VCF_HEADER_BYTES = 16 * 1024 * 1024
+export const DEFAULT_MAX_VCF_HEADER_LINES = 100_000
+
+const MAX_HEADER_BYTES_ENV = 'VARLENS_VCF_MAX_HEADER_BYTES'
+const MAX_HEADER_LINES_ENV = 'VARLENS_VCF_MAX_HEADER_LINES'
+
+function resolvePositiveLimit(
+  value: number | undefined,
+  envName: string,
+  fallback: number
+): number {
+  if (value !== undefined) return value
+  const parsed = Number(process.env[envName])
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export interface VcfHeaderLimitOptions {
+  maxHeaderBytes?: number
+  maxHeaderLines?: number
+}
+
+export class VcfHeaderLimitExceededError extends Error {
+  constructor(kind: 'bytes' | 'lines', maximum: number) {
+    super(`Refusing to parse a VCF header exceeding ${maximum} ${kind}`)
+    this.name = 'VcfHeaderLimitExceededError'
+  }
+}
+
+/** Independent budget for accumulated VCF metadata, separate from file/line caps. */
+export class VcfHeaderBudget {
+  private bytes = 0
+  private lines = 0
+  private readonly maxBytes: number
+  private readonly maxLines: number
+
+  constructor(options: VcfHeaderLimitOptions = {}) {
+    this.maxBytes = resolvePositiveLimit(
+      options.maxHeaderBytes,
+      MAX_HEADER_BYTES_ENV,
+      DEFAULT_MAX_VCF_HEADER_BYTES
+    )
+    this.maxLines = resolvePositiveLimit(
+      options.maxHeaderLines,
+      MAX_HEADER_LINES_ENV,
+      DEFAULT_MAX_VCF_HEADER_LINES
+    )
+  }
+
+  add(line: string): void {
+    this.lines += 1
+    if (this.lines > this.maxLines) {
+      throw new VcfHeaderLimitExceededError('lines', this.maxLines)
+    }
+
+    this.bytes += Buffer.byteLength(line, 'utf8') + 1
+    if (this.bytes > this.maxBytes) {
+      throw new VcfHeaderLimitExceededError('bytes', this.maxBytes)
+    }
+  }
+}

--- a/src/main/import/vcf/vcf-header-parser.ts
+++ b/src/main/import/vcf/vcf-header-parser.ts
@@ -10,6 +10,14 @@ import { createCappedLineStream } from '../stream-utils'
 import { detectGenomeBuildFromVcfHeaders } from '../../services/GenomeBuildDetector'
 import type { VcfHeader, InfoFieldDef, FormatFieldDef, ContigDef, AnnotationType } from './types'
 import { VcfHeaderBudget, type VcfHeaderLimitOptions } from './vcf-header-limits'
+import {
+  MAX_VCF_ANNOTATION_FIELDS,
+  MAX_VCF_COLUMNS,
+  MAX_VCF_STRUCTURED_HEADER_CHARS,
+  MAX_VCF_STRUCTURED_HEADER_FIELDS,
+  splitBounded,
+  VcfResourceLimitError
+} from './vcf-resource-limits'
 
 /** Parse result includes the header and optionally the first data line */
 export interface VcfHeaderParseResult {
@@ -22,12 +30,18 @@ export interface VcfHeaderParseResult {
  * Handles: ##INFO=<ID=X,Number=Y,Type=Z,Description="...">
  */
 function parseStructuredLine(line: string): Record<string, string> | null {
+  if (line.length > MAX_VCF_STRUCTURED_HEADER_CHARS) {
+    throw new VcfResourceLimitError(
+      `Structured VCF header line exceeds ${MAX_VCF_STRUCTURED_HEADER_CHARS} characters`
+    )
+  }
   const match = line.match(/^##\w+=<(.+)>$/)
   if (!match) return null
 
   const result: Record<string, string> = {}
   const content = match[1]
   let i = 0
+  let fieldCount = 0
 
   while (i < content.length) {
     // Find key
@@ -35,6 +49,12 @@ function parseStructuredLine(line: string): Record<string, string> | null {
     if (eqIdx === -1) break
 
     const key = content.substring(i, eqIdx)
+    fieldCount += 1
+    if (fieldCount > MAX_VCF_STRUCTURED_HEADER_FIELDS) {
+      throw new VcfResourceLimitError(
+        `Structured VCF header has more than ${MAX_VCF_STRUCTURED_HEADER_FIELDS} fields`
+      )
+    }
     i = eqIdx + 1
 
     // Find value
@@ -81,7 +101,13 @@ function extractCsqFields(description: string): string[] | null {
   const match = description.match(/Format:\s*(.+)/)
   if (!match) return null
 
-  return match[1].split('|').map((f) => f.trim())
+  const fields = splitBounded(match[1], '|', MAX_VCF_ANNOTATION_FIELDS)
+  if (fields === null) {
+    throw new VcfResourceLimitError(
+      `CSQ header has more than ${MAX_VCF_ANNOTATION_FIELDS} format fields`
+    )
+  }
+  return fields.map((field) => field.trim())
 }
 
 /**
@@ -156,7 +182,10 @@ export function parseVcfHeaderFromLines(lines: string[]): VcfHeader {
       }
     } else if (line.startsWith('#CHROM')) {
       // #CHROM line — extract sample names from columns 10+
-      const cols = line.split('\t')
+      const cols = splitBounded(line, '\t', MAX_VCF_COLUMNS)
+      if (cols === null) {
+        throw new VcfResourceLimitError(`#CHROM header has more than ${MAX_VCF_COLUMNS} columns`)
+      }
       if (cols.length > 9) {
         for (let i = 9; i < cols.length; i++) {
           samples.push(cols[i].trim())

--- a/src/main/import/vcf/vcf-header-parser.ts
+++ b/src/main/import/vcf/vcf-header-parser.ts
@@ -5,10 +5,8 @@
  * Extracts sample names, INFO/FORMAT definitions, contigs, and annotation type.
  */
 
-import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
-import { createGunzip } from 'node:zlib'
-import { isGzipped } from '../stream-utils'
+import { createCappedLineStream } from '../stream-utils'
 import { detectGenomeBuildFromVcfHeaders } from '../../services/GenomeBuildDetector'
 import type { VcfHeader, InfoFieldDef, FormatFieldDef, ContigDef, AnnotationType } from './types'
 
@@ -197,8 +195,9 @@ export function parseVcfHeaderFromLines(lines: string[]): VcfHeader {
  */
 export async function parseVcfHeader(filePath: string): Promise<VcfHeaderParseResult> {
   return new Promise((resolve, reject) => {
-    const raw = createReadStream(filePath)
-    const stream = isGzipped(filePath) ? raw.pipe(createGunzip()) : raw
+    // Shared capped reader guards against a giant single line and a
+    // decompression bomb -- see stream-utils.ts for the cap rationale.
+    const { stream } = createCappedLineStream(filePath)
 
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
 

--- a/src/main/import/vcf/vcf-header-parser.ts
+++ b/src/main/import/vcf/vcf-header-parser.ts
@@ -9,6 +9,7 @@ import { createInterface } from 'node:readline'
 import { createCappedLineStream } from '../stream-utils'
 import { detectGenomeBuildFromVcfHeaders } from '../../services/GenomeBuildDetector'
 import type { VcfHeader, InfoFieldDef, FormatFieldDef, ContigDef, AnnotationType } from './types'
+import { VcfHeaderBudget, type VcfHeaderLimitOptions } from './vcf-header-limits'
 
 /** Parse result includes the header and optionally the first data line */
 export interface VcfHeaderParseResult {
@@ -193,7 +194,10 @@ export function parseVcfHeaderFromLines(lines: string[]): VcfHeader {
  * Reads lines until the first non-# line, then returns the header
  * and the first data line (so the caller doesn't miss it).
  */
-export async function parseVcfHeader(filePath: string): Promise<VcfHeaderParseResult> {
+export async function parseVcfHeader(
+  filePath: string,
+  options: VcfHeaderLimitOptions = {}
+): Promise<VcfHeaderParseResult> {
   return new Promise((resolve, reject) => {
     // Shared capped reader guards against a giant single line and a
     // decompression bomb -- see stream-utils.ts for the cap rationale.
@@ -202,44 +206,47 @@ export async function parseVcfHeader(filePath: string): Promise<VcfHeaderParseRe
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
     const headerLines: string[] = []
+    const headerBudget = new VcfHeaderBudget(options)
     let firstDataLine: string | null = null
-    let resolved = false
+    let settled = false
 
-    rl.on('line', (line: string) => {
-      if (line.startsWith('#')) {
-        headerLines.push(line)
-      } else {
-        // First non-header line
-        firstDataLine = line
-        resolved = true
-        rl.close()
-      }
-    })
+    const cleanup = (): void => {
+      rl.close()
+      stream.destroy()
+    }
 
-    rl.on('close', () => {
-      if (!resolved) {
-        resolved = true
+    const settle = (error?: unknown): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (error !== undefined) {
+        reject(error)
+        return
       }
       try {
-        const header = parseVcfHeaderFromLines(headerLines)
-        resolve({ header, firstDataLine })
-      } catch (error) {
-        reject(error)
+        resolve({ header: parseVcfHeaderFromLines(headerLines), firstDataLine })
+      } catch (parseError) {
+        reject(parseError)
+      }
+    }
+
+    rl.on('line', (line: string) => {
+      if (settled) return
+      if (line.startsWith('#')) {
+        try {
+          headerBudget.add(line)
+          headerLines.push(line)
+        } catch (error) {
+          settle(error)
+        }
+      } else {
+        firstDataLine = line
+        settle()
       }
     })
 
-    rl.on('error', (error) => {
-      if (!resolved) {
-        resolved = true
-        reject(error)
-      }
-    })
-
-    stream.on('error', (error) => {
-      if (!resolved) {
-        resolved = true
-        reject(error)
-      }
-    })
+    rl.on('close', () => settle())
+    rl.on('error', settle)
+    stream.on('error', settle)
   })
 }

--- a/src/main/import/vcf/vcf-header-parser.ts
+++ b/src/main/import/vcf/vcf-header-parser.ts
@@ -12,7 +12,7 @@ import type { VcfHeader, InfoFieldDef, FormatFieldDef, ContigDef, AnnotationType
 import { VcfHeaderBudget, type VcfHeaderLimitOptions } from './vcf-header-limits'
 import {
   MAX_VCF_ANNOTATION_FIELDS,
-  MAX_VCF_COLUMNS,
+  MAX_VCF_HEADER_SAMPLES,
   MAX_VCF_STRUCTURED_HEADER_CHARS,
   MAX_VCF_STRUCTURED_HEADER_FIELDS,
   splitBounded,
@@ -23,6 +23,35 @@ import {
 export interface VcfHeaderParseResult {
   header: VcfHeader
   firstDataLine: string | null
+}
+
+/**
+ * Scan the #CHROM row without splitting a potentially tab-dense line into an
+ * unbounded temporary array. The header byte budget bounds string storage;
+ * this independent token budget bounds per-sample JS allocation overhead.
+ */
+function parseHeaderSamples(line: string): string[] {
+  const samples: string[] = []
+  let columnIndex = 0
+  let cursor = 0
+
+  while (cursor <= line.length) {
+    const delimiter = line.indexOf('\t', cursor)
+    const end = delimiter === -1 ? line.length : delimiter
+    if (columnIndex >= 9) {
+      if (samples.length >= MAX_VCF_HEADER_SAMPLES) {
+        throw new VcfResourceLimitError(
+          `#CHROM header has more than ${MAX_VCF_HEADER_SAMPLES} samples`
+        )
+      }
+      samples.push(line.slice(cursor, end).trim())
+    }
+    columnIndex += 1
+    if (delimiter === -1) break
+    cursor = delimiter + 1
+  }
+
+  return samples
 }
 
 /**
@@ -182,15 +211,7 @@ export function parseVcfHeaderFromLines(lines: string[]): VcfHeader {
       }
     } else if (line.startsWith('#CHROM')) {
       // #CHROM line — extract sample names from columns 10+
-      const cols = splitBounded(line, '\t', MAX_VCF_COLUMNS)
-      if (cols === null) {
-        throw new VcfResourceLimitError(`#CHROM header has more than ${MAX_VCF_COLUMNS} columns`)
-      }
-      if (cols.length > 9) {
-        for (let i = 9; i < cols.length; i++) {
-          samples.push(cols[i].trim())
-        }
-      }
+      samples.push(...parseHeaderSamples(line))
     }
   }
 

--- a/src/main/import/vcf/vcf-line-parser.ts
+++ b/src/main/import/vcf/vcf-line-parser.ts
@@ -7,6 +7,8 @@
 
 import type { VcfRawRecord } from './types'
 
+const QUAL_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+
 /**
  * Parse a single VCF data line into a raw record.
  *
@@ -61,8 +63,8 @@ export function parseVcfLine(
   // spec, so a bad value doesn't invalidate the record.
   let qual: number | null = null
   if (rawQual !== '.' && rawQual !== undefined) {
-    const parsedQual = Number.parseFloat(rawQual)
-    qual = Number.isNaN(parsedQual) ? null : parsedQual
+    const parsedQual = QUAL_NUMBER_PATTERN.test(rawQual) ? Number(rawQual) : Number.NaN
+    qual = Number.isFinite(parsedQual) ? parsedQual : null
   }
 
   // Parse INFO: semicolon-separated key=value pairs

--- a/src/main/import/vcf/vcf-line-parser.ts
+++ b/src/main/import/vcf/vcf-line-parser.ts
@@ -46,9 +46,9 @@ export function parseVcfLine(
   // (non-numeric, zero, negative, or fractional) is rejected outright rather
   // than allowed to flow forward as `NaN` — a NaN row would otherwise pass
   // silently through downstream mapping/insert paths.
-  const pos = Number.parseInt(rawPos, 10)
-  if (!Number.isInteger(pos) || pos <= 0 || !/^\d+$/.test(rawPos)) {
-    onSkip?.(`invalid POS "${rawPos}" (must be a positive integer)`)
+  const pos = Number(rawPos)
+  if (!Number.isSafeInteger(pos) || pos <= 0 || !/^\d+$/.test(rawPos)) {
+    onSkip?.(`invalid POS "${rawPos}" (must be a positive safe integer)`)
     return null
   }
 
@@ -58,13 +58,17 @@ export function parseVcfLine(
   // Parse ALT: comma-separated alleles
   const alt = rawAlt.split(',')
 
-  // Parse QUAL: "." (or absent) means missing; a malformed (non-numeric)
-  // QUAL becomes `null` rather than `NaN` — QUAL is optional per the VCF
-  // spec, so a bad value doesn't invalidate the record.
+  // Parse QUAL: "." (or absent) means missing. Any other value must be a
+  // complete finite number; malformed QUAL is a reasoned record skip rather
+  // than being silently reinterpreted as the semantically distinct ".".
   let qual: number | null = null
   if (rawQual !== '.' && rawQual !== undefined) {
     const parsedQual = QUAL_NUMBER_PATTERN.test(rawQual) ? Number(rawQual) : Number.NaN
-    qual = Number.isFinite(parsedQual) ? parsedQual : null
+    if (!Number.isFinite(parsedQual)) {
+      onSkip?.(`invalid QUAL "${rawQual}" (must be "." or a finite number)`)
+      return null
+    }
+    qual = parsedQual
   }
 
   // Parse INFO: semicolon-separated key=value pairs

--- a/src/main/import/vcf/vcf-line-parser.ts
+++ b/src/main/import/vcf/vcf-line-parser.ts
@@ -6,6 +6,16 @@
  */
 
 import type { VcfRawRecord } from './types'
+import {
+  MAX_VCF_ALT_ALLELES,
+  MAX_VCF_COLUMNS,
+  MAX_VCF_FORMAT_FIELDS,
+  MAX_VCF_INFO_CHARS,
+  MAX_VCF_INFO_FIELDS,
+  MAX_VCF_SAMPLE_FIELD_CHARS,
+  MAX_VCF_TOTAL_SAMPLE_VALUES,
+  splitBounded
+} from './vcf-resource-limits'
 
 const QUAL_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
 
@@ -25,10 +35,15 @@ export function parseVcfLine(
   sampleNames: string[],
   onSkip?: (reason: string) => void
 ): VcfRawRecord | null {
-  const cols = line.split('\t')
+  const cols = splitBounded(line, '\t', MAX_VCF_COLUMNS)
+  if (cols === null) {
+    onSkip?.(`too many VCF columns (maximum ${MAX_VCF_COLUMNS})`)
+    return null
+  }
 
   // VCF requires at least 8 fixed columns (CHROM through INFO)
   if (cols.length < 8) {
+    onSkip?.(`truncated VCF row (${cols.length} columns; expected at least 8)`)
     return null
   }
 
@@ -56,7 +71,11 @@ export function parseVcfLine(
   const id = rawId === '.' ? null : rawId
 
   // Parse ALT: comma-separated alleles
-  const alt = rawAlt.split(',')
+  const alt = splitBounded(rawAlt, ',', MAX_VCF_ALT_ALLELES)
+  if (alt === null) {
+    onSkip?.(`too many ALT alleles (maximum ${MAX_VCF_ALT_ALLELES})`)
+    return null
+  }
 
   // Parse QUAL: "." (or absent) means missing. Any other value must be a
   // complete finite number; malformed QUAL is a reasoned record skip rather
@@ -74,7 +93,15 @@ export function parseVcfLine(
   // Parse INFO: semicolon-separated key=value pairs
   const info = new Map<string, string>()
   if (rawInfo !== '.' && rawInfo !== undefined && rawInfo !== '') {
-    const infoParts = rawInfo.split(';')
+    if (rawInfo.length > MAX_VCF_INFO_CHARS) {
+      onSkip?.(`INFO field exceeds ${MAX_VCF_INFO_CHARS} characters`)
+      return null
+    }
+    const infoParts = splitBounded(rawInfo, ';', MAX_VCF_INFO_FIELDS)
+    if (infoParts === null) {
+      onSkip?.(`too many INFO fields (maximum ${MAX_VCF_INFO_FIELDS})`)
+      return null
+    }
     for (const part of infoParts) {
       const eqIdx = part.indexOf('=')
       if (eqIdx === -1) {
@@ -91,12 +118,32 @@ export function parseVcfLine(
   const samples = new Map<string, string[]>()
 
   if (cols.length > 8 && cols[8] !== undefined && cols[8] !== '') {
-    format = cols[8].split(':')
+    const parsedFormat = splitBounded(cols[8], ':', MAX_VCF_FORMAT_FIELDS)
+    if (parsedFormat === null) {
+      onSkip?.(`too many FORMAT fields (maximum ${MAX_VCF_FORMAT_FIELDS})`)
+      return null
+    }
+    format = parsedFormat
 
+    let totalSampleValues = 0
     for (let i = 0; i < sampleNames.length; i++) {
       const sampleCol = cols[9 + i]
       if (sampleCol !== undefined) {
-        samples.set(sampleNames[i], sampleCol.split(':'))
+        if (sampleCol.length > MAX_VCF_SAMPLE_FIELD_CHARS) {
+          onSkip?.(`sample field exceeds ${MAX_VCF_SAMPLE_FIELD_CHARS} characters`)
+          return null
+        }
+        const values = splitBounded(sampleCol, ':', MAX_VCF_FORMAT_FIELDS)
+        if (values === null) {
+          onSkip?.(`too many sample FORMAT values (maximum ${MAX_VCF_FORMAT_FIELDS})`)
+          return null
+        }
+        totalSampleValues += values.length
+        if (totalSampleValues > MAX_VCF_TOTAL_SAMPLE_VALUES) {
+          onSkip?.(`too many sample FORMAT values (maximum ${MAX_VCF_TOTAL_SAMPLE_VALUES})`)
+          return null
+        }
+        samples.set(sampleNames[i], values)
       }
     }
   }

--- a/src/main/import/vcf/vcf-line-parser.ts
+++ b/src/main/import/vcf/vcf-line-parser.ts
@@ -8,16 +8,33 @@
 import type { VcfRawRecord } from './types'
 import {
   MAX_VCF_ALT_ALLELES,
-  MAX_VCF_COLUMNS,
+  MAX_VCF_COMPATIBILITY_SAMPLES,
+  MAX_VCF_FORMAT_CHARS,
   MAX_VCF_FORMAT_FIELDS,
   MAX_VCF_INFO_CHARS,
   MAX_VCF_INFO_FIELDS,
   MAX_VCF_SAMPLE_FIELD_CHARS,
-  MAX_VCF_TOTAL_SAMPLE_VALUES,
   splitBounded
 } from './vcf-resource-limits'
 
 const QUAL_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+
+export interface VcfSelectedSampleColumn {
+  name: string
+  index: number
+}
+
+export function resolveVcfSelectedSampleColumn(
+  sampleNames: string[],
+  requestedSample?: string
+): VcfSelectedSampleColumn | null {
+  const name =
+    requestedSample !== undefined && requestedSample !== '' ? requestedSample : sampleNames[0]
+  if (name === undefined || name === '') return null
+  const index = sampleNames.indexOf(name)
+  if (index < 0) throw new Error(`Selected VCF sample "${name}" is not present in the header`)
+  return { name, index }
+}
 
 /**
  * Parse a single VCF data line into a raw record.
@@ -33,11 +50,34 @@ const QUAL_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
 export function parseVcfLine(
   line: string,
   sampleNames: string[],
-  onSkip?: (reason: string) => void
+  onSkip?: (reason: string) => void,
+  selectedSample?: VcfSelectedSampleColumn
 ): VcfRawRecord | null {
-  const cols = splitBounded(line, '\t', MAX_VCF_COLUMNS)
-  if (cols === null) {
-    onSkip?.(`too many VCF columns (maximum ${MAX_VCF_COLUMNS})`)
+  if (selectedSample === undefined && sampleNames.length > MAX_VCF_COMPATIBILITY_SAMPLES) {
+    onSkip?.(
+      `all-samples compatibility parsing exceeds ${MAX_VCF_COMPATIBILITY_SAMPLES} samples; select one sample`
+    )
+    return null
+  }
+  if (
+    selectedSample !== undefined &&
+    (!Number.isSafeInteger(selectedSample.index) ||
+      selectedSample.index < 0 ||
+      sampleNames[selectedSample.index] !== selectedSample.name)
+  ) {
+    onSkip?.(`selected VCF sample "${selectedSample.name}" is not present in the header`)
+    return null
+  }
+  const selectedSampleIndex = selectedSample?.index ?? -1
+  const {
+    fixedColumns: cols,
+    selectedColumn,
+    remainingColumns
+  } = scanVcfColumns(line, selectedSampleIndex)
+  if (remainingColumns === null) {
+    onSkip?.(
+      `all-samples compatibility parsing exceeds ${MAX_VCF_COMPATIBILITY_SAMPLES} sample columns`
+    )
     return null
   }
 
@@ -118,6 +158,10 @@ export function parseVcfLine(
   const samples = new Map<string, string[]>()
 
   if (cols.length > 8 && cols[8] !== undefined && cols[8] !== '') {
+    if (cols[8].length > MAX_VCF_FORMAT_CHARS) {
+      onSkip?.(`FORMAT field exceeds ${MAX_VCF_FORMAT_CHARS} characters`)
+      return null
+    }
     const parsedFormat = splitBounded(cols[8], ':', MAX_VCF_FORMAT_FIELDS)
     if (parsedFormat === null) {
       onSkip?.(`too many FORMAT fields (maximum ${MAX_VCF_FORMAT_FIELDS})`)
@@ -125,9 +169,12 @@ export function parseVcfLine(
     }
     format = parsedFormat
 
-    let totalSampleValues = 0
-    for (let i = 0; i < sampleNames.length; i++) {
-      const sampleCol = cols[9 + i]
+    const samplesToParse: Array<{ name: string; value: string | undefined }> =
+      selectedSample !== undefined
+        ? [{ name: selectedSample.name, value: selectedColumn }]
+        : sampleNames.map((name, index) => ({ name, value: remainingColumns[index] }))
+
+    for (const { name, value: sampleCol } of samplesToParse) {
       if (sampleCol !== undefined) {
         if (sampleCol.length > MAX_VCF_SAMPLE_FIELD_CHARS) {
           onSkip?.(`sample field exceeds ${MAX_VCF_SAMPLE_FIELD_CHARS} characters`)
@@ -138,12 +185,10 @@ export function parseVcfLine(
           onSkip?.(`too many sample FORMAT values (maximum ${MAX_VCF_FORMAT_FIELDS})`)
           return null
         }
-        totalSampleValues += values.length
-        if (totalSampleValues > MAX_VCF_TOTAL_SAMPLE_VALUES) {
-          onSkip?.(`too many sample FORMAT values (maximum ${MAX_VCF_TOTAL_SAMPLE_VALUES})`)
-          return null
-        }
-        samples.set(sampleNames[i], values)
+        samples.set(name, values)
+      } else if (selectedSample !== undefined) {
+        onSkip?.(`VCF row is missing selected sample column "${selectedSample.name}"`)
+        return null
       }
     }
   }
@@ -159,5 +204,63 @@ export function parseVcfLine(
     info,
     format,
     samples
+  }
+}
+
+/**
+ * Read the nine fixed/FORMAT fields plus at most one selected sample column.
+ * Production importers always provide a selected sample, so cohort-width does
+ * not create a cohort-width array or sample map. The compatibility path that
+ * omits a selected sample retains all remaining columns for small direct users.
+ */
+function scanVcfColumns(
+  line: string,
+  selectedSampleIndex: number
+): {
+  fixedColumns: string[]
+  selectedColumn: string | undefined
+  remainingColumns: string[] | null
+} {
+  const fixedColumns: string[] = []
+  let cursor = 0
+
+  while (fixedColumns.length < 9 && cursor <= line.length) {
+    const delimiter = line.indexOf('\t', cursor)
+    if (delimiter === -1) {
+      fixedColumns.push(line.slice(cursor))
+      cursor = line.length + 1
+      break
+    }
+    fixedColumns.push(line.slice(cursor, delimiter))
+    cursor = delimiter + 1
+  }
+
+  if (selectedSampleIndex >= 0) {
+    let sampleIndex = 0
+    while (cursor <= line.length) {
+      const delimiter = line.indexOf('\t', cursor)
+      const end = delimiter === -1 ? line.length : delimiter
+      if (sampleIndex === selectedSampleIndex) {
+        return {
+          fixedColumns,
+          selectedColumn: line.slice(cursor, end),
+          remainingColumns: []
+        }
+      }
+      if (delimiter === -1) break
+      cursor = delimiter + 1
+      sampleIndex += 1
+    }
+    return { fixedColumns, selectedColumn: undefined, remainingColumns: [] }
+  }
+
+  const remainingColumns =
+    cursor <= line.length
+      ? splitBounded(line.slice(cursor), '\t', MAX_VCF_COMPATIBILITY_SAMPLES)
+      : []
+  return {
+    fixedColumns,
+    selectedColumn: undefined,
+    remainingColumns
   }
 }

--- a/src/main/import/vcf/vcf-line-parser.ts
+++ b/src/main/import/vcf/vcf-line-parser.ts
@@ -12,9 +12,17 @@ import type { VcfRawRecord } from './types'
  *
  * @param line - Tab-separated VCF data line (non-header, non-comment)
  * @param sampleNames - Sample names from the VCF header (#CHROM line columns 10+)
- * @returns Parsed raw record
+ * @param onSkip - Optional callback invoked with a human-readable reason when
+ *   the line is rejected. Callers with a diagnostics/errors channel should
+ *   wire this through so a malformed line is a *counted, reasoned* skip
+ *   rather than a silent one.
+ * @returns Parsed raw record, or `null` if the line is rejected
  */
-export function parseVcfLine(line: string, sampleNames: string[]): VcfRawRecord | null {
+export function parseVcfLine(
+  line: string,
+  sampleNames: string[],
+  onSkip?: (reason: string) => void
+): VcfRawRecord | null {
   const cols = line.split('\t')
 
   // VCF requires at least 8 fixed columns (CHROM through INFO)
@@ -24,7 +32,7 @@ export function parseVcfLine(line: string, sampleNames: string[]): VcfRawRecord 
 
   // VCF has 8 fixed columns, optionally FORMAT + sample columns
   const chrom = cols[0]
-  const pos = parseInt(cols[1], 10)
+  const rawPos = cols[1]
   const rawId = cols[2]
   const ref = cols[3]
   const rawAlt = cols[4]
@@ -32,14 +40,30 @@ export function parseVcfLine(line: string, sampleNames: string[]): VcfRawRecord 
   const filter = cols[6]
   const rawInfo = cols[7]
 
+  // Parse POS: must be a positive integer per the VCF spec. A malformed POS
+  // (non-numeric, zero, negative, or fractional) is rejected outright rather
+  // than allowed to flow forward as `NaN` — a NaN row would otherwise pass
+  // silently through downstream mapping/insert paths.
+  const pos = Number.parseInt(rawPos, 10)
+  if (!Number.isInteger(pos) || pos <= 0 || !/^\d+$/.test(rawPos)) {
+    onSkip?.(`invalid POS "${rawPos}" (must be a positive integer)`)
+    return null
+  }
+
   // Parse ID: "." means missing
   const id = rawId === '.' ? null : rawId
 
   // Parse ALT: comma-separated alleles
   const alt = rawAlt.split(',')
 
-  // Parse QUAL: "." means missing
-  const qual = rawQual === '.' || rawQual === undefined ? null : parseFloat(rawQual)
+  // Parse QUAL: "." (or absent) means missing; a malformed (non-numeric)
+  // QUAL becomes `null` rather than `NaN` — QUAL is optional per the VCF
+  // spec, so a bad value doesn't invalidate the record.
+  let qual: number | null = null
+  if (rawQual !== '.' && rawQual !== undefined) {
+    const parsedQual = Number.parseFloat(rawQual)
+    qual = Number.isNaN(parsedQual) ? null : parsedQual
+  }
 
   // Parse INFO: semicolon-separated key=value pairs
   const info = new Map<string, string>()

--- a/src/main/import/vcf/vcf-preview.ts
+++ b/src/main/import/vcf/vcf-preview.ts
@@ -12,6 +12,7 @@ import { getFieldColumnMapping, DEFAULT_INFO_FIELD_MAPPINGS } from './info-field
 import { detectCaller } from './caller-detector'
 import type { VcfPreviewResult } from './types'
 import type { VcfMultiPreviewResult } from '../../../shared/types/import'
+import { VcfHeaderBudget } from './vcf-header-limits'
 
 /** Maximum number of data lines to count before estimating via file size */
 const MAX_COUNTED_LINES = 100_000
@@ -33,6 +34,7 @@ export async function getVcfPreview(filePath: string): Promise<VcfPreviewResult>
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
     const headerLines: string[] = []
+    const headerBudget = new VcfHeaderBudget()
     let dataLineCount = 0
     let bytesReadAtCap = 0
     let capped = false
@@ -40,7 +42,17 @@ export async function getVcfPreview(filePath: string): Promise<VcfPreviewResult>
 
     rl.on('line', (line: string) => {
       if (line.startsWith('#')) {
-        headerLines.push(line)
+        try {
+          headerBudget.add(line)
+          headerLines.push(line)
+        } catch (error) {
+          if (!resolved) {
+            resolved = true
+            rl.close()
+            stream.destroy()
+            reject(error)
+          }
+        }
       } else {
         dataLineCount++
         if (dataLineCount >= MAX_COUNTED_LINES) {
@@ -55,6 +67,7 @@ export async function getVcfPreview(filePath: string): Promise<VcfPreviewResult>
     rl.on('close', () => {
       if (resolved) return
       resolved = true
+      stream.destroy()
 
       try {
         const header = parseVcfHeaderFromLines(headerLines)

--- a/src/main/import/vcf/vcf-preview.ts
+++ b/src/main/import/vcf/vcf-preview.ts
@@ -3,11 +3,10 @@
  * Reads only headers + counts data lines without full parsing.
  */
 
-import { createReadStream, statSync, readdirSync } from 'node:fs'
+import { statSync, readdirSync } from 'node:fs'
 import { dirname, basename, extname, resolve as pathResolve } from 'node:path'
 import { createInterface } from 'node:readline'
-import { createGunzip } from 'node:zlib'
-import { isGzipped } from '../stream-utils'
+import { createCappedLineStream } from '../stream-utils'
 import { parseVcfHeaderFromLines } from './vcf-header-parser'
 import { getFieldColumnMapping, DEFAULT_INFO_FIELD_MAPPINGS } from './info-field-registry'
 import { detectCaller } from './caller-detector'
@@ -22,13 +21,14 @@ const MAX_COUNTED_LINES = 100_000
  * Reads headers for metadata and counts data lines for variant estimate.
  */
 export async function getVcfPreview(filePath: string): Promise<VcfPreviewResult> {
-  // Check gzip before creating stream — isGzipped uses openSync which throws for missing files
-  const gzipped = isGzipped(filePath)
+  // statSync throws synchronously for a missing file, failing fast before
+  // the stream/Promise machinery below is even set up.
   const fileSize = statSync(filePath).size
 
   return new Promise((resolve, reject) => {
-    const raw = createReadStream(filePath)
-    const stream = gzipped ? raw.pipe(createGunzip()) : raw
+    // Shared capped reader guards against a giant single line and a
+    // decompression bomb -- see stream-utils.ts for the cap rationale.
+    const { stream, rawBytesRead } = createCappedLineStream(filePath)
 
     const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
@@ -45,9 +45,9 @@ export async function getVcfPreview(filePath: string): Promise<VcfPreviewResult>
         dataLineCount++
         if (dataLineCount >= MAX_COUNTED_LINES) {
           capped = true
-          bytesReadAtCap = raw.bytesRead
+          bytesReadAtCap = rawBytesRead()
           rl.close()
-          raw.destroy()
+          stream.destroy()
         }
       }
     })

--- a/src/main/import/vcf/vcf-resource-limits.ts
+++ b/src/main/import/vcf/vcf-resource-limits.ts
@@ -1,11 +1,14 @@
 /** Practical allocation/fan-out budgets applied before VCF token arrays or maps are built. */
-export const MAX_VCF_COLUMNS = 10_010
 export const MAX_VCF_ALT_ALLELES = 1_000
 export const MAX_VCF_INFO_CHARS = 1024 * 1024
 export const MAX_VCF_INFO_FIELDS = 4_096
 export const MAX_VCF_FORMAT_FIELDS = 256
-export const MAX_VCF_TOTAL_SAMPLE_VALUES = 100_000
+export const MAX_VCF_FORMAT_CHARS = 64 * 1024
 export const MAX_VCF_SAMPLE_FIELD_CHARS = 64 * 1024
+/** Bounds JS token/map overhead while allowing cohorts well beyond the former 10k cap. */
+export const MAX_VCF_HEADER_SAMPLES = 100_000
+/** Legacy direct callers may request all samples; production resolves exactly one sample. */
+export const MAX_VCF_COMPATIBILITY_SAMPLES = MAX_VCF_HEADER_SAMPLES
 export const MAX_VCF_ANNOTATION_CHARS = 1024 * 1024
 export const MAX_VCF_ANNOTATIONS = 2_048
 export const MAX_VCF_ANNOTATION_FIELDS = 256

--- a/src/main/import/vcf/vcf-resource-limits.ts
+++ b/src/main/import/vcf/vcf-resource-limits.ts
@@ -1,0 +1,33 @@
+/** Practical allocation/fan-out budgets applied before VCF token arrays or maps are built. */
+export const MAX_VCF_COLUMNS = 10_010
+export const MAX_VCF_ALT_ALLELES = 1_000
+export const MAX_VCF_INFO_CHARS = 1024 * 1024
+export const MAX_VCF_INFO_FIELDS = 4_096
+export const MAX_VCF_FORMAT_FIELDS = 256
+export const MAX_VCF_TOTAL_SAMPLE_VALUES = 100_000
+export const MAX_VCF_SAMPLE_FIELD_CHARS = 64 * 1024
+export const MAX_VCF_ANNOTATION_CHARS = 1024 * 1024
+export const MAX_VCF_ANNOTATIONS = 2_048
+export const MAX_VCF_ANNOTATION_FIELDS = 256
+export const MAX_VCF_TOTAL_ANNOTATION_VALUES = 100_000
+export const MAX_VCF_STRUCTURED_HEADER_CHARS = 256 * 1024
+export const MAX_VCF_STRUCTURED_HEADER_FIELDS = 256
+export const MAX_VCF_GENOTYPE_ALLELES = 64
+
+export class VcfResourceLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'VcfResourceLimitError'
+  }
+}
+
+/** Native split honors its limit and stops tokenizing once the sentinel part is reached. */
+export function splitBounded(value: string, delimiter: string, maxParts: number): string[] | null {
+  const parts = value.split(delimiter, maxParts + 1)
+  return parts.length > maxParts ? null : parts
+}
+
+export function splitGenotypeAlleles(value: string): string[] | null {
+  const parts = value.split(/[/|]/, MAX_VCF_GENOTYPE_ALLELES + 1)
+  return parts.length > MAX_VCF_GENOTYPE_ALLELES ? null : parts
+}

--- a/src/main/ipc/handlers/gene-lists.ts
+++ b/src/main/ipc/handlers/gene-lists.ts
@@ -1,4 +1,5 @@
 import { wrapHandler } from '../errorHandler'
+import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import {
   GeneListIdSchema,
@@ -8,6 +9,7 @@ import {
   BedImportSchema
 } from '../../../shared/types/ipc-schemas'
 import { mainLogger } from '../../services/MainLogger'
+import { isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
 
 /**
  * Gene Lists and Region Files IPC handlers
@@ -212,6 +214,13 @@ export function registerGeneListHandlers({
           'gene-lists'
         )
         throw new Error('Invalid BED import parameters')
+      }
+
+      if (!isStrictlyEnrolledPath(validated.data.filePath)) {
+        throw new InvalidParametersError(
+          `region-files:importBed: filePath was not selected through a trusted dialog: ${validated.data.filePath}`,
+          'The selected file is not in an allowed location.'
+        )
       }
 
       const session = getDbManager().getCurrentSession()

--- a/src/main/ipc/handlers/gene-lists.ts
+++ b/src/main/ipc/handlers/gene-lists.ts
@@ -1,6 +1,5 @@
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
-import { readFile } from 'node:fs/promises'
 import {
   GeneListIdSchema,
   GeneListCreateSchema,
@@ -9,6 +8,9 @@ import {
   BedImportSchema
 } from '../../../shared/types/ipc-schemas'
 import { mainLogger } from '../../services/MainLogger'
+import { MAX_BED_FILTER_DECOMPRESSED_BYTES } from '../../import/vcf/bed-filter'
+import { readBedEntries } from '../../import/vcf/bed-reader'
+import { resolveMaxDecompressedBytes } from '../../import/stream-utils'
 
 /**
  * Gene Lists and Region Files IPC handlers
@@ -215,32 +217,10 @@ export function registerGeneListHandlers({
         throw new Error('Invalid BED import parameters')
       }
 
-      const content = await readFile(validated.data.filePath, 'utf-8')
       const entries: Array<{ chr: string; start: number; end: number; label?: string }> = []
-
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim()
-        if (
-          trimmed === '' ||
-          trimmed.startsWith('#') ||
-          trimmed.startsWith('browser') ||
-          trimmed.startsWith('track')
-        ) {
-          continue
-        }
-        const parts = trimmed.split('\t')
-        if (parts.length >= 3) {
-          const start = parseInt(parts[1], 10)
-          const end = parseInt(parts[2], 10)
-          if (!isNaN(start) && !isNaN(end)) {
-            entries.push({
-              chr: parts[0],
-              start,
-              end,
-              label: parts.length >= 4 ? parts[3] : undefined
-            })
-          }
-        }
+      const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
+      for await (const entry of readBedEntries(validated.data.filePath, maxBytes)) {
+        entries.push(entry)
       }
 
       const session = getDbManager().getCurrentSession()

--- a/src/main/ipc/handlers/gene-lists.ts
+++ b/src/main/ipc/handlers/gene-lists.ts
@@ -8,9 +8,6 @@ import {
   BedImportSchema
 } from '../../../shared/types/ipc-schemas'
 import { mainLogger } from '../../services/MainLogger'
-import { MAX_BED_FILTER_DECOMPRESSED_BYTES } from '../../import/vcf/bed-filter'
-import { readBedEntries } from '../../import/vcf/bed-reader'
-import { resolveMaxDecompressedBytes } from '../../import/stream-utils'
 
 /**
  * Gene Lists and Region Files IPC handlers
@@ -217,20 +214,11 @@ export function registerGeneListHandlers({
         throw new Error('Invalid BED import parameters')
       }
 
-      const entries: Array<{ chr: string; start: number; end: number; label?: string }> = []
-      const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
-      for await (const entry of readBedEntries(validated.data.filePath, maxBytes)) {
-        entries.push(entry)
-      }
-
       const session = getDbManager().getCurrentSession()
-      if (session.capabilities.backend === 'postgres') {
-        return await session.getWriteExecutor().execute({
-          type: 'region-files:importBed',
-          params: [validated.data.fileId, entries]
-        })
-      }
-      return getDb().geneLists.importBedEntries(validated.data.fileId, entries)
+      return await session.getWriteExecutor().execute({
+        type: 'region-files:importBed',
+        params: [validated.data.fileId, validated.data.filePath, { rejectMalformedRows: false }]
+      })
     })
   })
 }

--- a/src/main/ipc/handlers/import-logic-append.ts
+++ b/src/main/ipc/handlers/import-logic-append.ts
@@ -102,7 +102,11 @@ export async function importAdditionalFileToCase(
       }
 
       try {
-        const record = parseVcfLine(line, header.samples)
+        const record = parseVcfLine(line, header.samples, (reason) => {
+          if (errors.length < 10) {
+            errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
+          }
+        })
         if (record === null) {
           totalSkipped++
           continue

--- a/src/main/ipc/handlers/import-logic-append.ts
+++ b/src/main/ipc/handlers/import-logic-append.ts
@@ -24,7 +24,11 @@ import { createInterface } from 'node:readline'
 
 import { createCappedLineStream } from '../../import/stream-utils'
 import { parseVcfHeader, parseVcfHeaderFromLines } from '../../import/vcf/vcf-header-parser'
-import { parseVcfLine } from '../../import/vcf/vcf-line-parser'
+import {
+  parseVcfLine,
+  resolveVcfSelectedSampleColumn,
+  type VcfSelectedSampleColumn
+} from '../../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../../import/vcf/VcfMapper'
 import { detectCaller } from '../../import/vcf/caller-detector'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../../import/vcf/info-field-registry'
@@ -70,6 +74,7 @@ export async function importAdditionalFileToCase(
   const headerBudget = new VcfHeaderBudget()
   let header: VcfHeader | null = null
   let activeSample = ''
+  let activeSampleColumn: VcfSelectedSampleColumn | null = null
   let callerName: string | null = null
 
   let batch: VcfMappedVariant[] = []
@@ -90,13 +95,11 @@ export async function importAdditionalFileToCase(
         // Parse header once, on the first data line
         if (header === null) {
           header = parseVcfHeaderFromLines(headerLines)
-          const selectedSample = vcfOptions?.selectedSample
-          activeSample =
-            selectedSample !== undefined && selectedSample !== ''
-              ? selectedSample
-              : header.samples.length > 0
-                ? header.samples[0]
-                : ''
+          activeSampleColumn = resolveVcfSelectedSampleColumn(
+            header.samples,
+            vcfOptions?.selectedSample
+          )
+          activeSample = activeSampleColumn?.name ?? ''
 
           if (activeSample === '') {
             errors.push(`No sample found in VCF file: ${filePath}`)
@@ -108,11 +111,16 @@ export async function importAdditionalFileToCase(
         }
 
         try {
-          const record = parseVcfLine(line, header.samples, (reason) => {
-            if (errors.length < 10) {
-              errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
-            }
-          })
+          const record = parseVcfLine(
+            line,
+            header.samples,
+            (reason) => {
+              if (errors.length < 10) {
+                errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
+              }
+            },
+            activeSampleColumn ?? undefined
+          )
           if (record === null) {
             totalSkipped++
             continue

--- a/src/main/ipc/handlers/import-logic-append.ts
+++ b/src/main/ipc/handlers/import-logic-append.ts
@@ -3,7 +3,9 @@
  *
  * Unlike startImport (which creates a new case via a worker thread), this
  * variant reuses an existing caseId and streams variants into the same
- * case_id on the main thread. Used by the multi-file import session for
+ * case_id through an isolated SQLite connection. Parsing remains coordinated
+ * by the main process, but unrelated main-connection writes cannot enter this
+ * transaction. Used by the multi-file import session for
  * the 2nd..Nth files where we want a single case with per-file provenance.
  *
  * This runs on the main thread (not in a worker) because the worker
@@ -32,18 +34,20 @@ import {
 import { mapVcfRecord } from '../../import/vcf/VcfMapper'
 import { detectCaller } from '../../import/vcf/caller-detector'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../../import/vcf/info-field-registry'
-import type { VcfHeader, VcfMappedVariant } from '../../import/vcf/types'
+import type { VcfHeader } from '../../import/vcf/types'
 import type { ImportFilters } from '../../import/vcf/import-filters'
 import { passesPreMappingFilters, passesPostMappingFilters } from '../../import/vcf/import-filters'
 import { VcfHeaderBudget } from '../../import/vcf/vcf-header-limits'
 import { VcfResourceLimitError } from '../../import/vcf/vcf-resource-limits'
 import type { DatabaseService } from '../../database/DatabaseService'
+import { openWorkerDatabase } from '../../workers/worker-db'
+import { prepareStatements } from '../../workers/import-pipeline'
 import type { ImportCallbacks, ImportResult, VcfImportOptions } from './import-logic'
 
 const APPEND_BATCH_SIZE = 5000
 
 /**
- * Append a VCF file to an existing case by streaming it on the main thread.
+ * Append a VCF file to an existing case through an isolated write connection.
  *
  * Does NOT touch FTS triggers, does NOT update variant_count, and does NOT
  * rebuild the cohort summary — the caller (startMultiFileImport) manages all
@@ -58,9 +62,12 @@ export async function importAdditionalFileToCase(
   vcfOptions: VcfImportOptions | undefined,
   getDb: () => DatabaseService,
   callbacks: ImportCallbacks,
-  importFilters?: ImportFilters
+  importFilters?: ImportFilters,
+  signal?: AbortSignal
 ): Promise<ImportResult> {
   const db = getDb()
+  const appendDb = openWorkerDatabase(db.getPath(), db.getEncryptionKey())
+  const statements = prepareStatements(appendDb)
   const startTime = Date.now()
 
   // Shared capped reader guards against a giant single line and a
@@ -77,14 +84,17 @@ export async function importAdditionalFileToCase(
   let activeSampleColumn: VcfSelectedSampleColumn | null = null
   let callerName: string | null = null
 
-  let batch: VcfMappedVariant[] = []
+  let batch: Array<Record<string, unknown>> = []
   let totalInserted = 0
   let totalSkipped = 0
   const errors: string[] = []
+  const isCancelled = (): boolean => signal?.aborted === true
 
   try {
-    await db.runAsyncTransaction(async () => {
+    appendDb.exec('BEGIN IMMEDIATE')
+    try {
       for await (const line of rl) {
+        if (isCancelled()) throw new Error('Import cancelled by user')
         // Collect header lines
         if (line.startsWith('#')) {
           headerBudget.add(line)
@@ -154,11 +164,11 @@ export async function importAdditionalFileToCase(
           }
 
           for (const variant of mapped) {
-            batch.push(variant)
+            batch.push(variant as unknown as Record<string, unknown>)
           }
 
           if (batch.length >= APPEND_BATCH_SIZE) {
-            db.variants.insertBatch(batch, caseId)
+            statements.insertBatch(caseId, batch)
             totalInserted += batch.length
             batch = []
 
@@ -168,8 +178,12 @@ export async function importAdditionalFileToCase(
               elapsed: Date.now() - startTime,
               skipped: totalSkipped
             })
+            if (isCancelled()) throw new Error('Import cancelled by user')
           }
         } catch (lineError) {
+          if (isCancelled()) {
+            throw Object.assign(new Error('Import cancelled by user'), { cause: lineError })
+          }
           if (lineError instanceof VcfResourceLimitError) throw lineError
           totalSkipped++
           if (errors.length < 10) {
@@ -184,13 +198,20 @@ export async function importAdditionalFileToCase(
 
       // Flush remaining batch
       if (batch.length > 0) {
-        db.variants.insertBatch(batch, caseId)
+        if (isCancelled()) throw new Error('Import cancelled by user')
+        statements.insertBatch(caseId, batch)
         totalInserted += batch.length
       }
-    })
+      if (isCancelled()) throw new Error('Import cancelled by user')
+      appendDb.exec('COMMIT')
+    } catch (error) {
+      if (appendDb.inTransaction) appendDb.exec('ROLLBACK')
+      throw error
+    }
   } finally {
     // Ensure the file descriptor is released even on error
     stream.destroy()
+    appendDb.close()
   }
 
   return {

--- a/src/main/ipc/handlers/import-logic-append.ts
+++ b/src/main/ipc/handlers/import-logic-append.ts
@@ -32,6 +32,7 @@ import type { VcfHeader, VcfMappedVariant } from '../../import/vcf/types'
 import type { ImportFilters } from '../../import/vcf/import-filters'
 import { passesPreMappingFilters, passesPostMappingFilters } from '../../import/vcf/import-filters'
 import { VcfHeaderBudget } from '../../import/vcf/vcf-header-limits'
+import { VcfResourceLimitError } from '../../import/vcf/vcf-resource-limits'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { ImportCallbacks, ImportResult, VcfImportOptions } from './import-logic'
 
@@ -77,105 +78,108 @@ export async function importAdditionalFileToCase(
   const errors: string[] = []
 
   try {
-    for await (const line of rl) {
-      // Collect header lines
-      if (line.startsWith('#')) {
-        headerBudget.add(line)
-        headerLines.push(line)
-        continue
-      }
-
-      // Parse header once, on the first data line
-      if (header === null) {
-        header = parseVcfHeaderFromLines(headerLines)
-        const selectedSample = vcfOptions?.selectedSample
-        activeSample =
-          selectedSample !== undefined && selectedSample !== ''
-            ? selectedSample
-            : header.samples.length > 0
-              ? header.samples[0]
-              : ''
-
-        if (activeSample === '') {
-          errors.push(`No sample found in VCF file: ${filePath}`)
-          break
+    await db.runAsyncTransaction(async () => {
+      for await (const line of rl) {
+        // Collect header lines
+        if (line.startsWith('#')) {
+          headerBudget.add(line)
+          headerLines.push(line)
+          continue
         }
 
-        const callerInfo = detectCaller(headerLines)
-        callerName = callerInfo.name !== 'unknown' ? callerInfo.name : null
-      }
+        // Parse header once, on the first data line
+        if (header === null) {
+          header = parseVcfHeaderFromLines(headerLines)
+          const selectedSample = vcfOptions?.selectedSample
+          activeSample =
+            selectedSample !== undefined && selectedSample !== ''
+              ? selectedSample
+              : header.samples.length > 0
+                ? header.samples[0]
+                : ''
 
-      try {
-        const record = parseVcfLine(line, header.samples, (reason) => {
-          if (errors.length < 10) {
-            errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
+          if (activeSample === '') {
+            errors.push(`No sample found in VCF file: ${filePath}`)
+            break
           }
-        })
-        if (record === null) {
-          totalSkipped++
-          continue
+
+          const callerInfo = detectCaller(headerLines)
+          callerName = callerInfo.name !== 'unknown' ? callerInfo.name : null
         }
 
-        // Pre-mapping filter gate — shared with `VcfStrategy` via
-        // `import-filters.ts` so the worker path (first file) and the
-        // main-thread append path (2nd..Nth files) stay semantically
-        // identical.
-        if (!passesPreMappingFilters(record, importFilters)) {
-          totalSkipped++
-          continue
-        }
-
-        let mapped = mapVcfRecord(
-          record,
-          header,
-          activeSample,
-          DEFAULT_INFO_FIELD_MAPPINGS,
-          callerName
-        )
-
-        // Post-mapping filter gate — FORMAT/GQ and FORMAT/DP.
-        if (importFilters !== undefined) {
-          mapped = mapped.filter((v) => passesPostMappingFilters(v, importFilters))
-        }
-
-        if (mapped.length === 0) {
-          totalSkipped++
-          continue
-        }
-
-        for (const variant of mapped) {
-          batch.push(variant)
-        }
-
-        if (batch.length >= APPEND_BATCH_SIZE) {
-          db.variants.insertBatch(batch, caseId)
-          totalInserted += batch.length
-          batch = []
-
-          callbacks.onProgress?.({
-            phase: 'inserting',
-            count: totalInserted,
-            elapsed: Date.now() - startTime,
-            skipped: totalSkipped
+        try {
+          const record = parseVcfLine(line, header.samples, (reason) => {
+            if (errors.length < 10) {
+              errors.push(`Line skipped at ${line.substring(0, 50)}: ${reason}`)
+            }
           })
-        }
-      } catch (lineError) {
-        totalSkipped++
-        if (errors.length < 10) {
-          errors.push(
-            `Line parse error at ${line.substring(0, 50)}: ${
-              lineError instanceof Error ? lineError.message : String(lineError)
-            }`
+          if (record === null) {
+            totalSkipped++
+            continue
+          }
+
+          // Pre-mapping filter gate — shared with `VcfStrategy` via
+          // `import-filters.ts` so the worker path (first file) and the
+          // main-thread append path (2nd..Nth files) stay semantically
+          // identical.
+          if (!passesPreMappingFilters(record, importFilters)) {
+            totalSkipped++
+            continue
+          }
+
+          let mapped = mapVcfRecord(
+            record,
+            header,
+            activeSample,
+            DEFAULT_INFO_FIELD_MAPPINGS,
+            callerName
           )
+
+          // Post-mapping filter gate — FORMAT/GQ and FORMAT/DP.
+          if (importFilters !== undefined) {
+            mapped = mapped.filter((v) => passesPostMappingFilters(v, importFilters))
+          }
+
+          if (mapped.length === 0) {
+            totalSkipped++
+            continue
+          }
+
+          for (const variant of mapped) {
+            batch.push(variant)
+          }
+
+          if (batch.length >= APPEND_BATCH_SIZE) {
+            db.variants.insertBatch(batch, caseId)
+            totalInserted += batch.length
+            batch = []
+
+            callbacks.onProgress?.({
+              phase: 'inserting',
+              count: totalInserted,
+              elapsed: Date.now() - startTime,
+              skipped: totalSkipped
+            })
+          }
+        } catch (lineError) {
+          if (lineError instanceof VcfResourceLimitError) throw lineError
+          totalSkipped++
+          if (errors.length < 10) {
+            errors.push(
+              `Line parse error at ${line.substring(0, 50)}: ${
+                lineError instanceof Error ? lineError.message : String(lineError)
+              }`
+            )
+          }
         }
       }
-    }
 
-    // Flush remaining batch
-    if (batch.length > 0) {
-      db.variants.insertBatch(batch, caseId)
-      totalInserted += batch.length
-    }
+      // Flush remaining batch
+      if (batch.length > 0) {
+        db.variants.insertBatch(batch, caseId)
+        totalInserted += batch.length
+      }
+    })
   } finally {
     // Ensure the file descriptor is released even on error
     stream.destroy()

--- a/src/main/ipc/handlers/import-logic-append.ts
+++ b/src/main/ipc/handlers/import-logic-append.ts
@@ -20,12 +20,10 @@
  *   - The caller MUST ensure any genome build lock is enforced before
  *     calling this function (see checkGenomeBuildOrThrow below).
  */
-import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
-import { createGunzip } from 'node:zlib'
 
-import { isGzipped } from '../../import/stream-utils'
-import { parseVcfHeaderFromLines } from '../../import/vcf/vcf-header-parser'
+import { createCappedLineStream } from '../../import/stream-utils'
+import { parseVcfHeader, parseVcfHeaderFromLines } from '../../import/vcf/vcf-header-parser'
 import { parseVcfLine } from '../../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../../import/vcf/VcfMapper'
 import { detectCaller } from '../../import/vcf/caller-detector'
@@ -59,8 +57,9 @@ export async function importAdditionalFileToCase(
   const db = getDb()
   const startTime = Date.now()
 
-  const raw = createReadStream(filePath)
-  const stream = isGzipped(filePath) ? raw.pipe(createGunzip()) : raw
+  // Shared capped reader guards against a giant single line and a
+  // decompression bomb -- see stream-utils.ts for the cap rationale.
+  const { stream } = createCappedLineStream(filePath)
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
   const headerLines: string[] = []
@@ -174,7 +173,7 @@ export async function importAdditionalFileToCase(
     }
   } finally {
     // Ensure the file descriptor is released even on error
-    raw.destroy()
+    stream.destroy()
   }
 
   return {
@@ -193,27 +192,12 @@ export async function importAdditionalFileToCase(
  * Used by the multi-file session to enforce a per-case genome build lock:
  * if a subsequent file declares a different build than the case was created
  * with, the session aborts before any variants are inserted.
+ *
+ * Delegates to the shared `parseVcfHeader`, which is already routed through
+ * the capped reader (giant-line + decompression-bomb guards) -- see
+ * stream-utils.ts for the cap rationale.
  */
 export async function detectGenomeBuildFromFile(filePath: string): Promise<string | null> {
-  const raw = createReadStream(filePath)
-  const stream = isGzipped(filePath) ? raw.pipe(createGunzip()) : raw
-  const rl = createInterface({ input: stream, crlfDelay: Infinity })
-
-  const headerLines: string[] = []
-  try {
-    for await (const line of rl) {
-      if (line.startsWith('#')) {
-        headerLines.push(line)
-        continue
-      }
-      // First data line — header is complete, stop reading.
-      break
-    }
-  } finally {
-    raw.destroy()
-  }
-
-  if (headerLines.length === 0) return null
-  const header = parseVcfHeaderFromLines(headerLines)
+  const { header } = await parseVcfHeader(filePath)
   return header.genomeBuild ?? null
 }

--- a/src/main/ipc/handlers/import-logic-append.ts
+++ b/src/main/ipc/handlers/import-logic-append.ts
@@ -31,6 +31,7 @@ import { DEFAULT_INFO_FIELD_MAPPINGS } from '../../import/vcf/info-field-registr
 import type { VcfHeader, VcfMappedVariant } from '../../import/vcf/types'
 import type { ImportFilters } from '../../import/vcf/import-filters'
 import { passesPreMappingFilters, passesPostMappingFilters } from '../../import/vcf/import-filters'
+import { VcfHeaderBudget } from '../../import/vcf/vcf-header-limits'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { ImportCallbacks, ImportResult, VcfImportOptions } from './import-logic'
 
@@ -60,9 +61,12 @@ export async function importAdditionalFileToCase(
   // Shared capped reader guards against a giant single line and a
   // decompression bomb -- see stream-utils.ts for the cap rationale.
   const { stream } = createCappedLineStream(filePath)
+  stream.on('error', () => undefined)
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
+  rl.on('error', () => undefined)
 
   const headerLines: string[] = []
+  const headerBudget = new VcfHeaderBudget()
   let header: VcfHeader | null = null
   let activeSample = ''
   let callerName: string | null = null
@@ -76,6 +80,7 @@ export async function importAdditionalFileToCase(
     for await (const line of rl) {
       // Collect header lines
       if (line.startsWith('#')) {
+        headerBudget.add(line)
         headerLines.push(line)
         continue
       }

--- a/src/main/ipc/handlers/import-logic.ts
+++ b/src/main/ipc/handlers/import-logic.ts
@@ -16,7 +16,7 @@ import { mainLogger } from '../../services/MainLogger'
 import { API_CONFIG } from '../../../shared/config/api.config'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { ImportFilters } from '../../import/vcf/import-filters'
-import type { StorageImportExecutor, StorageImportFileFilters } from '../../storage/import-executor'
+import type { StorageImportFileFilters } from '../../storage/import-executor'
 import type { StorageSession } from '../../storage/session'
 
 /**
@@ -83,8 +83,28 @@ export interface VcfImportOptions {
   genomeBuild?: string
 }
 
-// Keep a reference to the active storage import executor for cancellation.
-let activeImportExecutor: StorageImportExecutor | null = null
+interface ActiveImportOperation {
+  cancel: () => void
+}
+
+// Keep the full operation (not only a worker client) reachable for cancellation.
+let activeImportOperation: ActiveImportOperation | null = null
+
+async function withActiveImportOperation<T>(
+  cancel: () => void,
+  operation: () => Promise<T>
+): Promise<T> {
+  if (activeImportOperation !== null) {
+    throw new Error('An import operation is already in progress')
+  }
+  const current = { cancel }
+  activeImportOperation = current
+  try {
+    return await operation()
+  } finally {
+    if (activeImportOperation === current) activeImportOperation = null
+  }
+}
 
 /**
  * Start a single-file import through the active storage session's executor.
@@ -101,29 +121,25 @@ export async function startImport(
 ): Promise<ImportResult> {
   const session = getSession()
   const executor = session.getImportExecutor()
-  activeImportExecutor = executor
-  try {
-    return await executor.importSingleFile({
-      filePath,
-      caseName,
-      vcfOptions,
-      throttleMs: API_CONFIG.PROGRESS_THROTTLE_MS,
-      onProgress: callbacks.onProgress
-    })
-  } finally {
-    if (activeImportExecutor === executor) {
-      activeImportExecutor = null
+  return withActiveImportOperation(
+    () => executor.cancel(),
+    async () => {
+      return executor.importSingleFile({
+        filePath,
+        caseName,
+        vcfOptions,
+        throttleMs: API_CONFIG.PROGRESS_THROTTLE_MS,
+        onProgress: callbacks.onProgress
+      })
     }
-  }
+  )
 }
 
 /**
  * Cancel the active import operation.
  */
 export function cancelImport(): void {
-  if (activeImportExecutor !== null) {
-    activeImportExecutor.cancel()
-  }
+  activeImportOperation?.cancel()
 }
 
 /**
@@ -190,9 +206,11 @@ async function startMultiFileImportSqlite(
   getSession: () => StorageSession,
   getDb: () => DatabaseService,
   callbacks: ImportCallbacks,
-  importFilters?: ImportFilters
+  importFilters?: ImportFilters,
+  signal?: AbortSignal
 ): Promise<MultiFileImportResult> {
   const startTime = Date.now()
+  const isCancelled = (): boolean => signal?.aborted === true
 
   if (files.length === 0) {
     throw new Error('No files provided for import')
@@ -228,13 +246,14 @@ async function startMultiFileImportSqlite(
 
   // Import first file — creates the case
   const firstFile = files[0]
-  const firstResult = await startImport(
-    firstFile.filePath,
+  const firstCallbacks = wrapCallbacksForFile(firstFile, 0)
+  const firstResult = await getSession().getImportExecutor().importSingleFile({
+    filePath: firstFile.filePath,
     caseName,
     vcfOptions,
-    getSession,
-    wrapCallbacksForFile(firstFile, 0)
-  )
+    throttleMs: API_CONFIG.PROGRESS_THROTTLE_MS,
+    onProgress: firstCallbacks.onProgress
+  })
 
   if (firstResult.caseId === 0) {
     throw new Error(
@@ -299,6 +318,7 @@ async function startMultiFileImportSqlite(
   try {
     // Append remaining files into the same case
     for (let i = 1; i < files.length; i++) {
+      if (isCancelled()) break
       const spec = files[i]
       try {
         // ── Genome build lock enforcement ───────────────────────────
@@ -322,7 +342,8 @@ async function startMultiFileImportSqlite(
           vcfOptions,
           getDb,
           wrapCallbacksForFile(spec, i),
-          importFilters
+          importFilters,
+          signal
         )
 
         db.cases.insertImportFile({
@@ -352,6 +373,7 @@ async function startMultiFileImportSqlite(
           variantCount: 0,
           error: message
         })
+        if (isCancelled()) break
       }
     }
   } finally {
@@ -461,36 +483,47 @@ export async function startMultiFileImport(
   filtersPayload?: ImportFiltersPayload
 ): Promise<MultiFileImportResult> {
   const session = getSession()
+  const executor = session.getImportExecutor()
+  const controller = new AbortController()
 
-  if (session.capabilities.backend === 'postgres') {
-    const executor = session.getImportExecutor()
-    const storageFilters =
-      filtersPayload !== undefined ? translateFiltersPayloadToStorage(filtersPayload) : undefined
-    const result = await executor.importMultiFile({
-      caseName,
-      files,
-      vcfOptions,
-      filters: storageFilters,
-      onProgress: callbacks.onProgress
-    })
-    return {
-      caseId: result.caseId,
-      totalVariants: result.variantCount,
-      totalSkipped: result.skipped,
-      files: result.files,
-      elapsed: result.elapsed
+  return withActiveImportOperation(
+    () => {
+      controller.abort()
+      executor.cancel()
+    },
+    async () => {
+      if (session.capabilities.backend === 'postgres') {
+        const storageFilters =
+          filtersPayload !== undefined
+            ? translateFiltersPayloadToStorage(filtersPayload)
+            : undefined
+        const result = await executor.importMultiFile({
+          caseName,
+          files,
+          vcfOptions,
+          filters: storageFilters,
+          onProgress: callbacks.onProgress
+        })
+        return {
+          caseId: result.caseId,
+          totalVariants: result.variantCount,
+          totalSkipped: result.skipped,
+          files: result.files,
+          elapsed: result.elapsed
+        }
+      }
+
+      return startMultiFileImportSqlite(
+        caseName,
+        files,
+        vcfOptions,
+        getSession,
+        getDb,
+        callbacks,
+        importFilters,
+        controller.signal
+      )
     }
-  }
-
-  // SQLite — existing append pipeline
-  return startMultiFileImportSqlite(
-    caseName,
-    files,
-    vcfOptions,
-    getSession,
-    getDb,
-    callbacks,
-    importFilters
   )
 }
 

--- a/src/main/ipc/handlers/import.ts
+++ b/src/main/ipc/handlers/import.ts
@@ -25,7 +25,6 @@ import type { ImportCallbacks, MultiFileImportSpec } from './import-logic'
 import type { ImportFilters } from '../../import/vcf/import-filters'
 import type { StorageSession } from '../../storage/session'
 import { BedFilter } from '../../import/vcf/bed-filter'
-import { mainLogger } from '../../services/MainLogger'
 
 /**
  * Serializable filter payload sent from the renderer over IPC.
@@ -42,9 +41,9 @@ type ImportFiltersIpcPayload = z.infer<typeof ImportFiltersIpcPayloadSchema>
  * when the payload has no meaningful filter content (so the append path can
  * skip the entire filter code path cheaply).
  */
-function buildImportFiltersFromIpc(
+async function buildImportFiltersFromIpc(
   payload: ImportFiltersIpcPayload | undefined
-): ImportFilters | undefined {
+): Promise<ImportFilters | undefined> {
   if (payload === undefined) return undefined
 
   const hasAny =
@@ -57,16 +56,7 @@ function buildImportFiltersFromIpc(
 
   let bedFilter: BedFilter | undefined
   if (payload.bedFile !== undefined && payload.bedFile !== null && payload.bedFile !== '') {
-    try {
-      bedFilter = BedFilter.fromFile(payload.bedFile, payload.bedPadding ?? 0)
-    } catch (e) {
-      mainLogger.warn(
-        `Failed to load BED filter from ${payload.bedFile}: ${
-          e instanceof Error ? e.message : String(e)
-        }`,
-        'import'
-      )
-    }
+    bedFilter = await BedFilter.fromFile(payload.bedFile, payload.bedPadding ?? 0)
   }
 
   return {
@@ -203,7 +193,7 @@ export function registerImportHandlers({
         // Build the SQLite-path ImportFilters (loads BedFilter into memory).
         // The PG path receives filtersPayload directly so it can extract the
         // BED file path without going through the BedFilter constructor.
-        const importFilters = buildImportFiltersFromIpc(validatedFiltersPayload)
+        const importFilters = await buildImportFiltersFromIpc(validatedFiltersPayload)
         return startMultiFileImport(
           validatedCaseName,
           validatedFiles,

--- a/src/main/security/import-path-allowlist.ts
+++ b/src/main/security/import-path-allowlist.ts
@@ -1,6 +1,8 @@
 import { realpathSync } from 'fs'
 import { app } from 'electron'
 import { isAbsolute, relative, resolve, sep } from 'path'
+import { homedir, tmpdir } from 'node:os'
+import { PathAuthorityStore } from './path-authority-store'
 
 /**
  * In-memory session allow-list of paths the user explicitly picked via an
@@ -12,16 +14,22 @@ import { isAbsolute, relative, resolve, sep } from 'path'
  * validated. BedFilter.fromFile keeps a worker-safe defensive check as
  * defence-in-depth.
  */
-const dialogAllowedPaths = new Set<string>()
+const dialogAllowedPaths = new PathAuthorityStore()
 
 export function addAllowedImportPath(absolutePath: string): void {
-  const resolved = resolve(absolutePath)
-  dialogAllowedPaths.add(resolved)
+  dialogAllowedPaths.add(absolutePath)
+}
 
-  const realPath = tryRealpath(resolved)
-  if (realPath !== null) {
-    dialogAllowedPaths.add(realPath)
-  }
+export function removeAllowedImportPath(absolutePath: string): void {
+  dialogAllowedPaths.remove(absolutePath)
+}
+
+/** Require explicit session enrollment; automatic trusted roots do not count. */
+export function isStrictlyEnrolledPath(candidate: string): boolean {
+  if (!isAbsolute(candidate)) return false
+  const abs = resolve(candidate)
+  if (abs !== candidate) return false
+  return dialogAllowedPaths.isAuthorized(abs)
 }
 
 export function isAllowedImportPath(candidate: string): boolean {
@@ -32,11 +40,8 @@ export function isAllowedImportPath(candidate: string): boolean {
 
   const realCandidate = tryRealpath(abs)
 
-  if (
-    dialogAllowedPaths.has(abs) ||
-    (realCandidate !== null && dialogAllowedPaths.has(realCandidate))
-  ) {
-    return true
+  if (dialogAllowedPaths.hasEnrollment(abs)) {
+    return dialogAllowedPaths.isAuthorized(abs)
   }
 
   const roots: string[] = []
@@ -49,7 +54,7 @@ export function isAllowedImportPath(candidate: string): boolean {
     if (process.env.HOME !== undefined && process.env.HOME !== '') {
       roots.push(process.env.HOME)
     }
-    roots.push('/tmp')
+    roots.push(homedir(), tmpdir())
   }
 
   return roots.some((root) => isUnderAutomaticRoot(abs, realCandidate, root))

--- a/src/main/security/path-authority-store.ts
+++ b/src/main/security/path-authority-store.ts
@@ -1,0 +1,75 @@
+import { lstatSync, realpathSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
+
+interface PathEnrollment {
+  realPath: string | null
+  realParent: string | null
+}
+
+/**
+ * Session-scoped capability store for paths returned by trusted dialogs.
+ * Existing symlinks are pinned to the target selected at enrollment time;
+ * a later retarget therefore invalidates the capability.
+ */
+export class PathAuthorityStore {
+  private readonly enrollments = new Map<string, PathEnrollment>()
+
+  add(filePath: string): void {
+    const lexicalPath = resolve(filePath)
+    this.enrollments.set(lexicalPath, {
+      realPath: tryRealpath(lexicalPath),
+      realParent: tryRealpath(dirname(lexicalPath))
+    })
+  }
+
+  remove(filePath: string): void {
+    this.enrollments.delete(resolve(filePath))
+  }
+
+  hasEnrollment(filePath: string): boolean {
+    return isAbsolute(filePath) && this.enrollments.has(resolve(filePath))
+  }
+
+  isAuthorized(filePath: string): boolean {
+    if (!isAbsolute(filePath)) return false
+    const lexicalPath = resolve(filePath)
+    if (lexicalPath !== filePath) return false
+
+    const enrollment = this.enrollments.get(lexicalPath)
+    if (enrollment === undefined) return false
+
+    const currentRealPath = tryRealpath(lexicalPath)
+    if (enrollment.realPath !== null) return currentRealPath === enrollment.realPath
+
+    // Save dialogs may enroll a path before it exists. Once created, accept
+    // only a regular path at the same stable parent, never a new symlink.
+    if (currentRealPath === null) return parentIsStable(lexicalPath, enrollment.realParent)
+    if (isSymbolicLink(lexicalPath)) return false
+    return parentIsStable(lexicalPath, enrollment.realParent)
+  }
+
+  clear(): void {
+    this.enrollments.clear()
+  }
+}
+
+function parentIsStable(filePath: string, enrolledParent: string | null): boolean {
+  const currentParent = tryRealpath(dirname(filePath))
+  return enrolledParent === null ? currentParent === null : currentParent === enrolledParent
+}
+
+function tryRealpath(filePath: string): string | null {
+  try {
+    return realpathSync.native(filePath)
+  } catch {
+    return null
+  }
+}
+
+function isSymbolicLink(filePath: string): boolean {
+  try {
+    return lstatSync(filePath).isSymbolicLink()
+  } catch {
+    return false
+  }
+}

--- a/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
+++ b/src/main/storage/postgres/PostgresCohortSummaryRepository.ts
@@ -85,14 +85,8 @@ const ACMG_RANK_SQL = (col: string) => `CASE ${col}
   WHEN 'Benign' THEN 1
   ELSE 0 END`
 
-/**
- * Deduped per-coordinate aggregate for a single case_id ($1). Mirrors the
- * SQLite INCREMENTAL_ADD_SQL / INCREMENTAL_REMOVE_SQL deduped sub-selects in
- * src/shared/sql/cohort-summary-rebuild.ts:134-184 — duplicate per-case rows
- * collapse to one carrier (Pass-2 #4). Emits carrier/het/hom deltas so both
- * the add and remove paths can reuse the same shape.
- */
-export const SCOPED_DEDUPED_AGG_SQL = (tbl: (t: string) => string) => `
+/** Deduped per-coordinate aggregate for one case, shared by add/remove. */
+export const SCOPED_DEDUPED_AGG_SQL = (tbl: (t: string) => string, includeProvisional = false) => `
   WITH deduped AS (
     SELECT v.chr, v.pos, v.ref, v.alt, v.variant_type, c.genome_build,
            MAX(v.end_pos) AS end_pos,
@@ -107,8 +101,8 @@ export const SCOPED_DEDUPED_AGG_SQL = (tbl: (t: string) => string) => `
            MAX(v.transcript) AS transcript,
            MAX(v.omim_mim_number) AS omim_mim_number,
            MAX(v.gt_num) AS gt_num
-    FROM ${tbl('variants')} v
-    JOIN ${tbl('cases')} c ON c.id = v.case_id
+    FROM ${tbl(includeProvisional ? 'variants_all' : 'variants')} v
+    JOIN ${tbl(includeProvisional ? 'cases_all' : 'cases')} c ON c.id = v.case_id
     WHERE v.case_id = $1
     GROUP BY v.chr, v.pos, v.ref, v.alt, v.variant_type, c.genome_build
   ),
@@ -275,14 +269,16 @@ export class PostgresCohortSummaryRepository {
   async recomputeCohortFrequency({
     schema,
     client,
-    affectedBuilds
-  }: ScopedClient & { affectedBuilds?: string[] }): Promise<void> {
+    affectedBuilds,
+    includeProvisional = false
+  }: ScopedClient & { affectedBuilds?: string[]; includeProvisional?: boolean }): Promise<void> {
     const tbl = (t: string): string => `"${schema}"."${t}"`
+    const casesTable = tbl(includeProvisional ? 'cases_all' : 'cases')
     if (affectedBuilds && affectedBuilds.length > 0) {
       await client.query(
         `UPDATE ${tbl('cohort_variant_summary')} cvs
          SET cohort_frequency = cvs.carrier_count::float / NULLIF(c.total, 0)
-         FROM (SELECT genome_build, COUNT(*) AS total FROM ${tbl('cases')} GROUP BY genome_build) c
+         FROM (SELECT genome_build, COUNT(*) AS total FROM ${casesTable} GROUP BY genome_build) c
          WHERE cvs.genome_build = c.genome_build
            AND cvs.genome_build = ANY($1::text[])`,
         [affectedBuilds]
@@ -291,7 +287,7 @@ export class PostgresCohortSummaryRepository {
       await client.query(
         `UPDATE ${tbl('cohort_variant_summary')} cvs
          SET cohort_frequency = cvs.carrier_count::float / NULLIF(c.total, 0)
-         FROM (SELECT genome_build, COUNT(*) AS total FROM ${tbl('cases')} GROUP BY genome_build) c
+         FROM (SELECT genome_build, COUNT(*) AS total FROM ${casesTable} GROUP BY genome_build) c
          WHERE cvs.genome_build = c.genome_build`
       )
     }
@@ -308,8 +304,13 @@ export class PostgresCohortSummaryRepository {
     schema,
     client,
     caseId,
-    genomeBuild
-  }: ScopedClient & { caseId: number; genomeBuild?: string }): Promise<void> {
+    genomeBuild,
+    includeProvisional = false
+  }: ScopedClient & {
+    caseId: number
+    genomeBuild?: string
+    includeProvisional?: boolean
+  }): Promise<void> {
     const tbl = (t: string): string => `"${schema}"."${t}"`
 
     await client.query(
@@ -320,7 +321,7 @@ export class PostgresCohortSummaryRepository {
          gnomad_af, cadd, transcript, omim_mim_number,
          carrier_count, het_count, hom_count, variant_key,
          has_star, has_comment, acmg_best, cohort_frequency)
-      ${SCOPED_DEDUPED_AGG_SQL(tbl)}
+      ${SCOPED_DEDUPED_AGG_SQL(tbl, includeProvisional)}
       SELECT
         pc.chr, pc.pos, pc.end_pos, pc.ref, pc.alt, pc.variant_type, pc.genome_build,
         pc.gene_symbol, pc.cdna, pc.aa_change, pc.consequence, pc.func, pc.clinvar,
@@ -397,7 +398,8 @@ export class PostgresCohortSummaryRepository {
     await this.recomputeCohortFrequency({
       schema,
       client,
-      affectedBuilds: genomeBuild !== undefined ? [genomeBuild] : undefined
+      affectedBuilds: genomeBuild !== undefined ? [genomeBuild] : undefined,
+      includeProvisional
     })
 
     // C1 lifecycle: incremental maintenance records its time but never touches
@@ -467,9 +469,11 @@ export class PostgresCohortSummaryRepository {
   async refreshColumnMetas({
     schema,
     client,
-    caseId
-  }: ScopedClient & { caseId: number }): Promise<void> {
+    caseId,
+    includeProvisional = false
+  }: ScopedClient & { caseId: number; includeProvisional?: boolean }): Promise<void> {
     const tbl = (t: string): string => `"${schema}"."${t}"`
+    const variantsTable = tbl(includeProvisional ? 'variants_all' : 'variants')
 
     await client.query(`DELETE FROM ${tbl('cohort_column_meta')} WHERE case_id = $1`, [caseId])
 
@@ -484,7 +488,7 @@ export class PostgresCohortSummaryRepository {
       }
     }
     const aggRes = await client.query(
-      `SELECT ${aggSelect.join(', ')} FROM ${tbl('variants')} WHERE case_id = $1`,
+      `SELECT ${aggSelect.join(', ')} FROM ${variantsTable} WHERE case_id = $1`,
       [caseId]
     )
     const aggRow = (aggRes.rows[0] ?? {}) as Record<string, string | number | null>
@@ -500,7 +504,7 @@ export class PostgresCohortSummaryRepository {
       const unionParts = lowCardinality.map(
         (col) =>
           `SELECT '${col}' AS col_key, CAST("${col}" AS TEXT) AS val
-             FROM ${tbl('variants')}
+             FROM ${variantsTable}
              WHERE case_id = $1 AND "${col}" IS NOT NULL
              GROUP BY "${col}"`
       )

--- a/src/main/storage/postgres/PostgresJsonImportRepository.ts
+++ b/src/main/storage/postgres/PostgresJsonImportRepository.ts
@@ -457,13 +457,15 @@ export class PostgresJsonImportRepository {
 export async function rebuildVariantFrequencyForCase(
   client: Pick<PoolClient, 'query'>,
   schema: string,
-  caseId: number
+  caseId: number,
+  includeProvisional = false
 ): Promise<void> {
   const schemaName = quoteIdentifier(schema)
+  const variantsTable = includeProvisional ? 'variants_all' : 'variants'
   await client.query(
     `INSERT INTO ${schemaName}."variant_frequency" (chr, pos, ref, alt, case_count)
      SELECT chr, pos, ref, alt, 1
-     FROM ${schemaName}."variants"
+     FROM ${schemaName}.${quoteIdentifier(variantsTable)}
      WHERE case_id = $1
      GROUP BY chr, pos, ref, alt
      ON CONFLICT (coord_hash)

--- a/src/main/storage/postgres/PostgresPanelsRepository.ts
+++ b/src/main/storage/postgres/PostgresPanelsRepository.ts
@@ -9,6 +9,9 @@ import type {
   PanelWithCount
 } from '../../../shared/types/panels'
 import { quoteIdentifier } from './identifiers'
+import { MAX_BED_FILTER_DECOMPRESSED_BYTES } from '../../import/vcf/bed-filter'
+import { readBedEntries, type BedEntry, type BedReaderOptions } from '../../import/vcf/bed-reader'
+import { resolveMaxDecompressedBytes } from '../../import/stream-utils'
 
 type Queryable = Pick<Pool, 'query' | 'connect'>
 type Row = Record<string, unknown>
@@ -356,9 +359,10 @@ export class PostgresPanelsRepository {
     await this.pool.query(`DELETE FROM ${this.table('region_files')} WHERE id = $1`, [id])
   }
 
-  async importBedEntries(
+  async importBedFile(
     fileId: number,
-    entries: Array<{ chr: string; start: number; end: number; label?: string }>
+    filePath: string,
+    options: BedReaderOptions = {}
   ): Promise<RegionFile> {
     return this.withTransaction(async (client) => {
       await client.query(
@@ -366,31 +370,20 @@ export class PostgresPanelsRepository {
         [fileId]
       )
 
-      const totalBases = entries.reduce((sum, entry) => sum + (entry.end - entry.start), 0)
-      for (let offset = 0; offset < entries.length; offset += REGION_FILE_INSERT_CHUNK_SIZE) {
-        const chunk = entries.slice(offset, offset + REGION_FILE_INSERT_CHUNK_SIZE)
-        await client.query(
-          `
-            INSERT INTO ${this.table('region_file_entries')} (
-              region_file_id,
-              chr,
-              start_pos,
-              end_pos,
-              label
-            )
-            SELECT $1, chr, start_pos, end_pos, label
-            FROM UNNEST($2::text[], $3::bigint[], $4::bigint[], $5::text[])
-              AS entry(chr, start_pos, end_pos, label)
-          `,
-          [
-            fileId,
-            chunk.map((entry) => entry.chr),
-            chunk.map((entry) => entry.start),
-            chunk.map((entry) => entry.end),
-            chunk.map((entry) => entry.label ?? null)
-          ]
-        )
+      const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
+      let chunk: BedEntry[] = []
+      let regionCount = 0
+      let totalBases = 0
+      for await (const entry of readBedEntries(filePath, maxBytes, options)) {
+        chunk.push(entry)
+        regionCount += 1
+        totalBases = addSafeBaseCount(totalBases, entry.end - entry.start)
+        if (chunk.length >= REGION_FILE_INSERT_CHUNK_SIZE) {
+          await this.insertRegionChunk(client, fileId, chunk)
+          chunk = []
+        }
       }
+      if (chunk.length > 0) await this.insertRegionChunk(client, fileId, chunk)
 
       await client.query(
         `
@@ -398,7 +391,7 @@ export class PostgresPanelsRepository {
           SET region_count = $1, total_bases = $2, updated_at = $3
           WHERE id = $4
         `,
-        [entries.length, totalBases, Date.now(), fileId]
+        [regionCount, totalBases, Date.now(), fileId]
       )
 
       const result = await client.query<Row>(
@@ -407,6 +400,34 @@ export class PostgresPanelsRepository {
       )
       return firstNormalized<RegionFile>(result) as RegionFile
     })
+  }
+
+  private async insertRegionChunk(
+    client: Pick<PoolClient, 'query'>,
+    fileId: number,
+    chunk: BedEntry[]
+  ): Promise<void> {
+    await client.query(
+      `
+        INSERT INTO ${this.table('region_file_entries')} (
+          region_file_id,
+          chr,
+          start_pos,
+          end_pos,
+          label
+        )
+        SELECT $1, chr, start_pos, end_pos, label
+        FROM UNNEST($2::text[], $3::bigint[], $4::bigint[], $5::text[])
+          AS entry(chr, start_pos, end_pos, label)
+      `,
+      [
+        fileId,
+        chunk.map((entry) => entry.chr),
+        chunk.map((entry) => entry.start),
+        chunk.map((entry) => entry.end),
+        chunk.map((entry) => entry.label ?? null)
+      ]
+    )
   }
 
   private async insertPanel(
@@ -492,4 +513,12 @@ export class PostgresPanelsRepository {
   private table(name: string): string {
     return `${quoteIdentifier(this.schema)}.${quoteIdentifier(name)}`
   }
+}
+
+function addSafeBaseCount(total: number, increment: number): number {
+  const next = total + increment
+  if (!Number.isSafeInteger(next)) {
+    throw new RangeError('BED total base count exceeds the safe integer range')
+  }
+  return next
 }

--- a/src/main/storage/postgres/PostgresPanelsRepository.ts
+++ b/src/main/storage/postgres/PostgresPanelsRepository.ts
@@ -365,6 +365,12 @@ export class PostgresPanelsRepository {
     options: BedReaderOptions = {}
   ): Promise<RegionFile> {
     return this.withTransaction(async (client) => {
+      const locked = await client.query<Row>(
+        `SELECT id FROM ${this.table('region_files')} WHERE id = $1 FOR UPDATE`,
+        [fileId]
+      )
+      if (locked.rows.length === 0) throw new Error(`Region file ${fileId} not found`)
+
       await client.query(
         `DELETE FROM ${this.table('region_file_entries')} WHERE region_file_id = $1`,
         [fileId]

--- a/src/main/storage/postgres/PostgresPanelsRepository.ts
+++ b/src/main/storage/postgres/PostgresPanelsRepository.ts
@@ -13,6 +13,8 @@ import { quoteIdentifier } from './identifiers'
 type Queryable = Pick<Pool, 'query' | 'connect'>
 type Row = Record<string, unknown>
 
+export const REGION_FILE_INSERT_CHUNK_SIZE = 10_000
+
 const integerFields = new Set([
   'id',
   'panel_id',
@@ -365,7 +367,8 @@ export class PostgresPanelsRepository {
       )
 
       const totalBases = entries.reduce((sum, entry) => sum + (entry.end - entry.start), 0)
-      if (entries.length > 0) {
+      for (let offset = 0; offset < entries.length; offset += REGION_FILE_INSERT_CHUNK_SIZE) {
+        const chunk = entries.slice(offset, offset + REGION_FILE_INSERT_CHUNK_SIZE)
         await client.query(
           `
             INSERT INTO ${this.table('region_file_entries')} (
@@ -381,10 +384,10 @@ export class PostgresPanelsRepository {
           `,
           [
             fileId,
-            entries.map((entry) => entry.chr),
-            entries.map((entry) => entry.start),
-            entries.map((entry) => entry.end),
-            entries.map((entry) => entry.label ?? null)
+            chunk.map((entry) => entry.chr),
+            chunk.map((entry) => entry.start),
+            chunk.map((entry) => entry.end),
+            chunk.map((entry) => entry.label ?? null)
           ]
         )
       }

--- a/src/main/storage/postgres/PostgresVcfImportRepository.ts
+++ b/src/main/storage/postgres/PostgresVcfImportRepository.ts
@@ -75,6 +75,17 @@ export interface PostgresVcfImportFileResult {
   variantCount: number
 }
 
+export interface PostgresProvisionalImport {
+  caseId: number
+  watermark: number
+  isNew: boolean
+}
+
+interface ProvisionalCleanupOptions {
+  restoreReady?: boolean
+  preserveNewCase?: boolean
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -90,6 +101,26 @@ function pickColumns<T extends string>(
   return out
 }
 
+async function inTransaction<T>(
+  client: Pick<PoolClient, 'query'>,
+  operation: () => Promise<T>
+): Promise<T> {
+  await client.query('BEGIN')
+  try {
+    const result = await operation()
+    await client.query('COMMIT')
+    return result
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK')
+    } catch {
+      // Preserve the operation/commit failure. Closing the import connection
+      // releases its advisory lease; the next owner resumes idempotently.
+    }
+    throw error
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Repository
 // ---------------------------------------------------------------------------
@@ -99,6 +130,146 @@ export class PostgresVcfImportRepository {
 
   constructor(schema: string) {
     this.schemaName = quoteIdentifier(schema)
+  }
+
+  async beginProvisionalImport(
+    client: Pick<PoolClient, 'query'>,
+    request: Pick<
+      PostgresVcfImportRequestBase,
+      'caseName' | 'filePath' | 'fileSize' | 'genomeBuild'
+    >,
+    existingCaseId?: number
+  ): Promise<PostgresProvisionalImport> {
+    if (existingCaseId === undefined) {
+      await this.assertCaseNameAvailable(client, request.caseName)
+      const result = await client.query(
+        `INSERT INTO ${this.schemaName}."cases_all"
+         (name, file_path, file_size, variant_count, created_at, genome_build,
+          import_status, import_variant_watermark, import_is_new)
+         VALUES ($1, $2, $3, 0, $4, $5, 'importing', 0, TRUE)
+         RETURNING id`,
+        [request.caseName, request.filePath, request.fileSize, Date.now(), request.genomeBuild]
+      )
+      return {
+        caseId: toNumericId((result.rows[0] as { id: unknown } | undefined)?.id),
+        watermark: 0,
+        isNew: true
+      }
+    }
+
+    const watermarkResult = await client.query(
+      `SELECT COALESCE(MAX(id), 0)::bigint AS watermark
+       FROM ${this.schemaName}."variants_all" WHERE case_id = $1`,
+      [existingCaseId]
+    )
+    const watermark = toNumericId(
+      (watermarkResult.rows[0] as { watermark: unknown } | undefined)?.watermark ?? 0
+    )
+    await client.query(
+      `UPDATE ${this.schemaName}."cases_all"
+       SET import_status = 'importing', import_variant_watermark = $2, import_is_new = FALSE
+       WHERE id = $1`,
+      [existingCaseId, watermark]
+    )
+    return { caseId: existingCaseId, watermark, isNew: false }
+  }
+
+  async captureVariantWatermark(
+    client: Pick<PoolClient, 'query'>,
+    caseId: number
+  ): Promise<number> {
+    const result = await client.query(
+      `SELECT COALESCE(MAX(id), 0)::bigint AS watermark
+       FROM ${this.schemaName}."variants_all" WHERE case_id = $1`,
+      [caseId]
+    )
+    return toNumericId((result.rows[0] as { watermark?: unknown } | undefined)?.watermark ?? 0)
+  }
+
+  async finishProvisionalImport(
+    client: Pick<PoolClient, 'query'>,
+    caseId: number,
+    fileName: string,
+    importFileType: string
+  ): Promise<void> {
+    const now = Date.now()
+    await client.query(
+      `INSERT INTO ${this.schemaName}."case_data_info"
+         (case_id, import_file_name, import_file_type, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $4)
+       ON CONFLICT (case_id) DO UPDATE SET import_file_name = EXCLUDED.import_file_name,
+         import_file_type = EXCLUDED.import_file_type, updated_at = EXCLUDED.updated_at`,
+      [caseId, fileName, importFileType, now]
+    )
+    await client.query(
+      `UPDATE ${this.schemaName}."cases_all" SET import_status = 'ready',
+       import_variant_watermark = 0, import_is_new = FALSE
+       WHERE id = $1 AND import_status = 'importing'`,
+      [caseId]
+    )
+  }
+
+  async cleanupProvisionalImport(
+    client: Pick<PoolClient, 'query'>,
+    provisional: PostgresProvisionalImport,
+    options: ProvisionalCleanupOptions = {}
+  ): Promise<void> {
+    while (true) {
+      const deleted = await inTransaction(client, () =>
+        client.query(
+          `WITH doomed AS (
+             SELECT id FROM ${this.schemaName}."variants_all"
+             WHERE case_id = $1 AND id > $2 ORDER BY id LIMIT 10000
+           ) DELETE FROM ${this.schemaName}."variants_all" v USING doomed d
+             WHERE v.id = d.id RETURNING v.id`,
+          [provisional.caseId, provisional.watermark]
+        )
+      )
+      if (deleted.rows.length === 0) break
+    }
+    await inTransaction(client, async () => {
+      if (provisional.isNew && options.preserveNewCase !== true) {
+        await client.query({
+          text: `DELETE FROM ${this.schemaName}."cases_all" WHERE id = $1`,
+          values: [provisional.caseId]
+        })
+      } else if (options.restoreReady !== false) {
+        await client.query(
+          `UPDATE ${this.schemaName}."cases_all" SET import_status = 'ready',
+           import_variant_watermark = 0, import_is_new = FALSE WHERE id = $1`,
+          [provisional.caseId]
+        )
+      }
+    })
+  }
+
+  async recoverInterruptedImports(client: Pick<PoolClient, 'query'>): Promise<void> {
+    const result = await client.query(
+      `SELECT id, import_variant_watermark, import_is_new
+       FROM ${this.schemaName}."cases_all"
+       WHERE import_status = 'importing' ORDER BY id`
+    )
+    for (const row of result.rows as Array<Record<string, unknown>>) {
+      const caseId = toNumericId(row.id)
+      await this.cleanupProvisionalImport(client, {
+        caseId,
+        watermark: toNumericId(row.import_variant_watermark),
+        isNew: row.import_is_new === true
+      })
+    }
+  }
+
+  async assertCaseNameAvailable(
+    client: Pick<PoolClient, 'query'>,
+    caseName: string
+  ): Promise<void> {
+    const duplicate = await client.query(
+      `SELECT id FROM ${this.schemaName}."cases_all" WHERE name = $1`,
+      [caseName]
+    )
+    if ((duplicate.rows as unknown[]).length > 0) {
+      throw new UniqueConstraintError('case', caseName)
+    }
   }
 
   /**
@@ -210,7 +381,7 @@ export class PostgresVcfImportRepository {
     // quoted via `quoteIdentifier`, so we just append the (always-safe,
     // always-lowercase) "variants" table name. This survives schemas that
     // need quoting (hyphens, mixed case, reserved words, etc.).
-    const variantsRelation = `${this.schemaName}."variants"`
+    const variantsRelation = `${this.schemaName}."variants_all"`
     const idResult = await profilePhase('reserve-ids', () =>
       client.query(
         `SELECT g.ord                                              AS ordinal,
@@ -242,7 +413,7 @@ export class PostgresVcfImportRepository {
       runBulkCopy({
         client,
         sql:
-          `COPY ${this.schemaName}."variants" ` +
+          `COPY ${this.schemaName}."variants_all" ` +
           `(${(VARIANT_COPY_COLUMNS as readonly string[])
             .map((c) => quoteIdentifier(c))
             .join(', ')}) ` +

--- a/src/main/storage/postgres/PostgresWriteExecutor.ts
+++ b/src/main/storage/postgres/PostgresWriteExecutor.ts
@@ -83,7 +83,7 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
         | 'setGeneListGenes'
         | 'createRegionFile'
         | 'deleteRegionFile'
-        | 'importBedEntries'
+        | 'importBedFile'
       >
       filterPresets: Pick<
         PostgresFilterPresetsRepository,
@@ -268,7 +268,7 @@ export class PostgresWriteExecutor implements StorageWriteExecutor {
         return await this.workflow.panels.deleteRegionFile(task.params[0])
 
       case 'region-files:importBed':
-        return await this.workflow.panels.importBedEntries(...task.params)
+        return await this.workflow.panels.importBedFile(...task.params)
 
       case 'presets:create':
         return await this.workflow.filterPresets.createPreset(task.params[0])

--- a/src/main/storage/postgres/migrations/definitions.ts
+++ b/src/main/storage/postgres/migrations/definitions.ts
@@ -68,6 +68,11 @@ const MIGRATION_FILES: readonly MigrationFile[] = [
     version: '0013',
     name: 'central_audit_schema',
     fileName: '0013_central_audit_schema.sql'
+  },
+  {
+    version: '0014',
+    name: 'import_visibility',
+    fileName: '0014_import_visibility.sql'
   }
 ]
 

--- a/src/main/storage/postgres/migrations/sql/0014_import_visibility.sql
+++ b/src/main/storage/postgres/migrations/sql/0014_import_visibility.sql
@@ -1,0 +1,28 @@
+ALTER TABLE "__schema__"."cases"
+  ADD COLUMN IF NOT EXISTS import_status TEXT NOT NULL DEFAULT 'ready',
+  ADD COLUMN IF NOT EXISTS import_variant_watermark BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS import_is_new BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE "__schema__"."cases"
+  DROP CONSTRAINT IF EXISTS cases_import_status_check;
+
+ALTER TABLE "__schema__"."cases"
+  ADD CONSTRAINT cases_import_status_check
+  CHECK (import_status IN ('ready', 'importing'));
+
+CREATE INDEX IF NOT EXISTS idx_cases_import_status
+  ON "__schema__"."cases" (import_status);
+
+ALTER TABLE "__schema__"."cases" RENAME TO "cases_all";
+
+CREATE VIEW "__schema__"."cases" AS
+  SELECT * FROM "__schema__"."cases_all" WHERE import_status = 'ready';
+
+ALTER TABLE "__schema__"."variants" RENAME TO "variants_all";
+
+CREATE VIEW "__schema__"."variants" AS
+  SELECT v.* FROM "__schema__"."variants_all" v
+  WHERE EXISTS (
+    SELECT 1 FROM "__schema__"."cases_all" c
+    WHERE c.id = v.case_id AND c.import_status = 'ready'
+  );

--- a/src/main/storage/sqlite/SqliteImportExecutor.ts
+++ b/src/main/storage/sqlite/SqliteImportExecutor.ts
@@ -136,6 +136,8 @@ export class SqliteImportExecutor implements StorageImportExecutor {
     return new Promise<StorageImportSingleFileResult>((resolve, reject) => {
       let capturedCaseId = 0
       let capturedElapsed = 0
+      let capturedSkipped = 0
+      let capturedSkipReasons: string[] = []
 
       try {
         worker.start({
@@ -166,6 +168,8 @@ export class SqliteImportExecutor implements StorageImportExecutor {
           onFileComplete: (msg) => {
             capturedCaseId = msg.result.caseId
             capturedElapsed = msg.result.elapsed
+            capturedSkipped = msg.result.skipped ?? 0
+            capturedSkipReasons = msg.result.skipReasons ?? []
           },
           onComplete: (msg) => {
             this.workerClient = null
@@ -202,8 +206,8 @@ export class SqliteImportExecutor implements StorageImportExecutor {
               resolve({
                 caseId: capturedCaseId,
                 variantCount: detail.variantCount ?? 0,
-                skipped: 0,
-                errors: [],
+                skipped: capturedSkipped,
+                errors: capturedSkipReasons,
                 elapsed: capturedElapsed
               })
             } else {
@@ -254,7 +258,7 @@ export class SqliteImportExecutor implements StorageImportExecutor {
     params: StorageImportMultiFileParams
   ): Promise<StorageImportMultiFileResult> {
     const startedAt = Date.now()
-    const filters = this.translateFilters(params.filters)
+    const filters = await this.translateFilters(params.filters)
 
     // NOTE: params.onFileComplete is intentionally NOT plumbed through here.
     // The existing startMultiFileImport / ImportCallbacks shape in
@@ -304,7 +308,9 @@ export class SqliteImportExecutor implements StorageImportExecutor {
    * contains no active constraints, mirroring the behaviour of
    * `buildImportFiltersFromIpc` in `import.ts`.
    */
-  private translateFilters(filters?: StorageImportFileFilters): ImportFilters | undefined {
+  private async translateFilters(
+    filters?: StorageImportFileFilters
+  ): Promise<ImportFilters | undefined> {
     if (filters === undefined) return undefined
 
     const hasAny =
@@ -324,16 +330,7 @@ export class SqliteImportExecutor implements StorageImportExecutor {
       filters.bedFilePath !== null &&
       filters.bedFilePath !== ''
     ) {
-      try {
-        bedFilter = BedFilter.fromFile(filters.bedFilePath, filters.bedPadding ?? 0)
-      } catch (e) {
-        mainLogger.warn(
-          `Failed to load BED filter from ${filters.bedFilePath}: ${
-            e instanceof Error ? e.message : String(e)
-          }`,
-          'SqliteImportExecutor'
-        )
-      }
+      bedFilter = await BedFilter.fromFile(filters.bedFilePath, filters.bedPadding ?? 0)
     }
 
     return {

--- a/src/main/storage/sqlite/SqliteWriteExecutor.ts
+++ b/src/main/storage/sqlite/SqliteWriteExecutor.ts
@@ -18,9 +18,20 @@ function serializeAuditValue(value: unknown): string | null {
 }
 
 export class SqliteWriteExecutor implements StorageWriteExecutor {
+  private writeTail: Promise<void> = Promise.resolve()
+
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async execute(task: StorageWriteTask): Promise<unknown> {
+  execute(task: StorageWriteTask): Promise<unknown> {
+    const result = this.writeTail.then(() => this.executeTask(task))
+    this.writeTail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  private async executeTask(task: StorageWriteTask): Promise<unknown> {
     switch (task.type) {
       case 'cases:delete':
         this.databaseService.cases.deleteCase(task.params[0])
@@ -252,7 +263,7 @@ export class SqliteWriteExecutor implements StorageWriteExecutor {
         return undefined
 
       case 'region-files:importBed':
-        return this.databaseService.geneLists.importBedEntries(...task.params)
+        return await this.databaseService.geneLists.importBedFile(...task.params)
 
       case 'presets:create':
         return this.databaseService.filterPresets.createPreset(task.params[0])

--- a/src/main/storage/write-executor.ts
+++ b/src/main/storage/write-executor.ts
@@ -102,10 +102,7 @@ export type StorageWriteTask =
   | { type: 'region-files:delete'; params: [fileId: number] }
   | {
       type: 'region-files:importBed'
-      params: [
-        fileId: number,
-        entries: Array<{ chr: string; start: number; end: number; label?: string }>
-      ]
+      params: [fileId: number, filePath: string, options: { rejectMalformedRows: boolean }]
     }
   | { type: 'presets:create'; params: [params: FilterPresetCreate] }
   | { type: 'presets:update'; params: [id: number, updates: FilterPresetUpdate] }

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -327,7 +327,8 @@ export async function streamInsertVcf(
   stmts: ReturnType<typeof prepareStatements>,
   isCancelled: () => boolean,
   vcfSelectedSamples: string[] | undefined,
-  onProgress: (count: number) => void
+  onProgress: (count: number) => void,
+  onSkip?: (reason: string) => void
 ): Promise<number> {
   if (vcfSelectedSamples && vcfSelectedSamples.length > 1) {
     throw new Error(
@@ -381,7 +382,7 @@ export async function streamInsertVcf(
 
       // Parse the data line
       try {
-        const record = parseVcfLine(line, header.samples)
+        const record = parseVcfLine(line, header.samples, onSkip)
         if (record === null) continue // Skip truncated/corrupt lines
         const mapped = mapVcfRecord(
           record,

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -17,6 +17,7 @@ import { createFieldMapper } from '../import/transforms/FieldMapper'
 import { createObjectFormatMapper } from '../import/transforms/ObjectFormatMapper'
 import { resolveColumnIndices } from '../import/config/fieldMapping'
 import { createDecompressedStream, createCappedLineStream } from '../import/stream-utils'
+import { createJsonRecordBudget } from '../import/json-resource-budget'
 import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
 import { parseVcfLine } from '../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../import/vcf/VcfMapper'
@@ -24,6 +25,7 @@ import { detectCaller } from '../import/vcf/caller-detector'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../import/vcf/info-field-registry'
 import type { VcfHeader } from '../import/vcf/types'
 import { VcfHeaderBudget } from '../import/vcf/vcf-header-limits'
+import { VcfResourceLimitError } from '../import/vcf/vcf-resource-limits'
 
 import { DROP_FTS_TRIGGERS } from './worker-db'
 export { DROP_FTS_TRIGGERS }
@@ -410,6 +412,7 @@ export async function streamInsertVcf(
           }
         }
       } catch (e) {
+        if (e instanceof VcfResourceLimitError) throw e
         console.warn(
           '[import-pipeline] Skipping unparseable VCF line:',
           e instanceof Error ? e.message : String(e)
@@ -447,6 +450,7 @@ export async function createMapperPipeline(
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: 'variants' }),
+        createJsonRecordBudget(),
         streamArray.asStream(),
         createObjectFormatMapper()
       )
@@ -459,6 +463,7 @@ export async function createMapperPipeline(
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: samplePath }),
+        createJsonRecordBudget(),
         streamArray.asStream(),
         createObjectFormatMapper()
       )
@@ -477,6 +482,7 @@ export async function createMapperPipeline(
         createDecompressedStream(filePath),
         parser.asStream(),
         pick.asStream({ filter: dataPath }),
+        createJsonRecordBudget(),
         streamArray.asStream(),
         fieldMapper
       )
@@ -514,6 +520,7 @@ export async function parseHeader(
       createDecompressedStream(filePath),
       parser.asStream(),
       pick.asStream({ filter: headerPath }),
+      createJsonRecordBudget(),
       streamArray.asStream()
     )
 

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -19,7 +19,11 @@ import { resolveColumnIndices } from '../import/config/fieldMapping'
 import { createDecompressedStream, createCappedLineStream } from '../import/stream-utils'
 import { createJsonRecordBudget } from '../import/json-resource-budget'
 import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
-import { parseVcfLine } from '../import/vcf/vcf-line-parser'
+import {
+  parseVcfLine,
+  resolveVcfSelectedSampleColumn,
+  type VcfSelectedSampleColumn
+} from '../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../import/vcf/VcfMapper'
 import { detectCaller } from '../import/vcf/caller-detector'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../import/vcf/info-field-registry'
@@ -355,6 +359,7 @@ export async function streamInsertVcf(
   const headerBudget = new VcfHeaderBudget()
   let header: VcfHeader | null = null
   let activeSample = ''
+  let activeSampleColumn: VcfSelectedSampleColumn | null = null
   let callerName: string | null = null
 
   let batch: Array<Record<string, unknown>> = []
@@ -377,8 +382,8 @@ export async function streamInsertVcf(
       // Parse header once, on the first data line
       if (header === null) {
         header = parseVcfHeaderFromLines(headerLines)
-        const selectedSample = vcfSelectedSamples?.[0]
-        activeSample = selectedSample ?? (header.samples.length > 0 ? header.samples[0] : '')
+        activeSampleColumn = resolveVcfSelectedSampleColumn(header.samples, vcfSelectedSamples?.[0])
+        activeSample = activeSampleColumn?.name ?? ''
 
         if (activeSample === '') {
           break
@@ -391,7 +396,7 @@ export async function streamInsertVcf(
 
       // Parse the data line
       try {
-        const record = parseVcfLine(line, header.samples, onSkip)
+        const record = parseVcfLine(line, header.samples, onSkip, activeSampleColumn ?? undefined)
         if (record === null) continue // Skip truncated/corrupt lines
         const mapped = mapVcfRecord(
           record,

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -6,7 +6,7 @@
  */
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
 import { createInterface } from 'node:readline'
-import type { Readable } from 'node:stream'
+import { compose, type Readable } from 'node:stream'
 import { parser } from 'stream-json'
 import { pick } from 'stream-json/filters/pick.js'
 import { streamArray } from 'stream-json/streamers/stream-array.js'
@@ -23,6 +23,7 @@ import { mapVcfRecord } from '../import/vcf/VcfMapper'
 import { detectCaller } from '../import/vcf/caller-detector'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../import/vcf/info-field-registry'
 import type { VcfHeader } from '../import/vcf/types'
+import { VcfHeaderBudget } from '../import/vcf/vcf-header-limits'
 
 import { DROP_FTS_TRIGGERS } from './worker-db'
 export { DROP_FTS_TRIGGERS }
@@ -342,9 +343,14 @@ export async function streamInsertVcf(
   // Shared capped reader guards against a giant single line and a
   // decompression bomb -- see stream-utils.ts for the cap rationale.
   const { stream } = createCappedLineStream(filePath)
+  // Keep error ownership through destroy(); compose emits ABORT_ERR when a
+  // header-budget failure settles before the file naturally ends.
+  stream.on('error', () => undefined)
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
+  rl.on('error', () => undefined)
 
   const headerLines: string[] = []
+  const headerBudget = new VcfHeaderBudget()
   let header: VcfHeader | null = null
   let activeSample = ''
   let callerName: string | null = null
@@ -361,6 +367,7 @@ export async function streamInsertVcf(
 
       // Collect header lines
       if (line.startsWith('#')) {
+        headerBudget.add(line)
         headerLines.push(line)
         continue
       }
@@ -436,21 +443,25 @@ export async function createMapperPipeline(
 ): Promise<Readable> {
   switch (formatInfo.format) {
     case 'simple': {
-      const stream = createDecompressedStream(filePath)
-        .pipe(parser.asStream())
-        .pipe(pick.asStream({ filter: 'variants' }))
-        .pipe(streamArray.asStream())
-        .pipe(createObjectFormatMapper())
+      const stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: 'variants' }),
+        streamArray.asStream(),
+        createObjectFormatMapper()
+      )
       return stream
     }
 
     case 'object': {
       const samplePath = `samples.${formatInfo.caseKey}.variants`
-      const stream = createDecompressedStream(filePath)
-        .pipe(parser.asStream())
-        .pipe(pick.asStream({ filter: samplePath }))
-        .pipe(streamArray.asStream())
-        .pipe(createObjectFormatMapper())
+      const stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: samplePath }),
+        streamArray.asStream(),
+        createObjectFormatMapper()
+      )
       return stream
     }
 
@@ -462,11 +473,13 @@ export async function createMapperPipeline(
       const { dictionaries, columnIndices } = await parseHeader(filePath, headerPath)
       const fieldMapper = createFieldMapper(dictionaries, columnIndices)
 
-      const stream = createDecompressedStream(filePath)
-        .pipe(parser.asStream())
-        .pipe(pick.asStream({ filter: dataPath }))
-        .pipe(streamArray.asStream())
-        .pipe(fieldMapper)
+      const stream = compose(
+        createDecompressedStream(filePath),
+        parser.asStream(),
+        pick.asStream({ filter: dataPath }),
+        streamArray.asStream(),
+        fieldMapper
+      )
       return stream
     }
   }
@@ -497,13 +510,14 @@ export async function parseHeader(
     const fieldsToExtract = new Set(['Gene', 'Transcript', 'HpoSimScore', 'MoI'])
     let resolved = false
 
-    const stream = createDecompressedStream(filePath)
-      .pipe(parser.asStream())
-      .pipe(pick.asStream({ filter: headerPath }))
-      .pipe(streamArray.asStream())
+    const stream = compose(
+      createDecompressedStream(filePath),
+      parser.asStream(),
+      pick.asStream({ filter: headerPath }),
+      streamArray.asStream()
+    )
 
     const cleanup = (): void => {
-      stream.removeAllListeners()
       stream.destroy()
     }
 

--- a/src/main/workers/import-pipeline.ts
+++ b/src/main/workers/import-pipeline.ts
@@ -5,9 +5,7 @@
  * worker_threads imports. This module is testable in isolation.
  */
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
-import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
-import { createGunzip } from 'node:zlib'
 import type { Readable } from 'node:stream'
 import { parser } from 'stream-json'
 import { pick } from 'stream-json/filters/pick.js'
@@ -18,7 +16,7 @@ import type { FormatInfo } from '../import/strategies/ImportStrategy'
 import { createFieldMapper } from '../import/transforms/FieldMapper'
 import { createObjectFormatMapper } from '../import/transforms/ObjectFormatMapper'
 import { resolveColumnIndices } from '../import/config/fieldMapping'
-import { createDecompressedStream, isGzipped } from '../import/stream-utils'
+import { createDecompressedStream, createCappedLineStream } from '../import/stream-utils'
 import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
 import { parseVcfLine } from '../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../import/vcf/VcfMapper'
@@ -340,8 +338,9 @@ export async function streamInsertVcf(
   // Suppress unused-variable warning — formatInfo kept for API consistency
   void formatInfo
 
-  const raw = createReadStream(filePath)
-  const stream = isGzipped(filePath) ? raw.pipe(createGunzip()) : raw
+  // Shared capped reader guards against a giant single line and a
+  // decompression bomb -- see stream-utils.ts for the cap rationale.
+  const { stream } = createCappedLineStream(filePath)
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
   const headerLines: string[] = []
@@ -417,7 +416,7 @@ export async function streamInsertVcf(
       onProgress(totalInserted)
     }
     // Ensure stream resources are released
-    raw.destroy()
+    stream.destroy()
   }
 
   return totalInserted

--- a/src/main/workers/import-skip-tracker.ts
+++ b/src/main/workers/import-skip-tracker.ts
@@ -1,0 +1,14 @@
+import { MAX_IMPORT_SKIP_REASONS } from '../../shared/types/import-worker'
+
+export class ImportSkipTracker {
+  count = 0
+  readonly reasons: string[] = []
+
+  /** Record a skip and return whether its representative reason was retained. */
+  record(reason: string): boolean {
+    this.count += 1
+    if (this.reasons.length >= MAX_IMPORT_SKIP_REASONS) return false
+    this.reasons.push(reason)
+    return true
+  }
+}

--- a/src/main/workers/import-worker.ts
+++ b/src/main/workers/import-worker.ts
@@ -134,7 +134,7 @@ port.on('message', async (msg: MainMessage) => {
 
           const startTime = Date.now()
           let variantCount = 0
-          const fileSkipped = 0
+          let fileSkipped = 0
 
           try {
             // Emit parsing phase progress
@@ -179,7 +179,13 @@ port.on('message', async (msg: MainMessage) => {
                   stmts,
                   () => cancelled,
                   file.vcfSelectedSamples,
-                  onProgress
+                  onProgress,
+                  (reason) => {
+                    fileSkipped += 1
+                    if (fileSkipped <= 10) {
+                      console.warn(`[import-worker] VCF line skipped in ${fileName}:`, reason)
+                    }
+                  }
                 )
               } else {
                 variantCount = await streamInsertJson(

--- a/src/main/workers/import-worker.ts
+++ b/src/main/workers/import-worker.ts
@@ -21,6 +21,7 @@ import {
   streamInsertJson,
   streamInsertVcf
 } from './import-pipeline'
+import { ImportSkipTracker } from './import-skip-tracker'
 
 if (!parentPort) throw new Error('Must be run as worker thread')
 
@@ -134,7 +135,7 @@ port.on('message', async (msg: MainMessage) => {
 
           const startTime = Date.now()
           let variantCount = 0
-          let fileSkipped = 0
+          const skipTracker = new ImportSkipTracker()
 
           try {
             // Emit parsing phase progress
@@ -162,7 +163,7 @@ port.on('message', async (msg: MainMessage) => {
                   overallPercent: Math.round(((fileIndex + 0.5) / totalFiles) * 100),
                   phase: 'inserting',
                   variantCount: count,
-                  skipped: fileSkipped
+                  skipped: skipTracker.count
                 }
                 port.postMessage(progressMsg)
               }
@@ -181,8 +182,7 @@ port.on('message', async (msg: MainMessage) => {
                   file.vcfSelectedSamples,
                   onProgress,
                   (reason) => {
-                    fileSkipped += 1
-                    if (fileSkipped <= 10) {
+                    if (skipTracker.record(reason)) {
                       console.warn(`[import-worker] VCF line skipped in ${fileName}:`, reason)
                     }
                   }
@@ -231,7 +231,8 @@ port.on('message', async (msg: MainMessage) => {
                 caseId,
                 caseName: file.caseName,
                 variantCount,
-                skipped: fileSkipped,
+                skipped: skipTracker.count,
+                skipReasons: skipTracker.reasons,
                 elapsed
               }
             }

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -98,26 +98,6 @@ const defaultDeps: RunImportDeps = {
     streamMappedVcfRows(filePath, options.selectedSample, options.filters, options.onSkip)
 }
 
-async function cleanupIncompleteSingleFileVcfCase(args: {
-  client: Pick<Client, 'query'>
-  schema: string
-  caseId: number
-}): Promise<void> {
-  const { client, schema, caseId } = args
-  await client.query('BEGIN')
-  try {
-    await client.query(`DELETE FROM ${quoteIdentifier(schema)}."cases" WHERE id = $1`, [caseId])
-    await client.query('COMMIT')
-  } catch (err) {
-    try {
-      await client.query('ROLLBACK')
-    } catch {
-      // Preserve the original cleanup failure.
-    }
-    throw err
-  }
-}
-
 function recordParseSkip(args: { reason: string; errors: string[]; prefix?: string }): void {
   const { reason, errors, prefix } = args
   if (errors.length < 10) {
@@ -247,7 +227,6 @@ export async function runImport(
   const client = deps.createClient(clientConfigFromMessage(start.client))
   let beganTransaction = false
   let committed = false
-  let incompleteSingleFileVcfCaseId: number | null = null
 
   try {
     await client.connect()
@@ -290,14 +269,9 @@ export async function runImport(
             // ignore — used only for provenance
           }
 
-          // Open the first per-batch transaction (formerly the outer BEGIN at
-          // the top of runImport). `SET LOCAL synchronous_commit = OFF` makes
-          // each per-batch COMMIT skip the WAL fsync; the FINAL commit at
-          // the end of the post-loop bookkeeping re-enables synchronous
-          // commit so the import only reports success once every preceding
-          // WAL record has been fsynced (Postgres flushes WAL up to the
-          // last synchronous commit, which transitively makes every earlier
-          // async commit durable).
+          // Keep the entire file in one transaction. Batches bound application
+          // memory, but committing them independently would leave a partial
+          // case behind when a later row violates an import resource limit.
           await client.query('BEGIN')
           beganTransaction = true
           await client.query('SET LOCAL synchronous_commit = OFF')
@@ -375,7 +349,6 @@ export async function runImport(
             profileCount('batch', 1)
             if (!firstWritten) {
               caseId = result.caseId
-              incompleteSingleFileVcfCaseId = caseId
             }
             totalInserted += result.variantCount
             firstWritten = true
@@ -386,18 +359,6 @@ export async function runImport(
             cnv = []
             str = []
             ordinal = 0
-            // Commit per-batch so postgres releases per-tuple bookkeeping and
-            // the pg-node client releases its query/result references. Without
-            // this the worker's working set scales linearly with file size on
-            // large WGS imports — the original single-transaction shape OOMed
-            // multi-GB Node heaps on the GIAB HG002 fixture.
-            await profilePhase('per-batch-commit-begin', async () => {
-              await client.query('COMMIT')
-              await client.query('BEGIN')
-              // Re-apply per-batch synchronous_commit lever — SET LOCAL is
-              // transaction-scoped and must be re-issued after every BEGIN.
-              await client.query('SET LOCAL synchronous_commit = OFF')
-            })
             if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
               ;(globalThis as { gc?: () => void }).gc?.()
             }
@@ -459,7 +420,6 @@ export async function runImport(
             await client.query('COMMIT')
           }
           committed = true
-          incompleteSingleFileVcfCaseId = null
 
           profileFlush()
           post({
@@ -512,9 +472,6 @@ export async function runImport(
           totalInserted += batch.length
           batch = []
           post({ type: 'progress', phase: 'inserting', rowsProcessed: totalInserted, filePath })
-          // Commit per-batch — same rationale as the VCF branch above.
-          await client.query('COMMIT')
-          await client.query('BEGIN')
           if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
             ;(globalThis as { gc?: () => void }).gc?.()
           }
@@ -652,14 +609,14 @@ export async function runImport(
         for (let i = 0; i < start.files.length; i += 1) {
           if (cancelled) break
           const fileSpec = start.files[i]
+          const caseIdBeforeFile = caseId
           let fileVariantCount = 0
           try {
             await client.query('BEGIN')
             beganTransaction = true
-            // Per-file transaction: bound failure semantics ("file N failed"
-            // rolls back any in-flight batch) while the bracket transactions
-            // ABOVE keep the trigger DISABLE durable. SET LOCAL is
-            // transaction-scoped, so re-issue it on every per-file BEGIN.
+            // Each file is atomic: cancellation or any late parse/resource
+            // failure rolls back every batch from this file while preserving
+            // files that completed previously.
             await client.query('SET LOCAL synchronous_commit = OFF')
             const fileName = basename(fileSpec.filePath)
             let fileSize = 0
@@ -700,7 +657,7 @@ export async function runImport(
               //                       (looks up case + writes per-file provenance)
               //   - any file, batch >0: mode: 'append', caseId
               //                       (no lookup, no provenance — saves O(N) queries)
-              const isFirstFileFirstBatch = i === 0 && firstBatch
+              const isFirstFileFirstBatch = caseId === 0 && firstBatch
               const isAppend = !firstBatch && caseId !== 0
               const request: PostgresVcfImportRequest = isAppend
                 ? {
@@ -774,22 +731,13 @@ export async function runImport(
               cnv = []
               str = []
               ordinal = 0
-              // Commit per-batch — same rationale as the single-file branch.
-              // The per-file BEGIN/COMMIT around this loop still bounds the
-              // failure semantics ("file N failed" rolls back any in-flight
-              // batch), but each successful batch is now durable immediately.
-              await client.query('COMMIT')
-              await client.query('BEGIN')
-              // Re-apply per-batch synchronous_commit lever — SET LOCAL is
-              // transaction-scoped and must be re-issued after every BEGIN.
-              await client.query('SET LOCAL synchronous_commit = OFF')
               if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
                 ;(globalThis as { gc?: () => void }).gc?.()
               }
             }
 
             for await (const row of stream) {
-              if (cancelled) break
+              if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
               const { _transcripts, _sv, _cnv, _str, ...base } = row
               variants.push(base as unknown as Record<string, unknown>)
               if (Array.isArray(_transcripts)) {
@@ -811,25 +759,7 @@ export async function runImport(
             }
 
             if (cancelled) {
-              // Flush whatever was buffered before cancellation was detected
-              // then commit and break — partial state is left committed.
-              await flushBatch()
-              await client.query('COMMIT')
-              beganTransaction = false
-              committed = true
-              totalVariantCount += fileVariantCount
-              fileResults.push({
-                filePath: fileSpec.filePath,
-                variantType: fileSpec.variantType,
-                variantCount: fileVariantCount
-              })
-              post({
-                type: 'file-complete',
-                filePath: fileSpec.filePath,
-                caseId,
-                variantCount: fileVariantCount
-              })
-              break
+              throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
             }
 
             await flushBatch()
@@ -850,6 +780,7 @@ export async function runImport(
             })
           } catch (err) {
             beganTransaction = false
+            caseId = caseIdBeforeFile
 
             console.warn(
               `[postgres-import-worker] file ${i} (${fileSpec.filePath}) failed:`,
@@ -864,6 +795,7 @@ export async function runImport(
               )
             }
             const message = err instanceof Error ? err.message : String(err)
+            if (message === POSTGRES_IMPORT_CANCELLATION_MESSAGE) break
             fileResults.push({
               filePath: fileSpec.filePath,
               variantType: fileSpec.variantType,
@@ -878,9 +810,9 @@ export async function runImport(
           await client.query('BEGIN')
           beganTransaction = true
           // Force the final commit synchronous so the import only reports
-          // success once the WAL is fsynced. Postgres flushes WAL up to
-          // this commit's LSN, which transitively makes every earlier
-          // async-committed batch (per-file + per-batch) durable on disk.
+          // success once the WAL is fsynced. Postgres flushes WAL up to this
+          // commit's LSN, which transitively makes every earlier per-file
+          // async commit durable on disk.
           await client.query('SET LOCAL synchronous_commit = ON')
           try {
             await client.query(
@@ -946,24 +878,6 @@ export async function runImport(
         console.warn(
           '[postgres-import-worker] ROLLBACK failed:',
           rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
-        )
-      }
-    }
-    if (
-      incompleteSingleFileVcfCaseId !== null &&
-      message !== POSTGRES_IMPORT_CANCELLATION_MESSAGE
-    ) {
-      try {
-        await cleanupIncompleteSingleFileVcfCase({
-          client,
-          schema: start.schema,
-          caseId: incompleteSingleFileVcfCaseId
-        })
-        incompleteSingleFileVcfCaseId = null
-      } catch (cleanupErr) {
-        console.warn(
-          '[postgres-import-worker] Failed to delete incomplete single-file VCF case:',
-          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)
         )
       }
     }

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -1,8 +1,7 @@
 import { parentPort } from 'node:worker_threads'
 import { basename } from 'node:path'
-import { statSync, createReadStream } from 'node:fs'
+import { statSync } from 'node:fs'
 import type { Readable } from 'node:stream'
-import { createGunzip } from 'node:zlib'
 import { createInterface } from 'node:readline'
 import { Client, type ClientConfig, type Pool, type PoolClient } from 'pg'
 
@@ -38,7 +37,7 @@ import { parseVcfLine } from '../import/vcf/vcf-line-parser'
 import { mapVcfRecord } from '../import/vcf/VcfMapper'
 import { detectCaller } from '../import/vcf/caller-detector'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../import/vcf/info-field-registry'
-import { isGzipped } from '../import/stream-utils'
+import { createCappedLineStream } from '../import/stream-utils'
 import type { VcfHeader, VcfMappedVariant } from '../import/vcf/types'
 import { BedFilter } from '../import/vcf/bed-filter'
 import {
@@ -90,7 +89,7 @@ process.on('unhandledRejection', (reason) => {
  * threshold, BED region) are applied before `mapVcfRecord`, and post-mapping
  * filters (GQ, DP) are applied to each emitted variant independently.
  */
-async function* streamMappedVcfRows(
+export async function* streamMappedVcfRows(
   filePath: string,
   selectedSample: string,
   filters?: ImportFilters
@@ -104,22 +103,25 @@ async function* streamMappedVcfRows(
   // Task 15 root cause).
   statSync(filePath)
 
-  const raw = createReadStream(filePath)
-  const gunzip = isGzipped(filePath) ? createGunzip() : null
-  const stream = gunzip !== null ? raw.pipe(gunzip) : raw
+  // Shared capped reader guards against a giant single line and a
+  // decompression bomb -- see stream-utils.ts for the cap rationale.
+  const { stream } = createCappedLineStream(filePath)
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
 
   // Belt-and-suspenders: also capture any post-open stream errors (gzip
-  // corruption mid-file, EIO, etc.) and re-throw them from the generator so
-  // the caller's per-file `try/catch` handles them. Without this an
-  // unhandled `error` event would still surface as `uncaughtException`.
+  // corruption mid-file, DoS cap trip, EIO, etc.) and re-throw them from the
+  // generator so the caller's per-file `try/catch` handles them. Without
+  // this an unhandled `error` event would still surface as an
+  // `uncaughtException`. `stream` here is the composed capped pipeline --
+  // `stream.compose()` (see stream-utils.ts) forwards an error from any
+  // stage (raw read, gunzip, byte cap, line cap) to a single 'error' event
+  // on this one object, so one listener covers every failure mode.
   let streamError: Error | null = null
   const onStreamError = (err: Error): void => {
     if (streamError === null) streamError = err
     rl.close()
   }
-  raw.on('error', onStreamError)
-  gunzip?.on('error', onStreamError)
+  stream.on('error', onStreamError)
 
   const headerLines: string[] = []
   let header: VcfHeader | null = null
@@ -175,9 +177,8 @@ async function* streamMappedVcfRows(
     // gunzip integrity check at end-of-stream) still need to propagate.
     if (streamError !== null) throw streamError
   } finally {
-    raw.off('error', onStreamError)
-    gunzip?.off('error', onStreamError)
-    raw.destroy()
+    stream.off('error', onStreamError)
+    stream.destroy()
   }
 }
 

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -18,7 +18,8 @@ import {
 } from '../storage/postgres/PostgresJsonImportRepository'
 import {
   PostgresVcfImportRepository,
-  type PostgresVcfImportRequest
+  type PostgresVcfImportRequest,
+  type PostgresProvisionalImport
 } from '../storage/postgres/PostgresVcfImportRepository'
 import {
   profileStart,
@@ -127,14 +128,14 @@ export async function relaxImportSessionLimits(client: Pick<Client, 'query'>): P
  * still INSIDE the post-loop transaction the caller owns.
  *
  * The summary update is wrapped in a SAVEPOINT so a failure here cannot lose the
- * bookkeeping. On failure: ROLLBACK TO SAVEPOINT (keeps variant_count +
- * variant_frequency), COMMIT the outer transaction, then markStale in a separate
- * tiny transaction so the bookkeeping commit survives regardless. Staleness lives
- * in cohort_summary_state — it is NOT surfaced on the ImportResult (Pass-4 HIGH
- * #3); the next cohort-page load detects it and rebuilds.
+ * bookkeeping. On failure it rolls back to the savepoint (keeping count and
+ * frequency work) and marks the summary stale inside the same publication
+ * transaction. Staleness is not surfaced on ImportResult; the next cohort read
+ * detects it and rebuilds.
  *
- * Returns `true` when the caller still owns an open transaction it must COMMIT,
- * `false` when this helper already committed the outer transaction (failure path).
+ * Returns `true` while preserving the historical caller contract. The caller
+ * always retains the final publication transaction, including on stale-marking
+ * fallback, so visibility cannot split across commits.
  */
 async function updateCohortSummaryAfterImport(args: {
   client: Pick<Client, 'query'>
@@ -149,40 +150,40 @@ async function updateCohortSummaryAfterImport(args: {
   >[0]['client']
   try {
     await client.query('SAVEPOINT cohort_summary')
-    await summary.incrementalAdd({ schema, client: scoped, caseId, genomeBuild })
+    await summary.incrementalAdd({
+      schema,
+      client: scoped,
+      caseId,
+      genomeBuild,
+      includeProvisional: true
+    })
     await summary.recomputeCohortFrequency({
       schema,
       client: scoped,
-      affectedBuilds: [genomeBuild]
+      affectedBuilds: [genomeBuild],
+      includeProvisional: true
     })
-    await summary.refreshColumnMetas({ schema, client: scoped, caseId })
+    await summary.refreshColumnMetas({
+      schema,
+      client: scoped,
+      caseId,
+      includeProvisional: true
+    })
     await client.query('RELEASE SAVEPOINT cohort_summary')
     return true
   } catch (savepointErr) {
     await client.query('ROLLBACK TO SAVEPOINT cohort_summary')
-    // Commit the outer transaction NOW so the bookkeeping (variant_count +
-    // rebuildVariantFrequencyForCase) is durable before the stale-marking
-    // tiny transaction runs.
-    await client.query('COMMIT')
-    // Mark stale in a separate tiny transaction so the bookkeeping commit
-    // survives even if marking fails. Reuses the same idle client (this worker
-    // owns a single short-lived connection; the outer txn is already committed).
+    // Keep stale marking in the caller's final bookkeeping transaction.  The
+    // case is still hidden at this point, so committing here would create a
+    // crash window in which derived rows exist without a recoverable
+    // publication marker.
     try {
-      await client.query('BEGIN')
       await summary.markStale({
         schema,
         client: scoped,
         reason: `post_import_summary_failed_case_${caseId}`
       })
-      await client.query('COMMIT')
     } catch (markErr) {
-      try {
-        await client.query('ROLLBACK')
-      } catch {
-        // swallow — nothing more we can do; the outer commit already landed.
-      }
-      // Worker has no mainLogger access; console.warn is the documented worker
-      // exception (see AGENTS.md).
       console.warn(
         '[postgres-import-worker] Failed to mark cohort summary stale after post-import failure:',
         markErr instanceof Error ? markErr.message : String(markErr)
@@ -192,7 +193,7 @@ async function updateCohortSummaryAfterImport(args: {
       `[postgres-import-worker] Cohort summary update failed for case ${caseId}; marked stale:`,
       savepointErr instanceof Error ? savepointErr.message : String(savepointErr)
     )
-    return false
+    return true
   }
 }
 
@@ -226,7 +227,8 @@ export async function runImport(
       : POSTGRES_JSON_IMPORT_BATCH_SIZE
   const client = deps.createClient(clientConfigFromMessage(start.client))
   let beganTransaction = false
-  let committed = false
+  let provisionalImport: PostgresProvisionalImport | null = null
+  let publicationCommitAttempted = false
 
   try {
     await client.connect()
@@ -237,6 +239,16 @@ export async function runImport(
     // renderer-default 30 s statement_timeout. Auto-commit (no BEGIN
     // required) and per-session, so it does not leak to other connections.
     await profilePhase('relax-session-limits', () => relaxImportSessionLimits(client))
+    const lockResult = await client.query(
+      `SELECT pg_try_advisory_lock(hashtext($1), hashtext('varlens-import')) AS locked`,
+      [start.schema]
+    )
+    if ((lockResult.rows[0] as { locked?: boolean } | undefined)?.locked !== true) {
+      throw new Error('An import operation is already in progress for this PostgreSQL workspace')
+    }
+    await new PostgresVcfImportRepository(start.schema).recoverInterruptedImports(
+      client as unknown as Pick<PoolClient, 'query'>
+    )
 
     if (start.mode === 'single-file') {
       const filePath = start.filePath
@@ -269,14 +281,17 @@ export async function runImport(
             // ignore — used only for provenance
           }
 
-          // Keep the entire file in one transaction. Batches bound application
-          // memory, but committing them independently would leave a partial
-          // case behind when a later row violates an import resource limit.
-          await client.query('BEGIN')
-          beganTransaction = true
-          await client.query('SET LOCAL synchronous_commit = OFF')
-
           const repo = new PostgresVcfImportRepository(start.schema)
+          provisionalImport = await repo.beginProvisionalImport(
+            client as unknown as Pick<PoolClient, 'query'>,
+            {
+              caseName: start.caseName,
+              filePath,
+              fileSize: vcfFileSize,
+              genomeBuild
+            }
+          )
+          const caseId = provisionalImport.caseId
           // Single-file imports reject filters at the executor level, but pass
           // undefined defensively to keep the contract consistent.
           let totalSkipped = 0
@@ -298,60 +313,36 @@ export async function runImport(
           let str: Array<Record<string, unknown> & { ordinal: number }> = []
           let ordinal = 0
           let totalInserted = 0
-          let caseId = 0
-          let firstWritten = false
 
           const flush = async (): Promise<void> => {
             if (variants.length === 0) return
-            // First batch creates the case + writes provenance; subsequent
-            // batches use 'append' mode with the already-resolved caseId so we
-            // skip the per-batch `SELECT id FROM cases` lookup AND the
-            // per-batch case_data_info upsert (the row is already correct
-            // after the first batch). Saves O(N) redundant queries on WGS
-            // imports.
-            const request: PostgresVcfImportRequest = firstWritten
-              ? {
-                  mode: 'append',
-                  caseId,
-                  caseName: start.caseName,
-                  fileName: vcfFileName,
-                  filePath,
-                  fileSize: vcfFileSize,
-                  genomeBuild,
-                  caller: null,
-                  annotationFormat: null,
-                  variantType: 'snv-indel',
-                  variants,
-                  transcripts,
-                  sv,
-                  cnv,
-                  str
-                }
-              : {
-                  mode: 'single-file',
-                  caseName: start.caseName,
-                  fileName: vcfFileName,
-                  filePath,
-                  fileSize: vcfFileSize,
-                  genomeBuild,
-                  caller: null,
-                  annotationFormat: null,
-                  variantType: 'snv-indel',
-                  variants,
-                  transcripts,
-                  sv,
-                  cnv,
-                  str
-                }
-            const result = await profilePhase('writeVcfFile', () =>
+            const request: PostgresVcfImportRequest = {
+              mode: 'append',
+              caseId,
+              caseName: start.caseName,
+              fileName: vcfFileName,
+              filePath,
+              fileSize: vcfFileSize,
+              genomeBuild,
+              caller: null,
+              annotationFormat: null,
+              variantType: 'snv-indel',
+              variants,
+              transcripts,
+              sv,
+              cnv,
+              str
+            }
+            await client.query('BEGIN')
+            beganTransaction = true
+            await client.query('SET LOCAL synchronous_commit = OFF')
+            const variantCount = await profilePhase('writeVcfFile', () =>
               repo.writeVcfFile(client as unknown as Pick<PoolClient, 'query'>, request)
             )
+            await client.query('COMMIT')
+            beganTransaction = false
             profileCount('batch', 1)
-            if (!firstWritten) {
-              caseId = result.caseId
-            }
-            totalInserted += result.variantCount
-            firstWritten = true
+            totalInserted += variantCount.variantCount
             post({ type: 'progress', phase: 'inserting', rowsProcessed: totalInserted, filePath })
             variants = []
             transcripts = []
@@ -364,62 +355,85 @@ export async function runImport(
             }
           }
 
-          for await (const row of stream) {
-            if (cancelled) {
-              throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
-            }
-            const { _transcripts, _sv, _cnv, _str, ...base } = row
-            variants.push(base as unknown as Record<string, unknown>)
-            if (Array.isArray(_transcripts)) {
-              for (const t of _transcripts as unknown as Array<Record<string, unknown>>) {
-                transcripts.push({ ordinal, ...t })
+          try {
+            for await (const row of stream) {
+              if (cancelled) {
+                throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+              }
+              const { _transcripts, _sv, _cnv, _str, ...base } = row
+              variants.push(base as unknown as Record<string, unknown>)
+              if (Array.isArray(_transcripts)) {
+                for (const t of _transcripts as unknown as Array<Record<string, unknown>>) {
+                  transcripts.push({ ordinal, ...t })
+                }
+              }
+              if (_sv !== undefined && _sv !== null) {
+                sv.push({ ordinal, ...(_sv as unknown as Record<string, unknown>) })
+              }
+              if (_cnv !== undefined && _cnv !== null) {
+                cnv.push({ ordinal, ...(_cnv as unknown as Record<string, unknown>) })
+              }
+              if (_str !== undefined && _str !== null) {
+                str.push({ ordinal, ...(_str as unknown as Record<string, unknown>) })
+              }
+              ordinal += 1
+
+              if (variants.length >= batchSize) {
+                await flush()
               }
             }
-            if (_sv !== undefined && _sv !== null) {
-              sv.push({ ordinal, ...(_sv as unknown as Record<string, unknown>) })
+            await flush()
+            if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+          } catch (error) {
+            if (beganTransaction) {
+              await client.query('ROLLBACK')
+              beganTransaction = false
             }
-            if (_cnv !== undefined && _cnv !== null) {
-              cnv.push({ ordinal, ...(_cnv as unknown as Record<string, unknown>) })
-            }
-            if (_str !== undefined && _str !== null) {
-              str.push({ ordinal, ...(_str as unknown as Record<string, unknown>) })
-            }
-            ordinal += 1
-
-            if (variants.length >= batchSize) {
-              await flush()
-            }
+            throw error
           }
-          await flush()
 
-          if (caseId !== 0) {
-            await client.query(
-              `UPDATE ${quoteIdentifier(start.schema)}."cases" SET variant_count = $1 WHERE id = $2`,
-              [totalInserted, caseId]
-            )
+          if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+
+          // Bookkeeping may scan millions of rows, but contains no production
+          // COPY. MVCC keeps the previous ready snapshot visible until this
+          // transaction publishes the case and every derived structure
+          // together.
+          await client.query('BEGIN')
+          beganTransaction = true
+          await client.query('SET LOCAL synchronous_commit = ON')
+          await client.query(
+            `UPDATE ${quoteIdentifier(start.schema)}."cases_all" SET variant_count = $1 WHERE id = $2`,
+            [totalInserted, caseId]
+          )
+          if (totalInserted > 0) {
             await rebuildVariantFrequencyForCase(
               client as unknown as Pick<PoolClient, 'query'>,
               start.schema,
-              caseId
+              caseId,
+              true
             )
-          }
-          // Report success only after this commit fsyncs all prior async-committed batches.
-          await client.query('SET LOCAL synchronous_commit = ON')
-          // C3: incremental cohort-summary update inside this txn (SAVEPOINT-
-          // wrapped). On failure the helper rolls back to the savepoint and
-          // commits the outer txn itself, returning false.
-          if (caseId !== 0) {
+            // C3: incremental cohort-summary update inside this txn (SAVEPOINT-
+            // wrapped). On failure it rolls back only the summary savepoint
+            // and records staleness in this same publication transaction.
             const stillOwnsTxn = await updateCohortSummaryAfterImport({
               client,
               schema: start.schema,
               caseId,
               genomeBuild
             })
-            if (stillOwnsTxn) await client.query('COMMIT')
-          } else {
-            await client.query('COMMIT')
+            void stillOwnsTxn
           }
-          committed = true
+          await repo.finishProvisionalImport(
+            client as unknown as Pick<PoolClient, 'query'>,
+            caseId,
+            vcfFileName,
+            'vcf'
+          )
+          publicationCommitAttempted = true
+          await client.query('COMMIT')
+          beganTransaction = false
+          provisionalImport = null
+          publicationCommitAttempted = false
 
           profileFlush()
           post({
@@ -539,8 +553,6 @@ export async function runImport(
         })
         if (stillOwnsTxn) await client.query('COMMIT')
       }
-      committed = true
-
       post({
         type: 'complete',
         mode: 'single-file',
@@ -611,19 +623,35 @@ export async function runImport(
           const fileSpec = start.files[i]
           const caseIdBeforeFile = caseId
           let fileVariantCount = 0
+          let currentFileProvisional: PostgresProvisionalImport | null = null
           try {
-            await client.query('BEGIN')
-            beganTransaction = true
-            // Each file is atomic: cancellation or any late parse/resource
-            // failure rolls back every batch from this file while preserving
-            // files that completed previously.
-            await client.query('SET LOCAL synchronous_commit = OFF')
             const fileName = basename(fileSpec.filePath)
             let fileSize = 0
             try {
               fileSize = deps.statFile(fileSpec.filePath).size
             } catch {
               // ignore — used only for provenance
+            }
+            let fileCaseId: number
+            if (caseId === 0) {
+              provisionalImport = await repo.beginProvisionalImport(
+                client as unknown as Pick<PoolClient, 'query'>,
+                {
+                  caseName: start.caseName,
+                  filePath: fileSpec.filePath,
+                  fileSize,
+                  genomeBuild
+                }
+              )
+              currentFileProvisional = provisionalImport
+              fileCaseId = provisionalImport.caseId
+            } else {
+              const watermark = await repo.captureVariantWatermark(
+                client as unknown as Pick<PoolClient, 'query'>,
+                caseId
+              )
+              currentFileProvisional = { caseId, watermark, isNew: false }
+              fileCaseId = caseId
             }
 
             const stream = await deps.createVcfMappedStream(fileSpec.filePath, {
@@ -646,79 +674,36 @@ export async function runImport(
             let cnv: Array<Record<string, unknown> & { ordinal: number }> = []
             let str: Array<Record<string, unknown> & { ordinal: number }> = []
             let ordinal = 0
-            let firstBatch = true
 
             const flushBatch = async (): Promise<void> => {
               if (variants.length === 0) return
-              // Per-batch shape:
-              //   - file 0, batch 0:  mode: 'multi-file', fileIndex: 0
-              //                       (creates case + writes provenance)
-              //   - file N, batch 0:  mode: 'multi-file', fileIndex: 1
-              //                       (looks up case + writes per-file provenance)
-              //   - any file, batch >0: mode: 'append', caseId
-              //                       (no lookup, no provenance — saves O(N) queries)
-              const isFirstFileFirstBatch = caseId === 0 && firstBatch
-              const isAppend = !firstBatch && caseId !== 0
-              const request: PostgresVcfImportRequest = isAppend
-                ? {
-                    mode: 'append',
-                    caseId,
-                    caseName: start.caseName,
-                    fileName,
-                    filePath: fileSpec.filePath,
-                    fileSize,
-                    genomeBuild,
-                    caller: fileSpec.caller ?? null,
-                    annotationFormat: fileSpec.annotationFormat ?? null,
-                    variantType: fileSpec.variantType,
-                    variants,
-                    transcripts,
-                    sv,
-                    cnv,
-                    str
-                  }
-                : isFirstFileFirstBatch
-                  ? {
-                      mode: 'multi-file',
-                      fileIndex: 0,
-                      caseName: start.caseName,
-                      fileName,
-                      filePath: fileSpec.filePath,
-                      fileSize,
-                      genomeBuild,
-                      caller: fileSpec.caller ?? null,
-                      annotationFormat: fileSpec.annotationFormat ?? null,
-                      variantType: fileSpec.variantType,
-                      variants,
-                      transcripts,
-                      sv,
-                      cnv,
-                      str
-                    }
-                  : {
-                      mode: 'multi-file',
-                      fileIndex: 1,
-                      caseName: start.caseName,
-                      fileName,
-                      filePath: fileSpec.filePath,
-                      fileSize,
-                      genomeBuild,
-                      caller: fileSpec.caller ?? null,
-                      annotationFormat: fileSpec.annotationFormat ?? null,
-                      variantType: fileSpec.variantType,
-                      variants,
-                      transcripts,
-                      sv,
-                      cnv,
-                      str
-                    }
-              const result = await repo.writeVcfFile(
+              const request: PostgresVcfImportRequest = {
+                mode: 'append',
+                caseId: fileCaseId,
+                caseName: start.caseName,
+                fileName,
+                filePath: fileSpec.filePath,
+                fileSize,
+                genomeBuild,
+                caller: fileSpec.caller ?? null,
+                annotationFormat: fileSpec.annotationFormat ?? null,
+                variantType: fileSpec.variantType,
+                variants,
+                transcripts,
+                sv,
+                cnv,
+                str
+              }
+              await client.query('BEGIN')
+              beganTransaction = true
+              await client.query('SET LOCAL synchronous_commit = OFF')
+              const batchResult = await repo.writeVcfFile(
                 client as unknown as Pick<PoolClient, 'query'>,
                 request
               )
-              if (caseId === 0) caseId = result.caseId
-              fileVariantCount += result.variantCount
-              firstBatch = false
+              await client.query('COMMIT')
+              beganTransaction = false
+              fileVariantCount += batchResult.variantCount
               post({
                 type: 'progress',
                 phase: 'inserting',
@@ -763,9 +748,8 @@ export async function runImport(
             }
 
             await flushBatch()
-            await client.query('COMMIT')
-            beganTransaction = false
-            committed = true
+            if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+            caseId = fileCaseId
             totalVariantCount += fileVariantCount
             fileResults.push({
               filePath: fileSpec.filePath,
@@ -779,7 +763,6 @@ export async function runImport(
               variantCount: fileVariantCount
             })
           } catch (err) {
-            beganTransaction = false
             caseId = caseIdBeforeFile
 
             console.warn(
@@ -787,11 +770,28 @@ export async function runImport(
               err instanceof Error ? err.message : String(err)
             )
             try {
-              await client.query('ROLLBACK')
+              if (beganTransaction) await client.query('ROLLBACK')
+              beganTransaction = false
+              if (currentFileProvisional !== null) {
+                await repo.cleanupProvisionalImport(
+                  client as unknown as Pick<PoolClient, 'query'>,
+                  currentFileProvisional,
+                  caseIdBeforeFile === 0
+                    ? undefined
+                    : { restoreReady: false, preserveNewCase: true }
+                )
+                if (caseIdBeforeFile === 0) provisionalImport = null
+              }
             } catch (rollbackErr) {
               console.warn(
                 `[postgres-import-worker] file ${i} ROLLBACK after error failed:`,
                 rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
+              )
+              throw Object.assign(
+                new Error(
+                  `Failed to clean partial PostgreSQL rows for ${fileSpec.filePath}; import remains hidden for recovery`
+                ),
+                { cause: rollbackErr }
               )
             }
             const message = err instanceof Error ? err.message : String(err)
@@ -807,6 +807,10 @@ export async function runImport(
 
         // Post-loop bookkeeping — only if at least one file committed.
         if (caseId !== 0) {
+          if (provisionalImport === null) {
+            throw new Error('PostgreSQL import lost its provisional operation state')
+          }
+          if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
           await client.query('BEGIN')
           beganTransaction = true
           // Force the final commit synchronous so the import only reports
@@ -816,25 +820,34 @@ export async function runImport(
           await client.query('SET LOCAL synchronous_commit = ON')
           try {
             await client.query(
-              `UPDATE ${quoteIdentifier(start.schema)}."cases" SET variant_count = $1 WHERE id = $2`,
+              `UPDATE ${quoteIdentifier(start.schema)}."cases_all" SET variant_count = $1 WHERE id = $2`,
               [totalVariantCount, caseId]
             )
             await rebuildVariantFrequencyForCase(
               client as unknown as Pick<PoolClient, 'query'>,
               start.schema,
-              caseId
+              caseId,
+              true
             )
             // C3: incremental cohort-summary update inside this txn (SAVEPOINT-
-            // wrapped). On failure the helper commits the outer txn itself.
+            // wrapped). On failure it records staleness without publishing a
+            // partially updated derived snapshot.
             const stillOwnsTxn = await updateCohortSummaryAfterImport({
               client,
               schema: start.schema,
               caseId,
               genomeBuild
             })
-            if (stillOwnsTxn) await client.query('COMMIT')
+            void stillOwnsTxn
+            await repo.finishProvisionalImport(
+              client as unknown as Pick<PoolClient, 'query'>,
+              caseId,
+              basename(start.files[start.files.length - 1]?.filePath ?? ''),
+              'vcf'
+            )
+            publicationCommitAttempted = true
+            await client.query('COMMIT')
             beganTransaction = false
-            committed = true
           } catch (err) {
             beganTransaction = false
             try {
@@ -844,6 +857,8 @@ export async function runImport(
             }
             throw err
           }
+          provisionalImport = null
+          publicationCommitAttempted = false
         }
 
         profileFlush()
@@ -868,7 +883,7 @@ export async function runImport(
     )
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    if (beganTransaction && !committed) {
+    if (beganTransaction) {
       try {
         await client.query('ROLLBACK')
         beganTransaction = false
@@ -878,6 +893,21 @@ export async function runImport(
         console.warn(
           '[postgres-import-worker] ROLLBACK failed:',
           rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
+        )
+      }
+    }
+    if (provisionalImport !== null && !publicationCommitAttempted) {
+      try {
+        const repo = new PostgresVcfImportRepository(start.schema)
+        await repo.cleanupProvisionalImport(
+          client as unknown as Pick<PoolClient, 'query'>,
+          provisionalImport
+        )
+        provisionalImport = null
+      } catch (cleanupError) {
+        console.warn(
+          '[postgres-import-worker] provisional import cleanup failed:',
+          cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
         )
       }
     }
@@ -909,6 +939,13 @@ export async function runImport(
       post({ type: 'error', message })
     }
   } finally {
+    try {
+      await client.query(`SELECT pg_advisory_unlock(hashtext($1), hashtext('varlens-import'))`, [
+        start.schema
+      ])
+    } catch {
+      // Session close below also releases advisory locks.
+    }
     try {
       await client.end()
     } catch {

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -184,9 +184,14 @@ async function updateCohortSummaryAfterImport(args: {
         reason: `post_import_summary_failed_case_${caseId}`
       })
     } catch (markErr) {
-      console.warn(
-        '[postgres-import-worker] Failed to mark cohort summary stale after post-import failure:',
-        markErr instanceof Error ? markErr.message : String(markErr)
+      const summaryMessage =
+        savepointErr instanceof Error ? savepointErr.message : String(savepointErr)
+      const staleMessage = markErr instanceof Error ? markErr.message : String(markErr)
+      throw Object.assign(
+        new Error(
+          `Cohort summary update failed (${summaryMessage}) and stale marking failed (${staleMessage})`
+        ),
+        { cause: markErr }
       )
     }
     console.warn(
@@ -586,6 +591,7 @@ export async function runImport(
         let caseId = 0
         let totalVariantCount = 0
         let totalSkipped = 0
+        let lastSuccessfulFileName = ''
         const parseErrors: string[] = []
         const repo = new PostgresVcfImportRepository(start.schema)
         const selectedSample = start.vcfOptions?.selectedSample ?? ''
@@ -751,6 +757,7 @@ export async function runImport(
             if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
             caseId = fileCaseId
             totalVariantCount += fileVariantCount
+            lastSuccessfulFileName = fileName
             fileResults.push({
               filePath: fileSpec.filePath,
               variantType: fileSpec.variantType,
@@ -842,7 +849,7 @@ export async function runImport(
             await repo.finishProvisionalImport(
               client as unknown as Pick<PoolClient, 'query'>,
               caseId,
-              basename(start.files[start.files.length - 1]?.filePath ?? ''),
+              lastSuccessfulFileName,
               'vcf'
             )
             publicationCommitAttempted = true

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -78,6 +78,7 @@ export interface RunImportDeps {
   detectFormat: (filePath: string) => Promise<FormatInfo>
   createMapperPipeline: (filePath: string, formatInfo: FormatInfo) => Promise<Readable>
   statFile: (filePath: string) => { size: number }
+  isCancellationRequested?: () => boolean
   /** VCF mapped-row producer for the PG worker's VCF branch. */
   createVcfMappedStream: (
     filePath: string,
@@ -234,6 +235,10 @@ export async function runImport(
   let beganTransaction = false
   let provisionalImport: PostgresProvisionalImport | null = null
   let publicationCommitAttempted = false
+  const isCancelled = (): boolean => cancelled || deps.isCancellationRequested?.() === true
+  const throwIfCancelled = (): void => {
+    if (isCancelled()) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+  }
 
   try {
     await client.connect()
@@ -397,7 +402,7 @@ export async function runImport(
             throw error
           }
 
-          if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+          throwIfCancelled()
 
           // Bookkeeping may scan millions of rows, but contains no production
           // COPY. MVCC keeps the previous ready snapshot visible until this
@@ -428,12 +433,14 @@ export async function runImport(
             })
             void stillOwnsTxn
           }
+          throwIfCancelled()
           await repo.finishProvisionalImport(
             client as unknown as Pick<PoolClient, 'query'>,
             caseId,
             vcfFileName,
             'vcf'
           )
+          throwIfCancelled()
           publicationCommitAttempted = true
           await client.query('COMMIT')
           beganTransaction = false
@@ -817,7 +824,7 @@ export async function runImport(
           if (provisionalImport === null) {
             throw new Error('PostgreSQL import lost its provisional operation state')
           }
-          if (cancelled) throw new Error(POSTGRES_IMPORT_CANCELLATION_MESSAGE)
+          throwIfCancelled()
           await client.query('BEGIN')
           beganTransaction = true
           // Force the final commit synchronous so the import only reports
@@ -846,12 +853,14 @@ export async function runImport(
               genomeBuild
             })
             void stillOwnsTxn
+            throwIfCancelled()
             await repo.finishProvisionalImport(
               client as unknown as Pick<PoolClient, 'query'>,
               caseId,
               lastSuccessfulFileName,
               'vcf'
             )
+            throwIfCancelled()
             publicationCommitAttempted = true
             await client.query('COMMIT')
             beganTransaction = false

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -2,7 +2,6 @@ import { parentPort } from 'node:worker_threads'
 import { basename } from 'node:path'
 import { statSync } from 'node:fs'
 import type { Readable } from 'node:stream'
-import { createInterface } from 'node:readline'
 import { Client, type ClientConfig, type Pool, type PoolClient } from 'pg'
 
 import {
@@ -32,19 +31,12 @@ import { PostgresCohortSummaryRepository } from '../storage/postgres/PostgresCoh
 import { detectFormat as defaultDetectFormat } from '../import/format-detection'
 import type { FormatInfo } from '../import/strategies/ImportStrategy'
 import { createMapperPipeline as defaultCreateMapperPipeline } from './import-pipeline'
-import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
-import { parseVcfLine } from '../import/vcf/vcf-line-parser'
-import { mapVcfRecord } from '../import/vcf/VcfMapper'
-import { detectCaller } from '../import/vcf/caller-detector'
-import { DEFAULT_INFO_FIELD_MAPPINGS } from '../import/vcf/info-field-registry'
-import { createCappedLineStream } from '../import/stream-utils'
-import type { VcfHeader, VcfMappedVariant } from '../import/vcf/types'
+import type { VcfMappedVariant } from '../import/vcf/types'
 import { BedFilter } from '../import/vcf/bed-filter'
-import {
-  passesPreMappingFilters,
-  passesPostMappingFilters,
-  type ImportFilters
-} from '../import/vcf/import-filters'
+import type { ImportFilters } from '../import/vcf/import-filters'
+import { streamMappedVcfRows } from './postgres-vcf-stream'
+
+export { streamMappedVcfRows } from './postgres-vcf-stream'
 
 const POSTGRES_JSON_IMPORT_BATCH_SIZE = 1000
 
@@ -79,109 +71,6 @@ process.on('unhandledRejection', (reason) => {
     cause: stack
   } satisfies PostgresImportWorkerOutboundMessage)
 })
-
-/**
- * Async generator yielding mapped VCF variants one at a time.
- * Mirrors the streamInsertVcf parsing pipeline (header lines, parseVcfLine,
- * mapVcfRecord) but emits mapped variants instead of inserting them.
- *
- * When `filters` is provided, pre-mapping filters (FILTER column, QUAL
- * threshold, BED region) are applied before `mapVcfRecord`, and post-mapping
- * filters (GQ, DP) are applied to each emitted variant independently.
- */
-export async function* streamMappedVcfRows(
-  filePath: string,
-  selectedSample: string,
-  filters?: ImportFilters,
-  onSkip?: (reason: string) => void
-): AsyncGenerator<VcfMappedVariant, void, void> {
-  // Fail fast (synchronously, with a stack we can attach to the per-file
-  // result) for the most common open-time error class: missing/unreadable
-  // file. createReadStream defers `open(2)` to the next tick, so an ENOENT
-  // would otherwise surface as an asynchronous `error` event on the raw
-  // stream — and if no listener is attached when it fires, Node escalates
-  // it to an `uncaughtException`, tearing the whole worker down (Phase 9
-  // Task 15 root cause).
-  statSync(filePath)
-
-  // Shared capped reader guards against a giant single line and a
-  // decompression bomb -- see stream-utils.ts for the cap rationale.
-  const { stream } = createCappedLineStream(filePath)
-  const rl = createInterface({ input: stream, crlfDelay: Infinity })
-
-  // Belt-and-suspenders: also capture any post-open stream errors (gzip
-  // corruption mid-file, DoS cap trip, EIO, etc.) and re-throw them from the
-  // generator so the caller's per-file `try/catch` handles them. Without
-  // this an unhandled `error` event would still surface as an
-  // `uncaughtException`. `stream` here is the composed capped pipeline --
-  // `stream.compose()` (see stream-utils.ts) forwards an error from any
-  // stage (raw read, gunzip, byte cap, line cap) to a single 'error' event
-  // on this one object, so one listener covers every failure mode.
-  let streamError: Error | null = null
-  const onStreamError = (err: Error): void => {
-    if (streamError === null) streamError = err
-    rl.close()
-  }
-  stream.on('error', onStreamError)
-
-  const headerLines: string[] = []
-  let header: VcfHeader | null = null
-  let activeSample = ''
-  let callerName: string | null = null
-
-  try {
-    for await (const line of rl) {
-      if (streamError !== null) throw streamError
-      if (line.startsWith('#')) {
-        headerLines.push(line)
-        continue
-      }
-
-      if (header === null) {
-        header = parseVcfHeaderFromLines(headerLines)
-        activeSample = selectedSample !== '' ? selectedSample : (header.samples[0] ?? '')
-        if (activeSample === '') {
-          // No selectable sample — drain quietly.
-          break
-        }
-        const callerInfo = detectCaller(headerLines)
-        callerName = callerInfo.name !== 'unknown' ? callerInfo.name : null
-      }
-
-      try {
-        const record = parseVcfLine(line, header.samples, onSkip)
-        if (record === null) continue
-        // Apply pre-mapping filters (FILTER column, QUAL, BED region) before
-        // the expensive mapVcfRecord call — skips multi-allelic expansion too.
-        if (!passesPreMappingFilters(record, filters)) continue
-        const mapped = mapVcfRecord(
-          record,
-          header,
-          activeSample,
-          DEFAULT_INFO_FIELD_MAPPINGS,
-          callerName
-        )
-        for (const variant of mapped) {
-          // Apply post-mapping filters (GQ, DP) per emitted variant.
-          if (!passesPostMappingFilters(variant, filters)) continue
-          yield variant
-        }
-      } catch (e) {
-        // Skip unparseable lines — same behavior as streamInsertVcf
-        console.warn(
-          '[postgres-import-worker] Skipping unparseable VCF line:',
-          e instanceof Error ? e.message : String(e)
-        )
-      }
-    }
-    // Stream errors that fire AFTER the readline iterator drains (e.g. a
-    // gunzip integrity check at end-of-stream) still need to propagate.
-    if (streamError !== null) throw streamError
-  } finally {
-    stream.off('error', onStreamError)
-    stream.destroy()
-  }
-}
 
 export interface RunImportDeps {
   createClient: (config: ClientConfig) => Client
@@ -733,8 +622,8 @@ export async function runImport(
         const selectedSample = start.vcfOptions?.selectedSample ?? ''
         const genomeBuild = start.vcfOptions?.genomeBuild ?? 'GRCh38'
 
-        // Build ImportFilters once before the per-file loop so that
-        // BedFilter.fromFile (a sync file read) runs in the worker, not main.
+        // Build ImportFilters once before the per-file loop so BED parsing runs
+        // in the worker, not main. An explicit BED load must fail closed.
         let importFilters: ImportFilters | undefined
         if (start.filters !== undefined) {
           let bedFilter: BedFilter | undefined
@@ -743,20 +632,10 @@ export async function runImport(
             start.filters.bedFilePath !== undefined &&
             start.filters.bedFilePath !== ''
           ) {
-            try {
-              bedFilter = BedFilter.fromFile(
-                start.filters.bedFilePath,
-                start.filters.bedPadding ?? 0
-              )
-            } catch (err) {
-              // Worker can't use mainLogger; console.warn is the documented
-              // worker exception (see AGENTS.md). Continue without BED filtering
-              // rather than fail the whole import.
-              console.warn(
-                '[postgres-import-worker] BedFilter.fromFile failed:',
-                err instanceof Error ? err.message : String(err)
-              )
-            }
+            bedFilter = await BedFilter.fromFile(
+              start.filters.bedFilePath,
+              start.filters.bedPadding ?? 0
+            )
           }
           importFilters = {
             bedFilter,

--- a/src/main/workers/postgres-import-worker.ts
+++ b/src/main/workers/postgres-import-worker.ts
@@ -92,7 +92,8 @@ process.on('unhandledRejection', (reason) => {
 export async function* streamMappedVcfRows(
   filePath: string,
   selectedSample: string,
-  filters?: ImportFilters
+  filters?: ImportFilters,
+  onSkip?: (reason: string) => void
 ): AsyncGenerator<VcfMappedVariant, void, void> {
   // Fail fast (synchronously, with a stack we can attach to the per-file
   // result) for the most common open-time error class: missing/unreadable
@@ -148,7 +149,7 @@ export async function* streamMappedVcfRows(
       }
 
       try {
-        const record = parseVcfLine(line, header.samples)
+        const record = parseVcfLine(line, header.samples, onSkip)
         if (record === null) continue
         // Apply pre-mapping filters (FILTER column, QUAL, BED region) before
         // the expensive mapVcfRecord call — skips multi-allelic expansion too.
@@ -190,7 +191,12 @@ export interface RunImportDeps {
   /** VCF mapped-row producer for the PG worker's VCF branch. */
   createVcfMappedStream: (
     filePath: string,
-    options: { selectedSample: string; genomeBuild: string; filters?: ImportFilters }
+    options: {
+      selectedSample: string
+      genomeBuild: string
+      filters?: ImportFilters
+      onSkip?: (reason: string) => void
+    }
   ) => Promise<AsyncIterable<VcfMappedVariant>>
 }
 
@@ -200,7 +206,34 @@ const defaultDeps: RunImportDeps = {
   createMapperPipeline: defaultCreateMapperPipeline,
   statFile: (path: string) => ({ size: statSync(path).size }),
   createVcfMappedStream: async (filePath, options) =>
-    streamMappedVcfRows(filePath, options.selectedSample, options.filters)
+    streamMappedVcfRows(filePath, options.selectedSample, options.filters, options.onSkip)
+}
+
+async function cleanupIncompleteSingleFileVcfCase(args: {
+  client: Pick<Client, 'query'>
+  schema: string
+  caseId: number
+}): Promise<void> {
+  const { client, schema, caseId } = args
+  await client.query('BEGIN')
+  try {
+    await client.query(`DELETE FROM ${quoteIdentifier(schema)}."cases" WHERE id = $1`, [caseId])
+    await client.query('COMMIT')
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK')
+    } catch {
+      // Preserve the original cleanup failure.
+    }
+    throw err
+  }
+}
+
+function recordParseSkip(args: { reason: string; errors: string[]; prefix?: string }): void {
+  const { reason, errors, prefix } = args
+  if (errors.length < 10) {
+    errors.push(prefix === undefined ? reason : `${prefix}: ${reason}`)
+  }
 }
 
 /**
@@ -325,6 +358,7 @@ export async function runImport(
   const client = deps.createClient(clientConfigFromMessage(start.client))
   let beganTransaction = false
   let committed = false
+  let incompleteSingleFileVcfCaseId: number | null = null
 
   try {
     await client.connect()
@@ -382,10 +416,16 @@ export async function runImport(
           const repo = new PostgresVcfImportRepository(start.schema)
           // Single-file imports reject filters at the executor level, but pass
           // undefined defensively to keep the contract consistent.
+          let totalSkipped = 0
+          const errors: string[] = []
           const stream = await deps.createVcfMappedStream(filePath, {
             selectedSample,
             genomeBuild,
-            filters: undefined
+            filters: undefined,
+            onSkip: (reason) => {
+              totalSkipped += 1
+              recordParseSkip({ reason, errors })
+            }
           })
 
           let variants: Array<Record<string, unknown>> = []
@@ -444,7 +484,10 @@ export async function runImport(
               repo.writeVcfFile(client as unknown as Pick<PoolClient, 'query'>, request)
             )
             profileCount('batch', 1)
-            if (!firstWritten) caseId = result.caseId
+            if (!firstWritten) {
+              caseId = result.caseId
+              incompleteSingleFileVcfCaseId = caseId
+            }
             totalInserted += result.variantCount
             firstWritten = true
             post({ type: 'progress', phase: 'inserting', rowsProcessed: totalInserted, filePath })
@@ -527,6 +570,7 @@ export async function runImport(
             await client.query('COMMIT')
           }
           committed = true
+          incompleteSingleFileVcfCaseId = null
 
           profileFlush()
           post({
@@ -535,8 +579,8 @@ export async function runImport(
             result: {
               caseId,
               variantCount: totalInserted,
-              skipped: 0,
-              errors: [],
+              skipped: totalSkipped,
+              errors,
               elapsed: Date.now() - startedAt
             }
           })
@@ -683,6 +727,8 @@ export async function runImport(
         }> = []
         let caseId = 0
         let totalVariantCount = 0
+        let totalSkipped = 0
+        const parseErrors: string[] = []
         const repo = new PostgresVcfImportRepository(start.schema)
         const selectedSample = start.vcfOptions?.selectedSample ?? ''
         const genomeBuild = start.vcfOptions?.genomeBuild ?? 'GRCh38'
@@ -747,7 +793,15 @@ export async function runImport(
             const stream = await deps.createVcfMappedStream(fileSpec.filePath, {
               selectedSample,
               genomeBuild,
-              filters: start.files.length > 1 && i === 0 ? undefined : importFilters
+              filters: start.files.length > 1 && i === 0 ? undefined : importFilters,
+              onSkip: (reason) => {
+                totalSkipped += 1
+                recordParseSkip({
+                  reason,
+                  errors: parseErrors,
+                  prefix: basename(fileSpec.filePath)
+                })
+              }
             })
 
             let variants: Array<Record<string, unknown>> = []
@@ -989,8 +1043,8 @@ export async function runImport(
             caseId,
             variantCount: totalVariantCount,
             files: fileResults,
-            skipped: 0,
-            errors: cancelled ? [POSTGRES_IMPORT_CANCELLATION_MESSAGE] : [],
+            skipped: totalSkipped,
+            errors: cancelled ? [POSTGRES_IMPORT_CANCELLATION_MESSAGE] : parseErrors,
             elapsed: Date.now() - startedAt
           }
         })
@@ -1006,12 +1060,31 @@ export async function runImport(
     if (beganTransaction && !committed) {
       try {
         await client.query('ROLLBACK')
+        beganTransaction = false
       } catch (rollbackErr) {
         // Worker has no mainLogger access; console.warn is the documented
         // worker exception (see AGENTS.md). Swallow but preserve diagnostics.
         console.warn(
           '[postgres-import-worker] ROLLBACK failed:',
           rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
+        )
+      }
+    }
+    if (
+      incompleteSingleFileVcfCaseId !== null &&
+      message !== POSTGRES_IMPORT_CANCELLATION_MESSAGE
+    ) {
+      try {
+        await cleanupIncompleteSingleFileVcfCase({
+          client,
+          schema: start.schema,
+          caseId: incompleteSingleFileVcfCaseId
+        })
+        incompleteSingleFileVcfCaseId = null
+      } catch (cleanupErr) {
+        console.warn(
+          '[postgres-import-worker] Failed to delete incomplete single-file VCF case:',
+          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)
         )
       }
     }

--- a/src/main/workers/postgres-vcf-stream.ts
+++ b/src/main/workers/postgres-vcf-stream.ts
@@ -11,7 +11,11 @@ import {
 import { mapVcfRecord } from '../import/vcf/VcfMapper'
 import { VcfHeaderBudget } from '../import/vcf/vcf-header-limits'
 import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
-import { parseVcfLine } from '../import/vcf/vcf-line-parser'
+import {
+  parseVcfLine,
+  resolveVcfSelectedSampleColumn,
+  type VcfSelectedSampleColumn
+} from '../import/vcf/vcf-line-parser'
 import type { VcfHeader, VcfMappedVariant } from '../import/vcf/types'
 import { VcfResourceLimitError } from '../import/vcf/vcf-resource-limits'
 
@@ -39,6 +43,7 @@ export async function* streamMappedVcfRows(
   const headerBudget = new VcfHeaderBudget()
   let header: VcfHeader | null = null
   let activeSample = ''
+  let activeSampleColumn: VcfSelectedSampleColumn | null = null
   let callerName: string | null = null
 
   try {
@@ -52,14 +57,15 @@ export async function* streamMappedVcfRows(
 
       if (header === null) {
         header = parseVcfHeaderFromLines(headerLines)
-        activeSample = selectedSample !== '' ? selectedSample : (header.samples[0] ?? '')
+        activeSampleColumn = resolveVcfSelectedSampleColumn(header.samples, selectedSample)
+        activeSample = activeSampleColumn?.name ?? ''
         if (activeSample === '') break
         const callerInfo = detectCaller(headerLines)
         callerName = callerInfo.name !== 'unknown' ? callerInfo.name : null
       }
 
       try {
-        const record = parseVcfLine(line, header.samples, onSkip)
+        const record = parseVcfLine(line, header.samples, onSkip, activeSampleColumn ?? undefined)
         if (record === null || !passesPreMappingFilters(record, filters)) continue
         const mapped = mapVcfRecord(
           record,

--- a/src/main/workers/postgres-vcf-stream.ts
+++ b/src/main/workers/postgres-vcf-stream.ts
@@ -1,0 +1,85 @@
+import { statSync } from 'node:fs'
+import { createInterface } from 'node:readline'
+import { createCappedLineStream } from '../import/stream-utils'
+import { detectCaller } from '../import/vcf/caller-detector'
+import { DEFAULT_INFO_FIELD_MAPPINGS } from '../import/vcf/info-field-registry'
+import {
+  passesPostMappingFilters,
+  passesPreMappingFilters,
+  type ImportFilters
+} from '../import/vcf/import-filters'
+import { mapVcfRecord } from '../import/vcf/VcfMapper'
+import { VcfHeaderBudget } from '../import/vcf/vcf-header-limits'
+import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
+import { parseVcfLine } from '../import/vcf/vcf-line-parser'
+import type { VcfHeader, VcfMappedVariant } from '../import/vcf/types'
+
+/** Stream mapped VCF variants for the PostgreSQL COPY import path. */
+export async function* streamMappedVcfRows(
+  filePath: string,
+  selectedSample: string,
+  filters?: ImportFilters,
+  onSkip?: (reason: string) => void
+): AsyncGenerator<VcfMappedVariant, void, void> {
+  // createReadStream reports open failures asynchronously; fail before the
+  // worker's per-file error boundary can lose ownership of that event.
+  statSync(filePath)
+
+  const { stream } = createCappedLineStream(filePath)
+  const lines = createInterface({ input: stream, crlfDelay: Infinity })
+  let streamError: Error | null = null
+  const captureStreamError = (error: Error): void => {
+    streamError ??= error
+    lines.close()
+  }
+  stream.on('error', captureStreamError)
+
+  const headerLines: string[] = []
+  const headerBudget = new VcfHeaderBudget()
+  let header: VcfHeader | null = null
+  let activeSample = ''
+  let callerName: string | null = null
+
+  try {
+    for await (const line of lines) {
+      if (streamError !== null) throw streamError
+      if (line.startsWith('#')) {
+        headerBudget.add(line)
+        headerLines.push(line)
+        continue
+      }
+
+      if (header === null) {
+        header = parseVcfHeaderFromLines(headerLines)
+        activeSample = selectedSample !== '' ? selectedSample : (header.samples[0] ?? '')
+        if (activeSample === '') break
+        const callerInfo = detectCaller(headerLines)
+        callerName = callerInfo.name !== 'unknown' ? callerInfo.name : null
+      }
+
+      try {
+        const record = parseVcfLine(line, header.samples, onSkip)
+        if (record === null || !passesPreMappingFilters(record, filters)) continue
+        const mapped = mapVcfRecord(
+          record,
+          header,
+          activeSample,
+          DEFAULT_INFO_FIELD_MAPPINGS,
+          callerName
+        )
+        for (const variant of mapped) {
+          if (passesPostMappingFilters(variant, filters)) yield variant
+        }
+      } catch (error) {
+        console.warn(
+          '[postgres-import-worker] Skipping unparseable VCF line:',
+          error instanceof Error ? error.message : String(error)
+        )
+      }
+    }
+    if (streamError !== null) throw streamError
+  } finally {
+    lines.close()
+    stream.destroy()
+  }
+}

--- a/src/main/workers/postgres-vcf-stream.ts
+++ b/src/main/workers/postgres-vcf-stream.ts
@@ -13,6 +13,7 @@ import { VcfHeaderBudget } from '../import/vcf/vcf-header-limits'
 import { parseVcfHeaderFromLines } from '../import/vcf/vcf-header-parser'
 import { parseVcfLine } from '../import/vcf/vcf-line-parser'
 import type { VcfHeader, VcfMappedVariant } from '../import/vcf/types'
+import { VcfResourceLimitError } from '../import/vcf/vcf-resource-limits'
 
 /** Stream mapped VCF variants for the PostgreSQL COPY import path. */
 export async function* streamMappedVcfRows(
@@ -71,6 +72,7 @@ export async function* streamMappedVcfRows(
           if (passesPostMappingFilters(variant, filters)) yield variant
         }
       } catch (error) {
+        if (error instanceof VcfResourceLimitError) throw error
         console.warn(
           '[postgres-import-worker] Skipping unparseable VCF line:',
           error instanceof Error ? error.message : String(error)

--- a/src/shared/types/database-schema.ts
+++ b/src/shared/types/database-schema.ts
@@ -13,6 +13,9 @@ export interface CasesTable {
   file_path: string
   file_size: number
   variant_count: number
+  import_status: Generated<'ready' | 'importing'>
+  import_variant_watermark: Generated<number>
+  import_is_new: Generated<boolean>
   created_at: number
   genome_build: string
   source_format: string | null

--- a/src/shared/types/import-worker.ts
+++ b/src/shared/types/import-worker.ts
@@ -89,6 +89,9 @@ export interface FileImportRequest {
   vcfGenomeBuild?: string
 }
 
+/** Maximum number of representative skip reasons retained per imported file. */
+export const MAX_IMPORT_SKIP_REASONS = 10
+
 /** Worker -> Main messages */
 export type WorkerMessage =
   | {
@@ -109,6 +112,8 @@ export type WorkerMessage =
         caseName: string
         variantCount: number
         skipped: number
+        /** Representative reasons, capped at MAX_IMPORT_SKIP_REASONS. */
+        skipReasons: string[]
         elapsed: number
       }
     }

--- a/src/web/server/routes/import.ts
+++ b/src/web/server/routes/import.ts
@@ -199,6 +199,10 @@ export function buildImportOverrides(): Record<string, OverrideHandler> {
           if (resolved.ref !== null) pathToRef.set(resolved.path, resolved.ref)
         }
 
+        if (hasRawBedFilterPath(filters)) {
+          reply.code(403)
+          return serverPathImportDisabledResponse()
+        }
         const resolvedFilters = resolveFilterUploadRefs(filters, request.session.user?.id)
         if (resolvedFilters === null) {
           reply.code(404)
@@ -292,4 +296,10 @@ function resolveFilterUploadRefs(
   const resolved = resolveWebUploadPath(raw.bedFile, userId)
   if (resolved === null) return null
   return { ...raw, bedFile: resolved }
+}
+
+function hasRawBedFilterPath(filters: unknown): boolean {
+  if (filters === null || typeof filters !== 'object') return false
+  const bedFile = (filters as Record<string, unknown>).bedFile
+  return typeof bedFile === 'string' && !isWebUploadRef(bedFile)
 }

--- a/src/web/server/routes/region-files.ts
+++ b/src/web/server/routes/region-files.ts
@@ -1,41 +1,22 @@
-import { readFile } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
 
 import { RegionFileImportBedArgsSchema } from '../../../shared/api/schemas/region-files'
+import { resolveMaxDecompressedBytes } from '../../../main/import/stream-utils'
+import { MAX_BED_FILTER_DECOMPRESSED_BYTES } from '../../../main/import/vcf/bed-filter'
+import { readBedEntries } from '../../../main/import/vcf/bed-reader'
 import { serverPathImportDisabled, serverPathImportDisabledResponse } from './server-path-import'
 import type { OverrideHandler } from './types'
 import { isWebUploadRef, resolveWebUploadPath } from './upload-staging'
 
-function normalizeBedLine(
-  line: string
-): { chr: string; start: number; end: number; label?: string } | null {
-  const trimmed = line.trim()
-  if (trimmed === '' || trimmed.startsWith('#')) return null
-  const [chr, startRaw, endRaw, label] = trimmed.split(/\s+/u)
-  const start = Number(startRaw)
-  const end = Number(endRaw)
-  if (chr === undefined || !Number.isInteger(start) || !Number.isInteger(end)) {
-    throw new Error(`Invalid BED row: ${line}`)
-  }
-  return {
-    chr,
-    start,
-    end,
-    ...(label !== undefined && label !== '' ? { label } : {})
-  }
-}
-
-async function readBedEntries(
+async function collectBedEntries(
   filePath: string
 ): Promise<Array<{ chr: string; start: number; end: number; label?: string }>> {
-  const content = await readFile(filePath, 'utf8')
-  return content
-    .split(/\r?\n/u)
-    .map(normalizeBedLine)
-    .filter(
-      (entry): entry is { chr: string; start: number; end: number; label?: string } =>
-        entry !== null
-    )
+  const entries: Array<{ chr: string; start: number; end: number; label?: string }> = []
+  const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
+  for await (const entry of readBedEntries(filePath, maxBytes, { rejectMalformedRows: true })) {
+    entries.push(entry)
+  }
+  return entries
 }
 
 export function buildRegionFileOverrides(): Record<string, OverrideHandler> {
@@ -62,7 +43,7 @@ export function buildRegionFileOverrides(): Record<string, OverrideHandler> {
         }
         return await session.getWriteExecutor().execute({
           type: 'region-files:importBed',
-          params: [fileId, await readBedEntries(resolvedPath)]
+          params: [fileId, await collectBedEntries(resolvedPath)]
         })
       }
     }

--- a/src/web/server/routes/region-files.ts
+++ b/src/web/server/routes/region-files.ts
@@ -1,23 +1,9 @@
 import { isAbsolute } from 'node:path'
 
 import { RegionFileImportBedArgsSchema } from '../../../shared/api/schemas/region-files'
-import { resolveMaxDecompressedBytes } from '../../../main/import/stream-utils'
-import { MAX_BED_FILTER_DECOMPRESSED_BYTES } from '../../../main/import/vcf/bed-filter'
-import { readBedEntries } from '../../../main/import/vcf/bed-reader'
 import { serverPathImportDisabled, serverPathImportDisabledResponse } from './server-path-import'
 import type { OverrideHandler } from './types'
 import { isWebUploadRef, resolveWebUploadPath } from './upload-staging'
-
-async function collectBedEntries(
-  filePath: string
-): Promise<Array<{ chr: string; start: number; end: number; label?: string }>> {
-  const entries: Array<{ chr: string; start: number; end: number; label?: string }> = []
-  const maxBytes = Math.min(resolveMaxDecompressedBytes(), MAX_BED_FILTER_DECOMPRESSED_BYTES)
-  for await (const entry of readBedEntries(filePath, maxBytes, { rejectMalformedRows: true })) {
-    entries.push(entry)
-  }
-  return entries
-}
 
 export function buildRegionFileOverrides(): Record<string, OverrideHandler> {
   return {
@@ -43,7 +29,7 @@ export function buildRegionFileOverrides(): Record<string, OverrideHandler> {
         }
         return await session.getWriteExecutor().execute({
           type: 'region-files:importBed',
-          params: [fileId, await collectBedEntries(resolvedPath)]
+          params: [fileId, resolvedPath, { rejectMalformedRows: true }]
         })
       }
     }

--- a/tests/main/database/GeneListRepository.test.ts
+++ b/tests/main/database/GeneListRepository.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3-multiple-ciphers'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+
+import { initializeSchema } from '../../../src/main/database/schema'
+import { runMigrations } from '../../../src/main/database/migrations'
+import { createKysely } from '../../../src/main/database/kysely'
+import { GeneListRepository } from '../../../src/main/database/GeneListRepository'
+import { DecompressedSizeExceededError } from '../../../src/main/import/stream-utils'
+
+describe('GeneListRepository BED streaming', () => {
+  let db: InstanceType<typeof Database>
+  let repo: GeneListRepository
+  let tempDir: string
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    initializeSchema(db)
+    runMigrations(db)
+    repo = new GeneListRepository(db, createKysely(db))
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-sqlite-bed-'))
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('streams BED entries into one atomic replacement with exact metadata', async () => {
+    const regionFile = repo.createRegionFile('Capture', null)
+    const bedPath = join(tempDir, 'capture.bed')
+    writeFileSync(bedPath, 'chr1\t0\t10\tA\nchr2\t5\t9\n')
+
+    await expect(repo.importBedFile(regionFile.id, bedPath)).resolves.toMatchObject({
+      region_count: 2,
+      total_bases: 14
+    })
+    expect(
+      db
+        .prepare(
+          'SELECT chr, start_pos, end_pos, label FROM region_file_entries WHERE region_file_id = ? ORDER BY id'
+        )
+        .all(regionFile.id)
+    ).toEqual([
+      { chr: 'chr1', start_pos: 0, end_pos: 10, label: 'A' },
+      { chr: 'chr2', start_pos: 5, end_pos: 9, label: null }
+    ])
+  })
+
+  it('rolls back deletion and inserts when a strict stream encounters a malformed row', async () => {
+    const regionFile = repo.createRegionFile('Capture', null)
+    const originalPath = join(tempDir, 'original.bed')
+    writeFileSync(originalPath, 'chr1\t0\t10\toriginal\n')
+    await repo.importBedFile(regionFile.id, originalPath)
+
+    const malformedPath = join(tempDir, 'malformed.bed')
+    writeFileSync(malformedPath, 'chr2\t20\t30\tnew\nchr2\tbad\t40\n')
+    await expect(
+      repo.importBedFile(regionFile.id, malformedPath, { rejectMalformedRows: true })
+    ).rejects.toThrow(/invalid bed row/i)
+
+    expect(
+      db
+        .prepare(
+          'SELECT chr, start_pos, end_pos, label FROM region_file_entries WHERE region_file_id = ?'
+        )
+        .all(regionFile.id)
+    ).toEqual([{ chr: 'chr1', start_pos: 0, end_pos: 10, label: 'original' }])
+    expect(repo.listRegionFiles()).toEqual([
+      expect.objectContaining({ id: regionFile.id, region_count: 1, total_bases: 10 })
+    ])
+  })
+
+  it('preserves prior rows when the streamed file exceeds the decompressed-byte cap', async () => {
+    const regionFile = repo.createRegionFile('Capture', null)
+    const originalPath = join(tempDir, 'original.bed')
+    writeFileSync(originalPath, 'chr1\t0\t10\toriginal\n')
+    await repo.importBedFile(regionFile.id, originalPath)
+
+    const bombPath = join(tempDir, 'bomb.bed.gz')
+    writeFileSync(bombPath, gzipSync(Buffer.from('chr2\t0\t10\n'.repeat(1_000))))
+    const previousMaxBytes = process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES
+    process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES = '100'
+    try {
+      await expect(repo.importBedFile(regionFile.id, bombPath)).rejects.toThrow(
+        DecompressedSizeExceededError
+      )
+    } finally {
+      if (previousMaxBytes === undefined) delete process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES
+      else process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES = previousMaxBytes
+    }
+
+    expect(
+      db
+        .prepare(
+          'SELECT chr, start_pos, end_pos, label FROM region_file_entries WHERE region_file_id = ?'
+        )
+        .all(regionFile.id)
+    ).toEqual([{ chr: 'chr1', start_pos: 0, end_pos: 10, label: 'original' }])
+  })
+
+  it('allows concurrent streams while keeping each final replacement atomic', async () => {
+    const first = repo.createRegionFile('First', null)
+    const second = repo.createRegionFile('Second', null)
+    const firstPath = join(tempDir, 'first.bed')
+    const secondPath = join(tempDir, 'second.bed')
+    writeFileSync(firstPath, 'chr1\t0\t10\nchr1\t20\t30\n')
+    writeFileSync(secondPath, 'chr2\t5\t9\n')
+
+    await expect(
+      Promise.all([
+        repo.importBedFile(first.id, firstPath),
+        repo.importBedFile(second.id, secondPath)
+      ])
+    ).resolves.toEqual([
+      expect.objectContaining({ id: first.id, region_count: 2, total_bases: 20 }),
+      expect.objectContaining({ id: second.id, region_count: 1, total_bases: 4 })
+    ])
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'region_file_import_%'"
+        )
+        .all()
+    ).toEqual([])
+  })
+})

--- a/tests/main/handlers/import-logic.test.ts
+++ b/tests/main/handlers/import-logic.test.ts
@@ -203,6 +203,46 @@ describe('import-logic VCF + multi-file routing', () => {
     expect(result.totalVariants).toBe(20)
   })
 
+  it('keeps PostgreSQL multi-file cancellation reachable for the full operation', async () => {
+    const cancel = vi.fn()
+    let resolveImport!: (result: unknown) => void
+    const importMultiFile = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveImport = resolve
+        })
+    )
+    const executor = { importSingleFile: vi.fn(), importMultiFile, cancel }
+    const session = {
+      capabilities: { backend: 'postgres' },
+      getImportExecutor: () => executor
+    }
+
+    const pending = startMultiFileImport(
+      'Multi case',
+      [{ filePath: '/abs/a.vcf', variantType: 'snv-indel', caller: null, annotationFormat: null }],
+      undefined,
+      () => session as never,
+      (() => ({})) as never,
+      {}
+    )
+    await expect(
+      startImport('/abs/second.vcf', 'Second', undefined, () => session as never, {})
+    ).rejects.toThrow(/already in progress/i)
+    cancelImport()
+
+    expect(cancel).toHaveBeenCalledOnce()
+    resolveImport({
+      caseId: 0,
+      variantCount: 0,
+      files: [],
+      skipped: 0,
+      errors: ['Import cancelled by user'],
+      elapsed: 1
+    })
+    await pending
+  })
+
   it('translates ImportFiltersPayload (bedFile) to StorageImportFileFilters (bedFilePath) on PG path', async () => {
     const importMultiFile = vi.fn(async () => ({
       caseId: 7,

--- a/tests/main/import/gzip-detection.test.ts
+++ b/tests/main/import/gzip-detection.test.ts
@@ -56,6 +56,31 @@ describe('isGzipped', () => {
 })
 
 describe('detectFormat with plain JSON', () => {
+  it('rejects an adversarial number of top-level keys within a fixed detection budget', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-format-budget-'))
+    const filePath = join(tmpDir, 'many-keys.json')
+    const entries = Array.from({ length: 20_000 }, (_, index) => `"k${index}":null`).join(',')
+    writeFileSync(filePath, `{"metadata":null,${entries}}`)
+
+    try {
+      await expect(detectFormat(filePath)).rejects.toThrow(/format detection.*top-level keys/i)
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an oversized top-level key before stream-json packs it', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-format-key-budget-'))
+    const filePath = join(tmpDir, 'giant-key.json')
+    writeFileSync(filePath, `{"metadata":null,"${'k'.repeat(2 * 1024 * 1024)}":null}`)
+
+    try {
+      await expect(detectFormat(filePath)).rejects.toThrow(/format detection.*key/i)
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   it('should detect simple format from plain JSON', async () => {
     const result = await detectFormat(join(FIXTURES_DIR, 'simple-format.json'))
     expect(result.format).toBe('simple')

--- a/tests/main/import/import-skip-tracker.test.ts
+++ b/tests/main/import/import-skip-tracker.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { ImportSkipTracker } from '../../../src/main/workers/import-skip-tracker'
+import { MAX_IMPORT_SKIP_REASONS } from '../../../src/shared/types/import-worker'
+
+describe('ImportSkipTracker', () => {
+  it('counts every skip while retaining only the bounded reason sample', () => {
+    const tracker = new ImportSkipTracker()
+    for (let index = 0; index < MAX_IMPORT_SKIP_REASONS + 5; index += 1) {
+      tracker.record(`reason-${index}`)
+    }
+
+    expect(tracker.count).toBe(MAX_IMPORT_SKIP_REASONS + 5)
+    expect(tracker.reasons).toHaveLength(MAX_IMPORT_SKIP_REASONS)
+    expect(tracker.reasons.at(-1)).toBe(`reason-${MAX_IMPORT_SKIP_REASONS - 1}`)
+  })
+})

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the shared DoS caps in stream-utils.ts:
+ *  - MAX_LINE_BYTES / LineTooLongError (per-line byte cap)
+ *  - MAX_DECOMPRESSED_BYTES / DecompressedSizeExceededError (total decompressed-byte cap)
+ *
+ * These caps are the shared implementation routed through all four VCF/BED
+ * line consumers (VcfStrategy import, vcf-preview, vcf-header-parser,
+ * bed-filter). Per-consumer routing/rejection is covered in each consumer's
+ * own test file; this file proves the shared primitives themselves.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { tmpdir } from 'node:os'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { createInterface } from 'node:readline'
+import {
+  createCappedLineStream,
+  readCappedFileSync,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../src/main/import/stream-utils'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'varlens-stream-caps-'))
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Collect lines from a capped stream via readline, resolving with lines or rejecting with the stream's error. */
+function collectLines(
+  filePath: string,
+  opts?: { maxLineBytes?: number; maxDecompressedBytes?: number }
+) {
+  return new Promise<string[]>((resolve, reject) => {
+    const { stream } = createCappedLineStream(filePath, opts)
+    const rl = createInterface({ input: stream, crlfDelay: Infinity })
+    const lines: string[] = []
+    let settled = false
+
+    rl.on('line', (line) => lines.push(line))
+    rl.on('close', () => {
+      if (settled) return
+      settled = true
+      resolve(lines)
+    })
+    rl.on('error', (error) => {
+      if (settled) return
+      settled = true
+      reject(error)
+    })
+    stream.on('error', (error) => {
+      if (settled) return
+      settled = true
+      reject(error)
+    })
+  })
+}
+
+describe('createCappedLineStream', () => {
+  it('rejects a line exceeding the per-line byte cap with LineTooLongError', async () => {
+    const filePath = join(tmpDir, 'giant-line.vcf')
+    const giantLine = 'A'.repeat(200) // over the 100-byte test cap below
+    writeFileSync(filePath, `short line\n${giantLine}\nafter\n`)
+
+    await expect(collectLines(filePath, { maxLineBytes: 100 })).rejects.toThrow(LineTooLongError)
+  })
+
+  it('rejects a decompressed plain stream exceeding the total-byte cap with DecompressedSizeExceededError', async () => {
+    const filePath = join(tmpDir, 'big-plain.vcf')
+    writeFileSync(filePath, 'line1\n'.repeat(1000)) // 6000 bytes total
+
+    await expect(collectLines(filePath, { maxDecompressedBytes: 100 })).rejects.toThrow(
+      DecompressedSizeExceededError
+    )
+  })
+
+  it('rejects a gzip stream whose decompressed size exceeds the total-byte cap (simulated bomb)', async () => {
+    const filePath = join(tmpDir, 'bomb.vcf.gz')
+    // Highly compressible content: a tiny gzip payload that inflates far
+    // past a small test cap -- stands in for a real decompression bomb.
+    const inflated = 'A'.repeat(1_000_000) + '\n'
+    writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+    await expect(
+      collectLines(filePath, { maxDecompressedBytes: 1000, maxLineBytes: 2_000_000 })
+    ).rejects.toThrow(DecompressedSizeExceededError)
+  })
+
+  it('reads a legitimate small file without false rejection (default caps)', async () => {
+    const filePath = join(tmpDir, 'legit.vcf')
+    writeFileSync(filePath, '##fileformat=VCFv4.2\n#CHROM\tPOS\nchr1\t100\n')
+
+    const lines = await collectLines(filePath)
+    expect(lines).toEqual(['##fileformat=VCFv4.2', '#CHROM\tPOS', 'chr1\t100'])
+  })
+
+  it('reads a legitimate gzipped file without false rejection (default caps)', async () => {
+    const filePath = join(tmpDir, 'legit.vcf.gz')
+    writeFileSync(filePath, gzipSync(Buffer.from('##fileformat=VCFv4.2\nchr1\t100\n')))
+
+    const lines = await collectLines(filePath)
+    expect(lines).toEqual(['##fileformat=VCFv4.2', 'chr1\t100'])
+  })
+})
+
+describe('readCappedFileSync', () => {
+  it('rejects an oversized plain file with DecompressedSizeExceededError', () => {
+    const filePath = join(tmpDir, 'big-plain.bed')
+    writeFileSync(filePath, 'chr1\t1\t2\n'.repeat(1000)) // ~9000 bytes
+
+    expect(() => readCappedFileSync(filePath, 100)).toThrow(DecompressedSizeExceededError)
+  })
+
+  it('rejects a gzip bomb via zlib maxOutputLength with DecompressedSizeExceededError', () => {
+    const filePath = join(tmpDir, 'bomb.bed.gz')
+    const inflated = 'chr1\t1\t2\n'.repeat(200_000) // highly compressible, large decompressed
+    writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+    expect(() => readCappedFileSync(filePath, 1000)).toThrow(DecompressedSizeExceededError)
+  })
+
+  it('reads a legitimate small plain file without false rejection', () => {
+    const filePath = join(tmpDir, 'legit.bed')
+    writeFileSync(filePath, 'chr1\t100\t200\n')
+
+    expect(readCappedFileSync(filePath)).toBe('chr1\t100\t200\n')
+  })
+
+  it('reads a legitimate small gzipped file without false rejection', () => {
+    const filePath = join(tmpDir, 'legit.bed.gz')
+    writeFileSync(filePath, gzipSync(Buffer.from('chr1\t100\t200\n')))
+
+    expect(readCappedFileSync(filePath)).toBe('chr1\t100\t200\n')
+  })
+})

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -19,7 +19,8 @@ import { createInterface } from 'node:readline'
 import {
   createCappedLineStream,
   LineTooLongError,
-  DecompressedSizeExceededError
+  DecompressedSizeExceededError,
+  DecompressionRatioExceededError
 } from '../../../src/main/import/stream-utils'
 
 let tmpDir: string
@@ -35,7 +36,12 @@ afterEach(() => {
 /** Collect lines from a capped stream via readline, resolving with lines or rejecting with the stream's error. */
 function collectLines(
   filePath: string,
-  opts?: { maxLineBytes?: number; maxDecompressedBytes?: number }
+  opts?: {
+    maxLineBytes?: number
+    maxDecompressedBytes?: number
+    maxCompressionRatio?: number
+    minCompressionRatioBytes?: number
+  }
 ) {
   return new Promise<string[]>((resolve, reject) => {
     const { stream } = createCappedLineStream(filePath, opts)
@@ -90,6 +96,78 @@ describe('createCappedLineStream', () => {
     await expect(
       collectLines(filePath, { maxDecompressedBytes: 1000, maxLineBytes: 2_000_000 })
     ).rejects.toThrow(DecompressedSizeExceededError)
+  })
+
+  it('rejects a gzip bomb by expansion ratio before the total-byte cap', async () => {
+    const filePath = join(tmpDir, 'ratio-bomb.vcf.gz')
+    writeFileSync(filePath, gzipSync(Buffer.from('A'.repeat(100_000) + '\n')))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 1_000_000,
+        maxLineBytes: 200_000,
+        maxCompressionRatio: 5,
+        minCompressionRatioBytes: 1_000
+      })
+    ).rejects.toThrow(DecompressionRatioExceededError)
+  })
+
+  it('applies the production expansion ratio when only the check floor is overridden', async () => {
+    const filePath = join(tmpDir, 'default-ratio-bomb.vcf.gz')
+    writeFileSync(filePath, gzipSync(Buffer.from('A'.repeat(2_000_000) + '\n')))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 3_000_000,
+        maxLineBytes: 3_000_000,
+        minCompressionRatioBytes: 1_000
+      })
+    ).rejects.toThrow(DecompressionRatioExceededError)
+  })
+
+  it('measures consumed gzip bytes so trailing padding cannot defeat the ratio guard', async () => {
+    const filePath = join(tmpDir, 'padded-ratio-bomb.vcf.gz')
+    const compressed = gzipSync(Buffer.from('A'.repeat(2_000_000) + '\n'))
+    writeFileSync(filePath, Buffer.concat([compressed, Buffer.alloc(1_000_000)]))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 3_000_000,
+        maxLineBytes: 3_000_000,
+        maxCompressionRatio: 50,
+        minCompressionRatioBytes: 1_000
+      })
+    ).rejects.toThrow(DecompressionRatioExceededError)
+  })
+
+  it('accepts a gzip below the configured expansion ratio', async () => {
+    const filePath = join(tmpDir, 'normal-ratio.vcf.gz')
+    const content = Array.from({ length: 500 }, (_, index) => `chr1\t${index}\t${index ** 2}`).join(
+      '\n'
+    )
+    writeFileSync(filePath, gzipSync(Buffer.from(content)))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 1_000_000,
+        maxCompressionRatio: 20,
+        minCompressionRatioBytes: 100
+      })
+    ).resolves.toHaveLength(500)
+  })
+
+  it('does not apply the ratio guard below its output floor', async () => {
+    const filePath = join(tmpDir, 'small-compressible.vcf.gz')
+    writeFileSync(filePath, gzipSync(Buffer.from('A'.repeat(5_000) + '\n')))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 10_000,
+        maxLineBytes: 10_000,
+        maxCompressionRatio: 1,
+        minCompressionRatioBytes: 8_000
+      })
+    ).resolves.toEqual(['A'.repeat(5_000)])
   })
 
   it('reads a legitimate small file without false rejection (default caps)', async () => {

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path'
 import { createGzip, gzipSync } from 'node:zlib'
 import { createInterface } from 'node:readline'
 import { once } from 'node:events'
+import { performance } from 'node:perf_hooks'
 import {
   createCappedLineStream,
   LineTooLongError,
@@ -25,6 +26,11 @@ import {
   MAX_GZIP_COMPRESSION_RATIO,
   MIN_GZIP_RATIO_CHECK_BYTES
 } from '../../../src/main/import/stream-utils'
+import {
+  GzipRatioPolicy,
+  MAX_GZIP_FORMAT_INSPECTION_BYTES,
+  MAX_VCF_GZIP_COMPRESSION_RATIO
+} from '../../../src/main/import/gzip-ratio-policy'
 
 let tmpDir: string
 
@@ -170,6 +176,20 @@ describe('createCappedLineStream', () => {
     ).rejects.toThrow(DecompressionRatioExceededError)
   })
 
+  it('does not grant the VCF allowance to header-shaped input with malformed data rows', async () => {
+    const filePath = join(tmpDir, 'spoofed-cohort.vcf.gz')
+    const samples = Array.from({ length: 1_000 }, (_, index) => `S${index}`).join('\t')
+    const content = `##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t${samples}\n${'A\n'.repeat(1_000_000)}`
+    writeFileSync(filePath, gzipSync(Buffer.from(content)))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 3_000_000,
+        minCompressionRatioBytes: 1_000
+      })
+    ).rejects.toThrow(DecompressionRatioExceededError)
+  })
+
   it('measures consumed gzip bytes so trailing padding cannot defeat the ratio guard', async () => {
     const filePath = join(tmpDir, 'padded-ratio-bomb.vcf.gz')
     const compressed = gzipSync(Buffer.from('A'.repeat(2_000_000) + '\n'))
@@ -239,5 +259,32 @@ describe('createCappedLineStream', () => {
 
     const lines = await collectLines(filePath)
     expect(lines).toEqual(['##fileformat=VCFv4.2', 'chr1\t100'])
+  })
+})
+
+describe('GzipRatioPolicy', () => {
+  it('caps the sample-derived VCF allowance at its hard maximum', () => {
+    const samples = Array.from({ length: 2_000 }, (_, index) => `S${index}`).join('\t')
+    const genotypes = Array.from({ length: 2_000 }, () => '0/0').join('\t')
+    const policy = new GzipRatioPolicy(MAX_GZIP_COMPRESSION_RATIO)
+    policy.observe(
+      Buffer.from(
+        `##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t${samples}\n1\t1\t.\tA\tG\t30\tPASS\t.\tGT\t${genotypes}\n`
+      )
+    )
+    expect(policy.maxRatio()).toBe(MAX_VCF_GZIP_COMPRESSION_RATIO)
+  })
+
+  it('stops inspecting a minified non-VCF prefix within a fixed byte budget', () => {
+    const policy = new GzipRatioPolicy(MAX_GZIP_COMPRESSION_RATIO)
+    const minifiedJson = Buffer.alloc(64 * 1024 * 1024, 0x61)
+    minifiedJson.write('{"variants":[')
+    const startedAt = performance.now()
+
+    policy.observe(minifiedJson)
+
+    expect(performance.now() - startedAt).toBeLessThan(100)
+    expect(MAX_GZIP_FORMAT_INSPECTION_BYTES).toBeLessThan(minifiedJson.length)
+    expect(policy.maxRatio()).toBe(MAX_GZIP_COMPRESSION_RATIO)
   })
 })

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -28,8 +28,7 @@ import {
 } from '../../../src/main/import/stream-utils'
 import {
   GzipRatioPolicy,
-  MAX_GZIP_FORMAT_INSPECTION_BYTES,
-  MAX_VCF_GZIP_COMPRESSION_RATIO
+  MAX_GZIP_FORMAT_INSPECTION_BYTES
 } from '../../../src/main/import/gzip-ratio-policy'
 
 let tmpDir: string
@@ -263,7 +262,7 @@ describe('createCappedLineStream', () => {
 })
 
 describe('GzipRatioPolicy', () => {
-  it('caps the sample-derived VCF allowance at its hard maximum', () => {
+  it('uses absolute byte/line/header budgets after structural VCF validation', () => {
     const samples = Array.from({ length: 2_000 }, (_, index) => `S${index}`).join('\t')
     const genotypes = Array.from({ length: 2_000 }, () => '0/0').join('\t')
     const policy = new GzipRatioPolicy(MAX_GZIP_COMPRESSION_RATIO)
@@ -272,7 +271,7 @@ describe('GzipRatioPolicy', () => {
         `##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t${samples}\n1\t1\t.\tA\tG\t30\tPASS\t.\tGT\t${genotypes}\n`
       )
     )
-    expect(policy.maxRatio()).toBe(MAX_VCF_GZIP_COMPRESSION_RATIO)
+    expect(policy.maxRatio()).toBe(Number.POSITIVE_INFINITY)
   })
 
   it('stops inspecting a minified non-VCF prefix within a fixed byte budget', () => {

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -12,15 +12,18 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { tmpdir } from 'node:os'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createWriteStream, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { gzipSync } from 'node:zlib'
+import { createGzip, gzipSync } from 'node:zlib'
 import { createInterface } from 'node:readline'
+import { once } from 'node:events'
 import {
   createCappedLineStream,
   LineTooLongError,
   DecompressedSizeExceededError,
-  DecompressionRatioExceededError
+  DecompressionRatioExceededError,
+  MAX_GZIP_COMPRESSION_RATIO,
+  MIN_GZIP_RATIO_CHECK_BYTES
 } from '../../../src/main/import/stream-utils'
 
 let tmpDir: string
@@ -66,6 +69,36 @@ function collectLines(
       reject(error)
     })
   })
+}
+
+async function writeHighSampleVcfGzip(
+  filePath: string
+): Promise<{ decompressedBytes: number; expectedLines: number }> {
+  const sampleCount = 500
+  const rowCount = 35_000
+  const gzip = createGzip()
+  const output = createWriteStream(filePath)
+  gzip.pipe(output)
+
+  const fileformat = '##fileformat=VCFv4.2\n'
+  const header = `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t${Array.from(
+    { length: sampleCount },
+    (_, index) => `S${index}`
+  ).join('\t')}\n`
+  gzip.write(fileformat)
+  gzip.write(header)
+  let decompressedBytes = Buffer.byteLength(fileformat) + Buffer.byteLength(header)
+  const genotypes = Array.from({ length: sampleCount }, () => '0/0').join('\t')
+  for (let position = 1; position <= rowCount; position += 1) {
+    const row = `1\t${position}\t.\tA\tG\t30\tPASS\t.\tGT\t${genotypes}\n`
+    decompressedBytes += Buffer.byteLength(row)
+    if (!gzip.write(row)) {
+      await once(gzip, 'drain')
+    }
+  }
+  gzip.end()
+  await once(output, 'close')
+  return { decompressedBytes, expectedLines: rowCount + 2 }
 }
 
 describe('createCappedLineStream', () => {
@@ -125,6 +158,18 @@ describe('createCappedLineStream', () => {
     ).rejects.toThrow(DecompressionRatioExceededError)
   })
 
+  it('rejects a gzip bomb made of many individually short lines', async () => {
+    const filePath = join(tmpDir, 'short-line-ratio-bomb.vcf.gz')
+    writeFileSync(filePath, gzipSync(Buffer.from('A\n'.repeat(1_000_000))))
+
+    await expect(
+      collectLines(filePath, {
+        maxDecompressedBytes: 3_000_000,
+        minCompressionRatioBytes: 1_000
+      })
+    ).rejects.toThrow(DecompressionRatioExceededError)
+  })
+
   it('measures consumed gzip bytes so trailing padding cannot defeat the ratio guard', async () => {
     const filePath = join(tmpDir, 'padded-ratio-bomb.vcf.gz')
     const compressed = gzipSync(Buffer.from('A'.repeat(2_000_000) + '\n'))
@@ -168,6 +213,16 @@ describe('createCappedLineStream', () => {
         minCompressionRatioBytes: 8_000
       })
     ).resolves.toEqual(['A'.repeat(5_000)])
+  })
+
+  it('accepts a valid high-sample VCF above the production ratio-check floor', async () => {
+    const filePath = join(tmpDir, 'joint-cohort.vcf.gz')
+    const { decompressedBytes, expectedLines } = await writeHighSampleVcfGzip(filePath)
+
+    expect(decompressedBytes).toBeGreaterThan(MIN_GZIP_RATIO_CHECK_BYTES)
+    expect(decompressedBytes / statSync(filePath).size).toBeGreaterThan(MAX_GZIP_COMPRESSION_RATIO)
+
+    await expect(collectLines(filePath)).resolves.toHaveLength(expectedLines)
   })
 
   it('reads a legitimate small file without false rejection (default caps)', async () => {

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -18,7 +18,6 @@ import { gzipSync } from 'node:zlib'
 import { createInterface } from 'node:readline'
 import {
   createCappedLineStream,
-  readCappedFileSync,
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../src/main/import/stream-utils'
@@ -107,36 +106,5 @@ describe('createCappedLineStream', () => {
 
     const lines = await collectLines(filePath)
     expect(lines).toEqual(['##fileformat=VCFv4.2', 'chr1\t100'])
-  })
-})
-
-describe('readCappedFileSync', () => {
-  it('rejects an oversized plain file with DecompressedSizeExceededError', () => {
-    const filePath = join(tmpDir, 'big-plain.bed')
-    writeFileSync(filePath, 'chr1\t1\t2\n'.repeat(1000)) // ~9000 bytes
-
-    expect(() => readCappedFileSync(filePath, 100)).toThrow(DecompressedSizeExceededError)
-  })
-
-  it('rejects a gzip bomb via zlib maxOutputLength with DecompressedSizeExceededError', () => {
-    const filePath = join(tmpDir, 'bomb.bed.gz')
-    const inflated = 'chr1\t1\t2\n'.repeat(200_000) // highly compressible, large decompressed
-    writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
-
-    expect(() => readCappedFileSync(filePath, 1000)).toThrow(DecompressedSizeExceededError)
-  })
-
-  it('reads a legitimate small plain file without false rejection', () => {
-    const filePath = join(tmpDir, 'legit.bed')
-    writeFileSync(filePath, 'chr1\t100\t200\n')
-
-    expect(readCappedFileSync(filePath)).toBe('chr1\t100\t200\n')
-  })
-
-  it('reads a legitimate small gzipped file without false rejection', () => {
-    const filePath = join(tmpDir, 'legit.bed.gz')
-    writeFileSync(filePath, gzipSync(Buffer.from('chr1\t100\t200\n')))
-
-    expect(readCappedFileSync(filePath)).toBe('chr1\t100\t200\n')
   })
 })

--- a/tests/main/import/stream-utils-caps.test.ts
+++ b/tests/main/import/stream-utils-caps.test.ts
@@ -76,6 +76,31 @@ function collectLines(
   })
 }
 
+/** Count a large capped stream without retaining every decompressed line. */
+function countLines(filePath: string): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const { stream } = createCappedLineStream(filePath)
+    const rl = createInterface({ input: stream, crlfDelay: Infinity })
+    let count = 0
+    let settled = false
+    rl.on('line', () => {
+      count += 1
+    })
+    rl.on('close', () => {
+      if (settled) return
+      settled = true
+      resolve(count)
+    })
+    const rejectOnce = (error: Error): void => {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+    rl.on('error', rejectOnce)
+    stream.on('error', rejectOnce)
+  })
+}
+
 async function writeHighSampleVcfGzip(
   filePath: string
 ): Promise<{ decompressedBytes: number; expectedLines: number }> {
@@ -241,7 +266,7 @@ describe('createCappedLineStream', () => {
     expect(decompressedBytes).toBeGreaterThan(MIN_GZIP_RATIO_CHECK_BYTES)
     expect(decompressedBytes / statSync(filePath).size).toBeGreaterThan(MAX_GZIP_COMPRESSION_RATIO)
 
-    await expect(collectLines(filePath)).resolves.toHaveLength(expectedLines)
+    await expect(countLines(filePath)).resolves.toBe(expectedLines)
   })
 
   it('reads a legitimate small file without false rejection (default caps)', async () => {
@@ -276,7 +301,7 @@ describe('GzipRatioPolicy', () => {
 
   it('stops inspecting a minified non-VCF prefix within a fixed byte budget', () => {
     const policy = new GzipRatioPolicy(MAX_GZIP_COMPRESSION_RATIO)
-    const minifiedJson = Buffer.alloc(64 * 1024 * 1024, 0x61)
+    const minifiedJson = Buffer.alloc(MAX_GZIP_FORMAT_INSPECTION_BYTES * 256, 0x61)
     minifiedJson.write('{"variants":[')
     const startedAt = performance.now()
 

--- a/tests/main/import/vcf/bed-filter.test.ts
+++ b/tests/main/import/vcf/bed-filter.test.ts
@@ -6,6 +6,11 @@ import {
   BedFilter,
   MAX_BED_FILTER_DECOMPRESSED_BYTES
 } from '../../../../src/main/import/vcf/bed-filter'
+import {
+  BedEntryLimitExceededError,
+  parseBedEntry,
+  readBedEntries
+} from '../../../../src/main/import/vcf/bed-reader'
 import { DecompressedSizeExceededError } from '../../../../src/main/import/stream-utils'
 import path from 'path'
 
@@ -44,6 +49,29 @@ describe('BedFilter', () => {
       // chr1:999000-1010000 with +/-100 -> chr1:998901-1010100 (1-based inclusive)
       expect(filter.contains('chr1', 998950)).toBe(true)
       expect(filter.contains('chr1', 998850)).toBe(false)
+    })
+
+    it('rejects more valid BED rows than the configured entry cap', async () => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-entries-'))
+      const filePath = path.join(tmpDir, 'too-many.bed')
+      writeFileSync(filePath, 'chr1\t0\t1\nchr1\t2\t3\nchr1\t4\t5\n')
+
+      try {
+        const collect = async (): Promise<void> => {
+          for await (const entry of readBedEntries(filePath, 10_000, { maxEntries: 2 })) {
+            void entry
+          }
+        }
+        await expect(collect()).rejects.toThrow(BedEntryLimitExceededError)
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects BED coordinates outside JavaScript safe-integer range', () => {
+      expect(
+        parseBedEntry(`chr1\t${Number.MAX_SAFE_INTEGER + 1}\t${Number.MAX_SAFE_INTEGER + 2}`)
+      ).toBeNull()
     })
   })
 

--- a/tests/main/import/vcf/bed-filter.test.ts
+++ b/tests/main/import/vcf/bed-filter.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { gzipSync } from 'node:zlib'
-import { BedFilter } from '../../../../src/main/import/vcf/bed-filter'
+import {
+  BedFilter,
+  MAX_BED_FILTER_DECOMPRESSED_BYTES
+} from '../../../../src/main/import/vcf/bed-filter'
 import { DecompressedSizeExceededError } from '../../../../src/main/import/stream-utils'
 import path from 'path'
 
@@ -102,6 +105,15 @@ describe('BedFilter', () => {
       tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-dos-'))
       const filePath = path.join(tmpDir, 'giant.bed')
       writeFileSync(filePath, 'chr1\t1\t2\n'.repeat(1000)) // ~9000 bytes > 1000-byte cap
+
+      expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
+    })
+
+    it('uses a BED-specific cap instead of the import-wide 256 GiB default', () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-specific-cap-'))
+      const filePath = path.join(tmpDir, 'oversized.bed')
+      writeFileSync(filePath, '')
+      truncateSync(filePath, MAX_BED_FILTER_DECOMPRESSED_BYTES + 1)
 
       expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
     })

--- a/tests/main/import/vcf/bed-filter.test.ts
+++ b/tests/main/import/vcf/bed-filter.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../../src/main/import/vcf/bed-reader'
 import { DecompressedSizeExceededError } from '../../../../src/main/import/stream-utils'
 import path from 'path'
+import { performance } from 'node:perf_hooks'
 
 const BED_PATH = path.join(__dirname, '../../../test-data/vcf/test-regions.bed')
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
@@ -72,6 +73,19 @@ describe('BedFilter', () => {
       expect(
         parseBedEntry(`chr1\t${Number.MAX_SAFE_INTEGER + 1}\t${Number.MAX_SAFE_INTEGER + 2}`)
       ).toBeNull()
+    })
+
+    it('parses only the first four fields of a token-dense BED line', () => {
+      const denseRemainder = ' ignored'.repeat(1_000_000)
+      const startedAt = performance.now()
+
+      expect(parseBedEntry(`chr1 0 10 label${denseRemainder}`)).toEqual({
+        chr: 'chr1',
+        start: 0,
+        end: 10,
+        label: 'label'
+      })
+      expect(performance.now() - startedAt).toBeLessThan(20)
     })
   })
 

--- a/tests/main/import/vcf/bed-filter.test.ts
+++ b/tests/main/import/vcf/bed-filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeAll } from 'vitest'
 import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { gzipSync } from 'node:zlib'
@@ -14,27 +14,33 @@ const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 
 describe('BedFilter', () => {
   describe('fromFile worker-safe defensive check', () => {
-    it('rejects relative paths', () => {
-      expect(() => BedFilter.fromFile('relative/foo.bed', 0)).toThrow(/must be an absolute path/i)
+    it('rejects relative paths', async () => {
+      await expect(BedFilter.fromFile('relative/foo.bed', 0)).rejects.toThrow(
+        /must be an absolute path/i
+      )
     })
 
-    it('rejects paths containing .. after resolve', () => {
-      expect(() => BedFilter.fromFile('/tmp/../etc/shadow', 0)).toThrow(/must not contain '\.\.'/i)
+    it('rejects paths containing .. after resolve', async () => {
+      await expect(BedFilter.fromFile('/tmp/../etc/shadow', 0)).rejects.toThrow(
+        /must not contain '\.\.'/i
+      )
     })
 
-    it('passes the defensive check for an absolute path that does not exist (fails on read, not on guard)', () => {
-      expect(() => BedFilter.fromFile('/tmp/does-not-exist.bed', 0)).toThrow(/ENOENT|no such file/i)
+    it('passes the defensive check for an absolute path that does not exist (fails on read, not on guard)', async () => {
+      await expect(BedFilter.fromFile('/tmp/does-not-exist.bed', 0)).rejects.toThrow(
+        /ENOENT|no such file/i
+      )
     })
   })
 
   describe('loadFromFile', () => {
-    it('loads intervals from a BED file', () => {
-      const filter = BedFilter.fromFile(BED_PATH, 0)
+    it('loads intervals from a BED file', async () => {
+      const filter = await BedFilter.fromFile(BED_PATH, 0)
       expect(filter.intervalCount()).toBe(4)
     })
 
-    it('applies padding to intervals', () => {
-      const filter = BedFilter.fromFile(BED_PATH, 100)
+    it('applies padding to intervals', async () => {
+      const filter = await BedFilter.fromFile(BED_PATH, 100)
       // chr1:999000-1010000 with +/-100 -> chr1:998901-1010100 (1-based inclusive)
       expect(filter.contains('chr1', 998950)).toBe(true)
       expect(filter.contains('chr1', 998850)).toBe(false)
@@ -42,7 +48,10 @@ describe('BedFilter', () => {
   })
 
   describe('contains (point query)', () => {
-    const filter = BedFilter.fromFile(BED_PATH, 0)
+    let filter: BedFilter
+    beforeAll(async () => {
+      filter = await BedFilter.fromFile(BED_PATH, 0)
+    })
 
     it('returns true for position inside interval', () => {
       expect(filter.contains('chr1', 1000000)).toBe(true)
@@ -68,7 +77,10 @@ describe('BedFilter', () => {
   })
 
   describe('containsRange (interval overlap query for SV/CNV)', () => {
-    const filter = BedFilter.fromFile(BED_PATH, 0)
+    let filter: BedFilter
+    beforeAll(async () => {
+      filter = await BedFilter.fromFile(BED_PATH, 0)
+    })
 
     it('returns true when range overlaps a BED region', () => {
       // Range chr1:990000-1005000 overlaps BED chr1:999001-1010000
@@ -100,25 +112,25 @@ describe('BedFilter', () => {
       if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
     })
 
-    it('rejects a plain BED file whose size exceeds the configured total-byte cap', () => {
+    it('rejects a plain BED file whose size exceeds the configured total-byte cap', async () => {
       process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
       tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-dos-'))
       const filePath = path.join(tmpDir, 'giant.bed')
       writeFileSync(filePath, 'chr1\t1\t2\n'.repeat(1000)) // ~9000 bytes > 1000-byte cap
 
-      expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
+      await expect(BedFilter.fromFile(filePath, 0)).rejects.toThrow(DecompressedSizeExceededError)
     })
 
-    it('uses a BED-specific cap instead of the import-wide 256 GiB default', () => {
+    it('uses a BED-specific cap instead of the import-wide 256 GiB default', async () => {
       tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-specific-cap-'))
       const filePath = path.join(tmpDir, 'oversized.bed')
       writeFileSync(filePath, '')
       truncateSync(filePath, MAX_BED_FILTER_DECOMPRESSED_BYTES + 1)
 
-      expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
+      await expect(BedFilter.fromFile(filePath, 0)).rejects.toThrow(DecompressedSizeExceededError)
     })
 
-    it('rejects a gzip decompression bomb once decompressed bytes exceed the configured cap', () => {
+    it('rejects a gzip decompression bomb once decompressed bytes exceed the configured cap', async () => {
       process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
       tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-bomb-'))
       const filePath = path.join(tmpDir, 'bomb.bed.gz')
@@ -127,13 +139,13 @@ describe('BedFilter', () => {
       const inflated = 'chr1\t1\t2\n'.repeat(200_000)
       writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
 
-      expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
+      await expect(BedFilter.fromFile(filePath, 0)).rejects.toThrow(DecompressedSizeExceededError)
     })
 
-    it('still loads a legitimate BED file under the default cap', () => {
+    it('still loads a legitimate BED file under the default cap', async () => {
       // No env override -- exercises the real default (256 GiB) cap, proving
       // no false rejection of a normal-sized file.
-      const filter = BedFilter.fromFile(BED_PATH, 0)
+      const filter = await BedFilter.fromFile(BED_PATH, 0)
       expect(filter.intervalCount()).toBe(4)
     })
   })

--- a/tests/main/import/vcf/bed-filter.test.ts
+++ b/tests/main/import/vcf/bed-filter.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../src/main/import/vcf/bed-filter'
 import {
   BedEntryLimitExceededError,
+  InvalidBedRowError,
   parseBedEntry,
   readBedEntries
 } from '../../../../src/main/import/vcf/bed-reader'
@@ -86,6 +87,28 @@ describe('BedFilter', () => {
         label: 'label'
       })
       expect(performance.now() - startedAt).toBeLessThan(20)
+    })
+
+    it('bounds strict malformed-row diagnostics independently of the line cap', async () => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-error-'))
+      const filePath = path.join(tmpDir, 'malformed.bed')
+      writeFileSync(filePath, `not-a-bed-row-${'x'.repeat(1024 * 1024)}\n`)
+
+      try {
+        const consume = async (): Promise<void> => {
+          for await (const entry of readBedEntries(filePath, 2 * 1024 * 1024, {
+            rejectMalformedRows: true
+          })) {
+            void entry
+          }
+        }
+        const error = await consume().catch((caught: unknown) => caught)
+
+        expect(error).toBeInstanceOf(InvalidBedRowError)
+        expect((error as Error).message.length).toBeLessThan(512)
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
     })
   })
 

--- a/tests/main/import/vcf/bed-filter.test.ts
+++ b/tests/main/import/vcf/bed-filter.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { gzipSync } from 'node:zlib'
 import { BedFilter } from '../../../../src/main/import/vcf/bed-filter'
+import { DecompressedSizeExceededError } from '../../../../src/main/import/stream-utils'
 import path from 'path'
 
 const BED_PATH = path.join(__dirname, '../../../test-data/vcf/test-regions.bed')
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 
 describe('BedFilter', () => {
   describe('fromFile worker-safe defensive check', () => {
@@ -81,6 +86,43 @@ describe('BedFilter', () => {
       const filter = BedFilter.empty()
       expect(filter.contains('chr1', 12345)).toBe(true)
       expect(filter.containsRange('chr1', 100, 200)).toBe(true)
+    })
+  })
+
+  describe('fromFile DoS guards (replaces unbounded gunzipSync(readFileSync()) full-slurp)', () => {
+    let tmpDir: string
+
+    afterEach(() => {
+      delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+      if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('rejects a plain BED file whose size exceeds the configured total-byte cap', () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-dos-'))
+      const filePath = path.join(tmpDir, 'giant.bed')
+      writeFileSync(filePath, 'chr1\t1\t2\n'.repeat(1000)) // ~9000 bytes > 1000-byte cap
+
+      expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
+    })
+
+    it('rejects a gzip decompression bomb once decompressed bytes exceed the configured cap', () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'varlens-bed-bomb-'))
+      const filePath = path.join(tmpDir, 'bomb.bed.gz')
+      // Highly compressible content: a tiny gzip payload that inflates far
+      // past the small test cap -- stands in for a real decompression bomb.
+      const inflated = 'chr1\t1\t2\n'.repeat(200_000)
+      writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+      expect(() => BedFilter.fromFile(filePath, 0)).toThrow(DecompressedSizeExceededError)
+    })
+
+    it('still loads a legitimate BED file under the default cap', () => {
+      // No env override -- exercises the real default (256 GiB) cap, proving
+      // no false rejection of a normal-sized file.
+      const filter = BedFilter.fromFile(BED_PATH, 0)
+      expect(filter.intervalCount()).toBe(4)
     })
   })
 })

--- a/tests/main/import/vcf/import-filters-apply.test.ts
+++ b/tests/main/import/vcf/import-filters-apply.test.ts
@@ -8,7 +8,7 @@
  * meant ONE test suite covers both paths.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll } from 'vitest'
 import {
   passesPreMappingFilters,
   passesPostMappingFilters,
@@ -76,12 +76,12 @@ function mapped(overrides: Partial<VcfMappedVariant> = {}): VcfMappedVariant {
   }
 }
 
-function buildBed(intervals: Array<[string, number, number]>): BedFilter {
+async function buildBed(intervals: Array<[string, number, number]>): Promise<BedFilter> {
   const content = intervals.map(([chr, s, e]) => `${chr}\t${s}\t${e}`).join('\n')
   const tmp = `/tmp/varlens-test-${Date.now()}-${Math.random().toString(36).slice(2)}.bed`
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('node:fs').writeFileSync(tmp, content)
-  const bed = BedFilter.fromFile(tmp, 0)
+  const bed = await BedFilter.fromFile(tmp, 0)
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('node:fs').unlinkSync(tmp)
   return bed
@@ -159,8 +159,11 @@ describe('passesPreMappingFilters', () => {
   })
 
   describe('bedFilter — point queries (SNV / indel)', () => {
-    const bed = buildBed([['chr1', 999, 2000]]) // 1-based inclusive [1000, 2000]
-    const withBed: ImportFilters = { ...DEFAULT_IMPORT_FILTERS, bedFilter: bed }
+    let withBed: ImportFilters
+    beforeAll(async () => {
+      const bed = await buildBed([['chr1', 999, 2000]])
+      withBed = { ...DEFAULT_IMPORT_FILTERS, bedFilter: bed }
+    })
 
     it('keeps SNV inside the BED interval', () => {
       expect(passesPreMappingFilters(rawRecord({ chrom: 'chr1', pos: 1500 }), withBed)).toBe(true)
@@ -185,11 +188,14 @@ describe('passesPreMappingFilters', () => {
 
   describe('bedFilter — range queries (SV / CNV / STR)', () => {
     // BED: chr1:[1000-2000]  AND  chr22:[5_000_000-6_000_000]
-    const bed = buildBed([
-      ['chr1', 999, 2000],
-      ['chr22', 4_999_999, 6_000_000]
-    ])
-    const withBed: ImportFilters = { ...DEFAULT_IMPORT_FILTERS, bedFilter: bed }
+    let withBed: ImportFilters
+    beforeAll(async () => {
+      const bed = await buildBed([
+        ['chr1', 999, 2000],
+        ['chr22', 4_999_999, 6_000_000]
+      ])
+      withBed = { ...DEFAULT_IMPORT_FILTERS, bedFilter: bed }
+    })
 
     it('keeps SV that overlaps a BED interval (DEL spanning interval)', () => {
       const del = rawRecord({
@@ -306,13 +312,16 @@ describe('passesPreMappingFilters', () => {
   })
 
   describe('combined filters — all three must pass', () => {
-    const bed = buildBed([['chr1', 999, 2000]])
-    const strict: ImportFilters = {
-      ...DEFAULT_IMPORT_FILTERS,
-      passOnly: true,
-      minQual: 30,
-      bedFilter: bed
-    }
+    let strict: ImportFilters
+    beforeAll(async () => {
+      const bed = await buildBed([['chr1', 999, 2000]])
+      strict = {
+        ...DEFAULT_IMPORT_FILTERS,
+        passOnly: true,
+        minQual: 30,
+        bedFilter: bed
+      }
+    })
 
     it('passes when everything is satisfied', () => {
       expect(

--- a/tests/main/import/vcf/import-filters-integration.test.ts
+++ b/tests/main/import/vcf/import-filters-integration.test.ts
@@ -239,9 +239,9 @@ describe('STR VCF import (Straglr)', () => {
 })
 
 describe('BED filter integration', () => {
-  it('filters SV variants by BED region', () => {
+  it('filters SV variants by BED region', async () => {
     const { variants } = parseVcfFile(SV_VCF)
-    const bedFilter = BedFilter.fromFile(BED_FILE, 0)
+    const bedFilter = await BedFilter.fromFile(BED_FILE, 0)
 
     const filtered = variants.filter((v) => {
       if (v.end_pos !== null && v.end_pos !== undefined) {
@@ -258,9 +258,9 @@ describe('BED filter integration', () => {
     expect(filtered.length).toBe(2)
   })
 
-  it('filters CNV variants by BED region', () => {
+  it('filters CNV variants by BED region', async () => {
     const { variants } = parseVcfFile(CNV_VCF)
-    const bedFilter = BedFilter.fromFile(BED_FILE, 0)
+    const bedFilter = await BedFilter.fromFile(BED_FILE, 0)
 
     const filtered = variants.filter((v) => {
       if (v.end_pos !== null && v.end_pos !== undefined) {
@@ -275,9 +275,9 @@ describe('BED filter integration', () => {
     expect(filtered.length).toBe(2)
   })
 
-  it('applies padding to expand BED regions', () => {
+  it('applies padding to expand BED regions', async () => {
     const { variants } = parseVcfFile(SV_VCF)
-    const bedFilter = BedFilter.fromFile(BED_FILE, 1000000) // 1M padding
+    const bedFilter = await BedFilter.fromFile(BED_FILE, 1000000) // 1M padding
 
     const filtered = variants.filter((v) => {
       if (v.end_pos !== null && v.end_pos !== undefined) {

--- a/tests/main/import/vcf/vcf-allele-splitter.test.ts
+++ b/tests/main/import/vcf/vcf-allele-splitter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { splitMultiAllelic } from '../../../../src/main/import/vcf/vcf-allele-splitter'
+import {
+  splitAlleleForSample,
+  splitMultiAllelic
+} from '../../../../src/main/import/vcf/vcf-allele-splitter'
 import type {
   VcfRawRecord,
   InfoFieldDef,
@@ -110,6 +113,30 @@ describe('vcf-allele-splitter', () => {
     expect(r2.alt).toEqual(['T'])
     expect(r2.info.get('AF')).toBe('0.2') // Number=A: select index 1
     expect(r2.info.get('AC')).toBe('10') // Number=A: select index 1
+  })
+
+  it('builds one ALT view containing only the selected sample', () => {
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 200,
+      id: 'rs1',
+      ref: 'A',
+      alt: ['G', 'T'],
+      qual: 95,
+      filter: 'PASS',
+      info: new Map([['AF', '0.1,0.2']]),
+      format: ['GT', 'AD'],
+      samples: new Map([
+        ['SELECTED', ['0/2', '24,0,24']],
+        ['UNSELECTED', ['0/1', '20,20,0']]
+      ])
+    }
+
+    const split = splitAlleleForSample(record, infoDefs, formatDefs, 1, 'SELECTED')
+
+    expect(split.alt).toEqual(['T'])
+    expect(split.info.get('AF')).toBe('0.2')
+    expect(split.samples).toEqual(new Map([['SELECTED', ['0/1', '24,24']]]))
   })
 
   it('remaps GT for multi-allelic splits', () => {

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { parseAnnotation } from '../../../../src/main/import/vcf/vcf-annotation-parser'
 import type { VcfHeader } from '../../../../src/main/import/vcf/types'
+import {
+  MAX_VCF_ANNOTATION_FIELDS,
+  MAX_VCF_ANNOTATIONS,
+  VcfResourceLimitError
+} from '../../../../src/main/import/vcf/vcf-resource-limits'
 
 function makeHeader(overrides: Partial<VcfHeader> = {}): VcfHeader {
   return {
@@ -189,6 +194,21 @@ describe('vcf-annotation-parser', () => {
       expect(result.geneSymbol).toBeNull()
       expect(result.consequence).toBeNull()
       expect(result.transcripts).toHaveLength(0)
+    })
+  })
+
+  describe('allocation budgets', () => {
+    it('rejects excessive annotation and per-annotation field fanout', () => {
+      const csqHeader = makeHeader({ annotationType: 'csq', csqFields: ['Allele'] })
+      const manyAnnotations = Array.from({ length: MAX_VCF_ANNOTATIONS + 1 }, () => 'G').join(',')
+      expect(() => parseAnnotation(new Map([['CSQ', manyAnnotations]]), csqHeader, 'G')).toThrow(
+        VcfResourceLimitError
+      )
+
+      const manyFields = Array.from({ length: MAX_VCF_ANNOTATION_FIELDS + 1 }, () => 'G').join('|')
+      expect(() =>
+        parseAnnotation(new Map([['ANN', manyFields]]), makeHeader({ annotationType: 'ann' }), 'G')
+      ).toThrow(VcfResourceLimitError)
     })
   })
 })

--- a/tests/main/import/vcf/vcf-annotation-parser.test.ts
+++ b/tests/main/import/vcf/vcf-annotation-parser.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { parseAnnotation } from '../../../../src/main/import/vcf/vcf-annotation-parser'
+import {
+  parseAnnotation,
+  parseAnnotationsForAlleles
+} from '../../../../src/main/import/vcf/vcf-annotation-parser'
 import type { VcfHeader } from '../../../../src/main/import/vcf/types'
 import {
   MAX_VCF_ANNOTATION_FIELDS,
@@ -108,6 +111,22 @@ describe('vcf-annotation-parser', () => {
       expect(result.geneSymbol).toBe('COMT')
     })
 
+    it('parses a multi-allelic annotation payload once into allele-indexed results', () => {
+      const info = new Map([
+        [
+          'CSQ',
+          'G|missense_variant|MODERATE|GENE1|E1|Transcript|T1|protein_coding||||||||||||||||,T|stop_gained|HIGH|GENE2|E2|Transcript|T2|protein_coding||||||||||||||||'
+        ]
+      ])
+
+      const [gResult, tResult] = parseAnnotationsForAlleles(info, header, ['G', 'T'], 'A')
+
+      expect(gResult.transcript).toBe('T1')
+      expect(tResult.transcript).toBe('T2')
+      expect(gResult.transcripts).toHaveLength(1)
+      expect(tResult.transcripts).toHaveLength(1)
+    })
+
     it('handles empty CSQ value', () => {
       const info = new Map([['CSQ', '']])
 
@@ -208,6 +227,19 @@ describe('vcf-annotation-parser', () => {
       const manyFields = Array.from({ length: MAX_VCF_ANNOTATION_FIELDS + 1 }, () => 'G').join('|')
       expect(() =>
         parseAnnotation(new Map([['ANN', manyFields]]), makeHeader({ annotationType: 'ann' }), 'G')
+      ).toThrow(VcfResourceLimitError)
+    })
+
+    it('rejects annotation-to-allele match amplification before building output graphs', () => {
+      const csqHeader = makeHeader({
+        annotationType: 'csq',
+        csqFields: ['Allele', 'Feature']
+      })
+      const annotations = Array.from({ length: 2_000 }, (_, index) => `-|T${index}`).join(',')
+      const deletionAlts = Array.from({ length: 1_000 }, () => 'A')
+
+      expect(() =>
+        parseAnnotationsForAlleles(new Map([['CSQ', annotations]]), csqHeader, deletionAlts, 'AA')
       ).toThrow(VcfResourceLimitError)
     })
   })

--- a/tests/main/import/vcf/vcf-header-parser.test.ts
+++ b/tests/main/import/vcf/vcf-header-parser.test.ts
@@ -9,6 +9,12 @@ import {
 } from '../../../../src/main/import/vcf/vcf-header-parser'
 import { VcfHeaderLimitExceededError } from '../../../../src/main/import/vcf/vcf-header-limits'
 import {
+  MAX_VCF_ANNOTATION_FIELDS,
+  MAX_VCF_COLUMNS,
+  MAX_VCF_STRUCTURED_HEADER_FIELDS,
+  VcfResourceLimitError
+} from '../../../../src/main/import/vcf/vcf-resource-limits'
+import {
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../../src/main/import/stream-utils'
@@ -120,6 +126,29 @@ describe('vcf-header-parser', () => {
       const header = parseVcfHeaderFromLines(sitesOnly)
       expect(header.samples).toEqual([])
       expect(header.annotationType).toBe('none')
+    })
+
+    it('rejects excessive #CHROM, structured-header, and CSQ field fanout', () => {
+      const wideChrom = `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO${'\tS'.repeat(MAX_VCF_COLUMNS)}`
+      expect(() => parseVcfHeaderFromLines([wideChrom])).toThrow(VcfResourceLimitError)
+
+      const structuredFields = Array.from(
+        { length: MAX_VCF_STRUCTURED_HEADER_FIELDS + 1 },
+        (_, index) => `K${index}=v`
+      ).join(',')
+      expect(() => parseVcfHeaderFromLines([`##INFO=<${structuredFields}>`])).toThrow(
+        VcfResourceLimitError
+      )
+
+      const csqFields = Array.from(
+        { length: MAX_VCF_ANNOTATION_FIELDS + 1 },
+        (_, index) => `F${index}`
+      ).join('|')
+      expect(() =>
+        parseVcfHeaderFromLines([
+          `##INFO=<ID=CSQ,Number=.,Type=String,Description="Format: ${csqFields}">`
+        ])
+      ).toThrow(VcfResourceLimitError)
     })
   })
 

--- a/tests/main/import/vcf/vcf-header-parser.test.ts
+++ b/tests/main/import/vcf/vcf-header-parser.test.ts
@@ -7,14 +7,16 @@ import {
   parseVcfHeader,
   parseVcfHeaderFromLines
 } from '../../../../src/main/import/vcf/vcf-header-parser'
+import { VcfHeaderLimitExceededError } from '../../../../src/main/import/vcf/vcf-header-limits'
 import {
-  MAX_LINE_BYTES,
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../../src/main/import/stream-utils'
 
 const SYNTHETIC_VCF = resolve(__dirname, '../../../test-data/vcf/synthetic-unit-test.vcf')
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
+const TEST_LINE_CAP = 1024
 
 describe('vcf-header-parser', () => {
   describe('parseVcfHeaderFromLines', () => {
@@ -144,12 +146,14 @@ describe('vcf-header-parser', () => {
 
     afterEach(() => {
       delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+      delete process.env[LINE_CAP_ENV_VAR]
       rmSync(tmpDir, { recursive: true, force: true })
     })
 
-    it('rejects a file containing a line over MAX_LINE_BYTES with LineTooLongError', async () => {
+    it('rejects a file containing a line over the production call-path cap', async () => {
+      process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
       const filePath = join(tmpDir, 'giant-line.vcf')
-      const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+      const giantLine = 'A'.repeat(TEST_LINE_CAP + 1)
       writeFileSync(filePath, `##fileformat=VCFv4.2\n${giantLine}\n#CHROM\tPOS\n`)
 
       await expect(parseVcfHeader(filePath)).rejects.toThrow(LineTooLongError)
@@ -162,6 +166,24 @@ describe('vcf-header-parser', () => {
       writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
 
       await expect(parseVcfHeader(filePath)).rejects.toThrow(DecompressedSizeExceededError)
+    })
+
+    it('rejects a header that exceeds its independent byte budget', async () => {
+      const filePath = join(tmpDir, 'wide-header.vcf')
+      writeFileSync(filePath, `##fileformat=VCFv4.2\n##source=${'x'.repeat(200)}\n#CHROM\tPOS\n`)
+
+      await expect(parseVcfHeader(filePath, { maxHeaderBytes: 100 })).rejects.toThrow(
+        VcfHeaderLimitExceededError
+      )
+    })
+
+    it('rejects a header that exceeds its independent line budget', async () => {
+      const filePath = join(tmpDir, 'many-header-lines.vcf')
+      writeFileSync(filePath, `##fileformat=VCFv4.2\n##source=a\n##source=b\n#CHROM\tPOS\n`)
+
+      await expect(parseVcfHeader(filePath, { maxHeaderLines: 3 })).rejects.toThrow(
+        VcfHeaderLimitExceededError
+      )
     })
   })
 })

--- a/tests/main/import/vcf/vcf-header-parser.test.ts
+++ b/tests/main/import/vcf/vcf-header-parser.test.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect } from 'vitest'
-import { resolve } from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { resolve, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
 import {
   parseVcfHeader,
   parseVcfHeaderFromLines
 } from '../../../../src/main/import/vcf/vcf-header-parser'
+import {
+  MAX_LINE_BYTES,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../../src/main/import/stream-utils'
 
 const SYNTHETIC_VCF = resolve(__dirname, '../../../test-data/vcf/synthetic-unit-test.vcf')
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 
 describe('vcf-header-parser', () => {
   describe('parseVcfHeaderFromLines', () => {
@@ -123,6 +132,36 @@ describe('vcf-header-parser', () => {
       expect(result.header.genomeBuild).toBe('GRCh38')
       expect(result.firstDataLine).toBeTruthy()
       expect(result.firstDataLine).toContain('chr22')
+    })
+  })
+
+  describe('parseVcfHeader DoS guards', () => {
+    let tmpDir: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'varlens-header-dos-'))
+    })
+
+    afterEach(() => {
+      delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+      rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('rejects a file containing a line over MAX_LINE_BYTES with LineTooLongError', async () => {
+      const filePath = join(tmpDir, 'giant-line.vcf')
+      const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+      writeFileSync(filePath, `##fileformat=VCFv4.2\n${giantLine}\n#CHROM\tPOS\n`)
+
+      await expect(parseVcfHeader(filePath)).rejects.toThrow(LineTooLongError)
+    })
+
+    it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      const filePath = join(tmpDir, 'bomb.vcf.gz')
+      const inflated = '##fileformat=VCFv4.2\n' + 'A'.repeat(1_000_000) + '\n'
+      writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+      await expect(parseVcfHeader(filePath)).rejects.toThrow(DecompressedSizeExceededError)
     })
   })
 })

--- a/tests/main/import/vcf/vcf-header-parser.test.ts
+++ b/tests/main/import/vcf/vcf-header-parser.test.ts
@@ -10,7 +10,7 @@ import {
 import { VcfHeaderLimitExceededError } from '../../../../src/main/import/vcf/vcf-header-limits'
 import {
   MAX_VCF_ANNOTATION_FIELDS,
-  MAX_VCF_COLUMNS,
+  MAX_VCF_HEADER_SAMPLES,
   MAX_VCF_STRUCTURED_HEADER_FIELDS,
   VcfResourceLimitError
 } from '../../../../src/main/import/vcf/vcf-resource-limits'
@@ -128,8 +128,18 @@ describe('vcf-header-parser', () => {
       expect(header.annotationType).toBe('none')
     })
 
+    it('accepts cohorts larger than the former 10,000-sample column cap', () => {
+      const sampleNames = Array.from({ length: 10_050 }, (_, index) => `S${index}`)
+      const header = parseVcfHeaderFromLines([
+        `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t${sampleNames.join('\t')}`
+      ])
+
+      expect(header.samples).toHaveLength(sampleNames.length)
+      expect(header.samples.at(-1)).toBe('S10049')
+    })
+
     it('rejects excessive #CHROM, structured-header, and CSQ field fanout', () => {
-      const wideChrom = `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO${'\tS'.repeat(MAX_VCF_COLUMNS)}`
+      const wideChrom = `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT${'\tS'.repeat(MAX_VCF_HEADER_SAMPLES + 1)}`
       expect(() => parseVcfHeaderFromLines([wideChrom])).toThrow(VcfResourceLimitError)
 
       const structuredFields = Array.from(

--- a/tests/main/import/vcf/vcf-line-parser.test.ts
+++ b/tests/main/import/vcf/vcf-line-parser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { parseVcfLine } from '../../../../src/main/import/vcf/vcf-line-parser'
 import {
   MAX_VCF_ALT_ALLELES,
-  MAX_VCF_COLUMNS,
+  MAX_VCF_COMPATIBILITY_SAMPLES,
   MAX_VCF_INFO_FIELDS
 } from '../../../../src/main/import/vcf/vcf-resource-limits'
 
@@ -225,12 +225,39 @@ describe('vcf-line-parser', () => {
       expect(onSkip).toHaveBeenCalledWith(expect.stringMatching(/truncated/i))
     })
 
-    it('rejects column fanout beyond the supported sample budget', () => {
+    it('parses only the selected sample from a cohort with more than 10,000 samples', () => {
+      const sampleNames = Array.from({ length: 10_050 }, (_, index) => `S${index}`)
+      const selectedSample = sampleNames.at(-1)!
       const onSkip = vi.fn()
-      const line = `chr1\t1\t.\tA\tG\t.\tPASS\t.${'\t0/1'.repeat(MAX_VCF_COLUMNS)}`
+      const format = 'GT:DP'
+      const selectedValues = '0/1:42'
+      const sampleColumns = Array.from({ length: sampleNames.length }, (_, index) =>
+        index === sampleNames.length - 1 ? selectedValues : '0'
+      ).join('\t')
+      const line = `chr1\t1\t.\tA\tG\t.\tPASS\t.\t${format}\t${sampleColumns}`
 
-      expect(parseVcfLine(line, [], onSkip)).toBeNull()
-      expect(onSkip).toHaveBeenCalledWith(expect.stringMatching(/too many VCF columns/i))
+      const record = parseVcfLine(line, sampleNames, onSkip, {
+        name: selectedSample,
+        index: sampleNames.length - 1
+      })
+
+      expect(record).not.toBeNull()
+      expect(record?.samples.size).toBe(1)
+      expect(record?.samples.get(selectedSample)).toEqual(['0/1', '42'])
+      expect(record?.samples.has(sampleNames[0])).toBe(false)
+      expect(onSkip).not.toHaveBeenCalled()
+    })
+
+    it('bounds the legacy all-samples compatibility path', () => {
+      const sampleNames = Array.from(
+        { length: MAX_VCF_COMPATIBILITY_SAMPLES + 1 },
+        (_, index) => `S${index}`
+      )
+      const line = `chr1\t1\t.\tA\tG\t.\tPASS\t.\tGT${'\t0'.repeat(sampleNames.length)}`
+      const reasons: string[] = []
+
+      expect(parseVcfLine(line, sampleNames, (reason) => reasons.push(reason))).toBeNull()
+      expect(reasons).toEqual([expect.stringMatching(/all-samples compatibility/i)])
     })
 
     it('rejects excessive ALT and INFO fanout without materializing every value', () => {

--- a/tests/main/import/vcf/vcf-line-parser.test.ts
+++ b/tests/main/import/vcf/vcf-line-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { parseVcfLine } from '../../../../src/main/import/vcf/vcf-line-parser'
+import {
+  MAX_VCF_ALT_ALLELES,
+  MAX_VCF_COLUMNS,
+  MAX_VCF_INFO_FIELDS
+} from '../../../../src/main/import/vcf/vcf-resource-limits'
 
 const SAMPLE_NAMES = ['HG005', 'HG006', 'HG007']
 
@@ -209,6 +214,35 @@ describe('vcf-line-parser', () => {
 
       expect(record?.qual).toBeNull()
       expect(onSkip).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('allocation budgets', () => {
+    it('reports truncated rows through onSkip', () => {
+      const onSkip = vi.fn()
+
+      expect(parseVcfLine('chr1\t1\t.\tA', [], onSkip)).toBeNull()
+      expect(onSkip).toHaveBeenCalledWith(expect.stringMatching(/truncated/i))
+    })
+
+    it('rejects column fanout beyond the supported sample budget', () => {
+      const onSkip = vi.fn()
+      const line = `chr1\t1\t.\tA\tG\t.\tPASS\t.${'\t0/1'.repeat(MAX_VCF_COLUMNS)}`
+
+      expect(parseVcfLine(line, [], onSkip)).toBeNull()
+      expect(onSkip).toHaveBeenCalledWith(expect.stringMatching(/too many VCF columns/i))
+    })
+
+    it('rejects excessive ALT and INFO fanout without materializing every value', () => {
+      const altSkip = vi.fn()
+      const alt = Array.from({ length: MAX_VCF_ALT_ALLELES + 1 }, () => 'A').join(',')
+      expect(parseVcfLine(`chr1\t1\t.\tC\t${alt}\t.\tPASS\t.`, [], altSkip)).toBeNull()
+      expect(altSkip).toHaveBeenCalledWith(expect.stringMatching(/too many ALT/i))
+
+      const infoSkip = vi.fn()
+      const info = Array.from({ length: MAX_VCF_INFO_FIELDS + 1 }, (_, i) => `K${i}=1`).join(';')
+      expect(parseVcfLine(`chr1\t1\t.\tC\tA\t.\tPASS\t${info}`, [], infoSkip)).toBeNull()
+      expect(infoSkip).toHaveBeenCalledWith(expect.stringMatching(/too many INFO/i))
     })
   })
 })

--- a/tests/main/import/vcf/vcf-line-parser.test.ts
+++ b/tests/main/import/vcf/vcf-line-parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { parseVcfLine } from '../../../../src/main/import/vcf/vcf-line-parser'
 
 const SAMPLE_NAMES = ['HG005', 'HG006', 'HG007']
@@ -104,5 +104,68 @@ describe('vcf-line-parser', () => {
 
     expect(record.ref).toBe('G')
     expect(record.alt).toEqual(['GACC'])
+  })
+
+  describe('invalid POS', () => {
+    it('rejects a non-numeric POS instead of producing a NaN row', () => {
+      const line = 'chr1\tNOTNUM\t.\tA\tG\t.\t.\t.'
+      const record = parseVcfLine(line, [])
+
+      expect(record).toBeNull()
+    })
+
+    it('rejects POS = "0"', () => {
+      const line = 'chr1\t0\t.\tA\tG\t.\t.\t.'
+      const record = parseVcfLine(line, [])
+
+      expect(record).toBeNull()
+    })
+
+    it('rejects POS = "-5"', () => {
+      const line = 'chr1\t-5\t.\tA\tG\t.\t.\t.'
+      const record = parseVcfLine(line, [])
+
+      expect(record).toBeNull()
+    })
+
+    it('rejects a fractional POS ("1.5")', () => {
+      const line = 'chr1\t1.5\t.\tA\tG\t.\t.\t.'
+      const record = parseVcfLine(line, [])
+
+      expect(record).toBeNull()
+    })
+
+    it('invokes the onSkip callback with a reason when POS is invalid', () => {
+      const line = 'chr1\tNOTNUM\t.\tA\tG\t.\t.\t.'
+      const reasons: string[] = []
+      const record = parseVcfLine(line, [], (reason) => reasons.push(reason))
+
+      expect(record).toBeNull()
+      expect(reasons).toHaveLength(1)
+      expect(reasons[0]).toMatch(/pos/i)
+    })
+
+    it('does not invoke onSkip for a valid line', () => {
+      const line = 'chr22\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1\t0/0\t0/0'
+      const onSkip = vi.fn()
+      const record = parseVcfLine(line, SAMPLE_NAMES, onSkip)
+
+      expect(record).not.toBeNull()
+      expect(onSkip).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('malformed QUAL', () => {
+    it('parses a malformed (non-numeric) QUAL as null, not NaN', () => {
+      const line = 'chr22\t100\t.\tA\tG\tabc\tPASS\t.\tGT\t0/1\t0/0\t0/0'
+      const record = parseVcfLine(line, SAMPLE_NAMES)
+
+      expect(record).not.toBeNull()
+      expect(record!.qual).toBeNull()
+      expect(Number.isNaN(record!.qual)).toBe(false)
+      // The rest of the record still parses correctly.
+      expect(record!.chrom).toBe('chr22')
+      expect(record!.pos).toBe(100)
+    })
   })
 })

--- a/tests/main/import/vcf/vcf-line-parser.test.ts
+++ b/tests/main/import/vcf/vcf-line-parser.test.ts
@@ -135,6 +135,17 @@ describe('vcf-line-parser', () => {
       expect(record).toBeNull()
     })
 
+    it('rejects a positive integer above Number.MAX_SAFE_INTEGER', () => {
+      const rawPos = String(Number.MAX_SAFE_INTEGER + 1)
+      const reasons: string[] = []
+      const record = parseVcfLine(`chr1\t${rawPos}\t.\tA\tG\t.\t.\t.`, [], (reason) =>
+        reasons.push(reason)
+      )
+
+      expect(record).toBeNull()
+      expect(reasons[0]).toMatch(/safe integer/i)
+    })
+
     it('invokes the onSkip callback with a reason when POS is invalid', () => {
       const line = 'chr1\tNOTNUM\t.\tA\tG\t.\t.\t.'
       const reasons: string[] = []
@@ -156,32 +167,28 @@ describe('vcf-line-parser', () => {
   })
 
   describe('malformed QUAL', () => {
-    it('parses a malformed (non-numeric) QUAL as null, not NaN', () => {
+    it('rejects a malformed non-dot QUAL with a reason', () => {
       const line = 'chr22\t100\t.\tA\tG\tabc\tPASS\t.\tGT\t0/1\t0/0\t0/0'
-      const record = parseVcfLine(line, SAMPLE_NAMES)
+      const reasons: string[] = []
+      const record = parseVcfLine(line, SAMPLE_NAMES, (reason) => reasons.push(reason))
 
-      expect(record).not.toBeNull()
-      expect(record!.qual).toBeNull()
-      expect(Number.isNaN(record!.qual)).toBe(false)
-      // The rest of the record still parses correctly.
-      expect(record!.chrom).toBe('chr22')
-      expect(record!.pos).toBe(100)
+      expect(record).toBeNull()
+      expect(reasons).toHaveLength(1)
+      expect(reasons[0]).toMatch(/qual/i)
     })
 
     it('does not accept numeric prefixes with trailing garbage', () => {
       const line = 'chr22\t100\t.\tA\tG\t99abc\tPASS\t.\tGT\t0/1\t0/0\t0/0'
       const record = parseVcfLine(line, SAMPLE_NAMES)
 
-      expect(record).not.toBeNull()
-      expect(record!.qual).toBeNull()
+      expect(record).toBeNull()
     })
 
     it('does not accept non-finite QUAL values', () => {
       const line = 'chr22\t100\t.\tA\tG\t1e309\tPASS\t.\tGT\t0/1\t0/0\t0/0'
       const record = parseVcfLine(line, SAMPLE_NAMES)
 
-      expect(record).not.toBeNull()
-      expect(record!.qual).toBeNull()
+      expect(record).toBeNull()
     })
 
     it('still accepts finite exponent notation', () => {
@@ -190,6 +197,18 @@ describe('vcf-line-parser', () => {
 
       expect(record).not.toBeNull()
       expect(record!.qual).toBe(150)
+    })
+
+    it('still accepts dot QUAL as an unreasoned missing value', () => {
+      const onSkip = vi.fn()
+      const record = parseVcfLine(
+        'chr22\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0/1\t0/0\t0/0',
+        SAMPLE_NAMES,
+        onSkip
+      )
+
+      expect(record?.qual).toBeNull()
+      expect(onSkip).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/main/import/vcf/vcf-line-parser.test.ts
+++ b/tests/main/import/vcf/vcf-line-parser.test.ts
@@ -167,5 +167,29 @@ describe('vcf-line-parser', () => {
       expect(record!.chrom).toBe('chr22')
       expect(record!.pos).toBe(100)
     })
+
+    it('does not accept numeric prefixes with trailing garbage', () => {
+      const line = 'chr22\t100\t.\tA\tG\t99abc\tPASS\t.\tGT\t0/1\t0/0\t0/0'
+      const record = parseVcfLine(line, SAMPLE_NAMES)
+
+      expect(record).not.toBeNull()
+      expect(record!.qual).toBeNull()
+    })
+
+    it('does not accept non-finite QUAL values', () => {
+      const line = 'chr22\t100\t.\tA\tG\t1e309\tPASS\t.\tGT\t0/1\t0/0\t0/0'
+      const record = parseVcfLine(line, SAMPLE_NAMES)
+
+      expect(record).not.toBeNull()
+      expect(record!.qual).toBeNull()
+    })
+
+    it('still accepts finite exponent notation', () => {
+      const line = 'chr22\t100\t.\tA\tG\t1.5e2\tPASS\t.\tGT\t0/1\t0/0\t0/0'
+      const record = parseVcfLine(line, SAMPLE_NAMES)
+
+      expect(record).not.toBeNull()
+      expect(record!.qual).toBe(150)
+    })
   })
 })

--- a/tests/main/import/vcf/vcf-mapper.test.ts
+++ b/tests/main/import/vcf/vcf-mapper.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { mapVcfRecord } from '../../../../src/main/import/vcf/VcfMapper'
 import type { VcfRawRecord, VcfHeader } from '../../../../src/main/import/vcf/types'
 import { DEFAULT_INFO_FIELD_MAPPINGS } from '../../../../src/main/import/vcf/info-field-registry'
+import { VcfResourceLimitError } from '../../../../src/main/import/vcf/vcf-resource-limits'
 
 function makeHeader(): VcfHeader {
   return {
@@ -257,5 +258,28 @@ describe('VcfMapper', () => {
     expect(v.gt_num).toBe('0/1')
     expect(v.gene_symbol).toBeNull()
     expect(v.gnomad_af).toBeCloseTo(0.1, 4) // mapped from AF via registry
+  })
+
+  it('rejects structural ALT fanout before expanded INFO output can exhaust memory', () => {
+    const alt = Array.from({ length: 1_000 }, (_, index) => `<DEL:${index}>`)
+    const record: VcfRawRecord = {
+      chrom: 'chr22',
+      pos: 100,
+      id: null,
+      ref: 'A',
+      alt,
+      qual: 50,
+      filter: 'PASS',
+      info: new Map([
+        ['SVTYPE', 'DEL'],
+        ['ADVERSARIAL_PAYLOAD', 'x'.repeat(100_000)]
+      ]),
+      format: ['GT'],
+      samples: new Map([['HG005', ['./.']]])
+    }
+
+    expect(() => mapVcfRecord(record, { ...header, annotationType: 'none' }, 'HG005', [])).toThrow(
+      VcfResourceLimitError
+    )
   })
 })

--- a/tests/main/import/vcf/vcf-preview.test.ts
+++ b/tests/main/import/vcf/vcf-preview.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest'
-import { resolve } from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { resolve, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
 import { getVcfPreview } from '../../../../src/main/import/vcf/vcf-preview'
+import {
+  MAX_LINE_BYTES,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../../src/main/import/stream-utils'
 
 const SYNTHETIC_VCF = resolve(__dirname, '../../../test-data/vcf/synthetic-unit-test.vcf')
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 
 describe('vcf-preview', () => {
   it('returns preview result for synthetic VCF', async () => {
@@ -42,5 +51,35 @@ describe('vcf-preview', () => {
 
   it('rejects for non-existent file', async () => {
     await expect(getVcfPreview('/tmp/does-not-exist.vcf')).rejects.toThrow('ENOENT')
+  })
+
+  describe('DoS guards', () => {
+    let tmpDir: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'varlens-preview-dos-'))
+    })
+
+    afterEach(() => {
+      delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+      rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('rejects a file containing a line over MAX_LINE_BYTES with LineTooLongError', async () => {
+      const filePath = join(tmpDir, 'giant-line.vcf')
+      const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+      writeFileSync(filePath, `##fileformat=VCFv4.2\n${giantLine}\nchr1\t100\n`)
+
+      await expect(getVcfPreview(filePath)).rejects.toThrow(LineTooLongError)
+    })
+
+    it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      const filePath = join(tmpDir, 'bomb.vcf.gz')
+      const inflated = '##fileformat=VCFv4.2\n' + 'A'.repeat(1_000_000) + '\n'
+      writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+      await expect(getVcfPreview(filePath)).rejects.toThrow(DecompressedSizeExceededError)
+    })
   })
 })

--- a/tests/main/import/vcf/vcf-preview.test.ts
+++ b/tests/main/import/vcf/vcf-preview.test.ts
@@ -5,13 +5,14 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { gzipSync } from 'node:zlib'
 import { getVcfPreview } from '../../../../src/main/import/vcf/vcf-preview'
 import {
-  MAX_LINE_BYTES,
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../../src/main/import/stream-utils'
 
 const SYNTHETIC_VCF = resolve(__dirname, '../../../test-data/vcf/synthetic-unit-test.vcf')
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
+const TEST_LINE_CAP = 1024
 
 describe('vcf-preview', () => {
   it('returns preview result for synthetic VCF', async () => {
@@ -62,12 +63,14 @@ describe('vcf-preview', () => {
 
     afterEach(() => {
       delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+      delete process.env[LINE_CAP_ENV_VAR]
       rmSync(tmpDir, { recursive: true, force: true })
     })
 
-    it('rejects a file containing a line over MAX_LINE_BYTES with LineTooLongError', async () => {
+    it('rejects a file containing a line over the production call-path cap', async () => {
+      process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
       const filePath = join(tmpDir, 'giant-line.vcf')
-      const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+      const giantLine = 'A'.repeat(TEST_LINE_CAP + 1)
       writeFileSync(filePath, `##fileformat=VCFv4.2\n${giantLine}\nchr1\t100\n`)
 
       await expect(getVcfPreview(filePath)).rejects.toThrow(LineTooLongError)

--- a/tests/main/import/vcf/vcf-strategy.test.ts
+++ b/tests/main/import/vcf/vcf-strategy.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { resolve } from 'node:path'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { DatabaseService } from '../../../../src/main/database/DatabaseService'
 import { VcfStrategy } from '../../../../src/main/import/vcf/VcfStrategy'
 import { detectFormat } from '../../../../src/main/import/format-detection'
@@ -180,6 +183,56 @@ describe('VcfStrategy', () => {
       .prepare('SELECT * FROM variants WHERE case_id = ? AND gene_symbol IS NOT NULL')
       .all(caseId) as Array<Record<string, unknown>>
     expect(variants.length).toBeGreaterThan(0)
+  })
+
+  it('rejects a malformed POS with a reasoned skip instead of a silent NaN row', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-vcf-strategy-'))
+    const malformedVcf = join(tmpDir, 'malformed-pos.vcf')
+
+    try {
+      writeFileSync(
+        malformedVcf,
+        [
+          '##fileformat=VCFv4.2',
+          '##FILTER=<ID=PASS,Description="All filters passed">',
+          '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+          '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+          'chr1\tNOTNUM\t.\tA\tG\t99\tPASS\t.\tGT\t0/1',
+          'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+        ].join('\n') + '\n'
+      )
+
+      const caseId = db.cases.createCase('test-malformed-pos', malformedVcf, 1000)
+
+      const options: ImportOptions = { caseName: 'test-malformed-pos' }
+      const context: StrategyContext = {
+        db,
+        formatInfo: { format: 'vcf', caseKey: '' },
+        caseId,
+        startTime: Date.now()
+      }
+
+      const result = await strategy.import(malformedVcf, options, context, {
+        selectedSamples: ['HG005'],
+        genomeBuild: 'GRCh38'
+      })
+
+      // Only the valid line is inserted; the malformed-POS line is rejected.
+      expect(result.variantCount).toBe(1)
+      expect(result.skipped).toBeGreaterThanOrEqual(1)
+
+      // The skip carries a reason -- not a silent drop.
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors.some((e) => /invalid POS/i.test(e))).toBe(true)
+
+      // No NaN-position row reached the database.
+      const variants = db.database
+        .prepare('SELECT pos FROM variants WHERE case_id = ?')
+        .all(caseId) as Array<{ pos: number }>
+      expect(variants.every((v) => Number.isInteger(v.pos))).toBe(true)
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/main/import/vcf/vcf-strategy.test.ts
+++ b/tests/main/import/vcf/vcf-strategy.test.ts
@@ -4,11 +4,19 @@ import { resolve } from 'node:path'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
 import { DatabaseService } from '../../../../src/main/database/DatabaseService'
 import { VcfStrategy } from '../../../../src/main/import/vcf/VcfStrategy'
 import { detectFormat } from '../../../../src/main/import/format-detection'
+import {
+  MAX_LINE_BYTES,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../../src/main/import/stream-utils'
 import type { ImportOptions } from '../../../../src/main/import/types'
 import type { StrategyContext } from '../../../../src/main/import/strategies/ImportStrategy'
+
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 
 const SYNTHETIC_VCF = resolve(__dirname, '../../../test-data/vcf/synthetic-unit-test.vcf')
 const SINGLE_SAMPLE_VCF = resolve(__dirname, '../../../test-data/vcf/single-sample.vcf.gz')
@@ -233,6 +241,86 @@ describe('VcfStrategy', () => {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true })
     }
+  })
+
+  describe('DoS guards', () => {
+    afterEach(() => {
+      delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+    })
+
+    it('rejects a VCF containing a line over MAX_LINE_BYTES with LineTooLongError', async () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-vcf-strategy-dos-'))
+      const filePath = join(tmpDir, 'giant-line.vcf')
+
+      try {
+        const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+        writeFileSync(
+          filePath,
+          [
+            '##fileformat=VCFv4.2',
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+            giantLine,
+            'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+          ].join('\n') + '\n'
+        )
+
+        const caseId = db.cases.createCase('test-giant-line', filePath, 1000)
+        const options: ImportOptions = { caseName: 'test-giant-line' }
+        const context: StrategyContext = {
+          db,
+          formatInfo: { format: 'vcf', caseKey: '' },
+          caseId,
+          startTime: Date.now()
+        }
+
+        await expect(
+          strategy.import(filePath, options, context, {
+            selectedSamples: ['HG005'],
+            genomeBuild: 'GRCh38'
+          })
+        ).rejects.toThrow(LineTooLongError)
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-vcf-strategy-bomb-'))
+      const filePath = join(tmpDir, 'bomb.vcf.gz')
+
+      try {
+        const inflated =
+          [
+            '##fileformat=VCFv4.2',
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005'
+          ].join('\n') +
+          '\n' +
+          'A'.repeat(1_000_000) +
+          '\n'
+        writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+        const caseId = db.cases.createCase('test-bomb', filePath, 1000)
+        const options: ImportOptions = { caseName: 'test-bomb' }
+        const context: StrategyContext = {
+          db,
+          formatInfo: { format: 'vcf', caseKey: '' },
+          caseId,
+          startTime: Date.now()
+        }
+
+        await expect(
+          strategy.import(filePath, options, context, {
+            selectedSamples: ['HG005'],
+            genomeBuild: 'GRCh38'
+          })
+        ).rejects.toThrow(DecompressedSizeExceededError)
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
   })
 })
 

--- a/tests/main/import/vcf/vcf-strategy.test.ts
+++ b/tests/main/import/vcf/vcf-strategy.test.ts
@@ -207,6 +207,7 @@ describe('VcfStrategy', () => {
           '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
           '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
           'chr1\tNOTNUM\t.\tA\tG\t99\tPASS\t.\tGT\t0/1',
+          'chr1\t99\t.\tA\tG\tBADQUAL\tPASS\t.\tGT\t0/1',
           'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
         ].join('\n') + '\n'
       )
@@ -228,11 +229,12 @@ describe('VcfStrategy', () => {
 
       // Only the valid line is inserted; the malformed-POS line is rejected.
       expect(result.variantCount).toBe(1)
-      expect(result.skipped).toBeGreaterThanOrEqual(1)
+      expect(result.skipped).toBeGreaterThanOrEqual(2)
 
       // The skip carries a reason -- not a silent drop.
       expect(result.errors.length).toBeGreaterThan(0)
       expect(result.errors.some((e) => /invalid POS/i.test(e))).toBe(true)
+      expect(result.errors.some((e) => /invalid QUAL/i.test(e))).toBe(true)
 
       // No NaN-position row reached the database.
       const variants = db.database

--- a/tests/main/import/vcf/vcf-strategy.test.ts
+++ b/tests/main/import/vcf/vcf-strategy.test.ts
@@ -9,7 +9,6 @@ import { DatabaseService } from '../../../../src/main/database/DatabaseService'
 import { VcfStrategy } from '../../../../src/main/import/vcf/VcfStrategy'
 import { detectFormat } from '../../../../src/main/import/format-detection'
 import {
-  MAX_LINE_BYTES,
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../../src/main/import/stream-utils'
@@ -17,6 +16,8 @@ import type { ImportOptions } from '../../../../src/main/import/types'
 import type { StrategyContext } from '../../../../src/main/import/strategies/ImportStrategy'
 
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
+const TEST_LINE_CAP = 1024
 
 const SYNTHETIC_VCF = resolve(__dirname, '../../../test-data/vcf/synthetic-unit-test.vcf')
 const SINGLE_SAMPLE_VCF = resolve(__dirname, '../../../test-data/vcf/single-sample.vcf.gz')
@@ -246,14 +247,16 @@ describe('VcfStrategy', () => {
   describe('DoS guards', () => {
     afterEach(() => {
       delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+      delete process.env[LINE_CAP_ENV_VAR]
     })
 
-    it('rejects a VCF containing a line over MAX_LINE_BYTES with LineTooLongError', async () => {
+    it('rejects a VCF containing a line over the production call-path cap', async () => {
+      process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
       const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-vcf-strategy-dos-'))
       const filePath = join(tmpDir, 'giant-line.vcf')
 
       try {
-        const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+        const giantLine = 'A'.repeat(TEST_LINE_CAP + 1)
         writeFileSync(
           filePath,
           [

--- a/tests/main/import/worker-types.test.ts
+++ b/tests/main/import/worker-types.test.ts
@@ -20,6 +20,13 @@ describe('import worker types', () => {
     }>()
   })
 
+  it('WorkerMessage file-complete carries bounded skip diagnostics', () => {
+    expectTypeOf<Extract<WorkerMessage, { type: 'file-complete' }>['result']>().toMatchTypeOf<{
+      skipped: number
+      skipReasons: string[]
+    }>()
+  })
+
   it('MainMessage start variant has required fields', () => {
     expectTypeOf<Extract<MainMessage, { type: 'start' }>>().toMatchTypeOf<{
       type: 'start'

--- a/tests/main/ipc/handlers/gene-lists.test.ts
+++ b/tests/main/ipc/handlers/gene-lists.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolve } from 'node:path'
+
+import { isIpcError } from '../../../../src/shared/types/errors'
+import { registerGeneListHandlers } from '../../../../src/main/ipc/handlers/gene-lists'
+import {
+  __resetAllowlistForTests,
+  addAllowedImportPath
+} from '../../../../src/main/security/import-path-allowlist'
+
+type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+function makeIpcMain(): { handle: ReturnType<typeof vi.fn> } {
+  return { handle: vi.fn() }
+}
+
+function makeDeps(ipcMain: { handle: ReturnType<typeof vi.fn> }) {
+  const execute = vi.fn().mockResolvedValue({ id: 1, region_count: 1 })
+  const getDbManager = vi.fn().mockReturnValue({
+    getCurrentSession: vi.fn().mockReturnValue({
+      capabilities: { backend: 'sqlite' },
+      getWriteExecutor: () => ({ execute })
+    })
+  })
+  return {
+    deps: {
+      ipcMain,
+      getDb: vi.fn(),
+      getDbPool: vi.fn().mockReturnValue(null),
+      getDbManager
+    },
+    execute
+  }
+}
+
+function getHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string
+): HandlerCallback {
+  const call = ipcMain.handle.mock.calls.find(([registered]) => registered === channel) as
+    [string, HandlerCallback] | undefined
+  if (call === undefined) throw new Error(`Handler for ${channel} not registered`)
+  return call[1]
+}
+
+describe('region-files:importBed IPC handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetAllowlistForTests()
+  })
+
+  it.each(['/etc/passwd', '/tmp/not-dialog-enrolled.bed'])(
+    'rejects non-enrolled renderer path %s before storage',
+    async (filePath) => {
+      const ipcMain = makeIpcMain()
+      const { deps, execute } = makeDeps(ipcMain)
+      registerGeneListHandlers(deps as never)
+
+      const result = await getHandler(ipcMain, 'region-files:importBed')({}, 1, filePath)
+
+      expect(isIpcError(result)).toBe(true)
+      expect(execute).not.toHaveBeenCalled()
+    }
+  )
+
+  it('routes a strictly dialog-enrolled BED path to streaming storage', async () => {
+    const ipcMain = makeIpcMain()
+    const { deps, execute } = makeDeps(ipcMain)
+    registerGeneListHandlers(deps as never)
+    const bedPath = resolve('external', 'regions.bed')
+    addAllowedImportPath(bedPath)
+
+    const result = await getHandler(ipcMain, 'region-files:importBed')({}, 1, bedPath)
+
+    expect(isIpcError(result)).toBe(false)
+    expect(execute).toHaveBeenCalledWith({
+      type: 'region-files:importBed',
+      params: [1, bedPath, { rejectMalformedRows: false }]
+    })
+  })
+})

--- a/tests/main/ipc/handlers/import-logic-append-dos.test.ts
+++ b/tests/main/ipc/handlers/import-logic-append-dos.test.ts
@@ -47,9 +47,12 @@ describe('import-logic-append.ts DoS guards', () => {
   let tmpDir: string
   let svc: DatabaseService
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'varlens-import-append-dos-'))
-    svc = new DatabaseService(':memory:')
+    svc = new DatabaseService(join(tmpDir, 'varlens.db'))
+    // Let DatabaseService's asynchronous startup cache cleanup release its
+    // connection before the append path acquires BEGIN IMMEDIATE.
+    await new Promise<void>((resolve) => setImmediate(resolve))
   })
 
   afterEach(() => {
@@ -143,6 +146,48 @@ describe('import-logic-append.ts DoS guards', () => {
 
       expect(result.variantCount).toBe(1)
       expect(result.errors).toEqual([])
+    })
+
+    it('uses an isolated connection and rolls back promptly when cancelled', async () => {
+      const filePath = join(tmpDir, 'cancel.vcf')
+      const rows = Array.from(
+        { length: 5_001 },
+        (_, index) => `chr1\t${index + 1}\t.\tA\tG\t99\tPASS\t.\tGT\t0/1`
+      )
+      writeFileSync(
+        filePath,
+        [
+          '##fileformat=VCFv4.2',
+          '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+          '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+          ...rows
+        ].join('\n') + '\n'
+      )
+      const caseId = svc.cases.createCase('test-append-cancel', filePath, 1000)
+      svc.variants.beginBulkInsert()
+      const controller = new AbortController()
+      let mainConnectionWasInTransaction = true
+
+      await expect(
+        importAdditionalFileToCase(
+          caseId,
+          filePath,
+          { selectedSample: 'HG005' },
+          () => svc,
+          {
+            onProgress: () => {
+              mainConnectionWasInTransaction = svc.database.inTransaction
+              controller.abort()
+            }
+          },
+          undefined,
+          controller.signal
+        )
+      ).rejects.toThrow(/cancelled/i)
+
+      expect(mainConnectionWasInTransaction).toBe(false)
+      svc.variants.recalculateCaseVariantCount(caseId)
+      expect(svc.cases.getCase(caseId)?.variant_count).toBe(0)
     })
   })
 

--- a/tests/main/ipc/handlers/import-logic-append-dos.test.ts
+++ b/tests/main/ipc/handlers/import-logic-append-dos.test.ts
@@ -26,12 +26,13 @@ import {
   detectGenomeBuildFromFile
 } from '../../../../src/main/ipc/handlers/import-logic-append'
 import {
-  MAX_LINE_BYTES,
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../../src/main/import/stream-utils'
 
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
+const TEST_LINE_CAP = 1024
 
 const GIANT_LINE_VCF = (giantLine: string): string =>
   [
@@ -55,12 +56,14 @@ describe('import-logic-append.ts DoS guards', () => {
     svc.close()
     rmSync(tmpDir, { recursive: true, force: true })
     delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+    delete process.env[LINE_CAP_ENV_VAR]
   })
 
   describe('importAdditionalFileToCase', () => {
     it('rejects a giant line with LineTooLongError -- not a silent per-line skip', async () => {
+      process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
       const filePath = join(tmpDir, 'giant-line.vcf')
-      writeFileSync(filePath, GIANT_LINE_VCF('A'.repeat(MAX_LINE_BYTES + 1)))
+      writeFileSync(filePath, GIANT_LINE_VCF('A'.repeat(TEST_LINE_CAP + 1)))
 
       const caseId = svc.cases.createCase('test-append-giant-line', filePath, 1000)
       svc.variants.beginBulkInsert()
@@ -122,11 +125,12 @@ describe('import-logic-append.ts DoS guards', () => {
 
   describe('detectGenomeBuildFromFile', () => {
     it('rejects a giant header-adjacent line with LineTooLongError', async () => {
+      process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
       const filePath = join(tmpDir, 'giant-header.vcf')
       // The oversized line sits among header lines (before #CHROM), so the
       // preflight header reader -- which only reads up to the first data
       // line -- still encounters it.
-      const giantHeaderLine = '##' + 'A'.repeat(MAX_LINE_BYTES + 1)
+      const giantHeaderLine = '##' + 'A'.repeat(TEST_LINE_CAP + 1)
       writeFileSync(
         filePath,
         [

--- a/tests/main/ipc/handlers/import-logic-append-dos.test.ts
+++ b/tests/main/ipc/handlers/import-logic-append-dos.test.ts
@@ -73,6 +73,29 @@ describe('import-logic-append.ts DoS guards', () => {
       ).rejects.toThrow(LineTooLongError)
     })
 
+    it('rolls back earlier batches when a late line exceeds the cap', async () => {
+      process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
+      const filePath = join(tmpDir, 'late-giant-line.vcf')
+      const validRows = Array.from(
+        { length: 10_000 },
+        (_, index) => `chr1\t${index + 1}\t.\tA\tG\t99\tPASS\t.\tGT\t0/1`
+      )
+      writeFileSync(
+        filePath,
+        GIANT_LINE_VCF(validRows.concat('A'.repeat(TEST_LINE_CAP + 1)).join('\n'))
+      )
+
+      const caseId = svc.cases.createCase('test-append-late-giant-line', filePath, 1000)
+      svc.variants.beginBulkInsert()
+
+      await expect(
+        importAdditionalFileToCase(caseId, filePath, { selectedSample: 'HG005' }, () => svc, {})
+      ).rejects.toThrow(LineTooLongError)
+
+      svc.variants.recalculateCaseVariantCount(caseId)
+      expect(svc.cases.getCase(caseId)?.variant_count).toBe(0)
+    })
+
     it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
       process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
       const filePath = join(tmpDir, 'bomb.vcf.gz')

--- a/tests/main/ipc/handlers/import-logic-append-dos.test.ts
+++ b/tests/main/ipc/handlers/import-logic-append-dos.test.ts
@@ -66,13 +66,7 @@ describe('import-logic-append.ts DoS guards', () => {
       svc.variants.beginBulkInsert()
 
       await expect(
-        importAdditionalFileToCase(
-          caseId,
-          filePath,
-          { selectedSample: 'HG005' },
-          () => svc,
-          {}
-        )
+        importAdditionalFileToCase(caseId, filePath, { selectedSample: 'HG005' }, () => svc, {})
       ).rejects.toThrow(LineTooLongError)
     })
 
@@ -94,13 +88,7 @@ describe('import-logic-append.ts DoS guards', () => {
       svc.variants.beginBulkInsert()
 
       await expect(
-        importAdditionalFileToCase(
-          caseId,
-          filePath,
-          { selectedSample: 'HG005' },
-          () => svc,
-          {}
-        )
+        importAdditionalFileToCase(caseId, filePath, { selectedSample: 'HG005' }, () => svc, {})
       ).rejects.toThrow(DecompressedSizeExceededError)
     })
 

--- a/tests/main/ipc/handlers/import-logic-append-dos.test.ts
+++ b/tests/main/ipc/handlers/import-logic-append-dos.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment node
+/**
+ * DoS-cap regression tests for the two VCF readers in
+ * `import-logic-append.ts`:
+ *   - `importAdditionalFileToCase` -- the main-thread multi-file append
+ *     reader (2nd..Nth file of a multi-file import session).
+ *   - `detectGenomeBuildFromFile` -- the genome-build preflight header
+ *     reader run before each appended file is imported.
+ *
+ * Before this fix both built their own raw
+ * `createReadStream`/`createGunzip`/`readline` pipeline with no per-line or
+ * total-decompressed-byte guard. This file proves both are now routed
+ * through the capped reader AND that a cap violation rejects the call
+ * instead of being swallowed by the per-line `catch` in
+ * `importAdditionalFileToCase` that skips unparseable rows (which would
+ * silently re-hide the DoS as a "skipped line").
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { DatabaseService } from '../../../../src/main/database/DatabaseService'
+import {
+  importAdditionalFileToCase,
+  detectGenomeBuildFromFile
+} from '../../../../src/main/ipc/handlers/import-logic-append'
+import {
+  MAX_LINE_BYTES,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../../src/main/import/stream-utils'
+
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+
+const GIANT_LINE_VCF = (giantLine: string): string =>
+  [
+    '##fileformat=VCFv4.2',
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+    '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+    giantLine,
+    'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+  ].join('\n') + '\n'
+
+describe('import-logic-append.ts DoS guards', () => {
+  let tmpDir: string
+  let svc: DatabaseService
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-import-append-dos-'))
+    svc = new DatabaseService(':memory:')
+  })
+
+  afterEach(() => {
+    svc.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+    delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+  })
+
+  describe('importAdditionalFileToCase', () => {
+    it('rejects a giant line with LineTooLongError -- not a silent per-line skip', async () => {
+      const filePath = join(tmpDir, 'giant-line.vcf')
+      writeFileSync(filePath, GIANT_LINE_VCF('A'.repeat(MAX_LINE_BYTES + 1)))
+
+      const caseId = svc.cases.createCase('test-append-giant-line', filePath, 1000)
+      svc.variants.beginBulkInsert()
+
+      await expect(
+        importAdditionalFileToCase(
+          caseId,
+          filePath,
+          { selectedSample: 'HG005' },
+          () => svc,
+          {}
+        )
+      ).rejects.toThrow(LineTooLongError)
+    })
+
+    it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      const filePath = join(tmpDir, 'bomb.vcf.gz')
+      const inflated =
+        [
+          '##fileformat=VCFv4.2',
+          '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+          '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005'
+        ].join('\n') +
+        '\n' +
+        'A'.repeat(1_000_000) +
+        '\n'
+      writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+      const caseId = svc.cases.createCase('test-append-bomb', filePath, 1000)
+      svc.variants.beginBulkInsert()
+
+      await expect(
+        importAdditionalFileToCase(
+          caseId,
+          filePath,
+          { selectedSample: 'HG005' },
+          () => svc,
+          {}
+        )
+      ).rejects.toThrow(DecompressedSizeExceededError)
+    })
+
+    it('still appends a legitimate small VCF without false rejection (sanity check)', async () => {
+      const filePath = join(tmpDir, 'legit.vcf')
+      writeFileSync(
+        filePath,
+        [
+          '##fileformat=VCFv4.2',
+          '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+          '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+          'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+        ].join('\n') + '\n'
+      )
+
+      const caseId = svc.cases.createCase('test-append-legit', filePath, 1000)
+      svc.variants.beginBulkInsert()
+
+      const result = await importAdditionalFileToCase(
+        caseId,
+        filePath,
+        { selectedSample: 'HG005' },
+        () => svc,
+        {}
+      )
+
+      expect(result.variantCount).toBe(1)
+      expect(result.errors).toEqual([])
+    })
+  })
+
+  describe('detectGenomeBuildFromFile', () => {
+    it('rejects a giant header-adjacent line with LineTooLongError', async () => {
+      const filePath = join(tmpDir, 'giant-header.vcf')
+      // The oversized line sits among header lines (before #CHROM), so the
+      // preflight header reader -- which only reads up to the first data
+      // line -- still encounters it.
+      const giantHeaderLine = '##' + 'A'.repeat(MAX_LINE_BYTES + 1)
+      writeFileSync(
+        filePath,
+        [
+          '##fileformat=VCFv4.2',
+          giantHeaderLine,
+          '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+          'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+        ].join('\n') + '\n'
+      )
+
+      await expect(detectGenomeBuildFromFile(filePath)).rejects.toThrow(LineTooLongError)
+    })
+
+    it('rejects a decompression bomb in the header preflight reader', async () => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+      const filePath = join(tmpDir, 'bomb-header.vcf.gz')
+      const inflated = '##' + 'A'.repeat(1_000_000) + '\n#CHROM\tPOS\n'
+      writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+      await expect(detectGenomeBuildFromFile(filePath)).rejects.toThrow(
+        DecompressedSizeExceededError
+      )
+    })
+
+    it('returns the declared genome build for a legitimate header (sanity check)', async () => {
+      const filePath = join(tmpDir, 'legit-header.vcf')
+      writeFileSync(
+        filePath,
+        [
+          '##fileformat=VCFv4.2',
+          '##reference=GRCh38',
+          '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+          'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+        ].join('\n') + '\n'
+      )
+
+      const build = await detectGenomeBuildFromFile(filePath)
+      expect(build).toBe('GRCh38')
+    })
+  })
+})

--- a/tests/main/security/import-path-allowlist.test.ts
+++ b/tests/main/security/import-path-allowlist.test.ts
@@ -1,10 +1,11 @@
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { describe, it, expect, beforeEach } from 'vitest'
 import {
   addAllowedImportPath,
   isAllowedImportPath,
+  isStrictlyEnrolledPath,
   __resetAllowlistForTests
 } from '../../../src/main/security/import-path-allowlist'
 
@@ -46,19 +47,42 @@ describe('import-path-allowlist', () => {
     }
   })
 
-  symlinkIt('accepts a dialog-registered symlink and its resolved target', () => {
+  symlinkIt('rejects a dialog-registered symlink after its target changes', () => {
     const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
     try {
-      const linkPath = join(root, 'passwd-link.vcf')
-      symlinkSync('/etc/passwd', linkPath)
-      const targetPath = realpathSync.native(linkPath)
+      const targetA = join(root, 'a.vcf')
+      const targetB = join(root, 'b.vcf')
+      const linkPath = join(root, 'selected.vcf')
+      writeFileSync(targetA, 'A')
+      writeFileSync(targetB, 'B')
+      symlinkSync(targetA, linkPath)
 
       addAllowedImportPath(linkPath)
-
       expect(isAllowedImportPath(linkPath)).toBe(true)
-      expect(isAllowedImportPath(targetPath)).toBe(true)
+
+      rmSync(linkPath)
+      symlinkSync(targetB, linkPath)
+      expect(isAllowedImportPath(linkPath)).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
+  })
+
+  describe('isStrictlyEnrolledPath', () => {
+    it('rejects an automatic-root path that was never dialog-enrolled', () => {
+      expect(isAllowedImportPath('/tmp/inside-tmp.bed')).toBe(true)
+      expect(isStrictlyEnrolledPath('/tmp/inside-tmp.bed')).toBe(false)
+    })
+
+    it('accepts an explicitly enrolled normalized absolute path', () => {
+      const filePath = '/tmp/dialog-selected.bed'
+      addAllowedImportPath(filePath)
+      expect(isStrictlyEnrolledPath(filePath)).toBe(true)
+    })
+
+    it('rejects relative and non-normalized paths', () => {
+      expect(isStrictlyEnrolledPath('relative.bed')).toBe(false)
+      expect(isStrictlyEnrolledPath('/tmp/../etc/shadow')).toBe(false)
+    })
   })
 })

--- a/tests/main/storage/postgres-import-visibility.test.ts
+++ b/tests/main/storage/postgres-import-visibility.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Real-PostgreSQL coverage for migration 0014's provisional import boundary.
+ *
+ * Gated by VARLENS_RUN_POSTGRES_E2E=1. Requires a reachable VARLENS_PG_URL.
+ */
+import { randomBytes } from 'node:crypto'
+
+import { Client, Pool, type PoolClient } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migrations/definitions'
+import { PostgresMigrationRunner } from '../../../src/main/storage/postgres/migrations/PostgresMigrationRunner'
+import { PostgresTranscriptsRepository } from '../../../src/main/storage/postgres/PostgresTranscriptsRepository'
+import { PostgresVcfImportRepository } from '../../../src/main/storage/postgres/PostgresVcfImportRepository'
+
+const RUN = process.env.VARLENS_RUN_POSTGRES_E2E === '1'
+const PG_URL =
+  process.env.VARLENS_PG_URL ??
+  'postgres://varlens:varlens_dev_password@127.0.0.1:55432/varlens_dev'
+
+describe.skipIf(!RUN)('Postgres provisional import visibility — real instance', () => {
+  const schema = `varlens_test_import_visibility_${Date.now()}_${randomBytes(4).toString('hex')}`
+  let pool: Pool
+  let probe: Client
+
+  beforeAll(async () => {
+    const provisioner = new Client({ connectionString: PG_URL })
+    await provisioner.connect()
+    await provisioner.query(`CREATE SCHEMA "${schema}"`)
+    await provisioner.end()
+
+    pool = new Pool({ connectionString: PG_URL, max: 2 })
+    probe = new Client({ connectionString: PG_URL })
+    await probe.connect()
+    await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (probe) await probe.end()
+    if (pool) await pool.end()
+    const cleaner = new Client({ connectionString: PG_URL })
+    await cleaner.connect()
+    await cleaner.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await cleaner.end()
+  }, 60_000)
+
+  it('hides provisional rows, publishes atomically, and cleans interrupted appends by watermark', async () => {
+    const repo = new PostgresVcfImportRepository(schema)
+    const provisional = await repo.beginProvisionalImport(probe as never, {
+      caseName: 'provisional-case',
+      filePath: '/tmp/base.vcf.gz',
+      fileSize: 1,
+      genomeBuild: 'GRCh38'
+    })
+
+    const inserted = await probe.query<{ id: string }>(
+      `INSERT INTO "${schema}"."variants_all"
+         (case_id, chr, pos, ref, alt, transcript, source_format)
+       VALUES ($1, '1', 100, 'A', 'T', 'old-transcript', 'vcf') RETURNING id`,
+      [provisional.caseId]
+    )
+    const variantId = Number(inserted.rows[0].id)
+    await probe.query(
+      `INSERT INTO "${schema}".variant_transcripts
+         (variant_id, transcript_id, gene_symbol, consequence, cdna, aa_change, is_selected)
+       VALUES ($1, 'ENST-new', 'GENE1', 'MODERATE', 'c.1A>T', 'p.K1N', 0)`,
+      [variantId]
+    )
+
+    const hidden = await probe.query<{ cases: string; variants: string }>(
+      `SELECT (SELECT COUNT(*) FROM "${schema}"."cases") AS cases,
+              (SELECT COUNT(*) FROM "${schema}"."variants") AS variants`
+    )
+    expect(Number(hidden.rows[0].cases)).toBe(0)
+    expect(Number(hidden.rows[0].variants)).toBe(0)
+
+    await repo.finishProvisionalImport(probe as never, provisional.caseId, 'base.vcf.gz', 'vcf')
+    const visible = await probe.query<{ cases: string; variants: string }>(
+      `SELECT (SELECT COUNT(*) FROM "${schema}"."cases") AS cases,
+              (SELECT COUNT(*) FROM "${schema}"."variants") AS variants`
+    )
+    expect(Number(visible.rows[0].cases)).toBe(1)
+    expect(Number(visible.rows[0].variants)).toBe(1)
+
+    await new PostgresTranscriptsRepository(pool, schema).switchSelectedTranscript(
+      variantId,
+      'ENST-new'
+    )
+    const selected = await probe.query<{ transcript: string }>(
+      `SELECT transcript FROM "${schema}"."variants_all" WHERE id = $1`,
+      [variantId]
+    )
+    expect(selected.rows[0].transcript).toBe('ENST-new')
+
+    const append = await repo.beginProvisionalImport(
+      probe as never,
+      {
+        caseName: 'provisional-case',
+        filePath: '/tmp/append.vcf.gz',
+        fileSize: 2,
+        genomeBuild: 'GRCh38'
+      },
+      provisional.caseId
+    )
+    await probe.query(
+      `INSERT INTO "${schema}"."variants_all" (case_id, chr, pos, ref, alt, source_format)
+       SELECT $1, '2', 1000 + n, 'C', 'G', 'vcf' FROM generate_series(1, 10001) AS n`,
+      [provisional.caseId]
+    )
+
+    const cleanupSql: string[] = []
+    const recordingClient = {
+      query: async (sql: string | { text: string }, params?: unknown[]) => {
+        const text = typeof sql === 'string' ? sql : sql.text
+        cleanupSql.push(text)
+        return probe.query(sql as never, params)
+      }
+    }
+    await repo.cleanupProvisionalImport(
+      recordingClient as unknown as Pick<PoolClient, 'query'>,
+      append
+    )
+
+    const remaining = await probe.query<{ id: string }>(
+      `SELECT id FROM "${schema}"."variants_all" WHERE case_id = $1 ORDER BY id`,
+      [provisional.caseId]
+    )
+    expect(remaining.rows.map((row) => Number(row.id))).toEqual([variantId])
+    expect(cleanupSql.filter((sql) => sql.includes('LIMIT 10000'))).toHaveLength(3)
+    expect(cleanupSql.every((sql) => !sql.includes('LIMIT 10001'))).toBe(true)
+
+    const restored = await probe.query<{ import_status: string }>(
+      `SELECT import_status FROM "${schema}"."cases_all" WHERE id = $1`,
+      [provisional.caseId]
+    )
+    expect(restored.rows[0].import_status).toBe('ready')
+
+    // The public names remain the compatibility write surface for ordinary
+    // ready-case lifecycle operations.  In particular, `variants` must stay
+    // automatically updatable; a joined visibility view would make every
+    // non-import INSERT/UPDATE/DELETE fail at runtime.
+    const ordinaryCase = await probe.query<{ id: string }>(
+      `INSERT INTO "${schema}"."cases"
+         (name, file_path, file_size, variant_count, created_at, genome_build)
+       VALUES ('ordinary-ready-case', '/tmp/ordinary.vcf', 1, 0, 1, 'GRCh38')
+       RETURNING id`
+    )
+    const ordinaryCaseId = Number(ordinaryCase.rows[0].id)
+    const ordinaryVariant = await probe.query<{ id: string }>(
+      `INSERT INTO "${schema}"."variants"
+         (case_id, chr, pos, ref, alt, source_format)
+       VALUES ($1, '3', 300, 'G', 'A', 'vcf') RETURNING id`,
+      [ordinaryCaseId]
+    )
+    const ordinaryVariantId = Number(ordinaryVariant.rows[0].id)
+    await probe.query(`UPDATE "${schema}"."variants" SET qual = 42 WHERE id = $1`, [
+      ordinaryVariantId
+    ])
+    const updated = await probe.query<{ qual: number }>(
+      `SELECT qual FROM "${schema}"."variants_all" WHERE id = $1`,
+      [ordinaryVariantId]
+    )
+    expect(updated.rows[0].qual).toBe(42)
+    await probe.query(`DELETE FROM "${schema}"."variants" WHERE id = $1`, [ordinaryVariantId])
+    await probe.query(`DELETE FROM "${schema}"."cases" WHERE id = $1`, [ordinaryCaseId])
+  }, 60_000)
+
+  it('recovers an interrupted import in bounded cleanup and remains idempotent', async () => {
+    const repo = new PostgresVcfImportRepository(schema)
+    const provisional = await repo.beginProvisionalImport(probe as never, {
+      caseName: 'interrupted-recovery-case',
+      filePath: '/tmp/interrupted.vcf.gz',
+      fileSize: 1,
+      genomeBuild: 'GRCh38'
+    })
+    await probe.query(
+      `INSERT INTO "${schema}"."variants_all"
+         (case_id, chr, pos, ref, alt, source_format)
+       VALUES ($1, '4', 400, 'A', 'C', 'vcf')`,
+      [provisional.caseId]
+    )
+
+    const hidden = await probe.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM "${schema}"."cases" WHERE id = $1`,
+      [provisional.caseId]
+    )
+    expect(Number(hidden.rows[0].count)).toBe(0)
+
+    await repo.recoverInterruptedImports(probe as never)
+    await repo.recoverInterruptedImports(probe as never)
+
+    const recovered = await probe.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM "${schema}"."cases_all" WHERE id = $1`,
+      [provisional.caseId]
+    )
+    expect(Number(recovered.rows[0].count)).toBe(0)
+    const visible = await probe.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM "${schema}"."variants" WHERE case_id = $1`,
+      [provisional.caseId]
+    )
+    expect(Number(visible.rows[0].count)).toBe(0)
+  }, 60_000)
+
+  it('writes COPY batches to the hidden physical table without duplicating generated fields', async () => {
+    const repo = new PostgresVcfImportRepository(schema)
+    const provisional = await repo.beginProvisionalImport(probe as never, {
+      caseName: 'copy-provisional-case',
+      filePath: '/tmp/copy.vcf.gz',
+      fileSize: 1,
+      genomeBuild: 'GRCh38'
+    })
+    await probe.query('BEGIN')
+    const result = await repo.writeVcfFile(probe as never, {
+      mode: 'append',
+      caseId: provisional.caseId,
+      caseName: 'copy-provisional-case',
+      fileName: 'copy.vcf.gz',
+      filePath: '/tmp/copy.vcf.gz',
+      fileSize: 1,
+      genomeBuild: 'GRCh38',
+      caller: null,
+      annotationFormat: null,
+      variantType: 'snv-indel',
+      variants: [
+        {
+          chr: '5',
+          pos: 500,
+          ref: 'A',
+          alt: 'G',
+          source_format: 'vcf',
+          variant_type: 'snv'
+        }
+      ],
+      transcripts: [],
+      sv: [],
+      cnv: [],
+      str: []
+    })
+    await probe.query('COMMIT')
+
+    expect(result).toEqual({ caseId: provisional.caseId, variantCount: 1 })
+    const physical = await probe.query<{ search_document: unknown }>(
+      `SELECT search_document FROM "${schema}"."variants_all" WHERE case_id = $1`,
+      [provisional.caseId]
+    )
+    expect(physical.rows).toHaveLength(1)
+    expect(physical.rows[0].search_document).not.toBeNull()
+    const visible = await probe.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM "${schema}"."variants" WHERE case_id = $1`,
+      [provisional.caseId]
+    )
+    expect(Number(visible.rows[0].count)).toBe(0)
+  }, 60_000)
+
+  it('serializes recovery ownership with the schema-scoped advisory lease', async () => {
+    const contender = new Client({ connectionString: PG_URL })
+    await contender.connect()
+    try {
+      const owner = await probe.query<{ locked: boolean }>(
+        `SELECT pg_try_advisory_lock(hashtext($1), hashtext('varlens-import')) AS locked`,
+        [schema]
+      )
+      expect(owner.rows[0].locked).toBe(true)
+      const rejected = await contender.query<{ locked: boolean }>(
+        `SELECT pg_try_advisory_lock(hashtext($1), hashtext('varlens-import')) AS locked`,
+        [schema]
+      )
+      expect(rejected.rows[0].locked).toBe(false)
+    } finally {
+      await probe.query(`SELECT pg_advisory_unlock(hashtext($1), hashtext('varlens-import'))`, [
+        schema
+      ])
+      await contender.end()
+    }
+  }, 60_000)
+})

--- a/tests/main/storage/postgres-json-import-repository.test.ts
+++ b/tests/main/storage/postgres-json-import-repository.test.ts
@@ -382,7 +382,7 @@ describe('PostgresJsonImportRepository.writeJsonImport', () => {
     }
   })
 
-  it('search_document is populated by trigger (not in INSERT column list)', async () => {
+  it('search_document is populated by generated column (not in INSERT column list)', async () => {
     const client = makeClient([
       { rows: [] }, // dup
       { rows: [{ id: '4' }] }, // case insert

--- a/tests/main/storage/postgres-migration-definitions.test.ts
+++ b/tests/main/storage/postgres-migration-definitions.test.ts
@@ -4,7 +4,7 @@ import { POSTGRES_MIGRATIONS } from '../../../src/main/storage/postgres/migratio
 
 describe('Postgres migration definitions', () => {
   it('loads the PostgreSQL migrations with SQL and sha256 checksums', () => {
-    expect(POSTGRES_MIGRATIONS).toHaveLength(13)
+    expect(POSTGRES_MIGRATIONS).toHaveLength(14)
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.version)).toEqual([
       '0001',
       '0002',
@@ -18,7 +18,8 @@ describe('Postgres migration definitions', () => {
       '0010',
       '0011',
       '0012',
-      '0013'
+      '0013',
+      '0014'
     ])
     expect(POSTGRES_MIGRATIONS.map((migration) => migration.name)).toEqual([
       'create_cases',
@@ -33,7 +34,8 @@ describe('Postgres migration definitions', () => {
       'cohort_summary',
       'projects_registry',
       'extend_audit_contract',
-      'central_audit_schema'
+      'central_audit_schema',
+      'import_visibility'
     ])
 
     for (const migration of POSTGRES_MIGRATIONS) {

--- a/tests/main/storage/postgres-panels-repository.test.ts
+++ b/tests/main/storage/postgres-panels-repository.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { PostgresPanelsRepository } from '../../../src/main/storage/postgres/PostgresPanelsRepository'
+import {
+  PostgresPanelsRepository,
+  REGION_FILE_INSERT_CHUNK_SIZE
+} from '../../../src/main/storage/postgres/PostgresPanelsRepository'
 
 const now = new Date('2026-04-29T00:00:00.000Z').getTime()
 
@@ -377,6 +380,47 @@ describe('PostgresPanelsRepository', () => {
       'DELETE FROM "public"."region_files" WHERE id = $1',
       [1]
     )
+  })
+
+  it('persists large region files in bounded parameter chunks', async () => {
+    const { client, pool } = makePool()
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT * FROM "public"."region_files"')) {
+        return {
+          rows: [
+            {
+              id: '1',
+              name: 'Large BED',
+              region_count: String(REGION_FILE_INSERT_CHUNK_SIZE + 1),
+              total_bases: String(REGION_FILE_INSERT_CHUNK_SIZE + 1)
+            }
+          ]
+        }
+      }
+      return { rows: [] }
+    })
+    const entries = Array.from({ length: REGION_FILE_INSERT_CHUNK_SIZE + 1 }, (_, index) => ({
+      chr: '1',
+      start: index * 2,
+      end: index * 2 + 1
+    }))
+    const repo = new PostgresPanelsRepository(pool as never, 'public')
+
+    await repo.importBedEntries(1, entries)
+
+    const insertCalls = client.query.mock.calls.filter(([sql]) =>
+      String(sql).includes('UNNEST($2::text[], $3::bigint[], $4::bigint[], $5::text[])')
+    )
+    expect(insertCalls).toHaveLength(2)
+    expect(insertCalls.map(([, params]) => (params as unknown[][])[1].length)).toEqual([
+      REGION_FILE_INSERT_CHUNK_SIZE,
+      1
+    ])
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('SET region_count = $1, total_bases = $2, updated_at = $3'),
+      [entries.length, entries.length, now, 1]
+    )
+    expect(client.query).toHaveBeenLastCalledWith('COMMIT')
   })
 
   it('rolls back replace operations and releases clients', async () => {

--- a/tests/main/storage/postgres-panels-repository.test.ts
+++ b/tests/main/storage/postgres-panels-repository.test.ts
@@ -12,7 +12,9 @@ const now = new Date('2026-04-29T00:00:00.000Z').getTime()
 
 function makePool() {
   const client = {
-    query: vi.fn(async () => ({ rows: [] })),
+    query: vi.fn(async (sql: string) => ({
+      rows: sql.includes('FOR UPDATE') ? [{ id: '1' }] : []
+    })),
     release: vi.fn()
   }
   const pool = {
@@ -332,6 +334,7 @@ describe('PostgresPanelsRepository', () => {
   it('creates, lists, deletes, and imports region file entries transactionally', async () => {
     const { client, pool } = makePool()
     client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('FOR UPDATE')) return { rows: [{ id: '1' }] }
       if (sql.includes('SELECT * FROM "public"."region_files"')) {
         return { rows: [{ id: '1', name: 'Exome BED', region_count: '2', total_bases: '150' }] }
       }
@@ -393,6 +396,7 @@ describe('PostgresPanelsRepository', () => {
   it('persists large region files in bounded parameter chunks', async () => {
     const { client, pool } = makePool()
     client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('FOR UPDATE')) return { rows: [{ id: '1' }] }
       if (sql.includes('SELECT * FROM "public"."region_files"')) {
         return {
           rows: [
@@ -451,6 +455,41 @@ describe('PostgresPanelsRepository', () => {
     )
     expect(client.query).toHaveBeenLastCalledWith('ROLLBACK')
     expect(client.release).toHaveBeenCalledOnce()
+  })
+
+  it('locks the parent region file before replacing rows', async () => {
+    const { client, pool } = makePool()
+    const bedPath = join(tempDir, 'locked.bed')
+    writeFileSync(bedPath, '1\t0\t10\n')
+    const repo = new PostgresPanelsRepository(pool as never, 'public')
+
+    await repo.importBedFile(1, bedPath)
+
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('SELECT id FROM "public"."region_files" WHERE id = $1 FOR UPDATE'),
+      [1]
+    )
+    expect(String(client.query.mock.calls[2]?.[0])).toContain('region_file_entries')
+  })
+
+  it('fails a BED replacement when the locked parent row does not exist', async () => {
+    const { client, pool } = makePool()
+    client.query.mockResolvedValue({ rows: [] })
+    const bedPath = join(tempDir, 'missing-parent.bed')
+    writeFileSync(bedPath, '1\t0\t10\n')
+    const repo = new PostgresPanelsRepository(pool as never, 'public')
+
+    await expect(repo.importBedFile(99, bedPath)).rejects.toThrow(/region file 99 not found/i)
+
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(client.query).toHaveBeenNthCalledWith(2, expect.stringContaining('FOR UPDATE'), [99])
+    expect(client.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('region_file_entries'),
+      expect.anything()
+    )
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK')
   })
 
   it('rolls back replace operations and releases clients', async () => {

--- a/tests/main/storage/postgres-panels-repository.test.ts
+++ b/tests/main/storage/postgres-panels-repository.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   PostgresPanelsRepository,
@@ -21,12 +24,16 @@ function makePool() {
 }
 
 describe('PostgresPanelsRepository', () => {
+  let tempDir: string
+
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
+    tempDir = mkdtempSync(join(tmpdir(), 'varlens-pg-bed-'))
   })
 
   afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
     vi.useRealTimers()
   })
 
@@ -345,12 +352,13 @@ describe('PostgresPanelsRepository', () => {
       region_count: 0,
       total_bases: 0
     })
-    await expect(
-      repo.importBedEntries(1, [
-        { chr: '1', start: 100, end: 200, label: 'A' },
-        { chr: '2', start: 20, end: 70 }
-      ])
-    ).resolves.toMatchObject({ id: 1, region_count: 2, total_bases: 150 })
+    const bedPath = join(tempDir, 'regions.bed')
+    writeFileSync(bedPath, '1\t100\t200\tA\n2\t20\t70\n')
+    await expect(repo.importBedFile(1, bedPath)).resolves.toMatchObject({
+      id: 1,
+      region_count: 2,
+      total_bases: 150
+    })
     await expect(repo.listRegionFiles()).resolves.toStrictEqual([
       { id: 1, name: 'Exome BED', region_count: 2, total_bases: 150 }
     ])
@@ -399,14 +407,17 @@ describe('PostgresPanelsRepository', () => {
       }
       return { rows: [] }
     })
-    const entries = Array.from({ length: REGION_FILE_INSERT_CHUNK_SIZE + 1 }, (_, index) => ({
-      chr: '1',
-      start: index * 2,
-      end: index * 2 + 1
-    }))
+    const entryCount = REGION_FILE_INSERT_CHUNK_SIZE + 1
+    const bedPath = join(tempDir, 'large.bed')
+    writeFileSync(
+      bedPath,
+      Array.from({ length: entryCount }, (_, index) => `1\t${index * 2}\t${index * 2 + 1}`)
+        .join('\n')
+        .concat('\n')
+    )
     const repo = new PostgresPanelsRepository(pool as never, 'public')
 
-    await repo.importBedEntries(1, entries)
+    await repo.importBedFile(1, bedPath)
 
     const insertCalls = client.query.mock.calls.filter(([sql]) =>
       String(sql).includes('UNNEST($2::text[], $3::bigint[], $4::bigint[], $5::text[])')
@@ -418,9 +429,28 @@ describe('PostgresPanelsRepository', () => {
     ])
     expect(client.query).toHaveBeenCalledWith(
       expect.stringContaining('SET region_count = $1, total_bases = $2, updated_at = $3'),
-      [entries.length, entries.length, now, 1]
+      [entryCount, entryCount, now, 1]
     )
     expect(client.query).toHaveBeenLastCalledWith('COMMIT')
+  })
+
+  it('rolls back a strict BED replacement when streaming encounters a malformed row', async () => {
+    const { client, pool } = makePool()
+    const bedPath = join(tempDir, 'malformed.bed')
+    writeFileSync(bedPath, '1\t0\t10\n1\tbad\t20\n')
+    const repo = new PostgresPanelsRepository(pool as never, 'public')
+
+    await expect(repo.importBedFile(1, bedPath, { rejectMalformedRows: true })).rejects.toThrow(
+      /invalid bed row/i
+    )
+
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(client.query).toHaveBeenCalledWith(
+      'DELETE FROM "public"."region_file_entries" WHERE region_file_id = $1',
+      [1]
+    )
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK')
+    expect(client.release).toHaveBeenCalledOnce()
   })
 
   it('rolls back replace operations and releases clients', async () => {

--- a/tests/main/storage/postgres-vcf-import-repository.copy.test.ts
+++ b/tests/main/storage/postgres-vcf-import-repository.copy.test.ts
@@ -50,7 +50,7 @@ describe('PostgresVcfImportRepository COPY column-list regression guards', () =>
     expect(VARIANT_COPY_COLUMNS as readonly string[]).not.toContain('coord_hash')
   })
 
-  it('VARIANT_COPY_COLUMNS excludes search_document (deferred to bulk UPDATE)', () => {
+  it('VARIANT_COPY_COLUMNS excludes search_document (generated column)', () => {
     expect(VARIANT_COPY_COLUMNS as readonly string[]).not.toContain('search_document')
   })
 

--- a/tests/main/storage/postgres-vcf-import-repository.test.ts
+++ b/tests/main/storage/postgres-vcf-import-repository.test.ts
@@ -278,7 +278,7 @@ describe('PostgresVcfImportRepository.writeVcfFile', () => {
       str: []
     })
 
-    const variantsCopy = bulkCopyCalls.find((c) => c.sql.includes('"variants"'))
+    const variantsCopy = bulkCopyCalls.find((c) => c.sql.includes('"variants_all"'))
     expect(variantsCopy).toBeDefined()
     expect(variantsCopy!.columnNames).toEqual(VARIANT_COPY_COLUMNS as unknown as string[])
     // First two columns are id, case_id.

--- a/tests/main/storage/postgres-write-executor.test.ts
+++ b/tests/main/storage/postgres-write-executor.test.ts
@@ -108,6 +108,21 @@ describe('PostgresWriteExecutor', () => {
     expect(workflow.panels.createPanel).toHaveBeenCalledWith({ name: 'Panel', source: 'manual' })
   })
 
+  it('routes BED paths and parsing policy without materializing entries', async () => {
+    const workflow = workflowRepositories()
+    workflow.panels = { importBedFile: vi.fn().mockResolvedValue({ id: 4 }) } as never
+    const executor = new PostgresWriteExecutor({} as never, {} as never, workflow)
+
+    await executor.execute({
+      type: 'region-files:importBed',
+      params: [4, '/tmp/regions.bed', { rejectMalformedRows: true }]
+    })
+
+    expect(workflow.panels.importBedFile).toHaveBeenCalledWith(4, '/tmp/regions.bed', {
+      rejectMalformedRows: true
+    })
+  })
+
   it('routes audit append tasks to the postgres audit repository', async () => {
     const workflow = workflowRepositories()
     workflow.audit = {

--- a/tests/main/storage/sqlite-import-executor.test.ts
+++ b/tests/main/storage/sqlite-import-executor.test.ts
@@ -78,6 +78,71 @@ describe('SqliteImportExecutor', () => {
     })
   })
 
+  it('returns the worker skip count and bounded reasons for malformed VCF rows', async () => {
+    const start = vi.fn()
+    const worker = {
+      get isRunning() {
+        return false
+      },
+      start,
+      cancel: vi.fn()
+    }
+    const executor = new SqliteImportExecutor({
+      getDatabaseService: () =>
+        ({
+          getPath: () => '/tmp/test.varlens',
+          getEncryptionKey: () => undefined,
+          variants: { updateFrequencies: vi.fn() }
+        }) as never,
+      createWorkerClient: () => worker as never
+    })
+
+    const promise = executor.importSingleFile({
+      filePath: '/tmp/input.vcf',
+      caseName: 'Imported',
+      throttleMs: 100
+    })
+    const callbacks = start.mock.calls[0][0]
+    callbacks.onFileComplete({
+      type: 'file-complete',
+      fileIndex: 0,
+      result: {
+        caseId: 7,
+        caseName: 'Imported',
+        variantCount: 3,
+        skipped: 2,
+        skipReasons: ['invalid POS "x"', 'invalid POS "-1"'],
+        elapsed: 5
+      }
+    })
+    callbacks.onComplete({
+      type: 'complete',
+      results: {
+        succeeded: 1,
+        failed: 0,
+        skipped: 0,
+        cancelled: false,
+        details: [
+          {
+            filePath: '/tmp/input.vcf',
+            fileName: 'input.vcf',
+            caseName: 'Imported',
+            status: 'success',
+            variantCount: 3
+          }
+        ]
+      }
+    })
+
+    await expect(promise).resolves.toStrictEqual({
+      caseId: 7,
+      variantCount: 3,
+      skipped: 2,
+      errors: ['invalid POS "x"', 'invalid POS "-1"'],
+      elapsed: 5
+    })
+  })
+
   it('resolves with cancellation result shape when the worker reports cancelled', async () => {
     const start = vi.fn()
     const worker = {
@@ -481,6 +546,29 @@ describe('SqliteImportExecutor.importMultiFile', () => {
     })
     // No bedFilter instance when bedFilePath is null
     expect((capturedFilters as { bedFilter?: unknown }).bedFilter).toBeUndefined()
+  })
+
+  it('fails closed when an explicitly requested BED filter cannot be loaded', async () => {
+    const delegate = vi.fn(async (): Promise<MultiFileImportResult> => makeFakeResult())
+    const executor = new SqliteImportExecutor({
+      getDatabaseService: () =>
+        ({
+          getPath: () => '/tmp/test.varlens',
+          getEncryptionKey: () => undefined
+        }) as never,
+      multiFileImportDelegate: delegate
+    })
+
+    await expect(
+      executor.importMultiFile({
+        caseName: 'Filtered',
+        files: [
+          { filePath: '/tmp/a.vcf', variantType: 'snv', caller: null, annotationFormat: null }
+        ],
+        filters: { bedFilePath: '/tmp/varlens-missing-filter.bed' }
+      })
+    ).rejects.toThrow(/ENOENT|no such file/i)
+    expect(delegate).not.toHaveBeenCalled()
   })
 
   it('passes undefined filters when no filters param is provided', async () => {

--- a/tests/main/storage/sqlite-write-executor.test.ts
+++ b/tests/main/storage/sqlite-write-executor.test.ts
@@ -69,4 +69,48 @@ describe('SqliteWriteExecutor', () => {
     ).rejects.toThrow('SQLite audit append does not support metadata')
     expect(databaseService.auditLog.appendEntry).not.toHaveBeenCalled()
   })
+
+  it('routes BED paths and parsing policy without materializing entries', async () => {
+    const databaseService = {
+      geneLists: {
+        importBedFile: vi.fn().mockResolvedValue({ id: 4 })
+      }
+    }
+    const executor = new SqliteWriteExecutor(databaseService as never)
+
+    await executor.execute({
+      type: 'region-files:importBed',
+      params: [4, '/tmp/regions.bed', { rejectMalformedRows: false }]
+    })
+
+    expect(databaseService.geneLists.importBedFile).toHaveBeenCalledWith(4, '/tmp/regions.bed', {
+      rejectMalformedRows: false
+    })
+  })
+
+  it('serializes later writes behind in-flight streamed BED persistence', async () => {
+    let finishImport!: () => void
+    const importPending = new Promise<void>((resolve) => {
+      finishImport = resolve
+    })
+    const databaseService = {
+      geneLists: {
+        importBedFile: vi.fn().mockReturnValue(importPending),
+        createRegionFile: vi.fn().mockReturnValue({ id: 5 })
+      }
+    }
+    const executor = new SqliteWriteExecutor(databaseService as never)
+
+    const first = executor.execute({
+      type: 'region-files:importBed',
+      params: [4, '/tmp/regions.bed', { rejectMalformedRows: false }]
+    })
+    const second = executor.execute({ type: 'region-files:create', params: ['Next', null] })
+
+    await Promise.resolve()
+    expect(databaseService.geneLists.createRegionFile).not.toHaveBeenCalled()
+    finishImport()
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, { id: 5 }])
+    expect(databaseService.geneLists.createRegionFile).toHaveBeenCalledWith('Next', null)
+  })
 })

--- a/tests/main/workers/import-pipeline-dos.test.ts
+++ b/tests/main/workers/import-pipeline-dos.test.ts
@@ -30,6 +30,12 @@ import {
 } from '../../../src/main/import/stream-utils'
 import type { FormatInfo } from '../../../src/main/import/strategies/ImportStrategy'
 import { VcfHeaderLimitExceededError } from '../../../src/main/import/vcf/vcf-header-limits'
+import {
+  JsonRecordLimitError,
+  MAX_JSON_RECORD_BYTES,
+  MAX_JSON_RECORD_CONTAINER_ENTRIES,
+  MAX_JSON_RECORD_DEPTH
+} from '../../../src/main/import/json-resource-budget'
 
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
@@ -266,4 +272,77 @@ describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker pat
       ).rejects.toThrow(DecompressedSizeExceededError)
     }
   )
+
+  it.each([
+    { name: 'plain', gzip: false },
+    { name: 'gzip', gzip: true }
+  ])('rejects one oversized JSON record before materialization ($name)', async ({ name, gzip }) => {
+    const filePath = join(tmpDir, `oversized-record-${name}.json${gzip ? '.gz' : ''}`)
+    const json = JSON.stringify({
+      variants: [
+        {
+          chr: '1',
+          pos: 1,
+          ref: 'A',
+          alt: 'T',
+          payload: 'x'.repeat(MAX_JSON_RECORD_BYTES + 1)
+        }
+      ]
+    })
+    writeFileSync(filePath, gzip ? gzipSync(Buffer.from(json)) : json)
+
+    const caseId = svc.cases.createCase(`test-oversized-${name}`, filePath, json.length)
+    const stmts = prepareStatements(svc.database)
+
+    await expect(
+      streamInsertJson(
+        filePath,
+        { format: 'simple', caseKey: 'variants' },
+        caseId,
+        5000,
+        stmts,
+        () => false,
+        () => {}
+      )
+    ).rejects.toThrow(JsonRecordLimitError)
+  })
+
+  it.each([
+    {
+      name: 'container entries',
+      makePayload: () => Array.from({ length: MAX_JSON_RECORD_CONTAINER_ENTRIES + 1 }, () => null)
+    },
+    {
+      name: 'nesting depth',
+      makePayload: () => {
+        const root: Record<string, unknown> = {}
+        let cursor = root
+        for (let index = 0; index < MAX_JSON_RECORD_DEPTH; index += 1) {
+          const child: Record<string, unknown> = {}
+          cursor.child = child
+          cursor = child
+        }
+        return root
+      }
+    }
+  ])('rejects a JSON record exceeding its $name budget', async ({ name, makePayload }) => {
+    const filePath = join(tmpDir, `oversized-${name.replace(' ', '-')}.json`)
+    const json = JSON.stringify({
+      variants: [{ chr: '1', pos: 1, ref: 'A', alt: 'T', payload: makePayload() }]
+    })
+    writeFileSync(filePath, json)
+    const caseId = svc.cases.createCase(`test-${name}`, filePath, json.length)
+
+    await expect(
+      streamInsertJson(
+        filePath,
+        { format: 'simple', caseKey: 'variants' },
+        caseId,
+        5000,
+        prepareStatements(svc.database),
+        () => false,
+        () => {}
+      )
+    ).rejects.toThrow(JsonRecordLimitError)
+  })
 })

--- a/tests/main/workers/import-pipeline-dos.test.ts
+++ b/tests/main/workers/import-pipeline-dos.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+/**
+ * DoS-cap regression tests for `streamInsertVcf` in `import-pipeline.ts` --
+ * the live SQLite single-file VCF import path (the default worker import
+ * route, used by `import-worker.ts`).
+ *
+ * Before this fix, `streamInsertVcf` built its own raw
+ * `createReadStream`/`createGunzip`/`readline` pipeline with no per-line or
+ * total-decompressed-byte guard, so a pathological giant line or a
+ * decompression bomb would buffer unboundedly in the worker thread. This
+ * file proves the shared capped reader (`createCappedLineStream`) is now
+ * wired in AND that a cap violation rejects the whole import instead of
+ * being swallowed by the per-line `catch` that skips unparseable rows
+ * (which would silently re-hide the DoS as a "skipped line").
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { DatabaseService } from '../../../src/main/database/DatabaseService'
+import { prepareStatements, streamInsertVcf } from '../../../src/main/workers/import-pipeline'
+import {
+  MAX_LINE_BYTES,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../src/main/import/stream-utils'
+import type { FormatInfo } from '../../../src/main/import/strategies/ImportStrategy'
+
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const VCF_FORMAT: FormatInfo = { format: 'vcf', caseKey: '' }
+
+describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker path)', () => {
+  let tmpDir: string
+  let svc: DatabaseService
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-import-pipeline-dos-'))
+    svc = new DatabaseService(':memory:')
+  })
+
+  afterEach(() => {
+    svc.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+    delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+  })
+
+  it('rejects a VCF containing a line over MAX_LINE_BYTES with LineTooLongError -- not a silent skip', async () => {
+    const filePath = join(tmpDir, 'giant-line.vcf')
+    const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        giantLine,
+        'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+
+    const caseId = svc.cases.createCase('test-giant-line', filePath, 1000)
+    const stmts = prepareStatements(svc.database)
+    stmts.beginBulkInsert()
+
+    await expect(
+      streamInsertVcf(
+        filePath,
+        VCF_FORMAT,
+        caseId,
+        5000,
+        stmts,
+        () => false,
+        ['HG005'],
+        () => {}
+      )
+    ).rejects.toThrow(LineTooLongError)
+
+    // The valid line preceding the giant line must NOT have been silently
+    // counted as a "successful partial import" that hides the failure --
+    // the promise itself rejects, which is what the worker's per-file
+    // try/catch treats as a hard file failure (see import-worker.ts).
+  })
+
+  it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
+    process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+    const filePath = join(tmpDir, 'bomb.vcf.gz')
+
+    const inflated =
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005'
+      ].join('\n') +
+      '\n' +
+      'A'.repeat(1_000_000) +
+      '\n'
+    writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+    const caseId = svc.cases.createCase('test-bomb', filePath, 1000)
+    const stmts = prepareStatements(svc.database)
+    stmts.beginBulkInsert()
+
+    await expect(
+      streamInsertVcf(
+        filePath,
+        VCF_FORMAT,
+        caseId,
+        5000,
+        stmts,
+        () => false,
+        ['HG005'],
+        () => {}
+      )
+    ).rejects.toThrow(DecompressedSizeExceededError)
+  })
+
+  it('still imports a legitimate small VCF without false rejection (sanity check)', async () => {
+    const filePath = join(tmpDir, 'legit.vcf')
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+
+    const caseId = svc.cases.createCase('test-legit', filePath, 1000)
+    const stmts = prepareStatements(svc.database)
+    stmts.beginBulkInsert()
+
+    const count = await streamInsertVcf(
+      filePath,
+      VCF_FORMAT,
+      caseId,
+      5000,
+      stmts,
+      () => false,
+      ['HG005'],
+      () => {}
+    )
+
+    expect(count).toBe(1)
+  })
+})

--- a/tests/main/workers/import-pipeline-dos.test.ts
+++ b/tests/main/workers/import-pipeline-dos.test.ts
@@ -164,6 +164,7 @@ describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker pat
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
         '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
         'chr1\tNOTNUM\trs-bad\tA\tG\t99\tPASS\t.\tGT\t0/1',
+        'chr1\t99\trs-bad-qual\tA\tG\tBADQUAL\tPASS\t.\tGT\t0/1',
         'chr1\t100\trs-good\tA\tG\t99\tPASS\t.\tGT\t0/1'
       ].join('\n') + '\n'
     )
@@ -186,8 +187,9 @@ describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker pat
     )
 
     expect(count).toBe(1)
-    expect(skips).toHaveLength(1)
-    expect(skips[0]).toMatch(/invalid POS/i)
+    expect(skips).toHaveLength(2)
+    expect(skips.some((reason) => /invalid POS/i.test(reason))).toBe(true)
+    expect(skips.some((reason) => /invalid QUAL/i.test(reason))).toBe(true)
   })
 
   it('rejects a VCF header exceeding the independent header-line budget', async () => {

--- a/tests/main/workers/import-pipeline-dos.test.ts
+++ b/tests/main/workers/import-pipeline-dos.test.ts
@@ -19,15 +19,22 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import { DatabaseService } from '../../../src/main/database/DatabaseService'
-import { prepareStatements, streamInsertVcf } from '../../../src/main/workers/import-pipeline'
 import {
-  MAX_LINE_BYTES,
+  prepareStatements,
+  streamInsertJson,
+  streamInsertVcf
+} from '../../../src/main/workers/import-pipeline'
+import {
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../src/main/import/stream-utils'
 import type { FormatInfo } from '../../../src/main/import/strategies/ImportStrategy'
+import { VcfHeaderLimitExceededError } from '../../../src/main/import/vcf/vcf-header-limits'
 
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
+const TEST_LINE_CAP = 1024
+const HEADER_LINES_CAP_ENV_VAR = 'VARLENS_VCF_MAX_HEADER_LINES'
 const VCF_FORMAT: FormatInfo = { format: 'vcf', caseKey: '' }
 
 describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker path)', () => {
@@ -43,11 +50,14 @@ describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker pat
     svc.close()
     rmSync(tmpDir, { recursive: true, force: true })
     delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+    delete process.env[LINE_CAP_ENV_VAR]
+    delete process.env[HEADER_LINES_CAP_ENV_VAR]
   })
 
-  it('rejects a VCF containing a line over MAX_LINE_BYTES with LineTooLongError -- not a silent skip', async () => {
+  it('rejects a VCF line over the production call-path cap -- not a silent skip', async () => {
+    process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
     const filePath = join(tmpDir, 'giant-line.vcf')
-    const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+    const giantLine = 'A'.repeat(TEST_LINE_CAP + 1)
     writeFileSync(
       filePath,
       [
@@ -179,4 +189,79 @@ describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker pat
     expect(skips).toHaveLength(1)
     expect(skips[0]).toMatch(/invalid POS/i)
   })
+
+  it('rejects a VCF header exceeding the independent header-line budget', async () => {
+    process.env[HEADER_LINES_CAP_ENV_VAR] = '3'
+    const filePath = join(tmpDir, 'many-header-lines.vcf')
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##source=a',
+        '##source=b',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+
+    const caseId = svc.cases.createCase('test-header-lines', filePath, 1000)
+    const stmts = prepareStatements(svc.database)
+
+    await expect(
+      streamInsertVcf(
+        filePath,
+        VCF_FORMAT,
+        caseId,
+        5000,
+        stmts,
+        () => false,
+        ['HG005'],
+        () => {}
+      )
+    ).rejects.toThrow(VcfHeaderLimitExceededError)
+  })
+
+  it.each<{
+    name: string
+    formatInfo: FormatInfo
+    json: string
+  }>([
+    {
+      name: 'simple',
+      formatInfo: { format: 'simple', caseKey: 'variants' },
+      json: `{"variants":[${' '.repeat(10_000)}]}`
+    },
+    {
+      name: 'object',
+      formatInfo: { format: 'object', caseKey: 'sample-1' },
+      json: `{"metadata":{},"samples":{"sample-1":{"variants":[${' '.repeat(10_000)}]}}}`
+    },
+    {
+      name: 'columnar',
+      formatInfo: { format: 'columnar', caseKey: '', wrapped: false },
+      json: `{"header":[],"data":[${' '.repeat(10_000)}]}`
+    }
+  ])(
+    'rejects a $name JSON gzip bomb through the live mapper path',
+    async ({ formatInfo, json }) => {
+      process.env[DECOMPRESSED_CAP_ENV_VAR] = '512'
+      const filePath = join(tmpDir, `${formatInfo.format}-bomb.json.gz`)
+      writeFileSync(filePath, gzipSync(Buffer.from(json)))
+
+      const caseId = svc.cases.createCase(`test-${formatInfo.format}-bomb`, filePath, 1000)
+      const stmts = prepareStatements(svc.database)
+
+      await expect(
+        streamInsertJson(
+          filePath,
+          formatInfo,
+          caseId,
+          5000,
+          stmts,
+          () => false,
+          () => {}
+        )
+      ).rejects.toThrow(DecompressedSizeExceededError)
+    }
+  )
 })

--- a/tests/main/workers/import-pipeline-dos.test.ts
+++ b/tests/main/workers/import-pipeline-dos.test.ts
@@ -144,4 +144,39 @@ describe('streamInsertVcf DoS guards (import-pipeline.ts, live SQLite worker pat
 
     expect(count).toBe(1)
   })
+
+  it('reports malformed POS lines through the skip callback while importing valid rows', async () => {
+    const filePath = join(tmpDir, 'invalid-pos.vcf')
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        'chr1\tNOTNUM\trs-bad\tA\tG\t99\tPASS\t.\tGT\t0/1',
+        'chr1\t100\trs-good\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+
+    const caseId = svc.cases.createCase('test-invalid-pos', filePath, 1000)
+    const stmts = prepareStatements(svc.database)
+    stmts.beginBulkInsert()
+    const skips: string[] = []
+
+    const count = await streamInsertVcf(
+      filePath,
+      VCF_FORMAT,
+      caseId,
+      5000,
+      stmts,
+      () => false,
+      ['HG005'],
+      () => {},
+      (reason) => skips.push(reason)
+    )
+
+    expect(count).toBe(1)
+    expect(skips).toHaveLength(1)
+    expect(skips[0]).toMatch(/invalid POS/i)
+  })
 })

--- a/tests/main/workers/postgres-import-worker-dos.test.ts
+++ b/tests/main/workers/postgres-import-worker-dos.test.ts
@@ -103,4 +103,28 @@ describe('streamMappedVcfRows DoS guards (postgres-import-worker.ts, live PG wor
     const rows = await drain(streamMappedVcfRows(filePath, 'HG005'))
     expect(rows.length).toBe(1)
   })
+
+  it('reports malformed POS lines through the skip callback while yielding valid rows', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-pg-worker-invalid-pos-'))
+    const filePath = join(tmpDir, 'invalid-pos.vcf')
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        'chr1\tNOTNUM\trs-bad\tA\tG\t99\tPASS\t.\tGT\t0/1',
+        'chr1\t100\trs-good\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+    const skips: string[] = []
+
+    const rows = await drain(
+      streamMappedVcfRows(filePath, 'HG005', undefined, (reason) => skips.push(reason))
+    )
+
+    expect(rows.length).toBe(1)
+    expect(skips).toHaveLength(1)
+    expect(skips[0]).toMatch(/invalid POS/i)
+  })
 })

--- a/tests/main/workers/postgres-import-worker-dos.test.ts
+++ b/tests/main/workers/postgres-import-worker-dos.test.ts
@@ -25,6 +25,10 @@ import {
   DecompressedSizeExceededError
 } from '../../../src/main/import/stream-utils'
 import type { VcfMappedVariant } from '../../../src/main/import/vcf/types'
+import {
+  MAX_VCF_ANNOTATIONS,
+  VcfResourceLimitError
+} from '../../../src/main/import/vcf/vcf-resource-limits'
 
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
 const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
@@ -131,5 +135,25 @@ describe('streamMappedVcfRows DoS guards (postgres-import-worker.ts, live PG wor
     expect(skips).toHaveLength(2)
     expect(skips.some((reason) => /invalid POS/i.test(reason))).toBe(true)
     expect(skips.some((reason) => /invalid QUAL/i.test(reason))).toBe(true)
+  })
+
+  it('propagates annotation resource limits instead of silently skipping the row', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-pg-worker-annotation-limit-'))
+    const filePath = join(tmpDir, 'annotation-limit.vcf')
+    const csq = Array.from({ length: MAX_VCF_ANNOTATIONS + 1 }, () => 'G').join(',')
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##INFO=<ID=CSQ,Number=.,Type=String,Description="Format: Allele">',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        `chr1\t100\trs1\tA\tG\t99\tPASS\tCSQ=${csq}\tGT\t0/1`
+      ].join('\n') + '\n'
+    )
+
+    await expect(drain(streamMappedVcfRows(filePath, 'HG005'))).rejects.toThrow(
+      VcfResourceLimitError
+    )
   })
 })

--- a/tests/main/workers/postgres-import-worker-dos.test.ts
+++ b/tests/main/workers/postgres-import-worker-dos.test.ts
@@ -117,6 +117,7 @@ describe('streamMappedVcfRows DoS guards (postgres-import-worker.ts, live PG wor
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
         '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
         'chr1\tNOTNUM\trs-bad\tA\tG\t99\tPASS\t.\tGT\t0/1',
+        'chr1\t99\trs-bad-qual\tA\tG\tBADQUAL\tPASS\t.\tGT\t0/1',
         'chr1\t100\trs-good\tA\tG\t99\tPASS\t.\tGT\t0/1'
       ].join('\n') + '\n'
     )
@@ -127,7 +128,8 @@ describe('streamMappedVcfRows DoS guards (postgres-import-worker.ts, live PG wor
     )
 
     expect(rows.length).toBe(1)
-    expect(skips).toHaveLength(1)
-    expect(skips[0]).toMatch(/invalid POS/i)
+    expect(skips).toHaveLength(2)
+    expect(skips.some((reason) => /invalid POS/i.test(reason))).toBe(true)
+    expect(skips.some((reason) => /invalid QUAL/i.test(reason))).toBe(true)
   })
 })

--- a/tests/main/workers/postgres-import-worker-dos.test.ts
+++ b/tests/main/workers/postgres-import-worker-dos.test.ts
@@ -19,15 +19,16 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { gzipSync } from 'node:zlib'
-import { streamMappedVcfRows } from '../../../src/main/workers/postgres-import-worker'
+import { streamMappedVcfRows } from '../../../src/main/workers/postgres-vcf-stream'
 import {
-  MAX_LINE_BYTES,
   LineTooLongError,
   DecompressedSizeExceededError
 } from '../../../src/main/import/stream-utils'
 import type { VcfMappedVariant } from '../../../src/main/import/vcf/types'
 
 const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+const LINE_CAP_ENV_VAR = 'VARLENS_TEST_IMPORT_MAX_LINE_BYTES'
+const TEST_LINE_CAP = 1024
 
 /** Drain an async generator into an array, surfacing any thrown error. */
 async function drain(
@@ -46,12 +47,14 @@ describe('streamMappedVcfRows DoS guards (postgres-import-worker.ts, live PG wor
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true })
     delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+    delete process.env[LINE_CAP_ENV_VAR]
   })
 
-  it('rejects a VCF containing a line over MAX_LINE_BYTES with LineTooLongError -- not a silent skip', async () => {
+  it('rejects a VCF line over the production call-path cap -- not a silent skip', async () => {
+    process.env[LINE_CAP_ENV_VAR] = String(TEST_LINE_CAP)
     tmpDir = mkdtempSync(join(tmpdir(), 'varlens-pg-worker-dos-'))
     const filePath = join(tmpDir, 'giant-line.vcf')
-    const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+    const giantLine = 'A'.repeat(TEST_LINE_CAP + 1)
     writeFileSync(
       filePath,
       [

--- a/tests/main/workers/postgres-import-worker-dos.test.ts
+++ b/tests/main/workers/postgres-import-worker-dos.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+/**
+ * DoS-cap regression tests for `streamMappedVcfRows` in
+ * `postgres-import-worker.ts` -- the live PostgreSQL VCF import path.
+ *
+ * `streamMappedVcfRows` is a pure async generator over a file (no DB
+ * connection needed to exercise the parsing/streaming layer), so it is
+ * unit-testable directly without a running Postgres container. Before this
+ * fix it built its own raw `createReadStream`/`createGunzip`/`readline`
+ * pipeline with no per-line or total-decompressed-byte guard. This file
+ * proves the shared capped reader (`createCappedLineStream`) is now wired
+ * in AND that a cap violation propagates as a thrown/rejected error from
+ * the generator instead of being swallowed by the per-line `catch` that
+ * skips unparseable lines (which would silently re-hide the DoS as a
+ * "skipped line" and keep yielding rows).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { streamMappedVcfRows } from '../../../src/main/workers/postgres-import-worker'
+import {
+  MAX_LINE_BYTES,
+  LineTooLongError,
+  DecompressedSizeExceededError
+} from '../../../src/main/import/stream-utils'
+import type { VcfMappedVariant } from '../../../src/main/import/vcf/types'
+
+const DECOMPRESSED_CAP_ENV_VAR = 'VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES'
+
+/** Drain an async generator into an array, surfacing any thrown error. */
+async function drain(
+  gen: AsyncGenerator<VcfMappedVariant, void, void>
+): Promise<VcfMappedVariant[]> {
+  const rows: VcfMappedVariant[] = []
+  for await (const row of gen) {
+    rows.push(row)
+  }
+  return rows
+}
+
+describe('streamMappedVcfRows DoS guards (postgres-import-worker.ts, live PG worker path)', () => {
+  let tmpDir: string
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+    delete process.env[DECOMPRESSED_CAP_ENV_VAR]
+  })
+
+  it('rejects a VCF containing a line over MAX_LINE_BYTES with LineTooLongError -- not a silent skip', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-pg-worker-dos-'))
+    const filePath = join(tmpDir, 'giant-line.vcf')
+    const giantLine = 'A'.repeat(MAX_LINE_BYTES + 1)
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        giantLine,
+        'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+
+    await expect(drain(streamMappedVcfRows(filePath, 'HG005'))).rejects.toThrow(LineTooLongError)
+  })
+
+  it('rejects a decompression bomb once decompressed bytes exceed the configured cap', async () => {
+    process.env[DECOMPRESSED_CAP_ENV_VAR] = '1000'
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-pg-worker-bomb-'))
+    const filePath = join(tmpDir, 'bomb.vcf.gz')
+
+    const inflated =
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005'
+      ].join('\n') +
+      '\n' +
+      'A'.repeat(1_000_000) +
+      '\n'
+    writeFileSync(filePath, gzipSync(Buffer.from(inflated)))
+
+    await expect(drain(streamMappedVcfRows(filePath, 'HG005'))).rejects.toThrow(
+      DecompressedSizeExceededError
+    )
+  })
+
+  it('still yields rows for a legitimate small VCF without false rejection (sanity check)', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-pg-worker-legit-'))
+    const filePath = join(tmpDir, 'legit.vcf')
+    writeFileSync(
+      filePath,
+      [
+        '##fileformat=VCFv4.2',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG005',
+        'chr1\t100\trs1\tA\tG\t99\tPASS\t.\tGT\t0/1'
+      ].join('\n') + '\n'
+    )
+
+    const rows = await drain(streamMappedVcfRows(filePath, 'HG005'))
+    expect(rows.length).toBe(1)
+  })
+})

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -142,6 +142,101 @@ describe('postgres-import-worker runImport', () => {
     expect(complete?.result.variantCount).toBe(1)
   })
 
+  it('deletes a partially committed single-file VCF case when the stream fails after a batch commit', async () => {
+    const queries: string[] = []
+    const client = {
+      connect: vi.fn(async () => undefined),
+      query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
+        const text = typeof sql === 'string' ? sql : sql.text
+        queries.push(text)
+        if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
+        if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) return { rows: [] }
+        if (text.startsWith('INSERT INTO') && text.includes('"cases"'))
+          return { rows: [{ id: 13 }] }
+        if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
+          const n = (params?.[1] as number) ?? 0
+          return {
+            rows: Array.from({ length: n }, (_, i) => ({
+              ordinal: String(i),
+              id: String(5000 + i)
+            }))
+          }
+        }
+        return { rows: [] }
+      }),
+      end: vi.fn(async () => undefined)
+    }
+    const messages: unknown[] = []
+    const fakeVariant = {
+      chr: '1',
+      pos: 100,
+      ref: 'A',
+      alt: 'T',
+      gene_symbol: null,
+      omim_mim_number: null,
+      consequence: null,
+      gnomad_af: null,
+      cadd: null,
+      clinvar: null,
+      gt_num: null,
+      func: null,
+      qual: null,
+      hpo_sim_score: null,
+      transcript: null,
+      cdna: null,
+      aa_change: null,
+      hpo_match: null,
+      moi: null,
+      gq: null,
+      dp: null,
+      ad_ref: null,
+      ad_alt: null,
+      ab: null,
+      filter: null,
+      info_json: null,
+      source_format: 'vcf',
+      variant_type: 'snv',
+      end_pos: null,
+      sv_type: null,
+      sv_length: null,
+      caller: null
+    }
+
+    async function* rows(): AsyncGenerator<typeof fakeVariant, void, void> {
+      yield fakeVariant
+      throw new Error('stream failed after committed batch')
+    }
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
+        createVcfMappedStream: async () => rows() as never,
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'single-file',
+        caseName: 'VCF case',
+        filePath: '/tmp/a.vcf.gz',
+        format: 'vcf',
+        vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' },
+        batchSize: 1
+      },
+      (m) => messages.push(m)
+    )
+
+    expect(queries).toContain('ROLLBACK')
+    expect(queries).toContain('DELETE FROM "public"."cases" WHERE id = $1')
+    const error = messages.find((m): m is { type: 'error'; message: string } => {
+      return (m as { type: string }).type === 'error'
+    })
+    expect(error?.message).toMatch(/stream failed after committed batch/)
+  })
+
   it('runs one transaction per file in multi-file mode and surfaces per-file errors', async () => {
     const queries: string[] = []
     // Track how many times a variant batch insert has been attempted so we can

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -493,6 +493,48 @@ describe('postgres-import-worker runImport', () => {
     expect(filters.bedFilter).toBeUndefined()
   })
 
+  it('fails closed when an explicitly requested BED filter cannot be loaded', async () => {
+    const client = {
+      connect: vi.fn(async () => undefined),
+      query: vi.fn(async () => ({ rows: [] })),
+      end: vi.fn(async () => undefined)
+    }
+    const createVcfMappedStream = vi.fn(async () => Readable.from([]) as never)
+    const messages: Array<{ type: string; message?: string }> = []
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
+        createVcfMappedStream,
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'multi-file',
+        caseName: 'F',
+        files: [
+          {
+            filePath: '/tmp/a.vcf.gz',
+            variantType: 'snv-indel',
+            annotationFormat: null,
+            caller: null
+          }
+        ],
+        filters: { bedFilePath: '/tmp/varlens-missing-pg-filter.bed' }
+      },
+      (message) => messages.push(message)
+    )
+
+    expect(createVcfMappedStream).not.toHaveBeenCalled()
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'error', message: expect.stringMatching(/ENOENT/i) })
+    )
+  })
+
   it('applies multi-file filters only to append files when a base file creates the case', async () => {
     const client = {
       connect: vi.fn(async () => undefined),

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -463,6 +463,12 @@ describe('postgres-import-worker runImport', () => {
     const result = complete!.result
     expect(result.files[0].error).toBeUndefined()
     expect(result.files[1].error).toMatch(/late failure in file 2/)
+
+    const provenanceCall = client.query.mock.calls.find(([sql]) => {
+      const text = typeof sql === 'string' ? sql : sql.text
+      return text.includes('INSERT INTO') && text.includes('"case_data_info"')
+    })
+    expect(provenanceCall?.[1]?.[1]).toBe('a.vcf.gz')
   })
 
   it('opens client, runs BEGIN/COMMIT for single-file JSON, posts complete', async () => {
@@ -977,6 +983,26 @@ describe('postgres-import-worker — C3 import wiring', () => {
       (m): m is { type: 'complete' } => (m as { type: string }).type === 'complete'
     )
     expect(complete).toBeDefined()
+  })
+
+  it('does not publish when summary maintenance and durable stale marking both fail', async () => {
+    incrementalAddSpy.mockRejectedValueOnce(new Error('summary write failed'))
+    markStaleSpy.mockRejectedValueOnce(new Error('stale marker failed'))
+    const queries: string[] = []
+    const client = makeClient(queries)
+    const messages: unknown[] = []
+
+    await runVcfSingleFile(client, messages)
+
+    expect(queries).toContain('ROLLBACK TO SAVEPOINT cohort_summary')
+    expect(queries.some((query) => query.includes("import_status = 'ready'"))).toBe(false)
+    expect(queries.some((query) => query.includes('DELETE FROM "public"."cases_all"'))).toBe(true)
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(/stale marker failed/)
+      })
+    )
   })
 
   it('ImportResult shape carries NO warnings field (Pass-4 HIGH #3)', async () => {

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -36,7 +36,10 @@ vi.mock('../../../src/main/storage/postgres/PostgresCohortSummaryRepository', ()
 }))
 
 import { runImport } from '../../../src/main/workers/postgres-import-worker'
-import type { PostgresImportWorkerStartMessage } from '../../../src/shared/types/postgres-import-worker'
+import {
+  POSTGRES_IMPORT_CANCELLATION_MESSAGE,
+  type PostgresImportWorkerStartMessage
+} from '../../../src/shared/types/postgres-import-worker'
 
 const acquiredImportLock = { rows: [{ locked: true }] }
 
@@ -830,7 +833,8 @@ describe('postgres-import-worker — C3 import wiring', () => {
 
   const runVcfSingleFile = async (
     client: ReturnType<typeof makeClient>,
-    messages: unknown[]
+    messages: unknown[],
+    overrides: { isCancellationRequested?: () => boolean } = {}
   ): Promise<void> => {
     await runImport(
       {
@@ -838,7 +842,8 @@ describe('postgres-import-worker — C3 import wiring', () => {
         detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
         createVcfMappedStream: async () => Readable.from([fakeVariant]) as never,
         createMapperPipeline: async () => Readable.from([]),
-        statFile: () => ({ size: 0 })
+        statFile: () => ({ size: 0 }),
+        ...overrides
       },
       {
         type: 'start',
@@ -921,6 +926,130 @@ describe('postgres-import-worker — C3 import wiring', () => {
     const publicationQueries = queries.slice(publicationBeginIndex, publicationCommitIndex + 1)
     expect(publicationQueries.some((query) => query.includes('"variant_frequency"'))).toBe(true)
     expect(publicationQueries).toContain('SAVEPOINT cohort_summary')
+  })
+
+  it('does not flip single-file visibility when cancellation arrives during final bookkeeping', async () => {
+    const queries: string[] = []
+    const client = makeClient(queries)
+    let cancelledDuringBookkeeping = false
+    const originalQuery = client.query
+    client.query = vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
+      const text = typeof sql === 'string' ? sql : sql.text
+      const result = await originalQuery(sql, params)
+      if (text === 'RELEASE SAVEPOINT cohort_summary') {
+        cancelledDuringBookkeeping = true
+      }
+      return result
+    })
+    const messages: unknown[] = []
+
+    await runVcfSingleFile(client, messages, {
+      isCancellationRequested: () => cancelledDuringBookkeeping
+    })
+
+    expect(queries.some((query) => query.includes("import_status = 'ready'"))).toBe(false)
+    expect(queries).toContain('ROLLBACK')
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'complete',
+        result: expect.objectContaining({
+          errors: [POSTGRES_IMPORT_CANCELLATION_MESSAGE]
+        })
+      })
+    )
+  })
+
+  it('rolls back single-file visibility when cancellation arrives before publication commit', async () => {
+    const queries: string[] = []
+    const client = makeClient(queries)
+    let cancelledBeforeCommit = false
+    const originalQuery = client.query
+    client.query = vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
+      const text = typeof sql === 'string' ? sql : sql.text
+      const result = await originalQuery(sql, params)
+      if (text.startsWith('UPDATE') && text.includes("import_status = 'ready'")) {
+        cancelledBeforeCommit = true
+      }
+      return result
+    })
+    const messages: unknown[] = []
+
+    await runVcfSingleFile(client, messages, {
+      isCancellationRequested: () => cancelledBeforeCommit
+    })
+
+    const readyIndex = queries.findIndex((query) => query.includes("import_status = 'ready'"))
+    const firstTxnBoundaryAfterReady = queries.find(
+      (query, index) => index > readyIndex && (query === 'COMMIT' || query === 'ROLLBACK')
+    )
+    expect(readyIndex).toBeGreaterThanOrEqual(0)
+    expect(firstTxnBoundaryAfterReady).toBe('ROLLBACK')
+    expect(
+      queries.findIndex((query, index) => index > readyIndex && query === 'ROLLBACK')
+    ).toBeGreaterThanOrEqual(0)
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'complete',
+        result: expect.objectContaining({
+          errors: [POSTGRES_IMPORT_CANCELLATION_MESSAGE]
+        })
+      })
+    )
+  })
+
+  it('does not flip multi-file visibility when cancellation arrives during final bookkeeping', async () => {
+    const queries: string[] = []
+    const client = makeClient(queries)
+    let cancelledDuringBookkeeping = false
+    const originalQuery = client.query
+    client.query = vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
+      const text = typeof sql === 'string' ? sql : sql.text
+      const result = await originalQuery(sql, params)
+      if (text === 'RELEASE SAVEPOINT cohort_summary') {
+        cancelledDuringBookkeeping = true
+      }
+      return result
+    })
+    const messages: unknown[] = []
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
+        createVcfMappedStream: async () => Readable.from([fakeVariant]) as never,
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 }),
+        isCancellationRequested: () => cancelledDuringBookkeeping
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'multi-file',
+        caseName: 'VCF case',
+        vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' },
+        files: [
+          {
+            filePath: '/tmp/a.vcf.gz',
+            variantType: 'snv-indel',
+            annotationFormat: null,
+            caller: null
+          }
+        ]
+      },
+      (m) => messages.push(m)
+    )
+
+    expect(queries.some((query) => query.includes("import_status = 'ready'"))).toBe(false)
+    expect(queries).toContain('ROLLBACK')
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'complete',
+        result: expect.objectContaining({
+          errors: [POSTGRES_IMPORT_CANCELLATION_MESSAGE]
+        })
+      })
+    )
   })
 
   it('never deletes work when the atomic publication commit outcome is uncertain', async () => {

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -38,7 +38,87 @@ vi.mock('../../../src/main/storage/postgres/PostgresCohortSummaryRepository', ()
 import { runImport } from '../../../src/main/workers/postgres-import-worker'
 import type { PostgresImportWorkerStartMessage } from '../../../src/shared/types/postgres-import-worker'
 
+const acquiredImportLock = { rows: [{ locked: true }] }
+
 describe('postgres-import-worker runImport', () => {
+  it('refuses a second workspace import while another session owns the advisory lock', async () => {
+    const messages: unknown[] = []
+    const detectFormat = vi.fn()
+    const client = {
+      connect: vi.fn(async () => undefined),
+      query: vi.fn(async (sql: string | { text: string }) => {
+        const text = typeof sql === 'string' ? sql : sql.text
+        if (text.includes('pg_try_advisory_lock')) return { rows: [{ locked: false }] }
+        return { rows: [] }
+      }),
+      end: vi.fn(async () => undefined)
+    }
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat,
+        createVcfMappedStream: async () => Readable.from([]) as never,
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'single-file',
+        caseName: 'locked',
+        filePath: '/tmp/a.vcf'
+      },
+      (message) => messages.push(message)
+    )
+
+    expect(detectFormat).not.toHaveBeenCalled()
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(/already in progress/)
+      })
+    )
+  })
+
+  it('fails closed when PostgreSQL does not confirm advisory-lock ownership', async () => {
+    const messages: unknown[] = []
+    const detectFormat = vi.fn()
+    const client = {
+      connect: vi.fn(async () => undefined),
+      query: vi.fn(async () => ({ rows: [] })),
+      end: vi.fn(async () => undefined)
+    }
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat,
+        createVcfMappedStream: async () => Readable.from([]) as never,
+        createMapperPipeline: async () => Readable.from([]),
+        statFile: () => ({ size: 0 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'single-file',
+        caseName: 'unconfirmed-lock',
+        filePath: '/tmp/a.vcf'
+      },
+      (message) => messages.push(message)
+    )
+
+    expect(detectFormat).not.toHaveBeenCalled()
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringMatching(/already in progress/)
+      })
+    )
+  })
+
   it('drives VCF parsing and writes through PostgresVcfImportRepository', async () => {
     const queries: string[] = []
     const client = {
@@ -46,10 +126,10 @@ describe('postgres-import-worker runImport', () => {
       query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
         const text = typeof sql === 'string' ? sql : sql.text
         queries.push(text)
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
-        if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) return { rows: [] }
-        if (text.startsWith('INSERT INTO') && text.includes('"cases"'))
-          return { rows: [{ id: 13 }] }
+        if (text.startsWith('SELECT id FROM') && text.includes('"cases')) return { rows: [] }
+        if (text.startsWith('INSERT INTO') && text.includes('"cases')) return { rows: [{ id: 13 }] }
         // Phase 16+: ID reservation via pg_get_serial_sequence + generate_series.
         if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
           const n = (params?.[1] as number) ?? 0
@@ -60,6 +140,7 @@ describe('postgres-import-worker runImport', () => {
             }))
           }
         }
+        if (text.includes('pg_get_serial_sequence')) return { rows: [{ id: 13 }] }
         return { rows: [] }
       }),
       end: vi.fn(async () => undefined)
@@ -106,7 +187,7 @@ describe('postgres-import-worker runImport', () => {
       {
         createClient: () => client as never,
         detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
-        createVcfMappedStream: async () => Readable.from([fakeVariant]) as never,
+        createVcfMappedStream: async () => Readable.from([fakeVariant, fakeVariant]) as never,
         createMapperPipeline: async () => Readable.from([]),
         statFile: () => ({ size: 0 })
       },
@@ -118,7 +199,8 @@ describe('postgres-import-worker runImport', () => {
         caseName: 'VCF case',
         filePath: '/tmp/a.vcf.gz',
         format: 'vcf',
-        vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' }
+        vcfOptions: { selectedSample: 'NA12878', genomeBuild: 'GRCh38' },
+        batchSize: 1
       },
       (m) => messages.push(m)
     )
@@ -127,19 +209,28 @@ describe('postgres-import-worker runImport', () => {
     // (and friends) before any BEGIN. The transaction lifecycle is still
     // present, just no longer the very first query.
     expect(queries).toContain('BEGIN')
-    expect(queries.at(-1)).toBe('COMMIT')
+    expect(queries).toContain('COMMIT')
     // VCF imports now write via COPY FROM STDIN (mocked at the runBulkCopy
     // boundary in this test's deps), but the post-loop bookkeeping
     // (variant_frequency rebuild + variant_count update) is unchanged.
     expect(queries.find((q) => q.includes('"variant_frequency"'))).toBeDefined()
     expect(queries.find((q) => q.startsWith('UPDATE') && q.includes('variant_count'))).toBeDefined()
+    const reserveIndexes = queries.flatMap((query, index) =>
+      query.includes('generate_series') ? [index] : []
+    )
+    const caseInsertIndex = queries.findIndex(
+      (query) => query.startsWith('INSERT INTO') && query.includes('"cases')
+    )
+    expect(reserveIndexes).toHaveLength(2)
+    expect(queries.slice(reserveIndexes[0], reserveIndexes[1])).toContain('COMMIT')
+    expect(caseInsertIndex).toBeLessThan(reserveIndexes[0])
 
     const complete = messages.find(
       (m): m is { type: 'complete'; result: { variantCount: number } } =>
         (m as { type: string }).type === 'complete'
     )
     expect(complete).toBeDefined()
-    expect(complete?.result.variantCount).toBe(1)
+    expect(complete?.result.variantCount).toBe(2)
   })
 
   it('rolls back a single-file VCF when the stream fails after a flushed batch', async () => {
@@ -149,10 +240,10 @@ describe('postgres-import-worker runImport', () => {
       query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
         const text = typeof sql === 'string' ? sql : sql.text
         queries.push(text)
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
-        if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) return { rows: [] }
-        if (text.startsWith('INSERT INTO') && text.includes('"cases"'))
-          return { rows: [{ id: 13 }] }
+        if (text.startsWith('SELECT id FROM') && text.includes('"cases')) return { rows: [] }
+        if (text.startsWith('INSERT INTO') && text.includes('"cases')) return { rows: [{ id: 13 }] }
         if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
           const n = (params?.[1] as number) ?? 0
           return {
@@ -162,6 +253,7 @@ describe('postgres-import-worker runImport', () => {
             }))
           }
         }
+        if (text.includes('pg_get_serial_sequence')) return { rows: [{ id: 13 }] }
         return { rows: [] }
       }),
       end: vi.fn(async () => undefined)
@@ -229,9 +321,11 @@ describe('postgres-import-worker runImport', () => {
       (m) => messages.push(m)
     )
 
-    expect(queries).toContain('ROLLBACK')
-    expect(queries).not.toContain('COMMIT')
-    expect(queries).not.toContain('DELETE FROM "public"."cases" WHERE id = $1')
+    expect(queries).toContain('COMMIT')
+    expect(queries.some((query) => query.includes('DELETE FROM "public"."variants_all"'))).toBe(
+      true
+    )
+    expect(queries.some((query) => query.includes('DELETE FROM "public"."cases_all"'))).toBe(true)
     const error = messages.find((m): m is { type: 'error'; message: string } => {
       return (m as { type: string }).type === 'error'
     })
@@ -245,18 +339,19 @@ describe('postgres-import-worker runImport', () => {
       query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
         const text = typeof sql === 'string' ? sql : sql.text
         queries.push(text)
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
         // For the duplicate check (fileIndex 0) return empty; for the case-lookup
         // (fileIndex >= 1) return the case that file 1 created.
-        if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) {
+        if (text.startsWith('SELECT id FROM') && text.includes('"cases')) {
           // File 1 duplicate check fires before INSERT — return empty.
           // File 2 case lookup fires after file 1 committed — return the case.
           const alreadyInserted = queries.filter(
-            (q) => q.startsWith('INSERT INTO') && q.includes('"cases"')
+            (q) => q.startsWith('INSERT INTO') && q.includes('"cases')
           ).length
           return alreadyInserted > 0 ? { rows: [{ id: 21 }] } : { rows: [] }
         }
-        if (text.startsWith('INSERT INTO') && text.includes('"cases"')) {
+        if (text.startsWith('INSERT INTO') && text.includes('"cases')) {
           return { rows: [{ id: 21 }] }
         }
         if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
@@ -349,15 +444,16 @@ describe('postgres-import-worker runImport', () => {
       (m) => messages.push(m)
     )
 
-    // Each file owns one transaction; successful files commit and a failed
-    // file rolls back before the final bookkeeping transaction.
+    // Each production batch commits independently; failed current-file rows
+    // are deleted in bounded cleanup transactions before bookkeeping.
     const beginCount = queries.filter((q) => q === 'BEGIN').length
-    expect(beginCount).toBe(3)
-    expect(queries.includes('ROLLBACK')).toBe(true)
+    // Two production batches, bounded failed-file cleanup, and one atomic
+    // bookkeeping/publication transaction.
+    expect(beginCount).toBe(5)
+    expect(queries.some((query) => query.includes('DELETE FROM "public"."variants_all"'))).toBe(
+      true
+    )
     expect(queries.includes('COMMIT')).toBe(true)
-    const beginIndexes = queries.flatMap((query, index) => (query === 'BEGIN' ? [index] : []))
-    const rollbackIndex = queries.indexOf('ROLLBACK', beginIndexes[1])
-    expect(queries.slice(beginIndexes[1] + 1, rollbackIndex)).not.toContain('COMMIT')
 
     const complete = messages.find(
       (m): m is { type: 'complete'; result: { files: Array<{ error?: string }> } } =>
@@ -376,6 +472,7 @@ describe('postgres-import-worker runImport', () => {
       query: vi.fn(async (sql: string | { text: string }) => {
         const text = typeof sql === 'string' ? sql : sql.text
         queries.push(text)
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rows: [] }
         if (typeof sql === 'string' && sql.startsWith('SELECT id FROM')) return { rows: [] }
         if (typeof sql === 'string' && sql.includes('"cases"') && sql.startsWith('INSERT')) {
@@ -418,7 +515,8 @@ describe('postgres-import-worker runImport', () => {
     expect(queries.some((q) => q.startsWith('SELECT id FROM'))).toBe(true)
     expect(queries.some((q) => q.includes('"cases"') && q.startsWith('INSERT'))).toBe(true)
     expect(queries.some((q) => q.includes('"variant_frequency"'))).toBe(true)
-    expect(queries.at(-1)).toBe('COMMIT')
+    expect(queries).toContain('COMMIT')
+    expect(queries.at(-1)).toContain('pg_advisory_unlock')
 
     const complete = messages.find(
       (m): m is { type: 'complete' } => (m as { type: string }).type === 'complete'
@@ -433,6 +531,7 @@ describe('postgres-import-worker runImport', () => {
       query: vi.fn(async (sql: string | { text: string }) => {
         const text = typeof sql === 'string' ? sql : sql.text
         queries.push(text)
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
         if (text.startsWith('SELECT id FROM')) return { rows: [] }
         if (text.startsWith('INSERT INTO') && text.includes('"cases"')) {
@@ -481,10 +580,10 @@ describe('postgres-import-worker runImport', () => {
       query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
         const text = typeof sql === 'string' ? sql : sql.text
         queries.push(text)
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
-        if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) return { rows: [] }
-        if (text.startsWith('INSERT INTO') && text.includes('"cases"'))
-          return { rows: [{ id: 11 }] }
+        if (text.startsWith('SELECT id FROM') && text.includes('"cases')) return { rows: [] }
+        if (text.startsWith('INSERT INTO') && text.includes('"cases')) return { rows: [{ id: 11 }] }
         if (text.includes('"variants"') && text.includes('jsonb_to_recordset')) {
           const payload = JSON.parse(String((params as unknown[])[0])) as unknown[]
           return { rows: payload.map((_, i) => ({ id: 6000 + i })) }
@@ -547,7 +646,10 @@ describe('postgres-import-worker runImport', () => {
   it('fails closed when an explicitly requested BED filter cannot be loaded', async () => {
     const client = {
       connect: vi.fn(async () => undefined),
-      query: vi.fn(async () => ({ rows: [] })),
+      query: vi.fn(async (sql: string | { text: string }) => {
+        const text = typeof sql === 'string' ? sql : sql.text
+        return text.includes('pg_try_advisory_lock') ? acquiredImportLock : { rows: [] }
+      }),
       end: vi.fn(async () => undefined)
     }
     const createVcfMappedStream = vi.fn(async () => Readable.from([]) as never)
@@ -591,7 +693,11 @@ describe('postgres-import-worker runImport', () => {
       connect: vi.fn(async () => undefined),
       query: vi.fn(async (sql: string | { text: string }) => {
         const text = typeof sql === 'string' ? sql : sql.text
+        if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
         if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
+        if (text.startsWith('INSERT INTO') && text.includes('"cases_all"')) {
+          return { rows: [{ id: 11 }] }
+        }
         return { rows: [] }
       }),
       end: vi.fn(async () => undefined)
@@ -701,9 +807,10 @@ describe('postgres-import-worker — C3 import wiring', () => {
     query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
       const text = typeof sql === 'string' ? sql : sql.text
       queries.push(text)
+      if (text.includes('pg_try_advisory_lock')) return acquiredImportLock
       if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
-      if (text.startsWith('SELECT id FROM') && text.includes('"cases"')) return { rows: [] }
-      if (text.startsWith('INSERT INTO') && text.includes('"cases"')) return { rows: [{ id: 13 }] }
+      if (text.startsWith('SELECT id FROM') && text.includes('"cases')) return { rows: [] }
+      if (text.startsWith('INSERT INTO') && text.includes('"cases')) return { rows: [{ id: 13 }] }
       if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
         const n = (params?.[1] as number) ?? 0
         return {
@@ -771,9 +878,73 @@ describe('postgres-import-worker — C3 import wiring', () => {
     )
     expect(bookkeepingIdx).toBeGreaterThanOrEqual(0)
     expect(savepointIdx).toBeGreaterThan(bookkeepingIdx)
-    expect(queries.at(-1)).toBe('COMMIT')
+    expect(queries.lastIndexOf('COMMIT')).toBeGreaterThan(savepointIdx)
 
     expect(markStaleSpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps the provisional case hidden and publishes derived bookkeeping atomically', async () => {
+    const queries: string[] = []
+    const client = makeClient(queries)
+    const messages: unknown[] = []
+    await runVcfSingleFile(client, messages)
+
+    const countIndex = queries.findIndex(
+      (query) => query.startsWith('UPDATE') && query.includes('variant_count')
+    )
+    const frequencyIndex = queries.findIndex((query) => query.includes('"variant_frequency"'))
+    const readyIndex = queries.findIndex(
+      (query) => query.startsWith('UPDATE') && query.includes("import_status = 'ready'")
+    )
+
+    expect(queries[countIndex]).toContain('"cases_all"')
+    expect(queries[frequencyIndex]).toContain('"variants_all"')
+    expect(readyIndex).toBeGreaterThan(frequencyIndex)
+
+    const publicationBeginIndex = queries.findLastIndex(
+      (query, index) => index < countIndex && query === 'BEGIN'
+    )
+    const publicationCommitIndex = queries.findIndex(
+      (query, index) => index > readyIndex && query === 'COMMIT'
+    )
+
+    expect(publicationBeginIndex).toBeGreaterThanOrEqual(0)
+    expect(queries.slice(frequencyIndex, readyIndex)).not.toContain('COMMIT')
+    expect(publicationCommitIndex).toBeGreaterThan(readyIndex)
+
+    const publicationQueries = queries.slice(publicationBeginIndex, publicationCommitIndex + 1)
+    expect(publicationQueries.some((query) => query.includes('"variant_frequency"'))).toBe(true)
+    expect(publicationQueries).toContain('SAVEPOINT cohort_summary')
+  })
+
+  it('never deletes work when the atomic publication commit outcome is uncertain', async () => {
+    const queries: string[] = []
+    const base = makeClient(queries)
+    let commitCount = 0
+    const originalQuery = base.query
+    base.query = vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
+      const text = typeof sql === 'string' ? sql : sql.text
+      if (text === 'COMMIT') {
+        commitCount += 1
+        if (commitCount === 2) {
+          queries.push(text)
+          throw new Error('connection lost while publishing')
+        }
+      }
+      return originalQuery(sql, params)
+    })
+    const messages: unknown[] = []
+
+    await runVcfSingleFile(base, messages)
+
+    expect(queries.some((query) => query.includes("import_status = 'ready'"))).toBe(true)
+    expect(queries.some((query) => query.includes('DELETE FROM "public"."variants_all"'))).toBe(
+      false
+    )
+    expect(queries.some((query) => query.includes('DELETE FROM "public"."cases_all"'))).toBe(false)
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'connection lost while publishing' })
+    )
   })
 
   it('preserves variant_count + rebuildVariantFrequencyForCase on summary failure', async () => {
@@ -794,8 +965,8 @@ describe('postgres-import-worker — C3 import wiring', () => {
     expect(queries).not.toContain('RELEASE SAVEPOINT cohort_summary')
     expect(queries).toContain('COMMIT')
 
-    // markStale runs in a separate tiny transaction (BEGIN/COMMIT after the
-    // outer COMMIT) so the bookkeeping commit survives regardless.
+    // markStale stays inside the same publication transaction so readers see
+    // either the old snapshot or the ready case plus its stale marker.
     expect(markStaleSpy).toHaveBeenCalledTimes(1)
     expect(markStaleSpy).toHaveBeenCalledWith(
       expect.objectContaining({ reason: 'post_import_summary_failed_case_13' })

--- a/tests/main/workers/postgres-import-worker.test.ts
+++ b/tests/main/workers/postgres-import-worker.test.ts
@@ -142,7 +142,7 @@ describe('postgres-import-worker runImport', () => {
     expect(complete?.result.variantCount).toBe(1)
   })
 
-  it('deletes a partially committed single-file VCF case when the stream fails after a batch commit', async () => {
+  it('rolls back a single-file VCF when the stream fails after a flushed batch', async () => {
     const queries: string[] = []
     const client = {
       connect: vi.fn(async () => undefined),
@@ -204,7 +204,7 @@ describe('postgres-import-worker runImport', () => {
 
     async function* rows(): AsyncGenerator<typeof fakeVariant, void, void> {
       yield fakeVariant
-      throw new Error('stream failed after committed batch')
+      throw new Error('stream failed after flushed batch')
     }
 
     await runImport(
@@ -230,18 +230,16 @@ describe('postgres-import-worker runImport', () => {
     )
 
     expect(queries).toContain('ROLLBACK')
-    expect(queries).toContain('DELETE FROM "public"."cases" WHERE id = $1')
+    expect(queries).not.toContain('COMMIT')
+    expect(queries).not.toContain('DELETE FROM "public"."cases" WHERE id = $1')
     const error = messages.find((m): m is { type: 'error'; message: string } => {
       return (m as { type: string }).type === 'error'
     })
-    expect(error?.message).toMatch(/stream failed after committed batch/)
+    expect(error?.message).toMatch(/stream failed after flushed batch/)
   })
 
   it('runs one transaction per file in multi-file mode and surfaces per-file errors', async () => {
     const queries: string[] = []
-    // Track how many times a variant batch insert has been attempted so we can
-    // inject a failure on the second file's insert (file 1 succeeds, file 2 fails).
-    let variantInsertCount = 0
     const client = {
       connect: vi.fn(async () => undefined),
       query: vi.fn(async (sql: string | { text: string }, params?: unknown[]) => {
@@ -261,12 +259,7 @@ describe('postgres-import-worker runImport', () => {
         if (text.startsWith('INSERT INTO') && text.includes('"cases"')) {
           return { rows: [{ id: 21 }] }
         }
-        // Phase 16+: per-batch ID reservation. We hijack this call site to
-        // inject the file-2 failure (was previously injected on the
-        // jsonb_to_recordset INSERT, which is no longer used).
         if (text.includes('pg_get_serial_sequence') && text.includes('generate_series')) {
-          variantInsertCount += 1
-          if (variantInsertCount === 2) throw new Error('inject failure on file 2 variant insert')
           const n = (params?.[1] as number) ?? 0
           return {
             rows: Array.from({ length: n }, (_, i) => ({
@@ -315,11 +308,18 @@ describe('postgres-import-worker runImport', () => {
       caller: null
     }
     const messages: unknown[] = []
+    async function* failingSecondFile(): AsyncGenerator<typeof fakeRow, void, void> {
+      yield fakeRow
+      throw new Error('late failure in file 2')
+    }
     await runImport(
       {
         createClient: () => client as never,
         detectFormat: async () => ({ format: 'vcf', caseKey: '' }) as never,
-        createVcfMappedStream: async () => Readable.from([fakeRow]) as never,
+        createVcfMappedStream: async (filePath) =>
+          filePath.endsWith('/b.vcf.gz')
+            ? (failingSecondFile() as never)
+            : (Readable.from([fakeRow]) as never),
         createMapperPipeline: async () => Readable.from([]),
         statFile: () => ({ size: 0 })
       },
@@ -343,18 +343,21 @@ describe('postgres-import-worker runImport', () => {
             annotationFormat: null,
             caller: null
           }
-        ]
+        ],
+        batchSize: 1
       },
       (m) => messages.push(m)
     )
 
-    // Phase 16.1: outer BEGIN/ROLLBACK is gone (no bracket transactions).
-    // Expected BEGINs: file-1 BEGIN + per-batch COMMIT/BEGIN cycle inside
-    // flushBatch + file-2 BEGIN + post-loop bookkeeping BEGIN = 4.
+    // Each file owns one transaction; successful files commit and a failed
+    // file rolls back before the final bookkeeping transaction.
     const beginCount = queries.filter((q) => q === 'BEGIN').length
-    expect(beginCount).toBe(4)
+    expect(beginCount).toBe(3)
     expect(queries.includes('ROLLBACK')).toBe(true)
     expect(queries.includes('COMMIT')).toBe(true)
+    const beginIndexes = queries.flatMap((query, index) => (query === 'BEGIN' ? [index] : []))
+    const rollbackIndex = queries.indexOf('ROLLBACK', beginIndexes[1])
+    expect(queries.slice(beginIndexes[1] + 1, rollbackIndex)).not.toContain('COMMIT')
 
     const complete = messages.find(
       (m): m is { type: 'complete'; result: { files: Array<{ error?: string }> } } =>
@@ -363,7 +366,7 @@ describe('postgres-import-worker runImport', () => {
     expect(complete).toBeDefined()
     const result = complete!.result
     expect(result.files[0].error).toBeUndefined()
-    expect(result.files[1].error).toMatch(/inject failure on file 2/)
+    expect(result.files[1].error).toMatch(/late failure in file 2/)
   })
 
   it('opens client, runs BEGIN/COMMIT for single-file JSON, posts complete', async () => {
@@ -421,6 +424,54 @@ describe('postgres-import-worker runImport', () => {
       (m): m is { type: 'complete' } => (m as { type: string }).type === 'complete'
     )
     expect(complete).toBeDefined()
+  })
+
+  it('rolls back a single-file JSON import when the stream fails after a flushed batch', async () => {
+    const queries: string[] = []
+    const client = {
+      connect: vi.fn(async () => undefined),
+      query: vi.fn(async (sql: string | { text: string }) => {
+        const text = typeof sql === 'string' ? sql : sql.text
+        queries.push(text)
+        if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] }
+        if (text.startsWith('SELECT id FROM')) return { rows: [] }
+        if (text.startsWith('INSERT INTO') && text.includes('"cases"')) {
+          return { rows: [{ id: 11 }] }
+        }
+        return { rows: [] }
+      }),
+      end: vi.fn(async () => undefined)
+    }
+    const messages: unknown[] = []
+    async function* rows(): AsyncGenerator<Record<string, unknown>, void, void> {
+      yield { chr: '1', pos: 1, ref: 'A', alt: 'T' }
+      throw new Error('late JSON stream failure')
+    }
+
+    await runImport(
+      {
+        createClient: () => client as never,
+        detectFormat: async () => ({ format: 'simple', caseKey: '' }) as never,
+        createMapperPipeline: async () => Readable.from(rows()),
+        createVcfMappedStream: async () => Readable.from([]) as never,
+        statFile: () => ({ size: 100 })
+      },
+      {
+        type: 'start',
+        client: { connectionString: 'postgres://x' },
+        schema: 'public',
+        mode: 'single-file',
+        caseName: 'JSON case',
+        filePath: '/tmp/a.json',
+        format: 'json',
+        batchSize: 1
+      },
+      (message) => messages.push(message)
+    )
+
+    expect(queries).toContain('ROLLBACK')
+    expect(queries).not.toContain('COMMIT')
+    expect(messages).toContainEqual({ type: 'error', message: 'late JSON stream failure' })
   })
 
   it('loads BedFilter and applies pre/post-mapping filters in multi-file mode', async () => {

--- a/tests/refactor-checkpoint/__snapshots__/transaction-boundaries.json
+++ b/tests/refactor-checkpoint/__snapshots__/transaction-boundaries.json
@@ -28,6 +28,11 @@
       "assignedTo": "transactionFn"
     },
     {
+      "file": "src/main/database/GeneListRepository.ts",
+      "callerFunction": "importBedFile",
+      "assignedTo": "insertChunk"
+    },
+    {
       "file": "src/main/database/migrations.ts",
       "callerFunction": "runMigrations",
       "assignedTo": "cleanupTransaction"

--- a/tests/web-gate/dispatcher-adapters-assets-annotations-export.test.ts
+++ b/tests/web-gate/dispatcher-adapters-assets-annotations-export.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from 'vitest'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
 
 import { buildDispatcher } from '../../src/web/server/dispatcher'
+import { DecompressedSizeExceededError } from '../../src/main/import/stream-utils'
 import { stageExistingFileUpload } from '../../src/web/server/routes/upload-staging'
 import { makeDeps } from './helpers/dispatcher-adapters'
 
@@ -228,6 +230,129 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
       else process.env.NODE_ENV = prevNodeEnv
       if (prevRecoveryDir === undefined) delete process.env.VARLENS_RECOVERY_KEY_DIR
       else process.env.VARLENS_RECOVERY_KEY_DIR = prevRecoveryDir
+    }
+  })
+
+  test('region-files.importBed streams a staged gzip BED through the shared reader', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
+    process.env.NODE_ENV = 'production'
+    const { deps, writeExecute, reply } = makeDeps()
+    const { overrides } = buildDispatcher(deps)
+    const dir = await mkdtemp(join(tmpdir(), 'varlens-bed-gzip-'))
+    process.env.VARLENS_RECOVERY_KEY_DIR = dir
+
+    try {
+      const filePath = join(dir, 'regions.bed.gz')
+      await writeFile(filePath, gzipSync(Buffer.from('chr1\t0\t10\tRegionA\nchr2\t5\t9\n')))
+      const upload = await stageExistingFileUpload({
+        userId: 7,
+        originalName: 'regions.bed.gz',
+        sourcePath: filePath
+      })
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      await overrides['region-files:importBed'].handle(
+        [4, upload.ref],
+        request as never,
+        reply as never,
+        deps
+      )
+
+      expect(writeExecute).toHaveBeenCalledWith({
+        type: 'region-files:importBed',
+        params: [
+          4,
+          [
+            { chr: 'chr1', start: 0, end: 10, label: 'RegionA' },
+            { chr: 'chr2', start: 5, end: 9 }
+          ]
+        ]
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevRecoveryDir === undefined) delete process.env.VARLENS_RECOVERY_KEY_DIR
+      else process.env.VARLENS_RECOVERY_KEY_DIR = prevRecoveryDir
+    }
+  })
+
+  test('region-files.importBed rejects malformed rows before persistence', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
+    process.env.NODE_ENV = 'production'
+    const { deps, writeExecute, reply } = makeDeps()
+    const { overrides } = buildDispatcher(deps)
+    const dir = await mkdtemp(join(tmpdir(), 'varlens-bed-malformed-'))
+    process.env.VARLENS_RECOVERY_KEY_DIR = dir
+
+    try {
+      const filePath = join(dir, 'regions.bed')
+      await writeFile(filePath, 'chr1\tbad\t10\n')
+      const upload = await stageExistingFileUpload({
+        userId: 7,
+        originalName: 'regions.bed',
+        sourcePath: filePath
+      })
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      await expect(
+        overrides['region-files:importBed'].handle(
+          [4, upload.ref],
+          request as never,
+          reply as never,
+          deps
+        )
+      ).rejects.toThrow(/invalid bed row/i)
+      expect(writeExecute).not.toHaveBeenCalled()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevRecoveryDir === undefined) delete process.env.VARLENS_RECOVERY_KEY_DIR
+      else process.env.VARLENS_RECOVERY_KEY_DIR = prevRecoveryDir
+    }
+  })
+
+  test('region-files.importBed enforces the shared decompressed-byte cap', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
+    const prevMaxBytes = process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES
+    process.env.NODE_ENV = 'production'
+    process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES = '100'
+    const { deps, writeExecute, reply } = makeDeps()
+    const { overrides } = buildDispatcher(deps)
+    const dir = await mkdtemp(join(tmpdir(), 'varlens-bed-cap-'))
+    process.env.VARLENS_RECOVERY_KEY_DIR = dir
+
+    try {
+      const filePath = join(dir, 'regions.bed.gz')
+      await writeFile(filePath, gzipSync(Buffer.from('chr1\t0\t10\n'.repeat(1_000))))
+      const upload = await stageExistingFileUpload({
+        userId: 7,
+        originalName: 'regions.bed.gz',
+        sourcePath: filePath
+      })
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      await expect(
+        overrides['region-files:importBed'].handle(
+          [4, upload.ref],
+          request as never,
+          reply as never,
+          deps
+        )
+      ).rejects.toThrow(DecompressedSizeExceededError)
+      expect(writeExecute).not.toHaveBeenCalled()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevRecoveryDir === undefined) delete process.env.VARLENS_RECOVERY_KEY_DIR
+      else process.env.VARLENS_RECOVERY_KEY_DIR = prevRecoveryDir
+      if (prevMaxBytes === undefined) delete process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES
+      else process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES = prevMaxBytes
     }
   })
 

--- a/tests/web-gate/dispatcher-adapters-assets-annotations-export.test.ts
+++ b/tests/web-gate/dispatcher-adapters-assets-annotations-export.test.ts
@@ -6,6 +6,7 @@ import { gzipSync } from 'node:zlib'
 
 import { buildDispatcher } from '../../src/web/server/dispatcher'
 import { DecompressedSizeExceededError } from '../../src/main/import/stream-utils'
+import { InvalidBedRowError } from '../../src/main/import/vcf/bed-reader'
 import { stageExistingFileUpload } from '../../src/web/server/routes/upload-staging'
 import { makeDeps } from './helpers/dispatcher-adapters'
 
@@ -187,7 +188,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
     })
   })
 
-  test('region-files.importBed reads BED rows before writing the import task', async () => {
+  test('region-files.importBed delegates the staged BED path to strict storage streaming', async () => {
     const prevNodeEnv = process.env.NODE_ENV
     const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
     process.env.NODE_ENV = 'production'
@@ -216,13 +217,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
       expect(reply.code).not.toHaveBeenCalled()
       expect(writeExecute).toHaveBeenCalledWith({
         type: 'region-files:importBed',
-        params: [
-          4,
-          [
-            { chr: 'chr1', start: 0, end: 10, label: 'RegionA' },
-            { chr: 'chr2', start: 5, end: 9 }
-          ]
-        ]
+        params: [4, upload.storedPath, { rejectMalformedRows: true }]
       })
     } finally {
       await rm(dir, { recursive: true, force: true })
@@ -233,7 +228,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
     }
   })
 
-  test('region-files.importBed streams a staged gzip BED through the shared reader', async () => {
+  test('region-files.importBed delegates a staged gzip BED to storage streaming', async () => {
     const prevNodeEnv = process.env.NODE_ENV
     const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
     process.env.NODE_ENV = 'production'
@@ -261,13 +256,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
 
       expect(writeExecute).toHaveBeenCalledWith({
         type: 'region-files:importBed',
-        params: [
-          4,
-          [
-            { chr: 'chr1', start: 0, end: 10, label: 'RegionA' },
-            { chr: 'chr2', start: 5, end: 9 }
-          ]
-        ]
+        params: [4, upload.storedPath, { rejectMalformedRows: true }]
       })
     } finally {
       await rm(dir, { recursive: true, force: true })
@@ -278,7 +267,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
     }
   })
 
-  test('region-files.importBed rejects malformed rows before persistence', async () => {
+  test('region-files.importBed propagates strict malformed-row rejection from storage', async () => {
     const prevNodeEnv = process.env.NODE_ENV
     const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
     process.env.NODE_ENV = 'production'
@@ -296,6 +285,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
         sourcePath: filePath
       })
       const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+      writeExecute.mockRejectedValueOnce(new InvalidBedRowError('chr1\tbad\t10'))
 
       await expect(
         overrides['region-files:importBed'].handle(
@@ -304,8 +294,11 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
           reply as never,
           deps
         )
-      ).rejects.toThrow(/invalid bed row/i)
-      expect(writeExecute).not.toHaveBeenCalled()
+      ).rejects.toThrow(InvalidBedRowError)
+      expect(writeExecute).toHaveBeenCalledWith({
+        type: 'region-files:importBed',
+        params: [4, upload.storedPath, { rejectMalformedRows: true }]
+      })
     } finally {
       await rm(dir, { recursive: true, force: true })
       if (prevNodeEnv === undefined) delete process.env.NODE_ENV
@@ -315,7 +308,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
     }
   })
 
-  test('region-files.importBed enforces the shared decompressed-byte cap', async () => {
+  test('region-files.importBed propagates the storage decompressed-byte cap', async () => {
     const prevNodeEnv = process.env.NODE_ENV
     const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
     const prevMaxBytes = process.env.VARLENS_IMPORT_MAX_DECOMPRESSED_BYTES
@@ -335,6 +328,7 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
         sourcePath: filePath
       })
       const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+      writeExecute.mockRejectedValueOnce(new DecompressedSizeExceededError(100))
 
       await expect(
         overrides['region-files:importBed'].handle(
@@ -344,7 +338,10 @@ describe('web dispatcher adapters: annotations, assets, and exports', () => {
           deps
         )
       ).rejects.toThrow(DecompressedSizeExceededError)
-      expect(writeExecute).not.toHaveBeenCalled()
+      expect(writeExecute).toHaveBeenCalledWith({
+        type: 'region-files:importBed',
+        params: [4, upload.storedPath, { rejectMalformedRows: true }]
+      })
     } finally {
       await rm(dir, { recursive: true, force: true })
       if (prevNodeEnv === undefined) delete process.env.NODE_ENV

--- a/tests/web-gate/dispatcher-adapters-auth-import.test.ts
+++ b/tests/web-gate/dispatcher-adapters-auth-import.test.ts
@@ -838,6 +838,103 @@ describe('web dispatcher adapters: auth and import', () => {
     }
   })
 
+  test('import.startMultiFile rejects a raw absolute BED filter server path', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
+    const tempDir = await mkdtemp(join(tmpdir(), 'varlens-web-bed-authority-'))
+    process.env.NODE_ENV = 'production'
+    process.env.VARLENS_RECOVERY_KEY_DIR = tempDir
+    try {
+      const sourcePath = join(tempDir, 'input.vcf')
+      await writeFile(sourcePath, '##fileformat=VCFv4.2\n')
+      const upload = await stageExistingFileUpload({
+        userId: 7,
+        originalName: 'input.vcf',
+        sourcePath
+      })
+      const { deps, importMultiFile, reply } = makeDeps()
+      const { overrides } = buildDispatcher(deps)
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      const result = await overrides['import:startMultiFile'].handle(
+        [
+          'Case A',
+          [{ filePath: upload.ref, variantType: 'snv', caller: null, annotationFormat: null }],
+          { genomeBuild: 'hg38' },
+          { bedFile: '/etc/passwd', bedPadding: 10 }
+        ],
+        request as never,
+        reply as never,
+        deps
+      )
+
+      expect(reply.code).toHaveBeenCalledWith(403)
+      expect(result).toEqual({
+        error: 'server-path-import-disabled',
+        message: 'Server-path import is disabled in web mode. Use browser upload refs instead.'
+      })
+      expect(importMultiFile).not.toHaveBeenCalled()
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevRecoveryDir === undefined) delete process.env.VARLENS_RECOVERY_KEY_DIR
+      else process.env.VARLENS_RECOVERY_KEY_DIR = prevRecoveryDir
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('import.startMultiFile resolves a user-scoped BED filter upload ref', async () => {
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR
+    const tempDir = await mkdtemp(join(tmpdir(), 'varlens-web-bed-upload-'))
+    process.env.NODE_ENV = 'production'
+    process.env.VARLENS_RECOVERY_KEY_DIR = tempDir
+    try {
+      const vcfPath = join(tempDir, 'input.vcf')
+      const bedPath = join(tempDir, 'filter.bed')
+      await writeFile(vcfPath, '##fileformat=VCFv4.2\n')
+      await writeFile(bedPath, 'chr1\t0\t10\n')
+      const vcfUpload = await stageExistingFileUpload({
+        userId: 7,
+        originalName: 'input.vcf',
+        sourcePath: vcfPath
+      })
+      const bedUpload = await stageExistingFileUpload({
+        userId: 7,
+        originalName: 'filter.bed',
+        sourcePath: bedPath
+      })
+      const { deps, importMultiFile, reply } = makeDeps()
+      const { overrides } = buildDispatcher(deps)
+      const request = { session: { user: { id: 7, username: 'admin', role: 'admin' } } }
+
+      await overrides['import:startMultiFile'].handle(
+        [
+          'Case A',
+          [{ filePath: vcfUpload.ref, variantType: 'snv', caller: null, annotationFormat: null }],
+          { genomeBuild: 'hg38' },
+          { bedFile: bedUpload.ref, bedPadding: 10 }
+        ],
+        request as never,
+        reply as never,
+        deps
+      )
+
+      expect(reply.code).not.toHaveBeenCalled()
+      expect(importMultiFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: expect.objectContaining({ bedFilePath: bedUpload.storedPath, bedPadding: 10 })
+        })
+      )
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevRecoveryDir === undefined) delete process.env.VARLENS_RECOVERY_KEY_DIR
+      else process.env.VARLENS_RECOVERY_KEY_DIR = prevRecoveryDir
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('import.startMultiFile rejects malformed filter payloads before import logic', async () => {
     const prevNodeEnv = process.env.NODE_ENV
     const prevRecoveryDir = process.env.VARLENS_RECOVERY_KEY_DIR


### PR DESCRIPTION
## Summary

Hardens VCF/BED import against malformed input and denial-of-service (finding C7 / Codex F-04). Import runs on the main/worker processes with no input bounds, so a crafted file could poison data or freeze/OOM the app.

**PR-E** of the staged security & bug remediation.

## What changed

**POS/QUAL validation (E1):** `parseVcfLine` previously did `parseInt(POS)`/`parseFloat(QUAL)` with no NaN check, so a bad `POS` produced a silent `NaN` row (dropped downstream with no diagnostic). Now a non-positive-integer `POS` is rejected on **all** parser call sites (unconditionally — the `1.5`-truncation edge is caught via a digit-string check), with a reason recorded where the import pipeline has a skip-reason channel; a malformed `QUAL` becomes `null` (VCF-correct), not `NaN`.

**Shared capped reader (E2):** a per-line byte cap (`MAX_LINE_BYTES=64MiB`, always-on) and a total-decompressed-byte cap (`MAX_DECOMPRESSED_BYTES=256GiB`, env-overridable) live in one shared reader in `stream-utils.ts`, implemented as pass-through Transform streams composed **after** gunzip (so a gzip bomb is caught by its *decompressed* size). The line splitter is byte-for-byte equivalent to the old reader (no variant-line drop/merge). Every VCF/BED line consumer is routed through it:
- VCF import: SQLite worker (`import-pipeline.ts`), Postgres worker (`postgres-import-worker.ts`), single-case strategy (`VcfStrategy`), multi-file append (`import-logic-append.ts`)
- VCF preview + header parsing
- BED filtering (`bed-filter.ts` no longer does an unbounded `gunzipSync(readFileSync())`)

A cap error (`LineTooLongError` / `DecompressedSizeExceededError`) **fails the import** — it escapes the per-line skip catch rather than being swallowed as a skipped row.

## Reviews

- **Codex-high (whole-branch gate):** first pass NO-GO caught that E2 had protected `VcfStrategy` but **missed the actual production import readers** (the SQLite/Postgres worker threads + append path) — all four were then routed through the capped reader — then **GO**. Codex confirmed decompressed-byte counting, cap-error propagation on each path, and no line-splitting regression (the only remaining raw reader is a bounded 1KB format sniff).
- Per-task reviews: E1 approved (unconditional NaN-row rejection verified); E2 approved (line-splitting equivalence proven via pass-through-only transforms).

## Verification

- `make test` (main + renderer): **3930 passing**, 0 failures; `make typecheck` clean.
- New tests: giant-line and simulated gzip-bomb rejected at each entry point (import worker, PG worker, append, preview, header, BED); legitimate files unaffected.

## Follow-ups (tracked, out of scope)

- JSON import path (`ObjectStrategy`/`ColumnarStrategy`) is not yet capped.
- `getVcfMultiPreview` swallows per-file preview errors (pre-existing); worker paths reject NaN rows but don't record the skip *reason*.

Part of the security & bug remediation series (PRs A–D: #306–#309; PRs F–I to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmqdEMGjqVhTX8EKr6QxoH
