### PR TITLE
fix(security): navigation scoping + dialog-origin path authority (S1,S2,S3,S5,S6) [PR-F]

### DIFF
--- a/.planning/plans/2026-07-13-strict-legacy-import-path-authority.md
+++ b/.planning/plans/2026-07-13-strict-legacy-import-path-authority.md
@@ -1,0 +1,53 @@
+# Strict Legacy Import Path Authority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Require exact trusted enrollment for every desktop legacy import file path.
+
+**Architecture:** Reuse the session-scoped `PathAuthorityStore` as the single import capability
+boundary. Remove automatic-root grants, keep file-granular trusted enrollment, and leave web and
+database authority in their existing independent layers.
+
+**Tech Stack:** TypeScript 6, Electron IPC, Vitest, Node filesystem APIs
+
+---
+
+### Task 1: Lock the authority contract with failing tests
+
+**Files:**
+- Modify: `tests/main/security/import-path-allowlist.test.ts`
+- Modify: `tests/main/ipc/handlers/import.test.ts`
+
+- [x] Replace automatic-root acceptance assertions with rejection assertions for unenrolled temp
+  and home paths.
+- [x] Add table-driven handler tests for `import:start`, `import:startMultiFile`,
+  `import:vcfPreview`, and `import:vcfMultiPreview` using an unenrolled temp file.
+- [x] Add enrolled-path success tests for those handlers and pinned-symlink acceptance/retarget
+  rejection tests at the handler boundary.
+- [x] Prove relative and non-normalized enrollment attempts cannot authorize their resolved aliases.
+- [x] Run `npx vitest run tests/main/security/import-path-allowlist.test.ts tests/main/ipc/handlers/import.test.ts`
+  and confirm failures show the automatic-root bypass.
+
+### Task 2: Remove permissive import authority
+
+**Files:**
+- Modify: `src/main/security/import-path-allowlist.ts`
+- Modify: `src/main/ipc/handlers/import.ts`
+- Modify: tests whose comments or assertions preserve automatic-root access
+
+- [x] Make the import predicate accept only absolute, normalized, enrolled paths whose pinned
+  target remains stable.
+- [x] Make import enrollment fail closed for relative and non-normalized paths.
+- [x] Route every legacy import path check through that strict predicate and remove obsolete
+  automatic-root helpers/imports/comments.
+- [x] Run the focused authority and handler tests and confirm they pass.
+
+### Task 3: Verify adjacent workflows and release gates
+
+**Files:**
+- Verify only: batch import selection/ZIP tests, database authority tests, web-gate handler seam
+
+- [x] Run focused import, batch-import, database-authority, ZIP-enrollment, and web handler tests.
+- [x] Run `make ci-full` because the change modifies Electron IPC authority.
+- [x] Run `git diff --check`, inspect `git status`, and verify only intended PR311 files changed.
+- [x] Commit as a descendant of `bb330d5c` using a Conventional Commit message.

--- a/.planning/plans/2026-07-13-strict-legacy-import-path-authority.md
+++ b/.planning/plans/2026-07-13-strict-legacy-import-path-authority.md
@@ -51,3 +51,24 @@ database authority in their existing independent layers.
 - [x] Run `make ci-full` because the change modifies Electron IPC authority.
 - [x] Run `git diff --check`, inspect `git status`, and verify only intended PR311 files changed.
 - [x] Commit as a descendant of `bb330d5c` using a Conventional Commit message.
+
+### Task 4: Close independent-review authority and lifecycle findings
+
+**Files:**
+- Modify: `src/main/security/database-path-allowlist.ts`
+- Create: `src/main/security/export-path-allowlist.ts`
+- Modify: `src/main/ipc/handlers/{database,export,import,shell}.ts`
+- Modify: `src/main/ipc/handlers/batch-import-logic.ts`
+- Modify: batch-import/import/export shared contracts, preload bindings, and renderer consumers
+- Test: nearest main, preload-contract, and renderer behavior tests
+
+- [x] Write failing tests for invalid database enrollment and stale enrolled symlink fallback.
+- [x] Make database enrollment lexical and make stale enrolled capabilities fail closed.
+- [x] Write failing concurrent ZIP ownership and targeted cleanup tests.
+- [x] Return opaque extraction IDs, own temp/enrollment state per ID, and update both renderer flows.
+- [x] Write failing sibling-BED and dropped-File provenance tests.
+- [x] Enroll trusted sibling BED results and use preload `webUtils` provenance for dropped files.
+- [x] Write failing export-only reveal capability tests.
+- [x] Move reveal from the generic shell/import authority boundary to the export domain.
+- [x] Run focused tests, `make typecheck`, `make agent-check`, and `make ci-full`.
+- [x] Run `git diff --check`, inspect the final diff, and commit descendant fixes.

--- a/.planning/specs/2026-07-13-strict-legacy-import-path-authority.md
+++ b/.planning/specs/2026-07-13-strict-legacy-import-path-authority.md
@@ -1,0 +1,36 @@
+# Strict legacy import path authority
+
+## Goal
+
+Remove the remaining desktop renderer path-authority bypass from the legacy import IPC domain.
+Every file consumed by `import:start`, `import:startMultiFile`, `import:vcfPreview`, or
+`import:vcfMultiPreview` must have been enrolled by a trusted Electron selector or by an existing
+derived-file workflow such as ZIP extraction.
+
+## Design
+
+The import path authority module will expose one capability boundary: an absolute, normalized path
+must exist in the session-scoped `PathAuthorityStore`, and an enrolled symlink remains valid only
+while it resolves to its originally pinned target. The automatic home, userData, and temp directory
+fallback will be removed rather than retained behind a second predicate. Enrollment attempts using
+relative or non-normalized paths fail closed instead of granting authority to a resolved alias.
+
+Trusted selectors continue to enroll each returned file. Folder selection and ZIP extraction remain
+responsible for enrolling each discovered or extracted file, rather than granting an entire directory
+tree. Database authority remains owned by `database-path-allowlist.ts`. Web import routes remain
+unchanged because they resolve user-scoped uploaded file references in the web server and do not
+register the Electron IPC handlers.
+
+## Error handling
+
+Unenrolled paths retain the current structured `INVALID_PARAMETERS` response. Runtime schema
+validation remains before authority validation. No IPC contract changes are required.
+
+## Tests
+
+- Invert the old automatic-root unit expectations so unenrolled home/temp files are rejected.
+- Exercise all four path-consuming legacy import handlers with unenrolled temp paths.
+- Exercise the handlers with explicitly enrolled paths.
+- Prove an enrolled symlink is accepted while pinned and rejected after retargeting.
+- Prove relative and non-normalized enrollment attempts do not authorize resolved aliases.
+- Retain selector, folder, ZIP extraction, database, and web-gate coverage.

--- a/.planning/specs/2026-07-13-strict-legacy-import-path-authority.md
+++ b/.planning/specs/2026-07-13-strict-legacy-import-path-authority.md
@@ -17,9 +17,9 @@ relative or non-normalized paths fail closed instead of granting authority to a 
 
 Trusted selectors continue to enroll each returned file. Folder selection and ZIP extraction remain
 responsible for enrolling each discovered or extracted file, rather than granting an entire directory
-tree. Database authority remains owned by `database-path-allowlist.ts`. Web import routes remain
-unchanged because they resolve user-scoped uploaded file references in the web server and do not
-register the Electron IPC handlers.
+tree. Database authority remains owned by `database-path-allowlist.ts`. Web imports continue to
+resolve user-scoped uploaded file references rather than registering Electron IPC handlers; their
+client and ZIP route mirror the revised desktop contract without sharing desktop path authority.
 
 Database dialog enrollment uses the same lexical and symlink-pinning rules. Relative or
 non-normalized database enrollment is ignored. If a dialog-enrolled database symlink is later

--- a/.planning/specs/2026-07-13-strict-legacy-import-path-authority.md
+++ b/.planning/specs/2026-07-13-strict-legacy-import-path-authority.md
@@ -21,10 +21,34 @@ tree. Database authority remains owned by `database-path-allowlist.ts`. Web impo
 unchanged because they resolve user-scoped uploaded file references in the web server and do not
 register the Electron IPC handlers.
 
+Database dialog enrollment uses the same lexical and symlink-pinning rules. Relative or
+non-normalized database enrollment is ignored. If a dialog-enrolled database symlink is later
+retargeted, the stale enrollment fails closed; matching the current or recent database list must
+not resurrect that stale capability.
+
+ZIP extraction ownership is represented by an opaque extraction ID. Every active extraction owns
+its temporary directory and the exact import-path enrollments derived from it. Cleanup accepts only
+that ID, revokes only those enrollments, and remains safe when extraction and cleanup requests race.
+
+Two trusted derived-path workflows remain usable without weakening the import gate:
+
+- Sibling BED files discovered by main while previewing already-authorized VCFs are individually
+  enrolled before being returned.
+- Dropped browser `File` objects are converted to native paths in preload with Electron
+  `webUtils.getPathForFile`; only those preload-derived normalized VCF paths are sent to main for
+  enrollment. The renderer cannot enroll a raw path string through the exposed API.
+
+Export reveal is a separate capability. Export handlers enroll successful save targets in an
+export-only store and expose an export-scoped reveal operation. Import authority never authorizes
+revealing a file, and the generic shell API no longer exposes that operation.
+
 ## Error handling
 
 Unenrolled paths retain the current structured `INVALID_PARAMETERS` response. Runtime schema
-validation remains before authority validation. No IPC contract changes are required.
+validation remains before authority validation. The typed IPC contract carries opaque ZIP
+extraction IDs for targeted cleanup, preload-provenance enrollment for dropped files, and an
+export-scoped reveal operation. Desktop, renderer mocks, and the web client preserve the same API
+shape; unsupported web reveal requests return an explicit failed `IpcResult`.
 
 ## Tests
 
@@ -34,3 +58,8 @@ validation remains before authority validation. No IPC contract changes are requ
 - Prove an enrolled symlink is accepted while pinned and rejected after retargeting.
 - Prove relative and non-normalized enrollment attempts do not authorize resolved aliases.
 - Retain selector, folder, ZIP extraction, database, and web-gate coverage.
+- Prove stale database symlinks cannot fall through to current/recent authority.
+- Prove concurrent ZIP extraction cleanup revokes only the addressed extraction.
+- Prove sibling-BED suggestions and genuine dropped files remain importable through trusted
+  enrollment, while raw renderer strings remain rejected.
+- Prove export reveal accepts only export-enrolled targets and import enrollment is insufficient.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, dialog, shell, nativeImage, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
+import { pathToFileURL } from 'url'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import Database from 'better-sqlite3-multiple-ciphers'
 import { registerIpcHandlers, destroyDbPool } from './ipc'
@@ -81,6 +82,9 @@ function createWindow(): void {
     }
   })
   const rendererUrl = process.env['ELECTRON_RENDERER_URL']
+  // Same path passed to `mainWindow.loadFile(...)` below — kept as a single
+  // source of truth so the navigation policy always matches what's loaded.
+  const appDocUrl = pathToFileURL(join(__dirname, '../renderer/index.html')).toString()
 
   mainWindow.on('ready-to-show', () => {
     if (hideE2eWindow) {
@@ -96,14 +100,16 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (isUrlSafeForExternal(url)) {
+    // Renderer-added domains (`shell:updateUserDomains`) must never reach
+    // this sink — only the built-in allowlist may open a new window/tab.
+    if (isUrlSafeForExternal(url, { includeUserDomains: false })) {
       setImmediate(() => shell.openExternal(url))
     }
     return { action: 'deny' }
   })
 
   mainWindow.webContents.on('will-navigate', (event, url) => {
-    const allowed = isMainWindowNavigationAllowed(url, rendererUrl)
+    const allowed = isMainWindowNavigationAllowed(url, rendererUrl, appDocUrl)
     if (!allowed) {
       mainLogger.warn(`Blocked in-page navigation to disallowed URL: ${url}`, 'main-window')
       event.preventDefault()

--- a/src/main/ipc/domains/jobs.ts
+++ b/src/main/ipc/domains/jobs.ts
@@ -1,26 +1,59 @@
 import { ipcMain } from 'electron'
 import { JOBS_CHANNELS } from '../../../shared/ipc/domains/jobs'
-import type { JobKind, JobStatus } from '../../../shared/types/jobs'
+import {
+  JobsGetParamsSchema,
+  JobsListParamsSchema,
+  JobsProgressParamsSchema
+} from '../../../shared/ipc/domains/jobs-schemas'
 import { jobRunner } from '../../services/jobs/runner'
 import { wrapHandler } from '../errorHandler'
+import { InvalidParametersError } from '../errors'
 
 /**
  * Registers the read-only `jobs:` channels against the process-wide
  * {@link jobRunner}. No renderer consumes these in PR-4; the contract exists so
  * Sprint D's jobs drawer can wire up without further IPC plumbing.
+ *
+ * Job ids are in-memory JobRunner Map keys (not filesystem paths), but every
+ * IPC arg is still validated at the boundary per repo convention.
  */
 export function registerJobsHandlers(): void {
-  ipcMain.handle(
-    JOBS_CHANNELS.list,
-    async (_event, filter?: { kind?: JobKind; status?: JobStatus }) =>
-      wrapHandler(async () => jobRunner.list(filter))
+  ipcMain.handle(JOBS_CHANNELS.list, async (_event, filter?: unknown) =>
+    wrapHandler(async () => {
+      const parsed = JobsListParamsSchema.safeParse([filter])
+      if (!parsed.success) {
+        throw new InvalidParametersError(
+          `Invalid ${JOBS_CHANNELS.list} params: ${parsed.error.message}`
+        )
+      }
+      const [validatedFilter] = parsed.data
+      return jobRunner.list(validatedFilter)
+    })
   )
 
-  ipcMain.handle(JOBS_CHANNELS.get, async (_event, jobId: string) =>
-    wrapHandler(async () => jobRunner.get(jobId) ?? null)
+  ipcMain.handle(JOBS_CHANNELS.get, async (_event, jobId?: unknown) =>
+    wrapHandler(async () => {
+      const parsed = JobsGetParamsSchema.safeParse([jobId])
+      if (!parsed.success) {
+        throw new InvalidParametersError(
+          `Invalid ${JOBS_CHANNELS.get} params: ${parsed.error.message}`
+        )
+      }
+      const [validatedJobId] = parsed.data
+      return jobRunner.get(validatedJobId) ?? null
+    })
   )
 
-  ipcMain.handle(JOBS_CHANNELS.progress, async (_event, jobId: string) =>
-    wrapHandler(async () => jobRunner.get(jobId)?.progress ?? null)
+  ipcMain.handle(JOBS_CHANNELS.progress, async (_event, jobId?: unknown) =>
+    wrapHandler(async () => {
+      const parsed = JobsProgressParamsSchema.safeParse([jobId])
+      if (!parsed.success) {
+        throw new InvalidParametersError(
+          `Invalid ${JOBS_CHANNELS.progress} params: ${parsed.error.message}`
+        )
+      }
+      const [validatedJobId] = parsed.data
+      return jobRunner.get(validatedJobId)?.progress ?? null
+    })
   )
 }

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -10,6 +10,7 @@ import { mainLogger } from '../../services/MainLogger'
 import { jobRunner } from '../../services/jobs/runner'
 import { checkDuplicates } from '../../import/batch-utils'
 import { ZipExtractor, TempDirectoryManager } from '../../import'
+import { addAllowedImportPath } from '../../security/import-path-allowlist'
 import { ImportWorkerClient } from '../../workers/import-worker-client'
 import { API_CONFIG } from '../../../shared/config'
 import type { FileImportRequest } from '../../../shared/types/import-worker'
@@ -278,6 +279,14 @@ export async function extractZip(
     const targetDir = zipTempManager.create()
 
     const result = await zipExtractor.extract(zipPath, targetDir, password)
+
+    // Files extracted from a dialog-enrolled ZIP were never themselves
+    // picked via a dialog. Enroll each one explicitly so the strict
+    // path-authority gate (batch-import:checkDuplicates / batch-import:start)
+    // accepts them in the subsequent review/import step.
+    for (const extractedFile of result.extractedFiles) {
+      addAllowedImportPath(extractedFile)
+    }
 
     return JSON.parse(
       JSON.stringify({

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -10,7 +10,6 @@ import { mainLogger } from '../../services/MainLogger'
 import { jobRunner } from '../../services/jobs/runner'
 import { checkDuplicates } from '../../import/batch-utils'
 import { ZipExtractor, TempDirectoryManager } from '../../import'
-import { addAllowedImportPath } from '../../security/import-path-allowlist'
 import { ImportWorkerClient } from '../../workers/import-worker-client'
 import { API_CONFIG } from '../../../shared/config'
 import type { FileImportRequest } from '../../../shared/types/import-worker'
@@ -268,7 +267,8 @@ export function testZipPassword(zipPath: string, password: string): { success: b
  */
 export async function extractZip(
   zipPath: string,
-  password?: string
+  password?: string,
+  onExtractedFile?: (filePath: string) => void
 ): Promise<{ files: string[]; errors: string[] }> {
   try {
     if (zipTempManager !== null) {
@@ -280,12 +280,10 @@ export async function extractZip(
 
     const result = await zipExtractor.extract(zipPath, targetDir, password)
 
-    // Files extracted from a dialog-enrolled ZIP were never themselves
-    // picked via a dialog. Enroll each one explicitly so the strict
-    // path-authority gate (batch-import:checkDuplicates / batch-import:start)
-    // accepts them in the subsequent review/import step.
-    for (const extractedFile of result.extractedFiles) {
-      addAllowedImportPath(extractedFile)
+    if (onExtractedFile !== undefined) {
+      for (const extractedFile of result.extractedFiles) {
+        onExtractedFile(extractedFile)
+      }
     }
 
     return JSON.parse(

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -30,6 +30,8 @@ let workerClient: ImportWorkerClient | null = null
 // ZIP extraction utilities
 const zipExtractor = new ZipExtractor()
 let zipTempManager: TempDirectoryManager | null = null
+let zipEnrolledPaths: string[] = []
+let revokeZipEnrollment: ((filePath: string) => void) | undefined
 
 /**
  * Check which files have duplicate case names in the database.
@@ -268,9 +270,11 @@ export function testZipPassword(zipPath: string, password: string): { success: b
 export async function extractZip(
   zipPath: string,
   password?: string,
-  onExtractedFile?: (filePath: string) => void
+  onExtractedFile?: (filePath: string) => void,
+  onRemoveExtractedFile?: (filePath: string) => void
 ): Promise<{ files: string[]; errors: string[] }> {
   try {
+    revokeExtractedPaths()
     if (zipTempManager !== null) {
       zipTempManager.cleanup()
     }
@@ -284,6 +288,8 @@ export async function extractZip(
       for (const extractedFile of result.extractedFiles) {
         onExtractedFile(extractedFile)
       }
+      zipEnrolledPaths = [...result.extractedFiles]
+      revokeZipEnrollment = onRemoveExtractedFile
     }
 
     return JSON.parse(
@@ -298,6 +304,7 @@ export async function extractZip(
       zipTempManager.cleanup()
       zipTempManager = null
     }
+    revokeExtractedPaths()
     return {
       files: [],
       errors: [error instanceof Error ? error.message : 'Extraction failed']
@@ -309,8 +316,19 @@ export async function extractZip(
  * Clean up temporary ZIP extraction directory.
  */
 export function cleanupZipTemp(): void {
+  revokeExtractedPaths()
   if (zipTempManager !== null) {
     zipTempManager.cleanup()
     zipTempManager = null
   }
+}
+
+function revokeExtractedPaths(): void {
+  if (revokeZipEnrollment !== undefined) {
+    for (const filePath of zipEnrolledPaths) {
+      revokeZipEnrollment(filePath)
+    }
+  }
+  zipEnrolledPaths = []
+  revokeZipEnrollment = undefined
 }

--- a/src/main/ipc/handlers/batch-import-logic.ts
+++ b/src/main/ipc/handlers/batch-import-logic.ts
@@ -6,6 +6,7 @@
  * without mocking Electron internals.
  */
 import { basename } from 'path'
+import { randomUUID } from 'node:crypto'
 import { mainLogger } from '../../services/MainLogger'
 import { jobRunner } from '../../services/jobs/runner'
 import { checkDuplicates } from '../../import/batch-utils'
@@ -29,9 +30,15 @@ let workerClient: ImportWorkerClient | null = null
 
 // ZIP extraction utilities
 const zipExtractor = new ZipExtractor()
-let zipTempManager: TempDirectoryManager | null = null
-let zipEnrolledPaths: string[] = []
-let revokeZipEnrollment: ((filePath: string) => void) | undefined
+
+interface ActiveZipExtraction {
+  manager: TempDirectoryManager
+  enrolledPaths: string[]
+  revokeEnrollment?: (filePath: string) => void
+}
+
+const zipExtractions = new Map<string, ActiveZipExtraction>()
+const MAX_ACTIVE_ZIP_EXTRACTIONS = 4
 
 /**
  * Check which files have duplicate case names in the database.
@@ -272,15 +279,16 @@ export async function extractZip(
   password?: string,
   onExtractedFile?: (filePath: string) => void,
   onRemoveExtractedFile?: (filePath: string) => void
-): Promise<{ files: string[]; errors: string[] }> {
+): Promise<{ files: string[]; errors: string[]; extractionId: string }> {
+  const manager = new TempDirectoryManager()
+  const extractionId = randomUUID()
   try {
-    revokeExtractedPaths()
-    if (zipTempManager !== null) {
-      zipTempManager.cleanup()
+    if (zipExtractions.size >= MAX_ACTIVE_ZIP_EXTRACTIONS) {
+      throw new Error('Too many active ZIP extractions; clean up an existing extraction first')
     }
-
-    zipTempManager = new TempDirectoryManager()
-    const targetDir = zipTempManager.create()
+    const targetDir = manager.create()
+    const extraction: ActiveZipExtraction = { manager, enrolledPaths: [] }
+    zipExtractions.set(extractionId, extraction)
 
     const result = await zipExtractor.extract(zipPath, targetDir, password)
 
@@ -288,26 +296,39 @@ export async function extractZip(
       for (const extractedFile of result.extractedFiles) {
         onExtractedFile(extractedFile)
       }
-      zipEnrolledPaths = [...result.extractedFiles]
-      revokeZipEnrollment = onRemoveExtractedFile
+      extraction.enrolledPaths = [...result.extractedFiles]
+      extraction.revokeEnrollment = onRemoveExtractedFile
     }
 
     return JSON.parse(
       JSON.stringify({
         files: result.extractedFiles,
-        errors: result.errors
+        errors: result.errors,
+        extractionId
       })
     )
   } catch (error) {
     mainLogger.error(`batch-import:extractZip error: ${error}`, 'import')
-    if (zipTempManager !== null) {
-      zipTempManager.cleanup()
-      zipTempManager = null
+    const extraction = zipExtractions.get(extractionId)
+    if (extraction !== undefined) {
+      revokeExtractedPaths(extraction)
+      try {
+        extraction.manager.cleanup()
+        zipExtractions.delete(extractionId)
+      } catch (cleanupError) {
+        mainLogger.error(`batch-import:cleanupZipTemp error: ${cleanupError}`, 'import')
+      }
+    } else {
+      try {
+        manager.cleanup()
+      } catch (cleanupError) {
+        mainLogger.error(`batch-import:cleanupZipTemp error: ${cleanupError}`, 'import')
+      }
     }
-    revokeExtractedPaths()
     return {
       files: [],
-      errors: [error instanceof Error ? error.message : 'Extraction failed']
+      errors: [error instanceof Error ? error.message : 'Extraction failed'],
+      extractionId
     }
   }
 }
@@ -315,20 +336,21 @@ export async function extractZip(
 /**
  * Clean up temporary ZIP extraction directory.
  */
-export function cleanupZipTemp(): void {
-  revokeExtractedPaths()
-  if (zipTempManager !== null) {
-    zipTempManager.cleanup()
-    zipTempManager = null
-  }
+export function cleanupZipTemp(extractionId: string): void {
+  const extraction = zipExtractions.get(extractionId)
+  if (extraction === undefined) return
+
+  revokeExtractedPaths(extraction)
+  extraction.manager.cleanup()
+  zipExtractions.delete(extractionId)
 }
 
-function revokeExtractedPaths(): void {
-  if (revokeZipEnrollment !== undefined) {
-    for (const filePath of zipEnrolledPaths) {
-      revokeZipEnrollment(filePath)
+function revokeExtractedPaths(extraction: ActiveZipExtraction): void {
+  if (extraction.revokeEnrollment !== undefined) {
+    for (const filePath of extraction.enrolledPaths) {
+      extraction.revokeEnrollment(filePath)
     }
   }
-  zipEnrolledPaths = []
-  revokeZipEnrollment = undefined
+  extraction.enrolledPaths = []
+  extraction.revokeEnrollment = undefined
 }

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -250,7 +250,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
         if (!isStrictlyEnrolledPath(validatedZipPath)) {
           throwUnallowedBatchPath('batch-import:extractZip', validatedZipPath, 'zipPath')
         }
-        return extractZip(validatedZipPath, validatedPassword)
+        return extractZip(validatedZipPath, validatedPassword, addAllowedImportPath)
       })
     }
   )

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -8,7 +8,11 @@ import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import { loadSettings, saveSettings } from '../utils/settings-io'
 import { safeEmit } from '../utils/safeEmit'
-import { addAllowedImportPath, isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
+import {
+  addAllowedImportPath,
+  isStrictlyEnrolledPath,
+  removeAllowedImportPath
+} from '../../security/import-path-allowlist'
 import {
   BatchImportCheckDuplicatesParamsSchema,
   BatchImportExtractZipParamsSchema,
@@ -250,7 +254,12 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
         if (!isStrictlyEnrolledPath(validatedZipPath)) {
           throwUnallowedBatchPath('batch-import:extractZip', validatedZipPath, 'zipPath')
         }
-        return extractZip(validatedZipPath, validatedPassword, addAllowedImportPath)
+        return extractZip(
+          validatedZipPath,
+          validatedPassword,
+          addAllowedImportPath,
+          removeAllowedImportPath
+        )
       })
     }
   )

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -15,6 +15,7 @@ import {
 } from '../../security/import-path-allowlist'
 import {
   BatchImportCheckDuplicatesParamsSchema,
+  BatchImportCleanupZipParamsSchema,
   BatchImportExtractZipParamsSchema,
   BatchImportStartParamsSchema,
   BatchImportTestZipPasswordParamsSchema
@@ -264,9 +265,15 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
     }
   )
 
-  ipcMain.handle('batch-import:cleanupZipTemp', async () => {
+  ipcMain.handle('batch-import:cleanupZipTemp', async (_event, extractionId: unknown) => {
     return wrapHandler(async () => {
-      cleanupZipTemp()
+      const parsed = BatchImportCleanupZipParamsSchema.safeParse([extractionId])
+      if (!parsed.success) {
+        throw new InvalidParametersError(
+          `Invalid batch-import:cleanupZipTemp params: ${parsed.error.message}`
+        )
+      }
+      cleanupZipTemp(parsed.data[0])
     })
   })
 }

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -3,11 +3,18 @@ import { dirname, join } from 'path'
 import { readdir } from 'fs/promises'
 import type { HandlerDependencies } from '../types'
 import { ZipExtractor } from '../../import'
-import type { DuplicateChoice } from '../../../shared/types/api'
 import { mainLogger } from '../../services/MainLogger'
 import { wrapHandler } from '../errorHandler'
+import { InvalidParametersError } from '../errors'
 import { loadSettings, saveSettings } from '../utils/settings-io'
 import { safeEmit } from '../utils/safeEmit'
+import { addAllowedImportPath, isAllowedImportPath } from '../../security/import-path-allowlist'
+import {
+  BatchImportCheckDuplicatesParamsSchema,
+  BatchImportExtractZipParamsSchema,
+  BatchImportStartParamsSchema,
+  BatchImportTestZipPasswordParamsSchema
+} from '../../../shared/ipc/domains/batch-import-schemas'
 import {
   checkDuplicateFiles,
   startBatchImport,
@@ -17,6 +24,13 @@ import {
   cleanupZipTemp
 } from './batch-import-logic'
 import type { BatchImportCallbacks } from './batch-import-logic'
+
+function throwUnallowedBatchPath(channel: string, filePath: string, label = 'filePath'): never {
+  throw new InvalidParametersError(
+    `${channel}: ${label} is not in the allowed import paths: ${filePath}`,
+    'The selected file is not in an allowed location.'
+  )
+}
 
 // ZIP extractor for isEncrypted check (stays in handler — used with dialog)
 const zipExtractor = new ZipExtractor()
@@ -50,6 +64,10 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
 
       const firstFile = result.filePaths[0]
       await saveSettings({ ...settings, lastImportDirectory: dirname(firstFile) })
+
+      for (const p of result.filePaths) {
+        addAllowedImportPath(p)
+      }
 
       return result.filePaths
     })
@@ -87,6 +105,14 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
           })
           .map((entry) => join(folderPath, entry.name))
 
+        // The user only picked the containing folder via a dialog, not each
+        // file individually — enroll every file discovered inside it so the
+        // later checkDuplicates/start calls (which validate against the
+        // allowlist) accept them.
+        for (const f of files) {
+          addAllowedImportPath(f)
+        }
+
         return files
       } catch (error) {
         mainLogger.error(`Failed to read directory: ${error}`, 'import')
@@ -100,9 +126,21 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
    */
   ipcMain.handle(
     'batch-import:checkDuplicates',
-    async (_event, filePaths: string[], stripText?: string) => {
+    async (_event, filePaths: unknown, stripText?: unknown) => {
       return wrapHandler(async () => {
-        return checkDuplicateFiles(getDb, filePaths, stripText)
+        const parsed = BatchImportCheckDuplicatesParamsSchema.safeParse([filePaths, stripText])
+        if (!parsed.success) {
+          throw new InvalidParametersError(
+            `Invalid batch-import:checkDuplicates params: ${parsed.error.message}`
+          )
+        }
+        const [validatedFilePaths, validatedStripText] = parsed.data
+        validatedFilePaths.forEach((filePath, index) => {
+          if (!isAllowedImportPath(filePath)) {
+            throwUnallowedBatchPath('batch-import:checkDuplicates', filePath, `filePaths[${index}]`)
+          }
+        })
+        return checkDuplicateFiles(getDb, validatedFilePaths, validatedStripText)
       })
     }
   )
@@ -112,13 +150,29 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
    */
   ipcMain.handle(
     'batch-import:start',
-    async (_event, filePaths: string[], duplicateStrategy: DuplicateChoice, stripText?: string) => {
+    async (_event, filePaths: unknown, duplicateStrategy: unknown, stripText?: unknown) => {
       return wrapHandler(async () => {
-        return startBatchImport(
-          getDb,
+        const parsed = BatchImportStartParamsSchema.safeParse([
           filePaths,
           duplicateStrategy,
-          stripText,
+          stripText
+        ])
+        if (!parsed.success) {
+          throw new InvalidParametersError(
+            `Invalid batch-import:start params: ${parsed.error.message}`
+          )
+        }
+        const [validatedFilePaths, validatedStrategy, validatedStripText] = parsed.data
+        validatedFilePaths.forEach((filePath, index) => {
+          if (!isAllowedImportPath(filePath)) {
+            throwUnallowedBatchPath('batch-import:start', filePath, `filePaths[${index}]`)
+          }
+        })
+        return startBatchImport(
+          getDb,
+          validatedFilePaths,
+          validatedStrategy,
+          validatedStripText,
           batchImportCallbacks
         )
       })
@@ -152,6 +206,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
 
         const filePath = result.filePaths[0]
         await saveSettings({ ...settings, lastImportDirectory: dirname(filePath) })
+        addAllowedImportPath(filePath)
 
         const isEncrypted = zipExtractor.isEncrypted(filePath)
         return { filePath, isEncrypted }
@@ -164,18 +219,41 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
 
   ipcMain.handle(
     'batch-import:testZipPassword',
-    async (_event, zipPath: string, password: string) => {
+    async (_event, zipPath: unknown, password: unknown) => {
       return wrapHandler(async () => {
-        return testZipPassword(zipPath, password)
+        const parsed = BatchImportTestZipPasswordParamsSchema.safeParse([zipPath, password])
+        if (!parsed.success) {
+          throw new InvalidParametersError(
+            `Invalid batch-import:testZipPassword params: ${parsed.error.message}`
+          )
+        }
+        const [validatedZipPath, validatedPassword] = parsed.data
+        if (!isAllowedImportPath(validatedZipPath)) {
+          throwUnallowedBatchPath('batch-import:testZipPassword', validatedZipPath, 'zipPath')
+        }
+        return testZipPassword(validatedZipPath, validatedPassword)
       })
     }
   )
 
-  ipcMain.handle('batch-import:extractZip', async (_event, zipPath: string, password?: string) => {
-    return wrapHandler(async () => {
-      return extractZip(zipPath, password)
-    })
-  })
+  ipcMain.handle(
+    'batch-import:extractZip',
+    async (_event, zipPath: unknown, password?: unknown) => {
+      return wrapHandler(async () => {
+        const parsed = BatchImportExtractZipParamsSchema.safeParse([zipPath, password])
+        if (!parsed.success) {
+          throw new InvalidParametersError(
+            `Invalid batch-import:extractZip params: ${parsed.error.message}`
+          )
+        }
+        const [validatedZipPath, validatedPassword] = parsed.data
+        if (!isAllowedImportPath(validatedZipPath)) {
+          throwUnallowedBatchPath('batch-import:extractZip', validatedZipPath, 'zipPath')
+        }
+        return extractZip(validatedZipPath, validatedPassword)
+      })
+    }
+  )
 
   ipcMain.handle('batch-import:cleanupZipTemp', async () => {
     return wrapHandler(async () => {

--- a/src/main/ipc/handlers/batch-import.ts
+++ b/src/main/ipc/handlers/batch-import.ts
@@ -8,7 +8,7 @@ import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import { loadSettings, saveSettings } from '../utils/settings-io'
 import { safeEmit } from '../utils/safeEmit'
-import { addAllowedImportPath, isAllowedImportPath } from '../../security/import-path-allowlist'
+import { addAllowedImportPath, isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
 import {
   BatchImportCheckDuplicatesParamsSchema,
   BatchImportExtractZipParamsSchema,
@@ -136,7 +136,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
         }
         const [validatedFilePaths, validatedStripText] = parsed.data
         validatedFilePaths.forEach((filePath, index) => {
-          if (!isAllowedImportPath(filePath)) {
+          if (!isStrictlyEnrolledPath(filePath)) {
             throwUnallowedBatchPath('batch-import:checkDuplicates', filePath, `filePaths[${index}]`)
           }
         })
@@ -164,7 +164,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
         }
         const [validatedFilePaths, validatedStrategy, validatedStripText] = parsed.data
         validatedFilePaths.forEach((filePath, index) => {
-          if (!isAllowedImportPath(filePath)) {
+          if (!isStrictlyEnrolledPath(filePath)) {
             throwUnallowedBatchPath('batch-import:start', filePath, `filePaths[${index}]`)
           }
         })
@@ -228,7 +228,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
           )
         }
         const [validatedZipPath, validatedPassword] = parsed.data
-        if (!isAllowedImportPath(validatedZipPath)) {
+        if (!isStrictlyEnrolledPath(validatedZipPath)) {
           throwUnallowedBatchPath('batch-import:testZipPassword', validatedZipPath, 'zipPath')
         }
         return testZipPassword(validatedZipPath, validatedPassword)
@@ -247,7 +247,7 @@ export function registerBatchImportHandlers({ ipcMain, getDb }: HandlerDependenc
           )
         }
         const [validatedZipPath, validatedPassword] = parsed.data
-        if (!isAllowedImportPath(validatedZipPath)) {
+        if (!isStrictlyEnrolledPath(validatedZipPath)) {
           throwUnallowedBatchPath('batch-import:extractZip', validatedZipPath, 'zipPath')
         }
         return extractZip(validatedZipPath, validatedPassword)

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -13,7 +13,10 @@ import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
-import { addAllowedImportPath, isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
+import {
+  addAllowedDatabasePath,
+  isStrictlyEnrolledDatabasePath
+} from '../../security/database-path-allowlist'
 import type { DatabaseManager } from '../../services/DatabaseManager'
 import {
   DatabaseOpenSchema,
@@ -208,13 +211,13 @@ function createInsecureLocalPostgresSecretStore(userDataPath: string): SecretSto
  *
  * A path is allowed only if it was picked via a dialog this session
  * (`database:selectFile` / `database:selectSaveLocation`, which enroll into
- * the same session allowlist `import.ts` uses for import paths), already
+ * a database-scoped session allowlist), already
  * appears in the recent databases list, or is the currently active
  * database. This mirrors the `deleteDbFile` precedent (recent-list +
  * active-DB checks) while still allowing `create`/`open` to work with a
  * freshly dialog-selected path that isn't in the recent list yet.
  *
- * Uses the STRICT enrollment check (`isStrictlyEnrolledPath`), not the
+ * Uses the database-scoped STRICT enrollment check, not the
  * permissive `isAllowedImportPath` — the automatic home/userData/temp roots
  * that predicate grants for the original import flow do not apply here.
  * An arbitrary renderer-supplied string with no dialog/recent/active
@@ -222,7 +225,7 @@ function createInsecureLocalPostgresSecretStore(userDataPath: string): SecretSto
  * directory or the OS temp dir.
  */
 function isAllowedDatabasePath(candidate: string, getDbManager: () => DatabaseManager): boolean {
-  if (isStrictlyEnrolledPath(candidate)) return true
+  if (isStrictlyEnrolledDatabasePath(candidate)) return true
   if (!isAbsolute(candidate)) return false
 
   const canonical = resolve(candidate)
@@ -271,7 +274,7 @@ export function registerDatabaseHandlers({
     }
 
     const filePath = result.filePaths[0]
-    addAllowedImportPath(filePath)
+    addAllowedDatabasePath(filePath)
     return filePath
   })
 
@@ -301,7 +304,7 @@ export function registerDatabaseHandlers({
       return null
     }
 
-    addAllowedImportPath(result.filePath)
+    addAllowedDatabasePath(result.filePath)
     return result.filePath
   })
 

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -8,10 +8,13 @@
 
 import { app, dialog, safeStorage, shell } from 'electron'
 import { mkdir, readFile, writeFile } from 'fs/promises'
-import { dirname, join } from 'path'
+import { dirname, isAbsolute, join, resolve } from 'path'
 import { wrapHandler } from '../errorHandler'
+import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
+import { addAllowedImportPath, isAllowedImportPath } from '../../security/import-path-allowlist'
+import type { DatabaseManager } from '../../services/DatabaseManager'
 import {
   DatabaseOpenSchema,
   DatabaseCreateSchema,
@@ -199,6 +202,44 @@ function createInsecureLocalPostgresSecretStore(userDataPath: string): SecretSto
   )
 }
 
+/**
+ * DB path-authority gate for `database:open` / `database:create` /
+ * `database:showInFolder` / `database:removeRecent`.
+ *
+ * A path is allowed only if it was picked via a dialog this session
+ * (`database:selectFile` / `database:selectSaveLocation`, which enroll into
+ * the same session allowlist `import.ts` uses for import paths), already
+ * appears in the recent databases list, or is the currently active
+ * database. This mirrors the `deleteDbFile` precedent (recent-list +
+ * active-DB checks) while still allowing `create`/`open` to work with a
+ * freshly dialog-selected path that isn't in the recent list yet.
+ *
+ * Unlike `isAllowedImportPath`'s automatic home/userData/temp roots (which
+ * remain in play via the shared allowlist), an arbitrary renderer-supplied
+ * string with no dialog/recent/active provenance is rejected.
+ */
+function isAllowedDatabasePath(candidate: string, getDbManager: () => DatabaseManager): boolean {
+  if (isAllowedImportPath(candidate)) return true
+  if (!isAbsolute(candidate)) return false
+
+  const canonical = resolve(candidate)
+  if (canonical !== candidate) return false
+
+  const manager = getDbManager()
+
+  const currentPath = manager.getCurrentPath()
+  if (currentPath !== null && resolve(currentPath) === canonical) return true
+
+  return manager.getRecentDatabases().some((db) => resolve(db.path) === canonical)
+}
+
+function throwUnallowedDatabasePath(channel: string, path: string): never {
+  throw new InvalidParametersError(
+    `${channel}: path is not in the database path authority set: ${path}`,
+    'The selected database file is not in an allowed location.'
+  )
+}
+
 export function registerDatabaseHandlers({
   ipcMain,
   getDb,
@@ -226,7 +267,9 @@ export function registerDatabaseHandlers({
       return null
     }
 
-    return result.filePaths[0]
+    const filePath = result.filePaths[0]
+    addAllowedImportPath(filePath)
+    return filePath
   })
 
   /**
@@ -255,6 +298,7 @@ export function registerDatabaseHandlers({
       return null
     }
 
+    addAllowedImportPath(result.filePath)
     return result.filePath
   })
 
@@ -267,6 +311,9 @@ export function registerDatabaseHandlers({
       if (!validated.success) {
         mainLogger.error(`Invalid database:open params: ${validated.error.message}`, 'database')
         throw new Error('Invalid database open parameters')
+      }
+      if (!isAllowedDatabasePath(validated.data.path, getDbManager)) {
+        throwUnallowedDatabasePath('database:open', validated.data.path)
       }
       return openDatabase(validated.data, getDb, getDbManager, lifecycleCallbacks)
     })
@@ -281,6 +328,9 @@ export function registerDatabaseHandlers({
       if (!validated.success) {
         mainLogger.error(`Invalid database:create params: ${validated.error.message}`, 'database')
         throw new Error('Invalid database create parameters')
+      }
+      if (!isAllowedDatabasePath(validated.data.path, getDbManager)) {
+        throwUnallowedDatabasePath('database:create', validated.data.path)
       }
       return createDatabase(validated.data, getDbManager)
     })
@@ -441,6 +491,9 @@ export function registerDatabaseHandlers({
         )
         throw new Error('Invalid file path')
       }
+      if (!isAllowedDatabasePath(validated.data, getDbManager)) {
+        throwUnallowedDatabasePath('database:removeRecent', validated.data)
+      }
       return removeRecentDatabase(validated.data, getDbManager)
     })
   })
@@ -467,6 +520,9 @@ export function registerDatabaseHandlers({
       const validated = FilePathSchema.safeParse(path)
       if (!validated.success) {
         throw new Error('Invalid file path')
+      }
+      if (!isAllowedDatabasePath(validated.data, getDbManager)) {
+        throwUnallowedDatabasePath('database:showInFolder', validated.data)
       }
       shell.showItemInFolder(validated.data)
       return { success: true }

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -8,16 +8,15 @@
 
 import { app, dialog, safeStorage, shell } from 'electron'
 import { mkdir, readFile, writeFile } from 'fs/promises'
-import { dirname, isAbsolute, join, resolve } from 'path'
+import { dirname, join } from 'path'
 import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
 import {
   addAllowedDatabasePath,
-  isStrictlyEnrolledDatabasePath
+  isAllowedDatabasePath
 } from '../../security/database-path-allowlist'
-import type { DatabaseManager } from '../../services/DatabaseManager'
 import {
   DatabaseOpenSchema,
   DatabaseCreateSchema,
@@ -224,21 +223,6 @@ function createInsecureLocalPostgresSecretStore(userDataPath: string): SecretSto
  * provenance is rejected even if it happens to live under the user's home
  * directory or the OS temp dir.
  */
-function isAllowedDatabasePath(candidate: string, getDbManager: () => DatabaseManager): boolean {
-  if (isStrictlyEnrolledDatabasePath(candidate)) return true
-  if (!isAbsolute(candidate)) return false
-
-  const canonical = resolve(candidate)
-  if (canonical !== candidate) return false
-
-  const manager = getDbManager()
-
-  const currentPath = manager.getCurrentPath()
-  if (currentPath !== null && resolve(currentPath) === canonical) return true
-
-  return manager.getRecentDatabases().some((db) => resolve(db.path) === canonical)
-}
-
 function throwUnallowedDatabasePath(channel: string, path: string): never {
   throw new InvalidParametersError(
     `${channel}: path is not in the database path authority set: ${path}`,

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -13,7 +13,7 @@ import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
-import { addAllowedImportPath, isAllowedImportPath } from '../../security/import-path-allowlist'
+import { addAllowedImportPath, isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
 import type { DatabaseManager } from '../../services/DatabaseManager'
 import {
   DatabaseOpenSchema,
@@ -214,12 +214,15 @@ function createInsecureLocalPostgresSecretStore(userDataPath: string): SecretSto
  * active-DB checks) while still allowing `create`/`open` to work with a
  * freshly dialog-selected path that isn't in the recent list yet.
  *
- * Unlike `isAllowedImportPath`'s automatic home/userData/temp roots (which
- * remain in play via the shared allowlist), an arbitrary renderer-supplied
- * string with no dialog/recent/active provenance is rejected.
+ * Uses the STRICT enrollment check (`isStrictlyEnrolledPath`), not the
+ * permissive `isAllowedImportPath` — the automatic home/userData/temp roots
+ * that predicate grants for the original import flow do not apply here.
+ * An arbitrary renderer-supplied string with no dialog/recent/active
+ * provenance is rejected even if it happens to live under the user's home
+ * directory or the OS temp dir.
  */
 function isAllowedDatabasePath(candidate: string, getDbManager: () => DatabaseManager): boolean {
-  if (isAllowedImportPath(candidate)) return true
+  if (isStrictlyEnrolledPath(candidate)) return true
   if (!isAbsolute(candidate)) return false
 
   const canonical = resolve(candidate)

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -216,12 +216,10 @@ function createInsecureLocalPostgresSecretStore(userDataPath: string): SecretSto
  * active-DB checks) while still allowing `create`/`open` to work with a
  * freshly dialog-selected path that isn't in the recent list yet.
  *
- * Uses the database-scoped STRICT enrollment check, not the
- * permissive `isAllowedImportPath` — the automatic home/userData/temp roots
- * that predicate grants for the original import flow do not apply here.
- * An arbitrary renderer-supplied string with no dialog/recent/active
- * provenance is rejected even if it happens to live under the user's home
- * directory or the OS temp dir.
+ * Uses the database-scoped enrollment check so import-file authority cannot
+ * authorize a database operation. An arbitrary renderer-supplied string with
+ * no dialog/recent/active provenance is rejected even if it happens to live
+ * under the user's home directory or the OS temp dir.
  */
 function throwUnallowedDatabasePath(channel: string, path: string): never {
   throw new InvalidParametersError(

--- a/src/main/ipc/handlers/export.ts
+++ b/src/main/ipc/handlers/export.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
+import { addAllowedImportPath } from '../../security/import-path-allowlist'
 import {
   CohortSearchParamsSchema,
   VariantExportParamsSchema
@@ -100,6 +101,11 @@ export function registerExportHandlers({
           outputFilePath = result.filePath
         }
 
+        // The renderer's "Open folder" action calls shell:showItemInFolder
+        // with this same path -- enroll it so that channel's dialog-origin
+        // gate (see shell.ts) accepts it.
+        addAllowedImportPath(outputFilePath)
+
         /** Wire progress events to renderer via safeEmit. */
         const exportCallbacks: ExportCallbacks = {
           onProgress: (data) => {
@@ -190,6 +196,11 @@ export function registerExportHandlers({
           }
           outputFilePath = result.filePath
         }
+
+        // The renderer's "Open folder" action calls shell:showItemInFolder
+        // with this same path -- enroll it so that channel's dialog-origin
+        // gate (see shell.ts) accepts it.
+        addAllowedImportPath(outputFilePath)
 
         /** Wire progress events to renderer via safeEmit. */
         const exportCallbacks: ExportCallbacks = {

--- a/src/main/ipc/handlers/export.ts
+++ b/src/main/ipc/handlers/export.ts
@@ -1,11 +1,16 @@
-import { dialog, BrowserWindow } from 'electron'
+import { dialog, BrowserWindow, shell } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { wrapHandler } from '../errorHandler'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
-import { addAllowedImportPath } from '../../security/import-path-allowlist'
+import {
+  addAllowedExportRevealPath,
+  isAllowedExportRevealPath
+} from '../../security/export-path-allowlist'
+import { FilePathSchema } from '../../../shared/types/ipc-schemas'
+import { InvalidParametersError } from '../errors'
 import {
   CohortSearchParamsSchema,
   VariantExportParamsSchema
@@ -39,6 +44,25 @@ export function registerExportHandlers({
   getDb,
   getDbManager
 }: HandlerDependencies): void {
+  ipcMain.handle('export:revealInFolder', async (_event, filePath: unknown) => {
+    return wrapHandler(async () => {
+      const validated = FilePathSchema.safeParse(filePath)
+      if (!validated.success) {
+        throw new InvalidParametersError(
+          `Invalid export:revealInFolder params: ${validated.error.message}`
+        )
+      }
+      if (!isAllowedExportRevealPath(validated.data)) {
+        throw new InvalidParametersError(
+          `export:revealInFolder: path has no successful export authority: ${validated.data}`,
+          'The exported file is no longer available to reveal.'
+        )
+      }
+      shell.showItemInFolder(validated.data)
+      return { success: true }
+    })
+  })
+
   ipcMain.handle(
     'export:variants',
     async (
@@ -101,11 +125,6 @@ export function registerExportHandlers({
           outputFilePath = result.filePath
         }
 
-        // The renderer's "Open folder" action calls shell:showItemInFolder
-        // with this same path -- enroll it so that channel's dialog-origin
-        // gate (see shell.ts) accepts it.
-        addAllowedImportPath(outputFilePath)
-
         /** Wire progress events to renderer via safeEmit. */
         const exportCallbacks: ExportCallbacks = {
           onProgress: (data) => {
@@ -125,14 +144,16 @@ export function registerExportHandlers({
               }
             ]
           })) as AsyncIterable<Record<string, unknown>>
-          return await exportPostgresVariants(rows, outputFilePath, exportCallbacks)
+          const result = await exportPostgresVariants(rows, outputFilePath, exportCallbacks)
+          if (result.success) addAllowedExportRevealPath(outputFilePath)
+          return result
         }
 
         if (preparation === null) {
           throw new Error('SQLite export preparation was not created')
         }
 
-        return exportVariants(
+        const result = await exportVariants(
           getDb,
           preparation.compiled,
           validated.data.filters,
@@ -140,6 +161,8 @@ export function registerExportHandlers({
           outputFilePath,
           exportCallbacks
         )
+        if (result.success) addAllowedExportRevealPath(outputFilePath)
+        return result
       }) as Promise<{ success: boolean; filePath?: string; error?: string }>
     }
   )
@@ -197,11 +220,6 @@ export function registerExportHandlers({
           outputFilePath = result.filePath
         }
 
-        // The renderer's "Open folder" action calls shell:showItemInFolder
-        // with this same path -- enroll it so that channel's dialog-origin
-        // gate (see shell.ts) accepts it.
-        addAllowedImportPath(outputFilePath)
-
         /** Wire progress events to renderer via safeEmit. */
         const exportCallbacks: ExportCallbacks = {
           onProgress: (data) => {
@@ -216,10 +234,14 @@ export function registerExportHandlers({
             type: 'export:cohort',
             params: [validated.data]
           })) as AsyncIterable<Record<string, unknown>>
-          return await exportPostgresCohort(rows, outputFilePath, exportCallbacks)
+          const result = await exportPostgresCohort(rows, outputFilePath, exportCallbacks)
+          if (result.success) addAllowedExportRevealPath(outputFilePath)
+          return result
         }
 
-        return exportCohort(getDb, validated.data, outputFilePath)
+        const result = await exportCohort(getDb, validated.data, outputFilePath)
+        if (result.success) addAllowedExportRevealPath(outputFilePath)
+        return result
       }) as Promise<{ success: boolean; filePath?: string; error?: string }>
     }
   )

--- a/src/main/ipc/handlers/gene-lists.ts
+++ b/src/main/ipc/handlers/gene-lists.ts
@@ -1,4 +1,5 @@
 import { wrapHandler } from '../errorHandler'
+import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { readFile } from 'node:fs/promises'
 import {
@@ -9,6 +10,7 @@ import {
   BedImportSchema
 } from '../../../shared/types/ipc-schemas'
 import { mainLogger } from '../../services/MainLogger'
+import { isAllowedImportPath } from '../../security/import-path-allowlist'
 
 /**
  * Gene Lists and Region Files IPC handlers
@@ -213,6 +215,13 @@ export function registerGeneListHandlers({
           'gene-lists'
         )
         throw new Error('Invalid BED import parameters')
+      }
+
+      if (!isAllowedImportPath(validated.data.filePath)) {
+        throw new InvalidParametersError(
+          `region-files:importBed: filePath is not in the allowed import paths: ${validated.data.filePath}`,
+          'The selected file is not in an allowed location.'
+        )
       }
 
       const content = await readFile(validated.data.filePath, 'utf-8')

--- a/src/main/ipc/handlers/gene-lists.ts
+++ b/src/main/ipc/handlers/gene-lists.ts
@@ -10,7 +10,7 @@ import {
   BedImportSchema
 } from '../../../shared/types/ipc-schemas'
 import { mainLogger } from '../../services/MainLogger'
-import { isAllowedImportPath } from '../../security/import-path-allowlist'
+import { isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
 
 /**
  * Gene Lists and Region Files IPC handlers
@@ -217,7 +217,7 @@ export function registerGeneListHandlers({
         throw new Error('Invalid BED import parameters')
       }
 
-      if (!isAllowedImportPath(validated.data.filePath)) {
+      if (!isStrictlyEnrolledPath(validated.data.filePath)) {
         throw new InvalidParametersError(
           `region-files:importBed: filePath is not in the allowed import paths: ${validated.data.filePath}`,
           'The selected file is not in an allowed location.'

--- a/src/main/ipc/handlers/import.ts
+++ b/src/main/ipc/handlers/import.ts
@@ -1,14 +1,22 @@
 import { dialog } from 'electron'
-import { dirname } from 'path'
+import { statSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
 import type { z } from 'zod'
 import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { safeEmit } from '../utils/safeEmit'
 import { loadSettings, saveSettings } from '../utils/settings-io'
-import { addAllowedImportPath, isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
+import {
+  addAllowedImportPath,
+  isStrictlyEnrolledPath,
+  isTrustedImportPathEnrollmentToken,
+  registerTrustedImportPathEnrollmentToken
+} from '../../security/import-path-allowlist'
 import {
   ImportFiltersIpcPayloadSchema,
+  ImportEnrollDroppedFilesParamsSchema,
+  ImportRegisterDroppedFileEnrollmentTokenParamsSchema,
   ImportStartMultiFileParamsSchema,
   ImportStartParamsSchema,
   ImportVcfMultiPreviewParamsSchema,
@@ -26,6 +34,7 @@ import type { ImportFilters } from '../../import/vcf/import-filters'
 import type { StorageSession } from '../../storage/session'
 import { BedFilter } from '../../import/vcf/bed-filter'
 import { mainLogger } from '../../services/MainLogger'
+import type { VcfMultiPreviewResult } from '../../../shared/types/import'
 
 /**
  * Serializable filter payload sent from the renderer over IPC.
@@ -84,6 +93,40 @@ function throwUnallowedImportPath(channel: string, filePath: string, label = 'fi
     `${channel}: ${label} is not in the allowed import paths: ${filePath}`,
     'The selected file is not in an allowed location.'
   )
+}
+
+function isSupportedDroppedVcf(filePath: string): boolean {
+  if (!isAbsolute(filePath) || resolve(filePath) !== filePath) return false
+  const lower = filePath.toLowerCase()
+  if (!lower.endsWith('.vcf') && !lower.endsWith('.vcf.gz')) return false
+  return isRegularFile(filePath)
+}
+
+function isRegularFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile()
+  } catch {
+    return false
+  }
+}
+
+function enrollTrustedSiblingBeds(
+  preview: VcfMultiPreviewResult,
+  selectedVcfPaths: string[]
+): void {
+  const selectedDirectories = new Set(selectedVcfPaths.map((filePath) => dirname(filePath)))
+  for (const bedFile of preview.siblingBedFiles) {
+    const lower = bedFile.toLowerCase()
+    if (
+      isAbsolute(bedFile) &&
+      resolve(bedFile) === bedFile &&
+      selectedDirectories.has(dirname(bedFile)) &&
+      (lower.endsWith('.bed') || lower.endsWith('.bed.gz')) &&
+      isRegularFile(bedFile)
+    ) {
+      addAllowedImportPath(bedFile)
+    }
+  }
 }
 
 /** Shared callbacks that wire logic-layer events to renderer via safeEmit. */
@@ -256,7 +299,45 @@ export function registerImportHandlers({
           throwUnallowedImportPath('import:vcfMultiPreview', filePath, `filePaths[${index}]`)
         }
       })
-      return getVcfMultiPreview(validatedPaths)
+      const preview = (await getVcfMultiPreview(validatedPaths)) as VcfMultiPreviewResult
+      enrollTrustedSiblingBeds(preview, validatedPaths)
+      return preview
+    })
+  })
+
+  // `window.api.import.enrollDroppedFiles` accepts browser File objects, not
+  // strings. Preload converts only genuine Electron-backed Files with
+  // webUtils.getPathForFile and attaches a preload-held token before invoking
+  // this internal channel.
+  ipcMain.handle('import:registerDroppedFileEnrollmentToken', async (_event, token: unknown) => {
+    return wrapHandler(async () => {
+      const parsed = ImportRegisterDroppedFileEnrollmentTokenParamsSchema.safeParse([token])
+      if (!parsed.success) {
+        throw new InvalidParametersError(
+          `Invalid import:registerDroppedFileEnrollmentToken params: ${parsed.error.message}`
+        )
+      }
+      registerTrustedImportPathEnrollmentToken(parsed.data[0])
+    })
+  })
+
+  ipcMain.handle('import:enrollDroppedFiles', async (_event, filePaths: unknown) => {
+    return wrapHandler(async () => {
+      const parsed = ImportEnrollDroppedFilesParamsSchema.safeParse([filePaths])
+      if (!parsed.success) {
+        throw new InvalidParametersError(
+          `Invalid import:enrollDroppedFiles params: ${parsed.error.message}`
+        )
+      }
+      const [payload] = parsed.data
+      if (!isTrustedImportPathEnrollmentToken(payload.token)) {
+        throw new InvalidParametersError(
+          'import:enrollDroppedFiles: missing trusted preload enrollment token'
+        )
+      }
+      const enrolledPaths = payload.filePaths.filter(isSupportedDroppedVcf)
+      for (const filePath of enrolledPaths) addAllowedImportPath(filePath)
+      return enrolledPaths
     })
   })
 

--- a/src/main/ipc/handlers/import.ts
+++ b/src/main/ipc/handlers/import.ts
@@ -6,7 +6,7 @@ import { InvalidParametersError } from '../errors'
 import type { HandlerDependencies } from '../types'
 import { safeEmit } from '../utils/safeEmit'
 import { loadSettings, saveSettings } from '../utils/settings-io'
-import { addAllowedImportPath, isAllowedImportPath } from '../../security/import-path-allowlist'
+import { addAllowedImportPath, isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
 import {
   ImportFiltersIpcPayloadSchema,
   ImportStartMultiFileParamsSchema,
@@ -142,7 +142,7 @@ export function registerImportHandlers({
         }
 
         const [validatedPath, validatedCaseName, validatedOptions] = parsed.data
-        if (!isAllowedImportPath(validatedPath)) {
+        if (!isStrictlyEnrolledPath(validatedPath)) {
           throwUnallowedImportPath('import:start', validatedPath)
         }
         return startImport(
@@ -181,7 +181,7 @@ export function registerImportHandlers({
         const [validatedCaseName, validatedFiles, validatedOptions, validatedFiltersPayload] =
           parsed.data
         validatedFiles.forEach((file, index) => {
-          if (!isAllowedImportPath(file.filePath)) {
+          if (!isStrictlyEnrolledPath(file.filePath)) {
             throwUnallowedImportPath(
               'import:startMultiFile',
               file.filePath,
@@ -195,7 +195,7 @@ export function registerImportHandlers({
           bedFile !== undefined &&
           bedFile !== null &&
           bedFile !== '' &&
-          !isAllowedImportPath(bedFile)
+          !isStrictlyEnrolledPath(bedFile)
         ) {
           throwUnallowedImportPath('import:startMultiFile', bedFile, 'filtersPayload.bedFile')
         }
@@ -234,7 +234,7 @@ export function registerImportHandlers({
       }
 
       const [validatedPath] = parsed.data
-      if (!isAllowedImportPath(validatedPath)) {
+      if (!isStrictlyEnrolledPath(validatedPath)) {
         throwUnallowedImportPath('import:vcfPreview', validatedPath)
       }
       return getVcfPreview(validatedPath)
@@ -252,7 +252,7 @@ export function registerImportHandlers({
 
       const [validatedPaths] = parsed.data
       validatedPaths.forEach((filePath, index) => {
-        if (!isAllowedImportPath(filePath)) {
+        if (!isStrictlyEnrolledPath(filePath)) {
           throwUnallowedImportPath('import:vcfMultiPreview', filePath, `filePaths[${index}]`)
         }
       })

--- a/src/main/ipc/handlers/shell.ts
+++ b/src/main/ipc/handlers/shell.ts
@@ -64,10 +64,9 @@ export function registerShellHandlers({ ipcMain, getDbManager }: HandlerDependen
    * Show file in system file manager
    * Used for export feedback ("Open folder" action). The path always
    * originates from a path this session's dialogs produced (an export
-   * save-dialog result, a picked import/BED/database file, ...), so it must
-   * be strictly dialog-enrolled -- the automatic home/userData/temp roots
-   * `isAllowedImportPath` grants for the import flow do not apply here, so
-   * an arbitrary renderer-supplied path under those roots is still rejected.
+   * save-dialog result, a picked import/BED/database file, ...), so an
+   * arbitrary renderer-supplied path is rejected even when it is under the
+   * user's home directory or the OS temp directory.
    */
   ipcMain.handle('shell:showItemInFolder', async (_event, filePath: unknown) => {
     return wrapHandler(async () => {

--- a/src/main/ipc/handlers/shell.ts
+++ b/src/main/ipc/handlers/shell.ts
@@ -6,6 +6,7 @@ import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import { setUserDomains, isUrlSafeForExternal } from '../../utils/url-validation'
 import { isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
+import { isAllowedDatabasePath } from '../../security/database-path-allowlist'
 
 /**
  * Shell IPC handlers
@@ -25,7 +26,7 @@ const FilePathSchema = z.string().min(1).max(1024)
 /** Schema for user domains array */
 const UserDomainsSchema = z.array(z.string().min(1).max(253)).max(100)
 
-export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
+export function registerShellHandlers({ ipcMain, getDbManager }: HandlerDependencies): void {
   ipcMain.handle('shell:updateUserDomains', async (_event, domains: unknown) => {
     return wrapHandler(async () => {
       // ANTI-07: Runtime validation at IPC boundary
@@ -80,9 +81,14 @@ export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
         throw new Error('Invalid parameters')
       }
 
-      if (!isStrictlyEnrolledPath(validated.data)) {
+      const hasImportAuthority = isStrictlyEnrolledPath(validated.data)
+      const hasDatabaseAuthority =
+        !hasImportAuthority && getDbManager !== undefined
+          ? isAllowedDatabasePath(validated.data, getDbManager)
+          : false
+      if (!hasImportAuthority && !hasDatabaseAuthority) {
         throw new InvalidParametersError(
-          `shell:showItemInFolder: filePath is not in the allowed import paths: ${validated.data}`,
+          `shell:showItemInFolder: filePath is not in the path authority set: ${validated.data}`,
           'The selected file is not in an allowed location.'
         )
       }

--- a/src/main/ipc/handlers/shell.ts
+++ b/src/main/ipc/handlers/shell.ts
@@ -3,7 +3,9 @@ import { shell } from 'electron'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
 import { wrapHandler } from '../errorHandler'
+import { InvalidParametersError } from '../errors'
 import { setUserDomains, isUrlSafeForExternal } from '../../utils/url-validation'
+import { isAllowedImportPath } from '../../security/import-path-allowlist'
 
 /**
  * Shell IPC handlers
@@ -59,7 +61,11 @@ export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
 
   /**
    * Show file in system file manager
-   * Used for export feedback ("Open folder" action)
+   * Used for export feedback ("Open folder" action). The path always
+   * originates from a path this session's dialogs produced (an export
+   * save-dialog result, a picked import/BED/database file, ...), so it is
+   * gated by the same session-scoped allowlist import.ts and database.ts
+   * enroll into -- an arbitrary renderer-supplied path is rejected.
    */
   ipcMain.handle('shell:showItemInFolder', async (_event, filePath: unknown) => {
     return wrapHandler(async () => {
@@ -71,6 +77,13 @@ export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
           'shell'
         )
         throw new Error('Invalid parameters')
+      }
+
+      if (!isAllowedImportPath(validated.data)) {
+        throw new InvalidParametersError(
+          `shell:showItemInFolder: filePath is not in the allowed import paths: ${validated.data}`,
+          'The selected file is not in an allowed location.'
+        )
       }
 
       shell.showItemInFolder(validated.data)

--- a/src/main/ipc/handlers/shell.ts
+++ b/src/main/ipc/handlers/shell.ts
@@ -5,7 +5,7 @@ import { mainLogger } from '../../services/MainLogger'
 import { wrapHandler } from '../errorHandler'
 import { InvalidParametersError } from '../errors'
 import { setUserDomains, isUrlSafeForExternal } from '../../utils/url-validation'
-import { isAllowedImportPath } from '../../security/import-path-allowlist'
+import { isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
 
 /**
  * Shell IPC handlers
@@ -63,9 +63,10 @@ export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
    * Show file in system file manager
    * Used for export feedback ("Open folder" action). The path always
    * originates from a path this session's dialogs produced (an export
-   * save-dialog result, a picked import/BED/database file, ...), so it is
-   * gated by the same session-scoped allowlist import.ts and database.ts
-   * enroll into -- an arbitrary renderer-supplied path is rejected.
+   * save-dialog result, a picked import/BED/database file, ...), so it must
+   * be strictly dialog-enrolled -- the automatic home/userData/temp roots
+   * `isAllowedImportPath` grants for the import flow do not apply here, so
+   * an arbitrary renderer-supplied path under those roots is still rejected.
    */
   ipcMain.handle('shell:showItemInFolder', async (_event, filePath: unknown) => {
     return wrapHandler(async () => {
@@ -79,7 +80,7 @@ export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
         throw new Error('Invalid parameters')
       }
 
-      if (!isAllowedImportPath(validated.data)) {
+      if (!isStrictlyEnrolledPath(validated.data)) {
         throw new InvalidParametersError(
           `shell:showItemInFolder: filePath is not in the allowed import paths: ${validated.data}`,
           'The selected file is not in an allowed location.'

--- a/src/main/ipc/handlers/shell.ts
+++ b/src/main/ipc/handlers/shell.ts
@@ -3,30 +3,23 @@ import { shell } from 'electron'
 import type { HandlerDependencies } from '../types'
 import { mainLogger } from '../../services/MainLogger'
 import { wrapHandler } from '../errorHandler'
-import { InvalidParametersError } from '../errors'
 import { setUserDomains, isUrlSafeForExternal } from '../../utils/url-validation'
-import { isStrictlyEnrolledPath } from '../../security/import-path-allowlist'
-import { isAllowedDatabasePath } from '../../security/database-path-allowlist'
 
 /**
  * Shell IPC handlers
- * Channels: shell:openExternal, shell:showItemInFolder, shell:updateUserDomains
+ * Channels: shell:openExternal, shell:updateUserDomains
  *
  * Opens external URLs in the system browser with security validation.
  * Only HTTPS URLs on whitelisted domains are allowed.
- * Shows files in system file manager for export feedback.
  */
 
 /** Schema for URL string */
 const UrlSchema = z.string().min(1).max(2048)
 
-/** Schema for file path string */
-const FilePathSchema = z.string().min(1).max(1024)
-
 /** Schema for user domains array */
 const UserDomainsSchema = z.array(z.string().min(1).max(253)).max(100)
 
-export function registerShellHandlers({ ipcMain, getDbManager }: HandlerDependencies): void {
+export function registerShellHandlers({ ipcMain }: HandlerDependencies): void {
   ipcMain.handle('shell:updateUserDomains', async (_event, domains: unknown) => {
     return wrapHandler(async () => {
       // ANTI-07: Runtime validation at IPC boundary
@@ -56,43 +49,6 @@ export function registerShellHandlers({ ipcMain, getDbManager }: HandlerDependen
       }
 
       await shell.openExternal(validated.data)
-      return { success: true }
-    })
-  })
-
-  /**
-   * Show file in system file manager
-   * Used for export feedback ("Open folder" action). The path always
-   * originates from a path this session's dialogs produced (an export
-   * save-dialog result, a picked import/BED/database file, ...), so an
-   * arbitrary renderer-supplied path is rejected even when it is under the
-   * user's home directory or the OS temp directory.
-   */
-  ipcMain.handle('shell:showItemInFolder', async (_event, filePath: unknown) => {
-    return wrapHandler(async () => {
-      // ANTI-07: Runtime validation at IPC boundary
-      const validated = FilePathSchema.safeParse(filePath)
-      if (!validated.success) {
-        mainLogger.error(
-          `Invalid shell:showItemInFolder params: ${validated.error.message}`,
-          'shell'
-        )
-        throw new Error('Invalid parameters')
-      }
-
-      const hasImportAuthority = isStrictlyEnrolledPath(validated.data)
-      const hasDatabaseAuthority =
-        !hasImportAuthority && getDbManager !== undefined
-          ? isAllowedDatabasePath(validated.data, getDbManager)
-          : false
-      if (!hasImportAuthority && !hasDatabaseAuthority) {
-        throw new InvalidParametersError(
-          `shell:showItemInFolder: filePath is not in the path authority set: ${validated.data}`,
-          'The selected file is not in an allowed location.'
-        )
-      }
-
-      shell.showItemInFolder(validated.data)
       return { success: true }
     })
   })

--- a/src/main/security/database-path-allowlist.ts
+++ b/src/main/security/database-path-allowlist.ts
@@ -1,10 +1,12 @@
-import { isAbsolute, resolve } from 'path'
+import { lstatSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
 import type { DatabaseManager } from '../services/DatabaseManager'
 import { PathAuthorityStore } from './path-authority-store'
 
 const dialogAllowedDatabasePaths = new PathAuthorityStore()
 
 export function addAllowedDatabasePath(absolutePath: string): void {
+  if (!isAbsolute(absolutePath) || resolve(absolutePath) !== absolutePath) return
   dialogAllowedDatabasePaths.add(absolutePath)
 }
 
@@ -27,10 +29,40 @@ export function isAllowedDatabasePath(
   const canonical = resolve(candidate)
   if (canonical !== candidate) return false
 
+  // A dialog enrollment is a pinned capability. If its target changed,
+  // fail closed instead of resurrecting the stale path merely because the
+  // same lexical string is still present in current/recent metadata.
+  if (dialogAllowedDatabasePaths.hasEnrollment(canonical)) {
+    return dialogAllowedDatabasePaths.isAuthorized(canonical)
+  }
+
+  // Persisted current/recent metadata records only a lexical path; it does
+  // not retain the real target needed to pin a symlink. Require the user to
+  // select such paths again so the session store can capture that target.
+  if (resolvesThroughSymlink(canonical)) return false
+
   const manager = getDbManager()
   const currentPath = manager.getCurrentPath()
-  if (currentPath !== null && resolve(currentPath) === canonical) return true
-  return manager.getRecentDatabases().some((db) => resolve(db.path) === canonical)
+  if (currentPath !== null && isExactMetadataPath(currentPath, canonical)) return true
+  return manager.getRecentDatabases().some((db) => isExactMetadataPath(db.path, canonical))
+}
+
+function isExactMetadataPath(storedPath: string, candidate: string): boolean {
+  return isAbsolute(storedPath) && resolve(storedPath) === storedPath && storedPath === candidate
+}
+
+function resolvesThroughSymlink(filePath: string): boolean {
+  let cursor = filePath
+  while (true) {
+    try {
+      if (lstatSync(cursor).isSymbolicLink()) return true
+    } catch {
+      // Missing leaf paths may still have a symlinked existing ancestor.
+    }
+    const parent = dirname(cursor)
+    if (parent === cursor) return false
+    cursor = parent
+  }
 }
 
 /** Test-only reset helper. Do not call from production code. */

--- a/src/main/security/database-path-allowlist.ts
+++ b/src/main/security/database-path-allowlist.ts
@@ -1,0 +1,40 @@
+import { realpathSync } from 'fs'
+import { isAbsolute, resolve } from 'path'
+
+const dialogAllowedDatabasePaths = new Set<string>()
+
+export function addAllowedDatabasePath(absolutePath: string): void {
+  const resolved = resolve(absolutePath)
+  dialogAllowedDatabasePaths.add(resolved)
+
+  const realPath = tryRealpath(resolved)
+  if (realPath !== null) {
+    dialogAllowedDatabasePaths.add(realPath)
+  }
+}
+
+export function isStrictlyEnrolledDatabasePath(candidate: string): boolean {
+  if (!isAbsolute(candidate)) return false
+
+  const resolved = resolve(candidate)
+  if (resolved !== candidate) return false
+
+  const realCandidate = tryRealpath(resolved)
+  return (
+    dialogAllowedDatabasePaths.has(resolved) ||
+    (realCandidate !== null && dialogAllowedDatabasePaths.has(realCandidate))
+  )
+}
+
+/** Test-only reset helper. Do not call from production code. */
+export function __resetDatabasePathAllowlistForTests(): void {
+  dialogAllowedDatabasePaths.clear()
+}
+
+function tryRealpath(filePath: string): string | null {
+  try {
+    return realpathSync.native(filePath)
+  } catch {
+    return null
+  }
+}

--- a/src/main/security/database-path-allowlist.ts
+++ b/src/main/security/database-path-allowlist.ts
@@ -1,16 +1,11 @@
-import { realpathSync } from 'fs'
 import { isAbsolute, resolve } from 'path'
+import type { DatabaseManager } from '../services/DatabaseManager'
+import { PathAuthorityStore } from './path-authority-store'
 
-const dialogAllowedDatabasePaths = new Set<string>()
+const dialogAllowedDatabasePaths = new PathAuthorityStore()
 
 export function addAllowedDatabasePath(absolutePath: string): void {
-  const resolved = resolve(absolutePath)
-  dialogAllowedDatabasePaths.add(resolved)
-
-  const realPath = tryRealpath(resolved)
-  if (realPath !== null) {
-    dialogAllowedDatabasePaths.add(realPath)
-  }
+  dialogAllowedDatabasePaths.add(absolutePath)
 }
 
 export function isStrictlyEnrolledDatabasePath(candidate: string): boolean {
@@ -19,22 +14,26 @@ export function isStrictlyEnrolledDatabasePath(candidate: string): boolean {
   const resolved = resolve(candidate)
   if (resolved !== candidate) return false
 
-  const realCandidate = tryRealpath(resolved)
-  return (
-    dialogAllowedDatabasePaths.has(resolved) ||
-    (realCandidate !== null && dialogAllowedDatabasePaths.has(realCandidate))
-  )
+  return dialogAllowedDatabasePaths.isAuthorized(resolved)
+}
+
+export function isAllowedDatabasePath(
+  candidate: string,
+  getDbManager: () => DatabaseManager
+): boolean {
+  if (isStrictlyEnrolledDatabasePath(candidate)) return true
+  if (!isAbsolute(candidate)) return false
+
+  const canonical = resolve(candidate)
+  if (canonical !== candidate) return false
+
+  const manager = getDbManager()
+  const currentPath = manager.getCurrentPath()
+  if (currentPath !== null && resolve(currentPath) === canonical) return true
+  return manager.getRecentDatabases().some((db) => resolve(db.path) === canonical)
 }
 
 /** Test-only reset helper. Do not call from production code. */
 export function __resetDatabasePathAllowlistForTests(): void {
   dialogAllowedDatabasePaths.clear()
-}
-
-function tryRealpath(filePath: string): string | null {
-  try {
-    return realpathSync.native(filePath)
-  } catch {
-    return null
-  }
 }

--- a/src/main/security/export-path-allowlist.ts
+++ b/src/main/security/export-path-allowlist.ts
@@ -1,0 +1,20 @@
+import { isAbsolute, resolve } from 'node:path'
+import { PathAuthorityStore } from './path-authority-store'
+
+/** Export-only session capabilities used by `export:revealInFolder`. */
+const exportRevealPaths = new PathAuthorityStore()
+
+export function addAllowedExportRevealPath(filePath: string): void {
+  if (!isAbsolute(filePath) || resolve(filePath) !== filePath) return
+  exportRevealPaths.add(filePath)
+}
+
+export function isAllowedExportRevealPath(filePath: string): boolean {
+  if (!isAbsolute(filePath) || resolve(filePath) !== filePath) return false
+  return exportRevealPaths.isAuthorized(filePath)
+}
+
+/** Test-only reset helper. Do not call from production code. */
+export function __resetExportPathAllowlistForTests(): void {
+  exportRevealPaths.clear()
+}

--- a/src/main/security/import-path-allowlist.ts
+++ b/src/main/security/import-path-allowlist.ts
@@ -13,6 +13,9 @@ import { PathAuthorityStore } from './path-authority-store'
  * defence-in-depth.
  */
 const dialogAllowedPaths = new PathAuthorityStore()
+const trustedImportPathEnrollmentTokens = new Set<string>()
+const MAX_TRUSTED_IMPORT_PATH_ENROLLMENT_TOKENS = 16
+const TRUSTED_IMPORT_PATH_ENROLLMENT_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32,128}$/
 
 export function addAllowedImportPath(absolutePath: string): void {
   if (!isAbsolute(absolutePath) || resolve(absolutePath) !== absolutePath) return
@@ -21,6 +24,22 @@ export function addAllowedImportPath(absolutePath: string): void {
 
 export function removeAllowedImportPath(absolutePath: string): void {
   dialogAllowedPaths.remove(absolutePath)
+}
+
+export function registerTrustedImportPathEnrollmentToken(token: string): void {
+  if (!TRUSTED_IMPORT_PATH_ENROLLMENT_TOKEN_PATTERN.test(token)) return
+  if (
+    trustedImportPathEnrollmentTokens.size >= MAX_TRUSTED_IMPORT_PATH_ENROLLMENT_TOKENS &&
+    !trustedImportPathEnrollmentTokens.has(token)
+  ) {
+    const oldest = trustedImportPathEnrollmentTokens.values().next().value as string | undefined
+    if (oldest !== undefined) trustedImportPathEnrollmentTokens.delete(oldest)
+  }
+  trustedImportPathEnrollmentTokens.add(token)
+}
+
+export function isTrustedImportPathEnrollmentToken(token: string): boolean {
+  return trustedImportPathEnrollmentTokens.has(token)
 }
 
 /**
@@ -41,4 +60,5 @@ export function isStrictlyEnrolledPath(candidate: string): boolean {
 /** Test-only reset helper. Do not call from production code. */
 export function __resetAllowlistForTests(): void {
   dialogAllowedPaths.clear()
+  trustedImportPathEnrollmentTokens.clear()
 }

--- a/src/main/security/import-path-allowlist.ts
+++ b/src/main/security/import-path-allowlist.ts
@@ -1,7 +1,4 @@
-import { realpathSync } from 'fs'
-import { app } from 'electron'
-import { isAbsolute, relative, resolve, sep } from 'path'
-import { homedir, tmpdir } from 'node:os'
+import { isAbsolute, resolve } from 'path'
 import { PathAuthorityStore } from './path-authority-store'
 
 /**
@@ -9,16 +6,6 @@ import { PathAuthorityStore } from './path-authority-store'
  * Electron file dialog this session (or that were derived from one — files
  * discovered inside a dialog-picked folder, files extracted from a
  * dialog-picked ZIP). Cleared on app restart.
- *
- * This module exposes two predicates over that state:
- *
- *   - `isAllowedImportPath` — the enrolled set OR the three Electron-managed
- *     directory roots (home, userData, temp). Intentionally permissive;
- *     reserved for the original `import.ts` single/batch-file import flow.
- *   - `isStrictlyEnrolledPath` — the enrolled set ONLY, never the automatic
- *     roots. Use this for any other gate (DB open/create, BED import,
- *     batch-import paths, shell reveal) where "the user picked this exact
- *     path via a dialog this session" is the intended authority boundary.
  *
  * Main-process only. Workers cannot import 'electron' and therefore cannot
  * consult this allow-list; they receive paths that main has already
@@ -28,6 +15,7 @@ import { PathAuthorityStore } from './path-authority-store'
 const dialogAllowedPaths = new PathAuthorityStore()
 
 export function addAllowedImportPath(absolutePath: string): void {
+  if (!isAbsolute(absolutePath) || resolve(absolutePath) !== absolutePath) return
   dialogAllowedPaths.add(absolutePath)
 }
 
@@ -36,27 +24,10 @@ export function removeAllowedImportPath(absolutePath: string): void {
 }
 
 /**
- * True only if `candidate` (after the same canonicalization used elsewhere
- * in this module) is in the explicitly dialog-enrolled set. Never consults
- * the automatic home/userData/temp roots below.
- */
-function isDialogEnrolled(abs: string, realCandidate: string | null): boolean {
-  void realCandidate
-  return dialogAllowedPaths.isAuthorized(abs)
-}
-
-/**
  * Strict path-authority check: true only if `candidate` was explicitly
  * enrolled this session via `addAllowedImportPath` (picked through an
  * Electron file dialog, or derived from one — a file discovered inside a
  * dialog-picked folder, or a file extracted from a dialog-picked ZIP).
- *
- * Unlike `isAllowedImportPath`, this does NOT grant the automatic
- * home/userData/temp roots. Those roots are appropriate for the original
- * `import.ts` flow (see module docblock) but are far too broad for gates
- * where "the user picked this exact path via a dialog this session" is the
- * intended authority boundary — DB open/create, BED import, batch-import
- * paths, and shell "reveal in folder".
  */
 export function isStrictlyEnrolledPath(candidate: string): boolean {
   if (!isAbsolute(candidate)) return false
@@ -64,71 +35,10 @@ export function isStrictlyEnrolledPath(candidate: string): boolean {
   const abs = resolve(candidate)
   if (abs !== candidate) return false
 
-  const realCandidate = tryRealpath(abs)
-
-  return isDialogEnrolled(abs, realCandidate)
-}
-
-export function isAllowedImportPath(candidate: string): boolean {
-  if (!isAbsolute(candidate)) return false
-
-  const abs = resolve(candidate)
-  if (abs !== candidate) return false
-
-  const realCandidate = tryRealpath(abs)
-
-  if (dialogAllowedPaths.hasEnrollment(abs)) {
-    return isDialogEnrolled(abs, realCandidate)
-  }
-
-  const roots: string[] = []
-  try {
-    roots.push(app.getPath('home'), app.getPath('userData'), app.getPath('temp'))
-  } catch {
-    if (process.env.TMPDIR !== undefined && process.env.TMPDIR !== '') {
-      roots.push(process.env.TMPDIR)
-    }
-    if (process.env.HOME !== undefined && process.env.HOME !== '') {
-      roots.push(process.env.HOME)
-    }
-    roots.push(homedir(), tmpdir())
-  }
-
-  return roots.some((root) => isUnderAutomaticRoot(abs, realCandidate, root))
+  return dialogAllowedPaths.isAuthorized(abs)
 }
 
 /** Test-only reset helper. Do not call from production code. */
 export function __resetAllowlistForTests(): void {
   dialogAllowedPaths.clear()
-}
-
-function tryRealpath(filePath: string): string | null {
-  try {
-    return realpathSync.native(filePath)
-  } catch {
-    return null
-  }
-}
-
-function isUnderAutomaticRoot(abs: string, realCandidate: string | null, root: string): boolean {
-  const resolvedRoot = resolve(root)
-  const realRoot = tryRealpath(resolvedRoot)
-
-  if (realCandidate !== null && realRoot !== null) {
-    return containsPath(realRoot, realCandidate)
-  }
-
-  if (realCandidate !== null) {
-    return false
-  }
-
-  return containsPath(resolvedRoot, abs)
-}
-
-function containsPath(root: string, candidate: string): boolean {
-  const fromRoot = relative(root, candidate)
-  return (
-    fromRoot === '' ||
-    (fromRoot !== '..' && !fromRoot.startsWith(`..${sep}`) && !isAbsolute(fromRoot))
-  )
 }

--- a/src/main/security/import-path-allowlist.ts
+++ b/src/main/security/import-path-allowlist.ts
@@ -1,6 +1,8 @@
 import { realpathSync } from 'fs'
 import { app } from 'electron'
 import { isAbsolute, relative, resolve, sep } from 'path'
+import { homedir, tmpdir } from 'node:os'
+import { PathAuthorityStore } from './path-authority-store'
 
 /**
  * In-memory session allow-list of paths the user explicitly picked via an
@@ -23,16 +25,14 @@ import { isAbsolute, relative, resolve, sep } from 'path'
  * validated. BedFilter.fromFile keeps a worker-safe defensive check as
  * defence-in-depth.
  */
-const dialogAllowedPaths = new Set<string>()
+const dialogAllowedPaths = new PathAuthorityStore()
 
 export function addAllowedImportPath(absolutePath: string): void {
-  const resolved = resolve(absolutePath)
-  dialogAllowedPaths.add(resolved)
+  dialogAllowedPaths.add(absolutePath)
+}
 
-  const realPath = tryRealpath(resolved)
-  if (realPath !== null) {
-    dialogAllowedPaths.add(realPath)
-  }
+export function removeAllowedImportPath(absolutePath: string): void {
+  dialogAllowedPaths.remove(absolutePath)
 }
 
 /**
@@ -41,9 +41,8 @@ export function addAllowedImportPath(absolutePath: string): void {
  * the automatic home/userData/temp roots below.
  */
 function isDialogEnrolled(abs: string, realCandidate: string | null): boolean {
-  return (
-    dialogAllowedPaths.has(abs) || (realCandidate !== null && dialogAllowedPaths.has(realCandidate))
-  )
+  void realCandidate
+  return dialogAllowedPaths.isAuthorized(abs)
 }
 
 /**
@@ -78,8 +77,8 @@ export function isAllowedImportPath(candidate: string): boolean {
 
   const realCandidate = tryRealpath(abs)
 
-  if (isDialogEnrolled(abs, realCandidate)) {
-    return true
+  if (dialogAllowedPaths.hasEnrollment(abs)) {
+    return isDialogEnrolled(abs, realCandidate)
   }
 
   const roots: string[] = []
@@ -92,7 +91,7 @@ export function isAllowedImportPath(candidate: string): boolean {
     if (process.env.HOME !== undefined && process.env.HOME !== '') {
       roots.push(process.env.HOME)
     }
-    roots.push('/tmp')
+    roots.push(homedir(), tmpdir())
   }
 
   return roots.some((root) => isUnderAutomaticRoot(abs, realCandidate, root))

--- a/src/main/security/import-path-allowlist.ts
+++ b/src/main/security/import-path-allowlist.ts
@@ -4,8 +4,19 @@ import { isAbsolute, relative, resolve, sep } from 'path'
 
 /**
  * In-memory session allow-list of paths the user explicitly picked via an
- * Electron file dialog this session, plus the three Electron-managed
- * directory roots (home, userData, temp). Cleared on app restart.
+ * Electron file dialog this session (or that were derived from one — files
+ * discovered inside a dialog-picked folder, files extracted from a
+ * dialog-picked ZIP). Cleared on app restart.
+ *
+ * This module exposes two predicates over that state:
+ *
+ *   - `isAllowedImportPath` — the enrolled set OR the three Electron-managed
+ *     directory roots (home, userData, temp). Intentionally permissive;
+ *     reserved for the original `import.ts` single/batch-file import flow.
+ *   - `isStrictlyEnrolledPath` — the enrolled set ONLY, never the automatic
+ *     roots. Use this for any other gate (DB open/create, BED import,
+ *     batch-import paths, shell reveal) where "the user picked this exact
+ *     path via a dialog this session" is the intended authority boundary.
  *
  * Main-process only. Workers cannot import 'electron' and therefore cannot
  * consult this allow-list; they receive paths that main has already
@@ -24,6 +35,41 @@ export function addAllowedImportPath(absolutePath: string): void {
   }
 }
 
+/**
+ * True only if `candidate` (after the same canonicalization used elsewhere
+ * in this module) is in the explicitly dialog-enrolled set. Never consults
+ * the automatic home/userData/temp roots below.
+ */
+function isDialogEnrolled(abs: string, realCandidate: string | null): boolean {
+  return (
+    dialogAllowedPaths.has(abs) || (realCandidate !== null && dialogAllowedPaths.has(realCandidate))
+  )
+}
+
+/**
+ * Strict path-authority check: true only if `candidate` was explicitly
+ * enrolled this session via `addAllowedImportPath` (picked through an
+ * Electron file dialog, or derived from one — a file discovered inside a
+ * dialog-picked folder, or a file extracted from a dialog-picked ZIP).
+ *
+ * Unlike `isAllowedImportPath`, this does NOT grant the automatic
+ * home/userData/temp roots. Those roots are appropriate for the original
+ * `import.ts` flow (see module docblock) but are far too broad for gates
+ * where "the user picked this exact path via a dialog this session" is the
+ * intended authority boundary — DB open/create, BED import, batch-import
+ * paths, and shell "reveal in folder".
+ */
+export function isStrictlyEnrolledPath(candidate: string): boolean {
+  if (!isAbsolute(candidate)) return false
+
+  const abs = resolve(candidate)
+  if (abs !== candidate) return false
+
+  const realCandidate = tryRealpath(abs)
+
+  return isDialogEnrolled(abs, realCandidate)
+}
+
 export function isAllowedImportPath(candidate: string): boolean {
   if (!isAbsolute(candidate)) return false
 
@@ -32,10 +78,7 @@ export function isAllowedImportPath(candidate: string): boolean {
 
   const realCandidate = tryRealpath(abs)
 
-  if (
-    dialogAllowedPaths.has(abs) ||
-    (realCandidate !== null && dialogAllowedPaths.has(realCandidate))
-  ) {
+  if (isDialogEnrolled(abs, realCandidate)) {
     return true
   }
 

--- a/src/main/security/path-authority-store.ts
+++ b/src/main/security/path-authority-store.ts
@@ -1,0 +1,77 @@
+import { lstatSync, realpathSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
+
+interface PathEnrollment {
+  realPath: string | null
+  realParent: string | null
+}
+
+/**
+ * Session-scoped capability store for paths returned by trusted dialogs.
+ * Existing symlinks are pinned to the target selected at enrollment time;
+ * a later retarget therefore invalidates the capability.
+ */
+export class PathAuthorityStore {
+  private readonly enrollments = new Map<string, PathEnrollment>()
+
+  add(filePath: string): void {
+    const lexicalPath = resolve(filePath)
+    this.enrollments.set(lexicalPath, {
+      realPath: tryRealpath(lexicalPath),
+      realParent: tryRealpath(dirname(lexicalPath))
+    })
+  }
+
+  remove(filePath: string): void {
+    this.enrollments.delete(resolve(filePath))
+  }
+
+  hasEnrollment(filePath: string): boolean {
+    return isAbsolute(filePath) && this.enrollments.has(resolve(filePath))
+  }
+
+  isAuthorized(filePath: string): boolean {
+    if (!isAbsolute(filePath)) return false
+    const lexicalPath = resolve(filePath)
+    if (lexicalPath !== filePath) return false
+
+    const enrollment = this.enrollments.get(lexicalPath)
+    if (enrollment === undefined) return false
+
+    const currentRealPath = tryRealpath(lexicalPath)
+    if (enrollment.realPath !== null) {
+      return currentRealPath === enrollment.realPath
+    }
+
+    // Save dialogs can enroll a path before the file exists. Once created,
+    // accept a regular path at the same stable parent, never a new symlink.
+    if (currentRealPath === null) return parentIsStable(lexicalPath, enrollment.realParent)
+    if (isSymbolicLink(lexicalPath)) return false
+    return parentIsStable(lexicalPath, enrollment.realParent)
+  }
+
+  clear(): void {
+    this.enrollments.clear()
+  }
+}
+
+function parentIsStable(filePath: string, enrolledParent: string | null): boolean {
+  const currentParent = tryRealpath(dirname(filePath))
+  return enrolledParent === null ? currentParent === null : currentParent === enrolledParent
+}
+
+function tryRealpath(filePath: string): string | null {
+  try {
+    return realpathSync.native(filePath)
+  } catch {
+    return null
+  }
+}
+
+function isSymbolicLink(filePath: string): boolean {
+  try {
+    return lstatSync(filePath).isSymbolicLink()
+  } catch {
+    return false
+  }
+}

--- a/src/main/utils/url-validation.ts
+++ b/src/main/utils/url-validation.ts
@@ -18,12 +18,25 @@ export function setUserDomains(domains: string[]): void {
   userDomains = domains.filter(isValidHostname).map((d) => d.toLowerCase())
 }
 
+/** Options controlling whether renderer-added user domains are consulted. */
+export interface DomainAllowedOptions {
+  /**
+   * Whether user-configured domains (`shell:updateUserDomains`) count as
+   * allowed, in addition to the built-in `ALLOWED_DOMAINS`. Defaults to
+   * `true`. Callers that gate a sink a compromised renderer could otherwise
+   * escalate through (`setWindowOpenHandler`) must pass `false` — user
+   * domains are meant for `shell.openExternal` only.
+   */
+  includeUserDomains?: boolean
+}
+
 /**
  * Check if a hostname matches an allowed domain exactly or is a subdomain of it.
  * Uses dot-boundary matching to prevent suffix attacks (evilgithub.com != github.com).
  */
-export function isDomainAllowed(hostname: string): boolean {
-  const allDomains = [...ALLOWED_DOMAINS, ...userDomains]
+export function isDomainAllowed(hostname: string, opts?: DomainAllowedOptions): boolean {
+  const includeUserDomains = opts?.includeUserDomains !== false
+  const allDomains = includeUserDomains ? [...ALLOWED_DOMAINS, ...userDomains] : ALLOWED_DOMAINS
   return allDomains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`))
 }
 
@@ -31,11 +44,11 @@ export function isDomainAllowed(hostname: string): boolean {
  * Check if a URL is safe to open externally.
  * Requires HTTPS protocol and an allowed domain.
  */
-export function isUrlSafeForExternal(url: string): boolean {
+export function isUrlSafeForExternal(url: string, opts?: DomainAllowedOptions): boolean {
   try {
     const parsed = new URL(url)
     if (parsed.protocol !== 'https:') return false
-    return isDomainAllowed(parsed.hostname)
+    return isDomainAllowed(parsed.hostname, opts)
   } catch {
     return false
   }

--- a/src/main/window-navigation-policy.ts
+++ b/src/main/window-navigation-policy.ts
@@ -1,9 +1,40 @@
+/**
+ * Decide whether the main frame is allowed to navigate to `url` (fired from
+ * the `will-navigate` webContents event).
+ *
+ * A compromised or malicious renderer script can trigger top-frame
+ * navigation (e.g. `window.location = ...`, a same-tab link). If we let that
+ * navigation through, the main frame keeps its preload/`window.api` bridge,
+ * so navigating to an arbitrary page would hand it privileged IPC access.
+ * The policy therefore only allows two destinations:
+ *
+ *  - the dev renderer origin (`ELECTRON_RENDERER_URL`), compared by WHATWG
+ *    origin (not `startsWith`, which `http://localhost:5173.evil.com` would
+ *    satisfy against `http://localhost:5173`);
+ *  - the packaged app document (`appDocUrl`), compared by exact `file:`
+ *    path — not merely `startsWith('file://')`, which would allow
+ *    navigation to any local file.
+ */
 export function isMainWindowNavigationAllowed(
   url: string,
-  rendererUrl: string | undefined
+  rendererUrl: string | undefined,
+  appDocUrl: string
 ): boolean {
-  return (
-    (rendererUrl !== undefined && rendererUrl !== '' && url.startsWith(rendererUrl)) ||
-    url.startsWith('file://')
-  )
+  try {
+    const target = new URL(url)
+
+    if (rendererUrl !== undefined && rendererUrl !== '') {
+      const dev = new URL(rendererUrl)
+      if (target.origin === dev.origin) return true
+    }
+
+    const doc = new URL(appDocUrl)
+    return (
+      target.protocol === 'file:' &&
+      doc.protocol === 'file:' &&
+      decodeURIComponent(target.pathname) === decodeURIComponent(doc.pathname)
+    )
+  } catch {
+    return false
+  }
 }

--- a/src/main/window-navigation-policy.ts
+++ b/src/main/window-navigation-policy.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 /**
  * Decide whether the main frame is allowed to navigate to `url` (fired from
  * the `will-navigate` webContents event).
@@ -32,7 +34,9 @@ export function isMainWindowNavigationAllowed(
     return (
       target.protocol === 'file:' &&
       doc.protocol === 'file:' &&
-      decodeURIComponent(target.pathname) === decodeURIComponent(doc.pathname)
+      target.host === doc.host &&
+      target.search === '' &&
+      fileURLToPath(target) === fileURLToPath(doc)
     )
   } catch {
     return false

--- a/src/preload/domains/batch-import.ts
+++ b/src/preload/domains/batch-import.ts
@@ -15,6 +15,7 @@ export function createBatchImportApi(): BatchImportDomainContract {
       ipcRenderer.invoke('batch-import:testZipPassword', zipPath, password),
     extractZip: (zipPath, password) =>
       ipcRenderer.invoke('batch-import:extractZip', zipPath, password),
-    cleanupZipTemp: () => ipcRenderer.invoke('batch-import:cleanupZipTemp')
+    cleanupZipTemp: (extractionId) =>
+      ipcRenderer.invoke('batch-import:cleanupZipTemp', extractionId)
   }
 }

--- a/src/preload/domains/export.ts
+++ b/src/preload/domains/export.ts
@@ -5,6 +5,7 @@ export function createExportApi(): ExportDomainContract {
   return {
     variants: (caseId, filters, caseName) =>
       ipcRenderer.invoke('export:variants', caseId, filters, caseName),
-    cohort: (params) => ipcRenderer.invoke('export:cohort', params)
+    cohort: (params) => ipcRenderer.invoke('export:cohort', params),
+    revealInFolder: (filePath) => ipcRenderer.invoke('export:revealInFolder', filePath)
   }
 }

--- a/src/preload/domains/import.ts
+++ b/src/preload/domains/import.ts
@@ -1,11 +1,53 @@
-import { ipcRenderer } from 'electron'
+import { ipcRenderer, webUtils } from 'electron'
 import type { ImportDomainContract } from '../../shared/ipc/domains/import'
+
+const droppedFileEnrollmentToken = createDroppedFileEnrollmentToken()
+let droppedFileEnrollmentTokenRegistration: Promise<unknown> | null = null
+
+function createDroppedFileEnrollmentToken(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(32)
+    globalThis.crypto.getRandomValues(bytes)
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  }
+  throw new Error('Secure dropped-file enrollment is unavailable')
+}
+
+async function ensureDroppedFileEnrollmentTokenRegistered(): Promise<void> {
+  droppedFileEnrollmentTokenRegistration ??= ipcRenderer.invoke(
+    'import:registerDroppedFileEnrollmentToken',
+    droppedFileEnrollmentToken
+  )
+  await droppedFileEnrollmentTokenRegistration
+}
 
 export function createImportApi(): ImportDomainContract {
   return {
     selectFile: () => ipcRenderer.invoke('import:selectFile'),
     selectFiles: () => ipcRenderer.invoke('import:selectFiles'),
     selectBedFile: () => ipcRenderer.invoke('import:selectBedFile'),
+    enrollDroppedFiles: async (files) => {
+      const paths: string[] = []
+      if (Array.isArray(files)) {
+        for (const file of files.slice(0, 1000)) {
+          try {
+            const filePath = webUtils.getPathForFile(file)
+            if (filePath !== '') paths.push(filePath)
+          } catch {
+            // Constructed values and renderer strings have no native-file
+            // provenance and therefore grant no path authority.
+          }
+        }
+      }
+      await ensureDroppedFileEnrollmentTokenRegistered()
+      return ipcRenderer.invoke('import:enrollDroppedFiles', {
+        token: droppedFileEnrollmentToken,
+        filePaths: paths
+      })
+    },
     start: (filePath, caseName, vcfOptions) =>
       ipcRenderer.invoke('import:start', filePath, caseName, vcfOptions),
     startMultiFile: (caseName, files, vcfOptions, filters) =>

--- a/src/preload/window-api/core-api.ts
+++ b/src/preload/window-api/core-api.ts
@@ -76,6 +76,7 @@ export function createCoreApi(domains: PreloadDomainApis): CoreWindowApi {
       selectFile: () => importDomain.selectFile(),
       selectFiles: () => importDomain.selectFiles(),
       selectBedFile: () => importDomain.selectBedFile(),
+      enrollDroppedFiles: (files) => importDomain.enrollDroppedFiles(files),
       start: (filePath, caseName, vcfOptions) => importDomain.start(filePath, caseName, vcfOptions),
       startMultiFile: (caseName, files, vcfOptions, filters) =>
         importDomain.startMultiFile(caseName, files, vcfOptions, filters),
@@ -96,13 +97,13 @@ export function createCoreApi(domains: PreloadDomainApis): CoreWindowApi {
 
     export: {
       variants: (caseId, filters, caseName) => exportDomain.variants(caseId, filters, caseName),
-      cohort: (params) => exportDomain.cohort(params)
+      cohort: (params) => exportDomain.cohort(params),
+      revealInFolder: (filePath) => exportDomain.revealInFolder(filePath)
     },
 
     shell: {
       openExternal: (url) => ipcRenderer.invoke('shell:openExternal', url),
-      updateDomains: (domains) => ipcRenderer.invoke('shell:updateUserDomains', domains),
-      showItemInFolder: (filePath) => ipcRenderer.invoke('shell:showItemInFolder', filePath)
+      updateDomains: (domains) => ipcRenderer.invoke('shell:updateUserDomains', domains)
     },
 
     database: {
@@ -137,7 +138,7 @@ export function createCoreApi(domains: PreloadDomainApis): CoreWindowApi {
       selectZip: () => batchImportDomain.selectZip(),
       testZipPassword: (zipPath, password) => batchImportDomain.testZipPassword(zipPath, password),
       extractZip: (zipPath, password) => batchImportDomain.extractZip(zipPath, password),
-      cleanupZipTemp: () => batchImportDomain.cleanupZipTemp(),
+      cleanupZipTemp: (extractionId) => batchImportDomain.cleanupZipTemp(extractionId),
       onProgress: (callback) => subscribeToIpcEvent('batch-import:progress', callback),
       onComplete: (callback) => subscribeToIpcEvent('batch-import:complete', callback)
     } as WindowAPI['batchImport'],

--- a/src/renderer/src/components/BatchImportDialog.vue
+++ b/src/renderer/src/components/BatchImportDialog.vue
@@ -89,7 +89,9 @@ import type {
   DuplicateCheckItem
 } from '../../../shared/types/api'
 import { useApiService } from '../composables/useApiService'
+import { useZipExtractionLifecycle } from '../composables/useZipExtractionLifecycle'
 import { useImportStatusStore } from '../stores/importStatusStore'
+import { logService } from '../services/LogService'
 import BatchReviewPhase from './batch-import/BatchReviewPhase.vue'
 import BatchProgressPhase from './batch-import/BatchProgressPhase.vue'
 import BatchSummaryPhase from './batch-import/BatchSummaryPhase.vue'
@@ -101,6 +103,7 @@ type Phase = 'idle' | 'review' | 'importing' | 'summary' | 'zip-password'
 
 const { api } = useApiService()
 const importStore = useImportStatusStore()
+const zipExtraction = useZipExtractionLifecycle((id) => api!.batchImport.cleanupZipTemp(id))
 
 const dialog = ref(false)
 const phase = ref<Phase>('idle')
@@ -176,7 +179,7 @@ let recheckTimeout: ReturnType<typeof setTimeout> | null = null
 watch(dialog, (newVal, oldVal) => {
   if (oldVal === true && newVal === false && phase.value === 'summary') {
     if (isZipImport.value === true) {
-      api!.batchImport.cleanupZipTemp()
+      void cleanupActiveZipExtraction()
     }
     if (summary.value.succeeded > 0) {
       emit('batch-import-complete', { totalImported: summary.value.succeeded })
@@ -247,13 +250,14 @@ const show = async (mode: 'files' | 'folder' | 'zip'): Promise<void> => {
 const extractAndShowReview = async (zipFilePath: string, password?: string): Promise<void> => {
   try {
     const result = unwrapIpcResult(await api!.batchImport.extractZip(zipFilePath, password))
+    zipExtraction.track(result.extractionId)
 
     if (result.files.length === 0) {
       zipErrorMessage.value = 'No importable files found in archive.'
       if (result.errors.length > 0) {
         zipErrorMessage.value += ' Errors: ' + result.errors.join('; ')
       }
-      unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+      await cleanupActiveZipExtraction()
       return
     }
 
@@ -271,7 +275,7 @@ const extractAndShowReview = async (zipFilePath: string, password?: string): Pro
         : isIpcError(error)
           ? (error.userMessage ?? error.message)
           : 'Failed to extract archive'
-    unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+    await cleanupActiveZipExtraction()
   }
 }
 
@@ -338,6 +342,20 @@ const startImport = async (
           ? (error.userMessage ?? error.message)
           : 'Unknown error'
     )
+  } finally {
+    if (isZipImport.value) {
+      try {
+        await cleanupActiveZipExtraction()
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : isIpcError(error)
+              ? (error.userMessage ?? error.message)
+              : 'Unknown cleanup error'
+        logService.warn(`ZIP extraction cleanup failed: ${message}`, 'BatchImportDialog')
+      }
+    }
   }
 }
 
@@ -373,7 +391,7 @@ const handleZipUnlock = async (): Promise<void> => {
  * Cancel ZIP flow and clean up temp directory
  */
 const handleZipCancel = async (): Promise<void> => {
-  unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+  await cleanupActiveZipExtraction()
   dialog.value = false
 }
 
@@ -402,7 +420,7 @@ const continueInBackground = (): void => {
  */
 const closeDialog = async (): Promise<void> => {
   if (isZipImport.value === true) {
-    unwrapIpcResult(await api!.batchImport.cleanupZipTemp())
+    await cleanupActiveZipExtraction()
   }
   dialog.value = false
 }
@@ -411,6 +429,7 @@ const closeDialog = async (): Promise<void> => {
  * Reset all state for a fresh import
  */
 const resetState = (): void => {
+  void cleanupActiveZipExtraction()
   phase.value = 'idle'
   selectedFilePaths.value = []
   duplicateCheckFiles.value = []
@@ -430,6 +449,10 @@ const resetState = (): void => {
   showZipPassword.value = false
   zipErrorMessage.value = ''
   testingPassword.value = false
+}
+
+async function cleanupActiveZipExtraction(): Promise<void> {
+  await zipExtraction.cleanup()
 }
 
 // Setup IPC listeners

--- a/src/renderer/src/components/CohortTable.vue
+++ b/src/renderer/src/components/CohortTable.vue
@@ -449,7 +449,7 @@ const exportToExcel = async (): Promise<void> => {
         actionText: 'Open folder',
         actionCallback: () => {
           if (result.filePath != null && result.filePath !== '')
-            api.shell.showItemInFolder(result.filePath)
+            void api.export.revealInFolder(result.filePath)
         }
       }
     } else if (result?.error != null && result.error !== '') {

--- a/src/renderer/src/components/FilterToolbar.vue
+++ b/src/renderer/src/components/FilterToolbar.vue
@@ -593,7 +593,7 @@ const exportToExcel = async () => {
       filePath,
       action: {
         text: 'Open folder',
-        callback: () => api?.shell.showItemInFolder(filePath)
+        callback: () => api?.export.revealInFolder(filePath)
       }
     })
   }

--- a/src/renderer/src/components/import/ImportWizard.vue
+++ b/src/renderer/src/components/import/ImportWizard.vue
@@ -191,6 +191,7 @@ import type {
 } from '../../../../shared/types/api'
 import type { VcfPreviewResult } from '../../../../shared/types/vcf'
 import { useApiService } from '../../composables/useApiService'
+import { useZipExtractionLifecycle } from '../../composables/useZipExtractionLifecycle'
 import { useImportStatusStore } from '../../stores/importStatusStore'
 import { logService } from '../../services/LogService'
 import { unwrapIpcResult } from '../../../../shared/types/errors'
@@ -215,10 +216,9 @@ import {
 } from '@mdi/js'
 
 type ImportMode = ImportSourceMode
-
 const { api } = useApiService()
 const importStore = useImportStatusStore()
-
+const zipExtraction = useZipExtractionLifecycle((id) => api!.batchImport.cleanupZipTemp(id))
 const WEB_UPLOAD_EVENT = 'varlens:web-upload'
 const WEB_UPLOAD_CANCEL_EVENT = 'varlens:web-upload-cancel'
 
@@ -377,19 +377,13 @@ function formatIpcError(error: unknown, fallback: string): string {
 }
 
 function cleanupZipTempInBackground(context: string): void {
-  void api!.batchImport
-    .cleanupZipTemp()
-    .then((cleanupResult) => {
-      unwrapIpcResult(cleanupResult)
-    })
-    .catch((error) => {
-      logService.warn(
-        `ZIP temp cleanup failed after ${context}: ${formatIpcError(error, 'cleanup failed')}`,
-        'ImportWizard'
-      )
-    })
+  void zipExtraction.cleanup().catch((error) => {
+    logService.warn(
+      `ZIP temp cleanup failed after ${context}: ${formatIpcError(error, 'cleanup failed')}`,
+      'ImportWizard'
+    )
+  })
 }
-
 // Re-check duplicates when strip text changes
 watch(stripText, () => {
   if (recheckTimeout !== null) clearTimeout(recheckTimeout)
@@ -474,10 +468,14 @@ async function selectSource(mode: ImportMode): Promise<void> {
 }
 
 async function extractAndAdvance(path: string): Promise<void> {
-  const { files } = unwrapIpcResult(
+  const { files, extractionId } = unwrapIpcResult(
     await api!.batchImport.extractZip(path, zipPassword.value || undefined)
   )
-  if (files.length === 0) return
+  zipExtraction.track(extractionId)
+  if (files.length === 0) {
+    cleanupZipTempInBackground('empty extraction')
+    return
+  }
 
   selectedFilePaths.value = files
   zipPasswordNeeded.value = false
@@ -736,6 +734,7 @@ function handleClose(): void {
     continueInBackground()
     return
   }
+  if (isZipImport.value) cleanupZipTempInBackground('dialog close')
   dialog.value = false
   // Reset import store when closing from summary/error step
   if (step.value === 4 || importStore.phase === 'error') {
@@ -744,6 +743,7 @@ function handleClose(): void {
 }
 
 function resetState(): void {
+  cleanupZipTempInBackground('state reset')
   step.value = 1
   selectedMode.value = null
   selectedFilePaths.value = []

--- a/src/renderer/src/components/import/VcfImportDialog.vue
+++ b/src/renderer/src/components/import/VcfImportDialog.vue
@@ -521,7 +521,7 @@ async function browseFiles(): Promise<void> {
 
 async function handleDrop(event: DragEvent): Promise<void> {
   isDragging.value = false
-  if (event.dataTransfer === null) return
+  if (api === undefined || event.dataTransfer === null) return
   const files = Array.from(event.dataTransfer.files)
   if (files.length === 0) return
 
@@ -536,18 +536,18 @@ async function handleDrop(event: DragEvent): Promise<void> {
     return
   }
 
-  // Electron exposes full paths on dropped File objects
-  const paths = vcfFiles
-    .map((f) => (f as unknown as { path?: string }).path ?? '')
-    .filter((p) => p !== '')
-
-  if (paths.length === 0) {
-    errorMessage.value =
-      'Could not resolve file paths from dropped files. Use the Browse button instead.'
-    return
+  try {
+    // Preload resolves genuine Electron-backed Files; main enrolls their paths.
+    const paths = unwrapIpcResult(await api.import.enrollDroppedFiles(vcfFiles))
+    if (paths.length === 0) {
+      errorMessage.value =
+        'Could not resolve file paths from dropped files. Use the Browse button instead.'
+      return
+    }
+    await loadPreview(paths)
+  } catch (err) {
+    handleError('File drop failed', err)
   }
-
-  await loadPreview(paths)
 }
 
 async function loadPreview(filePaths: string[]): Promise<void> {

--- a/src/renderer/src/composables/useZipExtractionLifecycle.ts
+++ b/src/renderer/src/composables/useZipExtractionLifecycle.ts
@@ -1,0 +1,40 @@
+import { unwrapIpcResult, type IpcResult } from '../../../shared/types/errors'
+
+type ZipCleanup = (extractionId: string) => Promise<IpcResult<void>>
+
+export interface ZipExtractionLifecycle {
+  track: (extractionId: string) => void
+  cleanup: () => Promise<void>
+}
+
+/** Owns opaque ZIP extraction capabilities until targeted cleanup succeeds. */
+export function useZipExtractionLifecycle(cleanupZipTemp: ZipCleanup): ZipExtractionLifecycle {
+  const owned = new Set<string>()
+  const inFlight = new Map<string, Promise<void>>()
+
+  function track(extractionId: string): void {
+    owned.add(extractionId)
+  }
+
+  function cleanupOne(extractionId: string): Promise<void> {
+    const active = inFlight.get(extractionId)
+    if (active !== undefined) return active
+
+    const cleanup = (async (): Promise<void> => {
+      unwrapIpcResult(await cleanupZipTemp(extractionId))
+      owned.delete(extractionId)
+    })()
+    inFlight.set(extractionId, cleanup)
+    const clearInFlight = (): void => {
+      if (inFlight.get(extractionId) === cleanup) inFlight.delete(extractionId)
+    }
+    void cleanup.then(clearInFlight, clearInFlight)
+    return cleanup
+  }
+
+  async function cleanup(): Promise<void> {
+    await Promise.all([...owned].map(cleanupOne))
+  }
+
+  return { track, cleanup }
+}

--- a/src/renderer/src/mocks/mockApi.ts
+++ b/src/renderer/src/mocks/mockApi.ts
@@ -239,6 +239,7 @@ export const mockApi: WindowAPI = {
     selectFile: async () => '/mock/selected/file.json',
     selectFiles: async () => ['/mock/selected/file.vcf.gz'],
     selectBedFile: async () => '/mock/regions.bed',
+    enrollDroppedFiles: async (files) => files.map((file) => `/mock/uploads/${file.name}`),
     start: async () => ({
       caseId: cases.length + 1,
       variantCount: 1000,
@@ -286,15 +287,14 @@ export const mockApi: WindowAPI = {
 
   export: {
     variants: async () => ({ success: true, filePath: '/mock/export.xlsx' }),
-    cohort: async () => ({ success: true, filePath: '/mock/cohort_export.xlsx' })
+    cohort: async () => ({ success: true, filePath: '/mock/cohort_export.xlsx' }),
+    revealInFolder: async () => ({ success: false })
   },
-
   shell: {
     openExternal: async (url) => {
       window.open(url, '_blank')
       return { success: true }
     },
-    showItemInFolder: async () => {},
     updateDomains: async () => {}
   },
 
@@ -364,7 +364,7 @@ export const mockApi: WindowAPI = {
     onComplete: () => () => {},
     selectZip: async () => null,
     testZipPassword: async () => ({ success: false }),
-    extractZip: async () => ({ files: [], errors: [] }),
+    extractZip: async () => ({ files: [], errors: [], extractionId: 'mock-extraction' }),
     cleanupZipTemp: async () => {}
   },
 

--- a/src/shared/api/schemas/batch-import.ts
+++ b/src/shared/api/schemas/batch-import.ts
@@ -8,7 +8,7 @@ export const BatchImportInvokeBodySchemas = {
     args: z.tuple([z.string().min(1), z.string()])
   }),
   cleanupZipTemp: z.object({
-    args: z.tuple([])
+    args: z.tuple([z.string().min(1).max(128)])
   })
 } as const
 

--- a/src/shared/config/allowed-domains.ts
+++ b/src/shared/config/allowed-domains.ts
@@ -4,7 +4,7 @@
  */
 export const ALLOWED_DOMAINS = [
   'github.com',
-  'github.io',
+  'berntpopp.github.io', // VarLens docs site — not bare `github.io` (that would allow *.github.io)
   'opensource.org',
   'gnomad.broadinstitute.org',
   'ncbi.nlm.nih.gov', // Covers PubTator, LitVar, ClinVar

--- a/src/shared/ipc/domains/batch-import-schemas.ts
+++ b/src/shared/ipc/domains/batch-import-schemas.ts
@@ -45,3 +45,5 @@ export const BatchImportExtractZipParamsSchema = z.tuple([
   NonBlankFilePathSchema,
   ZipPasswordSchema.optional()
 ])
+
+export const BatchImportCleanupZipParamsSchema = z.tuple([nonBlankString(128)])

--- a/src/shared/ipc/domains/batch-import-schemas.ts
+++ b/src/shared/ipc/domains/batch-import-schemas.ts
@@ -7,7 +7,7 @@ import type { DuplicateChoice } from '../../types/api'
  * is read or forwarded to the import worker.
  *
  * File-path validation against the dialog-enrolled allowlist happens
- * separately in the handler (`isAllowedImportPath`); these schemas only
+ * separately in the handler (`isStrictlyEnrolledPath`); these schemas only
  * assert shape and primitive bounds, mirroring import-schemas.ts.
  */
 const nonBlankString = (maxLength: number) =>

--- a/src/shared/ipc/domains/batch-import-schemas.ts
+++ b/src/shared/ipc/domains/batch-import-schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+import type { DuplicateChoice } from '../../types/api'
+
+/**
+ * Batch-import IPC payload schemas. Used by
+ * src/main/ipc/handlers/batch-import.ts via safeParse before any file path
+ * is read or forwarded to the import worker.
+ *
+ * File-path validation against the dialog-enrolled allowlist happens
+ * separately in the handler (`isAllowedImportPath`); these schemas only
+ * assert shape and primitive bounds, mirroring import-schemas.ts.
+ */
+const nonBlankString = (maxLength: number) =>
+  z
+    .string()
+    .max(maxLength)
+    .refine((value) => value.trim().length > 0, {
+      message: 'Required'
+    })
+
+const NonBlankFilePathSchema = nonBlankString(4096)
+const StripTextSchema = z.string().max(255).optional()
+const ZipPasswordSchema = z.string().max(1024)
+
+/** Keep in sync with `DuplicateChoice` in src/shared/types/api.ts. */
+const DuplicateChoiceSchema: z.ZodType<DuplicateChoice> = z.enum(['skip', 'overwrite'])
+
+export const BatchImportCheckDuplicatesParamsSchema = z.tuple([
+  z.array(NonBlankFilePathSchema).max(5000),
+  StripTextSchema
+])
+
+export const BatchImportStartParamsSchema = z.tuple([
+  z.array(NonBlankFilePathSchema).max(5000),
+  DuplicateChoiceSchema,
+  StripTextSchema
+])
+
+export const BatchImportTestZipPasswordParamsSchema = z.tuple([
+  NonBlankFilePathSchema,
+  ZipPasswordSchema
+])
+
+export const BatchImportExtractZipParamsSchema = z.tuple([
+  NonBlankFilePathSchema,
+  ZipPasswordSchema.optional()
+])

--- a/src/shared/ipc/domains/batch-import.ts
+++ b/src/shared/ipc/domains/batch-import.ts
@@ -19,6 +19,6 @@ export interface BatchImportDomainContract {
   extractZip: (
     zipPath: string,
     password?: string
-  ) => Promise<IpcResult<{ files: string[]; errors: string[] }>>
-  cleanupZipTemp: () => Promise<IpcResult<void>>
+  ) => Promise<IpcResult<{ files: string[]; errors: string[]; extractionId: string }>>
+  cleanupZipTemp: (extractionId: string) => Promise<IpcResult<void>>
 }

--- a/src/shared/ipc/domains/export.ts
+++ b/src/shared/ipc/domains/export.ts
@@ -15,4 +15,5 @@ export interface ExportDomainContract {
     caseName: string
   ) => Promise<IpcResult<ExportResult>>
   cohort: (params: CohortSearchParams) => Promise<IpcResult<ExportResult>>
+  revealInFolder: (filePath: string) => Promise<IpcResult<{ success: boolean }>>
 }

--- a/src/shared/ipc/domains/import-schemas.ts
+++ b/src/shared/ipc/domains/import-schemas.ts
@@ -17,6 +17,11 @@ const nonBlankString = (maxLength: number) =>
 
 const NonBlankFilePathSchema = nonBlankString(4096)
 const NonBlankImportStringSchema = nonBlankString(255)
+const DroppedFileEnrollmentTokenSchema = z
+  .string()
+  .min(32)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/)
 
 export const ImportVcfOptionsSchema = z
   .object({
@@ -63,4 +68,17 @@ export const ImportVcfPreviewParamsSchema = z.tuple([NonBlankFilePathSchema])
 
 export const ImportVcfMultiPreviewParamsSchema = z.tuple([
   z.array(NonBlankFilePathSchema).min(1).max(1000)
+])
+
+export const ImportRegisterDroppedFileEnrollmentTokenParamsSchema = z.tuple([
+  DroppedFileEnrollmentTokenSchema
+])
+
+export const ImportEnrollDroppedFilesParamsSchema = z.tuple([
+  z
+    .object({
+      token: DroppedFileEnrollmentTokenSchema,
+      filePaths: z.array(NonBlankFilePathSchema).max(1000)
+    })
+    .strict()
 ])

--- a/src/shared/ipc/domains/import.ts
+++ b/src/shared/ipc/domains/import.ts
@@ -6,6 +6,7 @@ export interface ImportDomainContract {
   selectFile: () => Promise<IpcResult<string | null>>
   selectFiles: () => Promise<IpcResult<string[]>>
   selectBedFile: () => Promise<IpcResult<string | null>>
+  enrollDroppedFiles: (files: readonly File[]) => Promise<IpcResult<string[]>>
   start: (
     filePath: string,
     caseName: string,

--- a/src/shared/ipc/domains/jobs-schemas.ts
+++ b/src/shared/ipc/domains/jobs-schemas.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import type { JobKind, JobStatus } from '../../types/jobs'
+
+/**
+ * `jobs:*` IPC payload schemas. Job ids are in-memory JobRunner Map keys
+ * (ULID-style strings, see src/main/services/jobs/JobRunner.ts), but the
+ * repo convention is to validate every IPC arg at the boundary regardless
+ * of the trust level of the eventual lookup.
+ */
+const JobIdSchema = z.string().trim().min(1).max(64)
+
+/** Keep in sync with `JobKind` in src/shared/types/jobs.ts. */
+const JobKindSchema: z.ZodType<JobKind> = z.enum([
+  'import_single',
+  'import_batch',
+  'cohort_rebuild',
+  'association',
+  'export'
+])
+
+/** Keep in sync with `JobStatus` in src/shared/types/jobs.ts. */
+const JobStatusSchema: z.ZodType<JobStatus> = z.enum([
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'cancelled'
+])
+
+const JobsFilterSchema = z
+  .object({
+    kind: JobKindSchema.optional(),
+    status: JobStatusSchema.optional()
+  })
+  .strict()
+  .optional()
+
+export const JobsListParamsSchema = z.tuple([JobsFilterSchema])
+export const JobsGetParamsSchema = z.tuple([JobIdSchema])
+export const JobsProgressParamsSchema = z.tuple([JobIdSchema])

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -245,6 +245,7 @@ export interface ImportAPI {
   selectFile: () => Promise<string | null>
   selectFiles: () => Promise<string[]>
   selectBedFile: () => Promise<string | null>
+  enrollDroppedFiles: (files: readonly File[]) => Promise<IpcResult<string[]>>
   start: (
     filePath: string,
     caseName: string,
@@ -287,7 +288,6 @@ export interface ShellOpenExternalResult {
 
 export interface ShellAPI {
   openExternal: (url: string) => Promise<ShellOpenExternalResult>
-  showItemInFolder: (filePath: string) => Promise<void>
   updateDomains: (domains: string[]) => Promise<void>
 }
 
@@ -305,6 +305,7 @@ export interface ExportAPI {
     caseName: string
   ) => Promise<IpcResult<ExportResult>>
   cohort: (params: CohortSearchParams) => Promise<IpcResult<ExportResult>>
+  revealInFolder: (filePath: string) => Promise<IpcResult<{ success: boolean }>>
 }
 
 export type DatabaseAPI = DatabaseDomainContract
@@ -371,8 +372,8 @@ export interface BatchImportAPI {
   extractZip: (
     zipPath: string,
     password?: string
-  ) => Promise<IpcResult<{ files: string[]; errors: string[] }>>
-  cleanupZipTemp: () => Promise<IpcResult<void>>
+  ) => Promise<IpcResult<{ files: string[]; errors: string[]; extractionId: string }>>
+  cleanupZipTemp: (extractionId: string) => Promise<IpcResult<void>>
 }
 
 export interface CohortAPI {

--- a/src/web/client/api.ts
+++ b/src/web/client/api.ts
@@ -382,8 +382,22 @@ const SHELL_API = {
     window.open(url, '_blank', 'noopener,noreferrer')
     return Promise.resolve({ success: true } as unknown)
   },
-  showItemInFolder: () => Promise.resolve({ ok: false } as unknown),
   updateDomains: (_domains: string[]) => Promise.resolve(undefined)
+}
+
+function buildExportApi(): unknown {
+  const rpc = buildDomainProxy('export') as Record<string, unknown>
+  return new Proxy(
+    {},
+    {
+      get(_target, prop: string | symbol) {
+        if (prop === 'revealInFolder') {
+          return () => Promise.resolve({ success: false })
+        }
+        return typeof prop === 'string' ? rpc[prop] : undefined
+      }
+    }
+  )
 }
 
 const SYSTEM_API = {
@@ -436,6 +450,10 @@ function buildImportApi(): unknown {
             const refs = await pickAndUploadFiles({ multiple: false, accept: '.bed,.bed.gz,.gz' })
             return refs[0] ?? null
           }
+        }
+        if (prop === 'enrollDroppedFiles') {
+          return async (files: readonly File[]) =>
+            (await uploadImportFiles(files)).map((file) => file.ref)
         }
         return typeof prop === 'string' ? rpc[prop] : undefined
       }
@@ -529,6 +547,7 @@ const DOMAIN_OVERRIDES: Record<string, unknown> = {
   batchImport: buildBatchImportApi(),
   'batch-import': buildBatchImportApi(),
   cohort: buildCohortApi(),
+  export: buildExportApi(),
   import: buildImportApi(),
   perf: PERF_API,
   shell: SHELL_API,

--- a/src/web/server/routes/batch-import.ts
+++ b/src/web/server/routes/batch-import.ts
@@ -218,8 +218,13 @@ export function buildBatchImportOverrides(): Record<string, OverrideHandler> {
     },
 
     'batch-import:cleanupZipTemp': {
-      handle() {
-        cleanupZipTemp()
+      handle(args, _request, reply) {
+        const [extractionId] = args
+        if (typeof extractionId !== 'string' || extractionId.length === 0) {
+          reply.code(400)
+          return { error: 'invalid-extraction-id' }
+        }
+        cleanupZipTemp(extractionId)
       }
     }
   }
@@ -240,25 +245,29 @@ async function extractWebUploadZip(
   zipRef: string,
   userId: number | undefined,
   password: string | undefined
-): Promise<{ files: string[]; errors: string[] } | null> {
+): Promise<{ files: string[]; errors: string[]; extractionId: string } | null> {
   const upload = resolveUploadedFile(zipRef, userId)
   if (upload === null || userId === undefined) return null
 
   const result = await extractZip(upload.storedPath, password)
-  const stagedFiles = []
-  for (const filePath of result.files) {
-    stagedFiles.push(
-      await stageExistingFileUpload({
-        userId,
-        originalName: basename(filePath),
-        sourcePath: filePath
-      })
-    )
-  }
-  cleanupZipTemp()
-  return {
-    files: stagedFiles.map((file) => file.ref),
-    errors: result.errors
+  try {
+    const stagedFiles = []
+    for (const filePath of result.files) {
+      stagedFiles.push(
+        await stageExistingFileUpload({
+          userId,
+          originalName: basename(filePath),
+          sourcePath: filePath
+        })
+      )
+    }
+    return {
+      files: stagedFiles.map((file) => file.ref),
+      errors: result.errors,
+      extractionId: result.extractionId
+    }
+  } finally {
+    cleanupZipTemp(result.extractionId)
   }
 }
 

--- a/tests/main/handlers/postgres-export-routing.test.ts
+++ b/tests/main/handlers/postgres-export-routing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import {
   __resetAllowlistForTests,
-  isAllowedImportPath
+  isStrictlyEnrolledPath
 } from '../../../src/main/security/import-path-allowlist'
 
 const mocks = vi.hoisted(() => ({
@@ -67,10 +67,10 @@ describe('postgres export IPC routing', () => {
       getDbPool: (() => null) as never
     })
 
-    expect(isAllowedImportPath(outputPath)).toBe(false)
+    expect(isStrictlyEnrolledPath(outputPath)).toBe(false)
     const handler = handlers.get('export:variants')
     await handler!(undefined, 5, { gene_symbol: 'BRCA1' }, 'Postgres Case')
-    expect(isAllowedImportPath(outputPath)).toBe(true)
+    expect(isStrictlyEnrolledPath(outputPath)).toBe(true)
   })
 
   it('streams postgres variant exports through the active storage read executor', async () => {

--- a/tests/main/handlers/postgres-export-routing.test.ts
+++ b/tests/main/handlers/postgres-export-routing.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import {
   __resetAllowlistForTests,
+  addAllowedImportPath,
   isStrictlyEnrolledPath
 } from '../../../src/main/security/import-path-allowlist'
+import {
+  __resetExportPathAllowlistForTests,
+  isAllowedExportRevealPath
+} from '../../../src/main/security/export-path-allowlist'
 
 const mocks = vi.hoisted(() => ({
   showSaveDialog: vi.fn(),
@@ -10,7 +15,8 @@ const mocks = vi.hoisted(() => ({
   exportPostgresCohort: vi.fn(),
   prepareVariantExport: vi.fn(),
   exportVariants: vi.fn(),
-  exportCohort: vi.fn()
+  exportCohort: vi.fn(),
+  showItemInFolder: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -19,7 +25,8 @@ vi.mock('electron', () => ({
   },
   dialog: {
     showSaveDialog: mocks.showSaveDialog
-  }
+  },
+  shell: { showItemInFolder: mocks.showItemInFolder }
 }))
 
 vi.mock('../../../src/main/ipc/handlers/export-logic', () => ({
@@ -33,9 +40,10 @@ vi.mock('../../../src/main/ipc/handlers/export-logic', () => ({
 describe('postgres export IPC routing', () => {
   beforeEach(() => {
     __resetAllowlistForTests()
+    __resetExportPathAllowlistForTests()
   })
 
-  it('enrolls the export:variants save-dialog result so shell:showItemInFolder can reveal it', async () => {
+  it('enrolls the export:variants save-dialog result only for export-scoped reveal', async () => {
     const outputPath = '/some/custom/mount/case1_variants.csv'
     const execute = vi.fn().mockResolvedValue(
       (async function* () {
@@ -70,7 +78,35 @@ describe('postgres export IPC routing', () => {
     expect(isStrictlyEnrolledPath(outputPath)).toBe(false)
     const handler = handlers.get('export:variants')
     await handler!(undefined, 5, { gene_symbol: 'BRCA1' }, 'Postgres Case')
-    expect(isStrictlyEnrolledPath(outputPath)).toBe(true)
+    expect(isStrictlyEnrolledPath(outputPath)).toBe(false)
+    expect(isAllowedExportRevealPath(outputPath)).toBe(true)
+
+    const revealHandler = handlers.get('export:revealInFolder')
+    const revealResult = await revealHandler!(undefined, outputPath)
+    expect(revealResult).toEqual({ success: true })
+    expect(mocks.showItemInFolder).toHaveBeenCalledWith(outputPath)
+  })
+
+  it('does not let import path authority reveal a file through the export capability', async () => {
+    const importPath = '/some/custom/mount/imported.vcf'
+    addAllowedImportPath(importPath)
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler)
+      })
+    }
+    const { registerExportHandlers } = await import('../../../src/main/ipc/handlers/export')
+    registerExportHandlers({
+      ipcMain: ipcMain as never,
+      getDb: vi.fn() as never,
+      getDbManager: vi.fn() as never
+    })
+
+    const result = await handlers.get('export:revealInFolder')!(undefined, importPath)
+
+    expect(result).toMatchObject({ code: 'INVALID_PARAMETERS' })
+    expect(mocks.showItemInFolder).not.toHaveBeenCalled()
   })
 
   it('streams postgres variant exports through the active storage read executor', async () => {

--- a/tests/main/handlers/postgres-export-routing.test.ts
+++ b/tests/main/handlers/postgres-export-routing.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  __resetAllowlistForTests,
+  isAllowedImportPath
+} from '../../../src/main/security/import-path-allowlist'
 
 const mocks = vi.hoisted(() => ({
   showSaveDialog: vi.fn(),
@@ -27,6 +31,48 @@ vi.mock('../../../src/main/ipc/handlers/export-logic', () => ({
 }))
 
 describe('postgres export IPC routing', () => {
+  beforeEach(() => {
+    __resetAllowlistForTests()
+  })
+
+  it('enrolls the export:variants save-dialog result so shell:showItemInFolder can reveal it', async () => {
+    const outputPath = '/some/custom/mount/case1_variants.csv'
+    const execute = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield { id: 1 }
+      })()
+    )
+    const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler)
+      })
+    }
+
+    mocks.showSaveDialog.mockResolvedValue({ canceled: false, filePath: outputPath })
+    mocks.exportPostgresVariants.mockResolvedValue({ success: true, filePath: outputPath })
+
+    const { registerExportHandlers } = await import('../../../src/main/ipc/handlers/export')
+    registerExportHandlers({
+      ipcMain: ipcMain as never,
+      getDb: (() => {
+        throw new Error('getDb should not be called for postgres export:variants')
+      }) as never,
+      getDbManager: (() => ({
+        getCurrentSession: () => ({
+          capabilities: { backend: 'postgres' },
+          getReadExecutor: () => ({ execute })
+        })
+      })) as never,
+      getDbPool: (() => null) as never
+    })
+
+    expect(isAllowedImportPath(outputPath)).toBe(false)
+    const handler = handlers.get('export:variants')
+    await handler!(undefined, 5, { gene_symbol: 'BRCA1' }, 'Postgres Case')
+    expect(isAllowedImportPath(outputPath)).toBe(true)
+  })
+
   it('streams postgres variant exports through the active storage read executor', async () => {
     const rows = (async function* () {
       yield { id: 1 }

--- a/tests/main/ipc/domains/jobs.test.ts
+++ b/tests/main/ipc/domains/jobs.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the `jobs:` IPC domain Zod validation (F-path, Part B / Codex F-03).
+ *
+ * jobs:list/get/progress read from an in-memory Map keyed by job id, but the
+ * repo convention is to validate every IPC arg at the boundary. Mirrors the
+ * debug IPC domain test's strategy: mock `electron.ipcMain.handle` to capture
+ * the registered callbacks and invoke them directly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn()
+  }
+}))
+
+const list = vi.fn()
+const get = vi.fn()
+vi.mock('../../../../src/main/services/jobs/runner', () => ({
+  jobRunner: {
+    list: (...args: unknown[]) => list(...args),
+    get: (...args: unknown[]) => get(...args)
+  }
+}))
+
+import { ipcMain } from 'electron'
+import { registerJobsHandlers } from '../../../../src/main/ipc/domains/jobs'
+import { JOBS_CHANNELS } from '../../../../src/shared/ipc/domains/jobs'
+
+type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+function getHandler(channel: string): HandlerCallback {
+  const mockedHandle = ipcMain.handle as unknown as {
+    mock: { calls: Array<[string, HandlerCallback]> }
+  }
+  const call = mockedHandle.mock.calls.find(([c]) => c === channel)
+  if (!call) throw new Error(`No handler registered for channel: ${channel}`)
+  return call[1]
+}
+
+function expectInvalidParametersResult(result: unknown): void {
+  expect(isIpcError(result)).toBe(true)
+  if (isIpcError(result)) {
+    expect(result.code).toBe(ErrorCode.INVALID_PARAMETERS)
+  }
+}
+
+describe('jobs IPC domain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('jobs:list', () => {
+    it('returns INVALID_PARAMETERS for a malformed filter', async () => {
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.list)
+
+      const result = await handler({}, { kind: 'not_a_real_kind' })
+
+      expectInvalidParametersResult(result)
+      expect(list).not.toHaveBeenCalled()
+    })
+
+    it('passes a well-formed filter through to jobRunner.list', async () => {
+      list.mockReturnValue([])
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.list)
+
+      const result = await handler({}, { kind: 'import_batch', status: 'running' })
+
+      expect(result).toEqual([])
+      expect(list).toHaveBeenCalledWith({ kind: 'import_batch', status: 'running' })
+    })
+
+    it('accepts an absent filter', async () => {
+      list.mockReturnValue([])
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.list)
+
+      const result = await handler({})
+
+      expect(result).toEqual([])
+      expect(list).toHaveBeenCalledWith(undefined)
+    })
+  })
+
+  describe('jobs:get', () => {
+    it('returns INVALID_PARAMETERS for a non-string jobId', async () => {
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.get)
+
+      const result = await handler({}, 12345)
+
+      expectInvalidParametersResult(result)
+      expect(get).not.toHaveBeenCalled()
+    })
+
+    it('returns INVALID_PARAMETERS for an empty jobId', async () => {
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.get)
+
+      const result = await handler({}, '')
+
+      expectInvalidParametersResult(result)
+      expect(get).not.toHaveBeenCalled()
+    })
+
+    it('passes a valid jobId through to jobRunner.get', async () => {
+      get.mockReturnValue({ id: 'job-1' })
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.get)
+
+      const result = await handler({}, 'job-1')
+
+      expect(result).toEqual({ id: 'job-1' })
+      expect(get).toHaveBeenCalledWith('job-1')
+    })
+  })
+
+  describe('jobs:progress', () => {
+    it('returns INVALID_PARAMETERS for a non-string jobId', async () => {
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.progress)
+
+      const result = await handler({}, { not: 'a string' })
+
+      expectInvalidParametersResult(result)
+      expect(get).not.toHaveBeenCalled()
+    })
+
+    it('returns the progress snapshot for a valid jobId', async () => {
+      get.mockReturnValue({ id: 'job-1', progress: { current: 1, total: 2 } })
+      registerJobsHandlers()
+      const handler = getHandler(JOBS_CHANNELS.progress)
+
+      const result = await handler({}, 'job-1')
+
+      expect(result).toEqual({ current: 1, total: 2 })
+    })
+  })
+})

--- a/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
+++ b/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
@@ -22,7 +22,8 @@ import { extractZip, cleanupZipTemp } from '../../../../src/main/ipc/handlers/ba
 import {
   __resetAllowlistForTests,
   addAllowedImportPath,
-  isStrictlyEnrolledPath
+  isStrictlyEnrolledPath,
+  removeAllowedImportPath
 } from '../../../../src/main/security/import-path-allowlist'
 
 describe('extractZip — enrolls extracted files for the strict path-authority gate', () => {
@@ -48,12 +49,22 @@ describe('extractZip — enrolls extracted files for the strict path-authority g
     // Nothing extracted yet is enrolled (the temp dir doesn't even exist).
     // The desktop IPC handler passes addAllowedImportPath here after it has
     // validated the ZIP path against the strict dialog-enrolled allowlist.
-    const result = await extractZip(zipPath, undefined, addAllowedImportPath)
+    const result = await extractZip(
+      zipPath,
+      undefined,
+      addAllowedImportPath,
+      removeAllowedImportPath
+    )
 
     expect(result.errors).toEqual([])
     expect(result.files.length).toBe(2)
     for (const extractedFile of result.files) {
       expect(isStrictlyEnrolledPath(extractedFile)).toBe(true)
+    }
+
+    cleanupZipTemp()
+    for (const extractedFile of result.files) {
+      expect(isStrictlyEnrolledPath(extractedFile)).toBe(false)
     }
   })
 })

--- a/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
+++ b/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
@@ -1,0 +1,56 @@
+/**
+ * F-path hardening (Codex-high finding): batch-import:checkDuplicates and
+ * batch-import:start now gate on isStrictlyEnrolledPath, which only accepts
+ * paths explicitly enrolled via addAllowedImportPath this session. A file
+ * extracted from a dialog-enrolled ZIP was never itself picked via a
+ * dialog, so extractZip must explicitly enroll each extracted file — this
+ * is the "ZIP extract -> review -> start" continuity the strict gate
+ * depends on.
+ *
+ * This lives in its own file (rather than batch-import-logic.test.ts) so
+ * extractZip's real ZipExtractor/TempDirectoryManager path is exercised
+ * without interacting with that file's ImportWorkerClient mock, which
+ * relies on a lazy dynamic import specifically to avoid eager module
+ * evaluation ordering issues with its hoisted vi.mock factory.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import AdmZip from 'adm-zip'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { extractZip, cleanupZipTemp } from '../../../../src/main/ipc/handlers/batch-import-logic'
+import {
+  __resetAllowlistForTests,
+  isStrictlyEnrolledPath
+} from '../../../../src/main/security/import-path-allowlist'
+
+describe('extractZip — enrolls extracted files for the strict path-authority gate', () => {
+  let sourceDir: string
+
+  beforeEach(() => {
+    __resetAllowlistForTests()
+    sourceDir = mkdtempSync(join(tmpdir(), 'varlens-zip-src-'))
+  })
+
+  afterEach(() => {
+    cleanupZipTemp()
+    rmSync(sourceDir, { recursive: true, force: true })
+  })
+
+  it('enrolls each extracted file so the subsequent strict-gated call accepts it', async () => {
+    const zipPath = join(sourceDir, 'batch.zip')
+    const zip = new AdmZip()
+    zip.addFile('case1.json', Buffer.from('{"case":"1"}'))
+    zip.addFile('case2.json.gz', Buffer.from('not-really-gzipped-but-fine-for-this-test'))
+    zip.writeZip(zipPath)
+
+    // Nothing extracted yet is enrolled (the temp dir doesn't even exist).
+    const result = await extractZip(zipPath)
+
+    expect(result.errors).toEqual([])
+    expect(result.files.length).toBe(2)
+    for (const extractedFile of result.files) {
+      expect(isStrictlyEnrolledPath(extractedFile)).toBe(true)
+    }
+  })
+})

--- a/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
+++ b/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { extractZip, cleanupZipTemp } from '../../../../src/main/ipc/handlers/batch-import-logic'
 import {
   __resetAllowlistForTests,
+  addAllowedImportPath,
   isStrictlyEnrolledPath
 } from '../../../../src/main/security/import-path-allowlist'
 
@@ -45,7 +46,9 @@ describe('extractZip — enrolls extracted files for the strict path-authority g
     zip.writeZip(zipPath)
 
     // Nothing extracted yet is enrolled (the temp dir doesn't even exist).
-    const result = await extractZip(zipPath)
+    // The desktop IPC handler passes addAllowedImportPath here after it has
+    // validated the ZIP path against the strict dialog-enrolled allowlist.
+    const result = await extractZip(zipPath, undefined, addAllowedImportPath)
 
     expect(result.errors).toEqual([])
     expect(result.files.length).toBe(2)

--- a/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
+++ b/tests/main/ipc/handlers/batch-import-extract-zip-enrollment.test.ts
@@ -17,8 +17,9 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import AdmZip from 'adm-zip'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { extractZip, cleanupZipTemp } from '../../../../src/main/ipc/handlers/batch-import-logic'
+import { ZipExtractor } from '../../../../src/main/import/ZipExtractor'
 import {
   __resetAllowlistForTests,
   addAllowedImportPath,
@@ -28,6 +29,7 @@ import {
 
 describe('extractZip — enrolls extracted files for the strict path-authority gate', () => {
   let sourceDir: string
+  const extractionIds = new Set<string>()
 
   beforeEach(() => {
     __resetAllowlistForTests()
@@ -35,7 +37,9 @@ describe('extractZip — enrolls extracted files for the strict path-authority g
   })
 
   afterEach(() => {
-    cleanupZipTemp()
+    vi.restoreAllMocks()
+    for (const extractionId of extractionIds) cleanupZipTemp(extractionId)
+    extractionIds.clear()
     rmSync(sourceDir, { recursive: true, force: true })
   })
 
@@ -55,6 +59,7 @@ describe('extractZip — enrolls extracted files for the strict path-authority g
       addAllowedImportPath,
       removeAllowedImportPath
     )
+    extractionIds.add(result.extractionId)
 
     expect(result.errors).toEqual([])
     expect(result.files.length).toBe(2)
@@ -62,9 +67,100 @@ describe('extractZip — enrolls extracted files for the strict path-authority g
       expect(isStrictlyEnrolledPath(extractedFile)).toBe(true)
     }
 
-    cleanupZipTemp()
+    cleanupZipTemp(result.extractionId)
     for (const extractedFile of result.files) {
       expect(isStrictlyEnrolledPath(extractedFile)).toBe(false)
     }
+  })
+
+  it('keeps concurrent extraction ownership isolated during targeted cleanup', async () => {
+    const createZip = (name: string, caseName: string): string => {
+      const zipPath = join(sourceDir, name)
+      const zip = new AdmZip()
+      zip.addFile(`${caseName}.json`, Buffer.from(`{"case":"${caseName}"}`))
+      zip.writeZip(zipPath)
+      return zipPath
+    }
+
+    const [first, second] = await Promise.all(
+      [createZip('first.zip', 'first'), createZip('second.zip', 'second')].map((zipPath) =>
+        extractZip(zipPath, undefined, addAllowedImportPath, removeAllowedImportPath)
+      )
+    )
+    extractionIds.add(first.extractionId)
+    extractionIds.add(second.extractionId)
+
+    expect(first.extractionId).not.toBe(second.extractionId)
+    expect(first.files).toHaveLength(1)
+    expect(second.files).toHaveLength(1)
+    expect(isStrictlyEnrolledPath(first.files[0])).toBe(true)
+    expect(isStrictlyEnrolledPath(second.files[0])).toBe(true)
+
+    cleanupZipTemp(first.extractionId)
+
+    expect(isStrictlyEnrolledPath(first.files[0])).toBe(false)
+    expect(isStrictlyEnrolledPath(second.files[0])).toBe(true)
+
+    // A stale cleanup capability is idempotent and cannot revoke another
+    // extraction's enrollment.
+    cleanupZipTemp(first.extractionId)
+    expect(isStrictlyEnrolledPath(second.files[0])).toBe(true)
+  })
+
+  it('does not let cleanup of a completed extraction disturb another extraction in flight', async () => {
+    const firstZip = join(sourceDir, 'first.zip')
+    const secondZip = join(sourceDir, 'second.zip')
+    for (const [zipPath, caseName] of [
+      [firstZip, 'first'],
+      [secondZip, 'second']
+    ] as const) {
+      const zip = new AdmZip()
+      zip.addFile(`${caseName}.json`, Buffer.from(`{"case":"${caseName}"}`))
+      zip.writeZip(zipPath)
+    }
+
+    const originalExtract = ZipExtractor.prototype.extract
+    let releaseSecond!: () => void
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve
+    })
+    let markSecondStarted!: () => void
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve
+    })
+    vi.spyOn(ZipExtractor.prototype, 'extract').mockImplementation(
+      async function (zipPath, targetDir, password) {
+        if (zipPath === secondZip) {
+          markSecondStarted()
+          await secondGate
+        }
+        return originalExtract.call(this, zipPath, targetDir, password)
+      }
+    )
+
+    const first = await extractZip(
+      firstZip,
+      undefined,
+      addAllowedImportPath,
+      removeAllowedImportPath
+    )
+    extractionIds.add(first.extractionId)
+    const secondPromise = extractZip(
+      secondZip,
+      undefined,
+      addAllowedImportPath,
+      removeAllowedImportPath
+    )
+    await secondStarted
+
+    cleanupZipTemp(first.extractionId)
+    expect(isStrictlyEnrolledPath(first.files[0])).toBe(false)
+
+    releaseSecond()
+    const second = await secondPromise
+    extractionIds.add(second.extractionId)
+    expect(second.errors).toEqual([])
+    expect(second.files).toHaveLength(1)
+    expect(isStrictlyEnrolledPath(second.files[0])).toBe(true)
   })
 })

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -131,6 +131,20 @@ describe('batch-import IPC handlers', () => {
       expect(isIpcError(result)).toBe(false)
       expect(checkDuplicateFiles).toHaveBeenCalledWith(expect.any(Function), [filePath], undefined)
     })
+
+    it('rejects a path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+      // Strict enrollment gate: a path merely living under an automatic
+      // root (home/userData/temp) is not proof of dialog provenance.
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:checkDuplicates', [
+        '/tmp/not-dialog-enrolled.json'
+      ])
+
+      expectInvalidParametersResult(result)
+      expect(checkDuplicateFiles).not.toHaveBeenCalled()
+    })
   })
 
   describe('batch-import:start', () => {
@@ -177,6 +191,21 @@ describe('batch-import IPC handlers', () => {
       expect(isIpcError(result)).toBe(false)
       expect(startBatchImport).toHaveBeenCalled()
     })
+
+    it('rejects a path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:start',
+        ['/tmp/not-dialog-enrolled.json'],
+        'overwrite'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(startBatchImport).not.toHaveBeenCalled()
+    })
   })
 
   describe('batch-import:testZipPassword', () => {
@@ -216,6 +245,21 @@ describe('batch-import IPC handlers', () => {
       expect(isIpcError(result)).toBe(false)
       expect(testZipPassword).toHaveBeenCalledWith(zipPath, 'pw')
     })
+
+    it('rejects a zip path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:testZipPassword',
+        '/tmp/not-dialog-enrolled.zip',
+        'pw'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(testZipPassword).not.toHaveBeenCalled()
+    })
   })
 
   describe('batch-import:extractZip', () => {
@@ -239,6 +283,20 @@ describe('batch-import IPC handlers', () => {
 
       expect(isIpcError(result)).toBe(false)
       expect(extractZip).toHaveBeenCalledWith(zipPath, undefined)
+    })
+
+    it('rejects a zip path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:extractZip',
+        '/tmp/not-dialog-enrolled.zip'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(extractZip).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../../../src/main/ipc/handlers/batch-import-logic', () => ({
   }),
   cancelBatchImport: vi.fn(),
   testZipPassword: vi.fn().mockReturnValue({ success: true }),
-  extractZip: vi.fn().mockResolvedValue({ files: [], errors: [] }),
+  extractZip: vi.fn().mockResolvedValue({ files: [], errors: [], extractionId: 'extraction-1' }),
   cleanupZipTemp: vi.fn()
 }))
 
@@ -305,6 +305,29 @@ describe('batch-import IPC handlers', () => {
 
       expectInvalidParametersResult(result)
       expect(extractZip).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('batch-import:cleanupZipTemp', () => {
+    it('rejects a missing extraction ownership ID', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:cleanupZipTemp')
+
+      expectInvalidParametersResult(result)
+    })
+
+    it('cleans only the addressed extraction ownership ID', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:cleanupZipTemp', 'extraction-1')
+
+      expect(isIpcError(result)).toBe(false)
+      const { cleanupZipTemp } =
+        await import('../../../../src/main/ipc/handlers/batch-import-logic')
+      expect(cleanupZipTemp).toHaveBeenCalledWith('extraction-1')
     })
   })
 

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
+
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn()
+  }
+}))
+
+vi.mock('fs/promises', () => ({
+  readdir: vi.fn()
+}))
+
+vi.mock('../../../../src/main/import', () => ({
+  ZipExtractor: class {
+    isEncrypted(): boolean {
+      return false
+    }
+  }
+}))
+
+vi.mock('../../../../src/main/ipc/handlers/batch-import-logic', () => ({
+  checkDuplicateFiles: vi.fn().mockReturnValue({ files: [], duplicateCount: 0 }),
+  startBatchImport: vi.fn().mockResolvedValue({
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+    cancelled: false,
+    details: []
+  }),
+  cancelBatchImport: vi.fn(),
+  testZipPassword: vi.fn().mockReturnValue({ success: true }),
+  extractZip: vi.fn().mockResolvedValue({ files: [], errors: [] }),
+  cleanupZipTemp: vi.fn()
+}))
+
+vi.mock('../../../../src/main/ipc/utils/settings-io', () => ({
+  loadSettings: vi.fn().mockResolvedValue({}),
+  saveSettings: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { dialog } from 'electron'
+import { readdir } from 'fs/promises'
+import { registerBatchImportHandlers } from '../../../../src/main/ipc/handlers/batch-import'
+import {
+  checkDuplicateFiles,
+  startBatchImport,
+  testZipPassword,
+  extractZip
+} from '../../../../src/main/ipc/handlers/batch-import-logic'
+import {
+  __resetAllowlistForTests,
+  addAllowedImportPath,
+  isAllowedImportPath
+} from '../../../../src/main/security/import-path-allowlist'
+
+type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+function makeIpcMain(): { handle: ReturnType<typeof vi.fn> } {
+  return { handle: vi.fn() }
+}
+
+function makeDeps(ipcMain: { handle: ReturnType<typeof vi.fn> }): {
+  ipcMain: typeof ipcMain
+  getDb: ReturnType<typeof vi.fn>
+} {
+  return { ipcMain, getDb: vi.fn() }
+}
+
+function getHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string
+): HandlerCallback {
+  const call = ipcMain.handle.mock.calls.find(([c]) => c === channel) as
+    [string, HandlerCallback] | undefined
+  if (!call) throw new Error(`Handler for ${channel} not registered`)
+  return call[1]
+}
+
+async function invokeHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  const handler = getHandler(ipcMain, channel)
+  return handler({}, ...args)
+}
+
+function expectInvalidParametersResult(result: unknown): void {
+  expect(isIpcError(result)).toBe(true)
+  if (isIpcError(result)) {
+    expect(result.code).toBe(ErrorCode.INVALID_PARAMETERS)
+  }
+}
+
+describe('batch-import IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetAllowlistForTests()
+  })
+
+  describe('batch-import:checkDuplicates', () => {
+    it('returns INVALID_PARAMETERS for malformed args', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:checkDuplicates', 'not-an-array')
+
+      expectInvalidParametersResult(result)
+      expect(checkDuplicateFiles).not.toHaveBeenCalled()
+    })
+
+    it('rejects a non-enrolled file path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:checkDuplicates', ['/etc/passwd'])
+
+      expectInvalidParametersResult(result)
+      expect(checkDuplicateFiles).not.toHaveBeenCalled()
+    })
+
+    it('accepts a dialog-enrolled file path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const filePath = '/some/custom/mount/case1.json'
+      addAllowedImportPath(filePath)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:checkDuplicates', [filePath])
+
+      expect(isIpcError(result)).toBe(false)
+      expect(checkDuplicateFiles).toHaveBeenCalledWith(expect.any(Function), [filePath], undefined)
+    })
+  })
+
+  describe('batch-import:start', () => {
+    it('returns INVALID_PARAMETERS for malformed duplicateStrategy', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const filePath = '/some/custom/mount/case1.json'
+      addAllowedImportPath(filePath)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:start',
+        [filePath],
+        'not-a-real-strategy'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(startBatchImport).not.toHaveBeenCalled()
+    })
+
+    it('rejects a non-enrolled file path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:start',
+        ['/etc/passwd'],
+        'overwrite'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(startBatchImport).not.toHaveBeenCalled()
+    })
+
+    it('accepts a dialog-enrolled file path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const filePath = '/some/custom/mount/case1.json'
+      addAllowedImportPath(filePath)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:start', [filePath], 'overwrite')
+
+      expect(isIpcError(result)).toBe(false)
+      expect(startBatchImport).toHaveBeenCalled()
+    })
+  })
+
+  describe('batch-import:testZipPassword', () => {
+    it('returns INVALID_PARAMETERS for malformed args', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:testZipPassword', 123, 'pw')
+
+      expectInvalidParametersResult(result)
+      expect(testZipPassword).not.toHaveBeenCalled()
+    })
+
+    it('rejects a non-enrolled zip path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'batch-import:testZipPassword',
+        '/etc/passwd',
+        'pw'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(testZipPassword).not.toHaveBeenCalled()
+    })
+
+    it('accepts a dialog-enrolled zip path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const zipPath = '/some/custom/mount/batch.zip'
+      addAllowedImportPath(zipPath)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:testZipPassword', zipPath, 'pw')
+
+      expect(isIpcError(result)).toBe(false)
+      expect(testZipPassword).toHaveBeenCalledWith(zipPath, 'pw')
+    })
+  })
+
+  describe('batch-import:extractZip', () => {
+    it('rejects a non-enrolled zip path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:extractZip', '/etc/passwd')
+
+      expectInvalidParametersResult(result)
+      expect(extractZip).not.toHaveBeenCalled()
+    })
+
+    it('accepts a dialog-enrolled zip path', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const zipPath = '/some/custom/mount/batch.zip'
+      addAllowedImportPath(zipPath)
+
+      const result = await invokeHandler(ipcMain, 'batch-import:extractZip', zipPath)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(extractZip).toHaveBeenCalledWith(zipPath, undefined)
+    })
+  })
+
+  describe('dialog enrollment', () => {
+    it('enrolls files picked via batch-import:selectFiles', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const filePath = '/some/custom/mount/case1.json'
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [filePath]
+      } as never)
+
+      expect(isAllowedImportPath(filePath)).toBe(false)
+      const result = await invokeHandler(ipcMain, 'batch-import:selectFiles')
+
+      expect(result).toEqual([filePath])
+      expect(isAllowedImportPath(filePath)).toBe(true)
+    })
+
+    it('enrolls the zip picked via batch-import:selectZip', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const zipPath = '/some/custom/mount/batch.zip'
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [zipPath]
+      } as never)
+
+      expect(isAllowedImportPath(zipPath)).toBe(false)
+      await invokeHandler(ipcMain, 'batch-import:selectZip')
+
+      expect(isAllowedImportPath(zipPath)).toBe(true)
+    })
+
+    it('enrolls files discovered when a folder is selected via batch-import:selectFolder', async () => {
+      const ipcMain = makeIpcMain()
+      registerBatchImportHandlers(makeDeps(ipcMain) as never)
+      const folderPath = '/some/custom/mount/cases'
+      const discoveredFile = '/some/custom/mount/cases/case1.json'
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [folderPath]
+      } as never)
+      vi.mocked(readdir).mockResolvedValue([{ name: 'case1.json', isFile: () => true }] as never)
+
+      expect(isAllowedImportPath(discoveredFile)).toBe(false)
+      const result = await invokeHandler(ipcMain, 'batch-import:selectFolder')
+
+      expect(result).toEqual([discoveredFile])
+      expect(isAllowedImportPath(discoveredFile)).toBe(true)
+    })
+  })
+})

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -52,7 +52,7 @@ import {
 import {
   __resetAllowlistForTests,
   addAllowedImportPath,
-  isAllowedImportPath,
+  isStrictlyEnrolledPath,
   removeAllowedImportPath
 } from '../../../../src/main/security/import-path-allowlist'
 
@@ -136,9 +136,8 @@ describe('batch-import IPC handlers', () => {
       expect(checkDuplicateFiles).toHaveBeenCalledWith(expect.any(Function), [filePath], undefined)
     })
 
-    it('rejects a path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
-      // Strict enrollment gate: a path merely living under an automatic
-      // root (home/userData/temp) is not proof of dialog provenance.
+    it('rejects a temp path that was never dialog-enrolled', async () => {
+      // Filesystem location is not proof of dialog provenance.
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
 
@@ -196,7 +195,7 @@ describe('batch-import IPC handlers', () => {
       expect(startBatchImport).toHaveBeenCalled()
     })
 
-    it('rejects a path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+    it('rejects a temp path that was never dialog-enrolled', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
 
@@ -250,7 +249,7 @@ describe('batch-import IPC handlers', () => {
       expect(testZipPassword).toHaveBeenCalledWith(zipPath, 'pw')
     })
 
-    it('rejects a zip path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+    it('rejects a temp ZIP path that was never dialog-enrolled', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
 
@@ -294,7 +293,7 @@ describe('batch-import IPC handlers', () => {
       )
     })
 
-    it('rejects a zip path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+    it('rejects a temp ZIP path that was never dialog-enrolled', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
 
@@ -319,11 +318,11 @@ describe('batch-import IPC handlers', () => {
         filePaths: [filePath]
       } as never)
 
-      expect(isAllowedImportPath(filePath)).toBe(false)
+      expect(isStrictlyEnrolledPath(filePath)).toBe(false)
       const result = await invokeHandler(ipcMain, 'batch-import:selectFiles')
 
       expect(result).toEqual([filePath])
-      expect(isAllowedImportPath(filePath)).toBe(true)
+      expect(isStrictlyEnrolledPath(filePath)).toBe(true)
     })
 
     it('enrolls the zip picked via batch-import:selectZip', async () => {
@@ -335,10 +334,10 @@ describe('batch-import IPC handlers', () => {
         filePaths: [zipPath]
       } as never)
 
-      expect(isAllowedImportPath(zipPath)).toBe(false)
+      expect(isStrictlyEnrolledPath(zipPath)).toBe(false)
       await invokeHandler(ipcMain, 'batch-import:selectZip')
 
-      expect(isAllowedImportPath(zipPath)).toBe(true)
+      expect(isStrictlyEnrolledPath(zipPath)).toBe(true)
     })
 
     it('enrolls files discovered when a folder is selected via batch-import:selectFolder', async () => {
@@ -346,17 +345,19 @@ describe('batch-import IPC handlers', () => {
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
       const folderPath = join(EXTERNAL_ROOT, 'cases')
       const discoveredFile = join(folderPath, 'case1.json')
+      const undiscoveredSibling = join(folderPath, 'case2.json')
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
         filePaths: [folderPath]
       } as never)
       vi.mocked(readdir).mockResolvedValue([{ name: 'case1.json', isFile: () => true }] as never)
 
-      expect(isAllowedImportPath(discoveredFile)).toBe(false)
+      expect(isStrictlyEnrolledPath(discoveredFile)).toBe(false)
       const result = await invokeHandler(ipcMain, 'batch-import:selectFolder')
 
       expect(result).toEqual([discoveredFile])
-      expect(isAllowedImportPath(discoveredFile)).toBe(true)
+      expect(isStrictlyEnrolledPath(discoveredFile)).toBe(true)
+      expect(isStrictlyEnrolledPath(undiscoveredSibling)).toBe(false)
     })
   })
 })

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join, parse } from 'node:path'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('electron', () => ({
@@ -51,10 +52,13 @@ import {
 import {
   __resetAllowlistForTests,
   addAllowedImportPath,
-  isAllowedImportPath
+  isAllowedImportPath,
+  removeAllowedImportPath
 } from '../../../../src/main/security/import-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+const EXTERNAL_ROOT = join(parse(process.cwd()).root, 'varlens-external')
 
 function makeIpcMain(): { handle: ReturnType<typeof vi.fn> } {
   return { handle: vi.fn() }
@@ -123,7 +127,7 @@ describe('batch-import IPC handlers', () => {
     it('accepts a dialog-enrolled file path', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const filePath = '/some/custom/mount/case1.json'
+      const filePath = join(EXTERNAL_ROOT, 'case1.json')
       addAllowedImportPath(filePath)
 
       const result = await invokeHandler(ipcMain, 'batch-import:checkDuplicates', [filePath])
@@ -151,7 +155,7 @@ describe('batch-import IPC handlers', () => {
     it('returns INVALID_PARAMETERS for malformed duplicateStrategy', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const filePath = '/some/custom/mount/case1.json'
+      const filePath = join(EXTERNAL_ROOT, 'case1.json')
       addAllowedImportPath(filePath)
 
       const result = await invokeHandler(
@@ -183,7 +187,7 @@ describe('batch-import IPC handlers', () => {
     it('accepts a dialog-enrolled file path', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const filePath = '/some/custom/mount/case1.json'
+      const filePath = join(EXTERNAL_ROOT, 'case1.json')
       addAllowedImportPath(filePath)
 
       const result = await invokeHandler(ipcMain, 'batch-import:start', [filePath], 'overwrite')
@@ -237,7 +241,7 @@ describe('batch-import IPC handlers', () => {
     it('accepts a dialog-enrolled zip path', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const zipPath = '/some/custom/mount/batch.zip'
+      const zipPath = join(EXTERNAL_ROOT, 'batch.zip')
       addAllowedImportPath(zipPath)
 
       const result = await invokeHandler(ipcMain, 'batch-import:testZipPassword', zipPath, 'pw')
@@ -276,13 +280,18 @@ describe('batch-import IPC handlers', () => {
     it('accepts a dialog-enrolled zip path', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const zipPath = '/some/custom/mount/batch.zip'
+      const zipPath = join(EXTERNAL_ROOT, 'batch.zip')
       addAllowedImportPath(zipPath)
 
       const result = await invokeHandler(ipcMain, 'batch-import:extractZip', zipPath)
 
       expect(isIpcError(result)).toBe(false)
-      expect(extractZip).toHaveBeenCalledWith(zipPath, undefined, addAllowedImportPath)
+      expect(extractZip).toHaveBeenCalledWith(
+        zipPath,
+        undefined,
+        addAllowedImportPath,
+        removeAllowedImportPath
+      )
     })
 
     it('rejects a zip path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
@@ -304,7 +313,7 @@ describe('batch-import IPC handlers', () => {
     it('enrolls files picked via batch-import:selectFiles', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const filePath = '/some/custom/mount/case1.json'
+      const filePath = join(EXTERNAL_ROOT, 'case1.json')
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
         filePaths: [filePath]
@@ -320,7 +329,7 @@ describe('batch-import IPC handlers', () => {
     it('enrolls the zip picked via batch-import:selectZip', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const zipPath = '/some/custom/mount/batch.zip'
+      const zipPath = join(EXTERNAL_ROOT, 'batch.zip')
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
         filePaths: [zipPath]
@@ -335,8 +344,8 @@ describe('batch-import IPC handlers', () => {
     it('enrolls files discovered when a folder is selected via batch-import:selectFolder', async () => {
       const ipcMain = makeIpcMain()
       registerBatchImportHandlers(makeDeps(ipcMain) as never)
-      const folderPath = '/some/custom/mount/cases'
-      const discoveredFile = '/some/custom/mount/cases/case1.json'
+      const folderPath = join(EXTERNAL_ROOT, 'cases')
+      const discoveredFile = join(folderPath, 'case1.json')
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
         filePaths: [folderPath]

--- a/tests/main/ipc/handlers/batch-import.test.ts
+++ b/tests/main/ipc/handlers/batch-import.test.ts
@@ -282,7 +282,7 @@ describe('batch-import IPC handlers', () => {
       const result = await invokeHandler(ipcMain, 'batch-import:extractZip', zipPath)
 
       expect(isIpcError(result)).toBe(false)
-      expect(extractZip).toHaveBeenCalledWith(zipPath, undefined)
+      expect(extractZip).toHaveBeenCalledWith(zipPath, undefined, addAllowedImportPath)
     })
 
     it('rejects a zip path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {

--- a/tests/main/ipc/handlers/database-path-authority.test.ts
+++ b/tests/main/ipc/handlers/database-path-authority.test.ts
@@ -1,0 +1,253 @@
+/**
+ * DB path-authority gate tests (F-path, Part B / S6, Codex F-03).
+ *
+ * database:open, database:create, database:showInFolder, and
+ * database:removeRecent must only accept a path that was picked via a
+ * dialog this session (database:selectFile / database:selectSaveLocation,
+ * sharing the import allowlist's dialog-enrolled set), already appears in
+ * the recent databases list, or is the currently active database. This
+ * mirrors the deleteFile precedent (recent-list + active-DB refusal) plus
+ * the import-path-allowlist's dialog-enrollment mechanism.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/nonexistent-electron-app-path'),
+    isPackaged: false
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showSaveDialog: vi.fn()
+  },
+  safeStorage: {
+    decryptString: vi.fn(),
+    encryptString: vi.fn(),
+    isEncryptionAvailable: vi.fn(() => true)
+  },
+  shell: {
+    showItemInFolder: vi.fn()
+  }
+}))
+
+vi.mock('../../../../src/main/ipc/handlers/database-logic', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../../src/main/ipc/handlers/database-logic')
+  >('../../../../src/main/ipc/handlers/database-logic')
+  return {
+    ...actual,
+    openDatabase: vi
+      .fn()
+      .mockResolvedValue({ success: true, info: { path: '', name: '', encrypted: false } }),
+    createDatabase: vi
+      .fn()
+      .mockResolvedValue({ success: true, info: { path: '', name: '', encrypted: false } }),
+    removeRecentDatabase: vi.fn().mockReturnValue({ success: true })
+  }
+})
+
+import { dialog, shell } from 'electron'
+import { registerDatabaseHandlers } from '../../../../src/main/ipc/handlers/database'
+import {
+  openDatabase,
+  createDatabase,
+  removeRecentDatabase
+} from '../../../../src/main/ipc/handlers/database-logic'
+import { __resetAllowlistForTests } from '../../../../src/main/security/import-path-allowlist'
+
+type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+function makeIpcMain(): { handle: ReturnType<typeof vi.fn> } {
+  return { handle: vi.fn() }
+}
+
+function makeDbManager(overrides: {
+  currentPath?: string | null
+  recentPaths?: string[]
+}): ReturnType<typeof vi.fn> {
+  return vi.fn().mockReturnValue({
+    getCurrentPath: vi.fn().mockReturnValue(overrides.currentPath ?? null),
+    getRecentDatabases: vi
+      .fn()
+      .mockReturnValue(
+        (overrides.recentPaths ?? []).map((path) => ({ path, name: path, lastOpened: 0 }))
+      )
+  })
+}
+
+function makeDeps(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  dbManagerOverrides: { currentPath?: string | null; recentPaths?: string[] } = {}
+): {
+  ipcMain: typeof ipcMain
+  getDb: ReturnType<typeof vi.fn>
+  getDbManager: ReturnType<typeof vi.fn>
+} {
+  return {
+    ipcMain,
+    getDb: vi.fn(),
+    getDbManager: makeDbManager(dbManagerOverrides)
+  }
+}
+
+function getHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string
+): HandlerCallback {
+  const call = ipcMain.handle.mock.calls.find(([c]) => c === channel) as
+    [string, HandlerCallback] | undefined
+  if (!call) throw new Error(`Handler for ${channel} not registered`)
+  return call[1]
+}
+
+async function invokeHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  const handler = getHandler(ipcMain, channel)
+  return handler({}, ...args)
+}
+
+function expectInvalidParametersResult(result: unknown): void {
+  expect(isIpcError(result)).toBe(true)
+  if (isIpcError(result)) {
+    // Path-authority rejections surface as UNKNOWN via wrapHandler's generic
+    // Error path (mirrors deleteDbFile's existing precedent).
+    expect([ErrorCode.INVALID_PARAMETERS, ErrorCode.UNKNOWN]).toContain(result.code)
+  }
+}
+
+// Path guaranteed to be outside any automatic root (home/userData/temp are
+// all mocked to '/nonexistent-electron-app-path' above) and never enrolled.
+const UNAUTHORIZED_PATH = '/some/other/mount/unrelated.db'
+
+describe('database path-authority gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetAllowlistForTests()
+  })
+
+  describe('database:open', () => {
+    it('rejects a path with no dialog/recent/active authority', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:open', UNAUTHORIZED_PATH)
+
+      expectInvalidParametersResult(result)
+      expect(openDatabase).not.toHaveBeenCalled()
+    })
+
+    it('accepts a path selected via database:selectFile this session', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [UNAUTHORIZED_PATH]
+      } as never)
+
+      const selected = await invokeHandler(ipcMain, 'database:selectFile')
+      expect(selected).toBe(UNAUTHORIZED_PATH)
+
+      const result = await invokeHandler(ipcMain, 'database:open', UNAUTHORIZED_PATH)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(openDatabase).toHaveBeenCalled()
+    })
+
+    it('accepts a path already in the recent databases list', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain, { recentPaths: [UNAUTHORIZED_PATH] }) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:open', UNAUTHORIZED_PATH)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(openDatabase).toHaveBeenCalled()
+    })
+
+    it('accepts the currently active database path', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain, { currentPath: UNAUTHORIZED_PATH }) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:open', UNAUTHORIZED_PATH)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(openDatabase).toHaveBeenCalled()
+    })
+  })
+
+  describe('database:create', () => {
+    it('rejects a path with no dialog authority', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:create', UNAUTHORIZED_PATH)
+
+      expectInvalidParametersResult(result)
+      expect(createDatabase).not.toHaveBeenCalled()
+    })
+
+    it('accepts a path selected via database:selectSaveLocation this session', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({
+        canceled: false,
+        filePath: UNAUTHORIZED_PATH
+      } as never)
+
+      const selected = await invokeHandler(ipcMain, 'database:selectSaveLocation', 'new-db.sqlite')
+      expect(selected).toBe(UNAUTHORIZED_PATH)
+
+      const result = await invokeHandler(ipcMain, 'database:create', UNAUTHORIZED_PATH)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(createDatabase).toHaveBeenCalled()
+    })
+  })
+
+  describe('database:removeRecent', () => {
+    it('rejects a path with no authority', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:removeRecent', UNAUTHORIZED_PATH)
+
+      expectInvalidParametersResult(result)
+      expect(removeRecentDatabase).not.toHaveBeenCalled()
+    })
+
+    it('accepts a path already in the recent databases list', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain, { recentPaths: [UNAUTHORIZED_PATH] }) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:removeRecent', UNAUTHORIZED_PATH)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(removeRecentDatabase).toHaveBeenCalled()
+    })
+  })
+
+  describe('database:showInFolder', () => {
+    it('rejects a path with no authority', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:showInFolder', UNAUTHORIZED_PATH)
+
+      expectInvalidParametersResult(result)
+      expect(shell.showItemInFolder).not.toHaveBeenCalled()
+    })
+
+    it('accepts the currently active database path', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain, { currentPath: UNAUTHORIZED_PATH }) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:showInFolder', UNAUTHORIZED_PATH)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(shell.showItemInFolder).toHaveBeenCalledWith(UNAUTHORIZED_PATH)
+    })
+  })
+})

--- a/tests/main/ipc/handlers/database-path-authority.test.ts
+++ b/tests/main/ipc/handlers/database-path-authority.test.ts
@@ -124,8 +124,7 @@ function expectInvalidParametersResult(result: unknown): void {
   }
 }
 
-// Path guaranteed to be outside any automatic root (home/userData/temp are
-// all mocked to '/nonexistent-electron-app-path' above) and never enrolled.
+// Path that is never enrolled and has no database recent/current authority.
 const UNAUTHORIZED_PATH = resolve('external', 'unrelated.db')
 
 describe('database path-authority gate', () => {
@@ -183,11 +182,9 @@ describe('database path-authority gate', () => {
       expect(openDatabase).toHaveBeenCalled()
     })
 
-    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
-      // isAllowedImportPath grants app.getPath('home')/userData/temp for the
-      // original import flow; the DB gate must use the STRICT check so a
-      // path merely living under the mocked "home" root (but never picked
-      // via a dialog, recent list, or active session) is still rejected.
+    it('rejects a home path that was never dialog-enrolled', async () => {
+      // Filesystem location is not database authority: the path also needs
+      // dialog, recent-list, or active-session provenance.
       const ipcMain = makeIpcMain()
       registerDatabaseHandlers(makeDeps(ipcMain) as never)
 
@@ -241,7 +238,7 @@ describe('database path-authority gate', () => {
       expect(createDatabase).toHaveBeenCalled()
     })
 
-    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
+    it('rejects a home path that was never dialog-enrolled', async () => {
       const ipcMain = makeIpcMain()
       registerDatabaseHandlers(makeDeps(ipcMain) as never)
 
@@ -299,7 +296,7 @@ describe('database path-authority gate', () => {
       expect(shell.showItemInFolder).toHaveBeenCalledWith(UNAUTHORIZED_PATH)
     })
 
-    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
+    it('rejects a home path that was never dialog-enrolled', async () => {
       const ipcMain = makeIpcMain()
       registerDatabaseHandlers(makeDeps(ipcMain) as never)
 

--- a/tests/main/ipc/handlers/database-path-authority.test.ts
+++ b/tests/main/ipc/handlers/database-path-authority.test.ts
@@ -176,6 +176,24 @@ describe('database path-authority gate', () => {
       expect(isIpcError(result)).toBe(false)
       expect(openDatabase).toHaveBeenCalled()
     })
+
+    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
+      // isAllowedImportPath grants app.getPath('home')/userData/temp for the
+      // original import flow; the DB gate must use the STRICT check so a
+      // path merely living under the mocked "home" root (but never picked
+      // via a dialog, recent list, or active session) is still rejected.
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'database:open',
+        '/nonexistent-electron-app-path/leaked.db'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(openDatabase).not.toHaveBeenCalled()
+    })
   })
 
   describe('database:create', () => {
@@ -204,6 +222,20 @@ describe('database path-authority gate', () => {
 
       expect(isIpcError(result)).toBe(false)
       expect(createDatabase).toHaveBeenCalled()
+    })
+
+    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'database:create',
+        '/nonexistent-electron-app-path/leaked.db'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(createDatabase).not.toHaveBeenCalled()
     })
   })
 
@@ -248,6 +280,20 @@ describe('database path-authority gate', () => {
 
       expect(isIpcError(result)).toBe(false)
       expect(shell.showItemInFolder).toHaveBeenCalledWith(UNAUTHORIZED_PATH)
+    })
+
+    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'database:showInFolder',
+        '/nonexistent-electron-app-path/leaked.db'
+      )
+
+      expectInvalidParametersResult(result)
+      expect(shell.showItemInFolder).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/main/ipc/handlers/database-path-authority.test.ts
+++ b/tests/main/ipc/handlers/database-path-authority.test.ts
@@ -4,7 +4,7 @@
  * database:open, database:create, database:showInFolder, and
  * database:removeRecent must only accept a path that was picked via a
  * dialog this session (database:selectFile / database:selectSaveLocation,
- * sharing the import allowlist's dialog-enrolled set), already appears in
+ * using a database-scoped dialog-enrolled set), already appears in
  * the recent databases list, or is the currently active database. This
  * mirrors the deleteFile precedent (recent-list + active-DB refusal) plus
  * the import-path-allowlist's dialog-enrollment mechanism.
@@ -54,7 +54,11 @@ import {
   createDatabase,
   removeRecentDatabase
 } from '../../../../src/main/ipc/handlers/database-logic'
-import { __resetAllowlistForTests } from '../../../../src/main/security/import-path-allowlist'
+import {
+  addAllowedImportPath,
+  __resetAllowlistForTests
+} from '../../../../src/main/security/import-path-allowlist'
+import { __resetDatabasePathAllowlistForTests } from '../../../../src/main/security/database-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
 
@@ -127,6 +131,7 @@ describe('database path-authority gate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     __resetAllowlistForTests()
+    __resetDatabasePathAllowlistForTests()
   })
 
   describe('database:open', () => {
@@ -190,6 +195,17 @@ describe('database path-authority gate', () => {
         'database:open',
         '/nonexistent-electron-app-path/leaked.db'
       )
+
+      expectInvalidParametersResult(result)
+      expect(openDatabase).not.toHaveBeenCalled()
+    })
+
+    it('rejects a path enrolled only through the import path allowlist', async () => {
+      addAllowedImportPath(UNAUTHORIZED_PATH)
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(ipcMain, 'database:open', UNAUTHORIZED_PATH)
 
       expectInvalidParametersResult(result)
       expect(openDatabase).not.toHaveBeenCalled()

--- a/tests/main/ipc/handlers/database-path-authority.test.ts
+++ b/tests/main/ipc/handlers/database-path-authority.test.ts
@@ -10,7 +10,9 @@
  * the import-path-allowlist's dialog-enrollment mechanism.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolve } from 'node:path'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('electron', () => ({
@@ -59,7 +61,11 @@ import {
   addAllowedImportPath,
   __resetAllowlistForTests
 } from '../../../../src/main/security/import-path-allowlist'
-import { __resetDatabasePathAllowlistForTests } from '../../../../src/main/security/database-path-allowlist'
+import {
+  __resetDatabasePathAllowlistForTests,
+  addAllowedDatabasePath,
+  isStrictlyEnrolledDatabasePath
+} from '../../../../src/main/security/database-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
 
@@ -133,6 +139,125 @@ describe('database path-authority gate', () => {
     __resetAllowlistForTests()
     __resetDatabasePathAllowlistForTests()
   })
+
+  it.each([
+    ['relative', 'relative.db', resolve('relative.db')],
+    ['non-normalized', `${tmpdir()}/authority/../database.db`, join(tmpdir(), 'database.db')]
+  ])('does not enroll a %s database path', (_label, candidate, resolvedAlias) => {
+    addAllowedDatabasePath(candidate)
+
+    expect(isStrictlyEnrolledDatabasePath(candidate)).toBe(false)
+    expect(isStrictlyEnrolledDatabasePath(resolvedAlias)).toBe(false)
+  })
+
+  const symlinkIt = process.platform === 'win32' ? it.skip : it
+  symlinkIt.each(['current', 'recent'])(
+    'rejects a retargeted dialog-enrolled symlink instead of falling through to %s authority',
+    async (fallback) => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-db-authority-'))
+      try {
+        const targetA = join(root, 'a.db')
+        const targetB = join(root, 'b.db')
+        const selectedPath = join(root, 'selected.db')
+        writeFileSync(targetA, 'a')
+        writeFileSync(targetB, 'b')
+        symlinkSync(targetA, selectedPath)
+        addAllowedDatabasePath(selectedPath)
+        expect(isStrictlyEnrolledDatabasePath(selectedPath)).toBe(true)
+
+        unlinkSync(selectedPath)
+        symlinkSync(targetB, selectedPath)
+
+        const ipcMain = makeIpcMain()
+        registerDatabaseHandlers(
+          makeDeps(ipcMain, {
+            currentPath: fallback === 'current' ? selectedPath : null,
+            recentPaths: fallback === 'recent' ? [selectedPath] : []
+          }) as never
+        )
+
+        const result = await invokeHandler(ipcMain, 'database:open', selectedPath)
+
+        expectInvalidParametersResult(result)
+        expect(openDatabase).not.toHaveBeenCalled()
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  symlinkIt(
+    'rejects an unenrolled current path beneath a retargetable symlinked directory',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-db-authority-'))
+      try {
+        const targetDir = join(root, 'target')
+        const linkedDir = join(root, 'linked')
+        const target = join(targetDir, 'database.db')
+        mkdirSync(targetDir)
+        writeFileSync(target, 'database')
+        symlinkSync(targetDir, linkedDir, 'dir')
+        const candidate = join(linkedDir, 'database.db')
+        const ipcMain = makeIpcMain()
+        registerDatabaseHandlers(makeDeps(ipcMain, { currentPath: candidate }) as never)
+
+        const result = await invokeHandler(ipcMain, 'database:open', candidate)
+
+        expectInvalidParametersResult(result)
+        expect(openDatabase).not.toHaveBeenCalled()
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  symlinkIt.each(['current', 'recent'])(
+    'rejects an unenrolled %s database symlink because its target was never pinned',
+    async (fallback) => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-db-authority-'))
+      try {
+        const target = join(root, 'target.db')
+        const symlinkPath = join(root, 'selected.db')
+        writeFileSync(target, 'database')
+        symlinkSync(target, symlinkPath)
+
+        const ipcMain = makeIpcMain()
+        registerDatabaseHandlers(
+          makeDeps(ipcMain, {
+            currentPath: fallback === 'current' ? symlinkPath : null,
+            recentPaths: fallback === 'recent' ? [symlinkPath] : []
+          }) as never
+        )
+
+        const result = await invokeHandler(ipcMain, 'database:open', symlinkPath)
+
+        expectInvalidParametersResult(result)
+        expect(openDatabase).not.toHaveBeenCalled()
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.each(['current', 'recent'])(
+    'rejects normalized aliases backed only by a non-normalized %s metadata path',
+    async (fallback) => {
+      const canonical = resolve('database.db')
+      const metadataAlias = `${join(dirname(canonical), 'nested')}/../${basename(canonical)}`
+      const ipcMain = makeIpcMain()
+      registerDatabaseHandlers(
+        makeDeps(ipcMain, {
+          currentPath: fallback === 'current' ? metadataAlias : null,
+          recentPaths: fallback === 'recent' ? [metadataAlias] : []
+        }) as never
+      )
+
+      const result = await invokeHandler(ipcMain, 'database:open', canonical)
+
+      expectInvalidParametersResult(result)
+      expect(openDatabase).not.toHaveBeenCalled()
+    }
+  )
 
   describe('database:open', () => {
     it('rejects a path with no dialog/recent/active authority', async () => {

--- a/tests/main/ipc/handlers/database-path-authority.test.ts
+++ b/tests/main/ipc/handlers/database-path-authority.test.ts
@@ -10,6 +10,7 @@
  * the import-path-allowlist's dialog-enrollment mechanism.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('electron', () => ({
@@ -125,7 +126,7 @@ function expectInvalidParametersResult(result: unknown): void {
 
 // Path guaranteed to be outside any automatic root (home/userData/temp are
 // all mocked to '/nonexistent-electron-app-path' above) and never enrolled.
-const UNAUTHORIZED_PATH = '/some/other/mount/unrelated.db'
+const UNAUTHORIZED_PATH = resolve('external', 'unrelated.db')
 
 describe('database path-authority gate', () => {
   beforeEach(() => {

--- a/tests/main/ipc/handlers/gene-lists.test.ts
+++ b/tests/main/ipc/handlers/gene-lists.test.ts
@@ -64,8 +64,7 @@ describe('region-files:importBed IPC handler', () => {
     const deps = makeDeps(ipcMain)
     registerGeneListHandlers(deps as never)
 
-    // Path outside all automatic roots (home/userData/temp) and never
-    // enrolled via a dialog this session.
+    // The path was never enrolled via a dialog this session.
     const result = await invokeHandler(ipcMain, 'region-files:importBed', 1, '/etc/passwd')
 
     expect(isIpcError(result)).toBe(true)
@@ -73,13 +72,9 @@ describe('region-files:importBed IPC handler', () => {
     expect(deps.getDb().geneLists.importBedEntries).not.toHaveBeenCalled()
   })
 
-  it('rejects a path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
-    // This gate must use the STRICT enrollment check, not the permissive
-    // isAllowedImportPath — a path merely living under the OS temp dir (or
-    // home/userData) is not proof the user picked it via a dialog this
-    // session. Previously this leaked in via isAllowedImportPath's
-    // automatic-root grant, letting a compromised renderer read any file
-    // under those roots without dialog enrollment.
+  it('rejects a temp path that was never dialog-enrolled', async () => {
+    // Filesystem location is not authority: living under temp is not proof
+    // the user picked the path through a trusted selector.
     const ipcMain = makeIpcMain()
     const deps = makeDeps(ipcMain)
     registerGeneListHandlers(deps as never)

--- a/tests/main/ipc/handlers/gene-lists.test.ts
+++ b/tests/main/ipc/handlers/gene-lists.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isIpcError } from '../../../../src/shared/types/errors'
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn()
+}))
+
+import { readFile } from 'node:fs/promises'
+import { registerGeneListHandlers } from '../../../../src/main/ipc/handlers/gene-lists'
+import {
+  __resetAllowlistForTests,
+  addAllowedImportPath
+} from '../../../../src/main/security/import-path-allowlist'
+
+type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+function makeIpcMain(): { handle: ReturnType<typeof vi.fn> } {
+  return { handle: vi.fn() }
+}
+
+function makeDeps(ipcMain: { handle: ReturnType<typeof vi.fn> }): {
+  ipcMain: typeof ipcMain
+  getDb: ReturnType<typeof vi.fn>
+  getDbPool: ReturnType<typeof vi.fn>
+  getDbManager: ReturnType<typeof vi.fn>
+} {
+  const importBedEntries = vi.fn().mockReturnValue({ id: 1, importedCount: 0 })
+  const getDb = vi.fn().mockReturnValue({ geneLists: { importBedEntries } })
+  const getDbManager = vi.fn().mockReturnValue({
+    getCurrentSession: vi.fn().mockReturnValue({ capabilities: { backend: 'sqlite' } })
+  })
+  const getDbPool = vi.fn().mockReturnValue(null)
+  return { ipcMain, getDb, getDbManager, getDbPool }
+}
+
+function getHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string
+): HandlerCallback {
+  const call = ipcMain.handle.mock.calls.find(([c]) => c === channel) as
+    [string, HandlerCallback] | undefined
+  if (!call) throw new Error(`Handler for ${channel} not registered`)
+  return call[1]
+}
+
+async function invokeHandler(
+  ipcMain: { handle: ReturnType<typeof vi.fn> },
+  channel: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  const handler = getHandler(ipcMain, channel)
+  return handler({}, ...args)
+}
+
+describe('region-files:importBed IPC handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetAllowlistForTests()
+  })
+
+  it('rejects a non-enrolled BED path before reading the file', async () => {
+    const ipcMain = makeIpcMain()
+    const deps = makeDeps(ipcMain)
+    registerGeneListHandlers(deps as never)
+
+    // Path outside all automatic roots (home/userData/temp) and never
+    // enrolled via a dialog this session.
+    const result = await invokeHandler(ipcMain, 'region-files:importBed', 1, '/etc/passwd')
+
+    expect(isIpcError(result)).toBe(true)
+    expect(readFile).not.toHaveBeenCalled()
+    expect(deps.getDb().geneLists.importBedEntries).not.toHaveBeenCalled()
+  })
+
+  it('accepts a dialog-enrolled BED path and imports its entries', async () => {
+    const ipcMain = makeIpcMain()
+    const deps = makeDeps(ipcMain)
+    registerGeneListHandlers(deps as never)
+
+    const bedPath = '/some/custom/mount/regions.bed'
+    addAllowedImportPath(bedPath)
+    vi.mocked(readFile).mockResolvedValue('chr1\t100\t200\tregion1\n')
+
+    const result = await invokeHandler(ipcMain, 'region-files:importBed', 1, bedPath)
+
+    expect(isIpcError(result)).toBe(false)
+    expect(readFile).toHaveBeenCalledWith(bedPath, 'utf-8')
+    expect(deps.getDb().geneLists.importBedEntries).toHaveBeenCalledWith(1, [
+      { chr: 'chr1', start: 100, end: 200, label: 'region1' }
+    ])
+  })
+})

--- a/tests/main/ipc/handlers/gene-lists.test.ts
+++ b/tests/main/ipc/handlers/gene-lists.test.ts
@@ -72,6 +72,29 @@ describe('region-files:importBed IPC handler', () => {
     expect(deps.getDb().geneLists.importBedEntries).not.toHaveBeenCalled()
   })
 
+  it('rejects a path under the automatic temp root that was never dialog-enrolled (F-path)', async () => {
+    // This gate must use the STRICT enrollment check, not the permissive
+    // isAllowedImportPath — a path merely living under the OS temp dir (or
+    // home/userData) is not proof the user picked it via a dialog this
+    // session. Previously this leaked in via isAllowedImportPath's
+    // automatic-root grant, letting a compromised renderer read any file
+    // under those roots without dialog enrollment.
+    const ipcMain = makeIpcMain()
+    const deps = makeDeps(ipcMain)
+    registerGeneListHandlers(deps as never)
+
+    const result = await invokeHandler(
+      ipcMain,
+      'region-files:importBed',
+      1,
+      '/tmp/not-dialog-enrolled.bed'
+    )
+
+    expect(isIpcError(result)).toBe(true)
+    expect(readFile).not.toHaveBeenCalled()
+    expect(deps.getDb().geneLists.importBedEntries).not.toHaveBeenCalled()
+  })
+
   it('accepts a dialog-enrolled BED path and imports its entries', async () => {
     const ipcMain = makeIpcMain()
     const deps = makeDeps(ipcMain)

--- a/tests/main/ipc/handlers/gene-lists.test.ts
+++ b/tests/main/ipc/handlers/gene-lists.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
 import { isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('node:fs/promises', () => ({
@@ -100,7 +101,7 @@ describe('region-files:importBed IPC handler', () => {
     const deps = makeDeps(ipcMain)
     registerGeneListHandlers(deps as never)
 
-    const bedPath = '/some/custom/mount/regions.bed'
+    const bedPath = resolve('external', 'regions.bed')
     addAllowedImportPath(bedPath)
     vi.mocked(readFile).mockResolvedValue('chr1\t100\t200\tregion1\n')
 

--- a/tests/main/ipc/handlers/import.test.ts
+++ b/tests/main/ipc/handlers/import.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -148,9 +148,16 @@ function clearPathConsumerMocks(): void {
   vi.mocked(getVcfMultiPreview).mockClear()
 }
 
+const TRUSTED_DROP_ENROLLMENT_TOKEN = 'trusted-drop-token-0123456789abcdef'
+
 describe('import IPC handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getVcfMultiPreview).mockResolvedValue({
+      files: [],
+      siblingBedFiles: [],
+      suggestedCaseName: 'Case A'
+    })
     __resetAllowlistForTests()
   })
 
@@ -391,6 +398,171 @@ describe('import IPC handlers', () => {
 
       expect(isIpcError(result)).toBe(false)
       expect(startMultiFileImport).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('enrolls a sibling BED discovered by trusted multi-VCF preview', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-sibling-bed-authority-'))
+    try {
+      const filePath = join(root, 'variants.vcf')
+      const bedFile = join(root, 'regions.bed')
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      writeFileSync(bedFile, 'chr1\t0\t10\n')
+      addAllowedImportPath(filePath)
+      vi.mocked(getVcfMultiPreview).mockResolvedValueOnce({
+        files: [],
+        siblingBedFiles: [bedFile],
+        suggestedCaseName: 'variants',
+        commonSamples: [],
+        detectedGenomeBuild: null
+      })
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      const preview = await invokeHandler(ipcMain, 'import:vcfMultiPreview', [filePath])
+      expect(isIpcError(preview)).toBe(false)
+      expect(isStrictlyEnrolledPath(bedFile)).toBe(true)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'import:startMultiFile',
+        'Case A',
+        [{ filePath, variantType: 'SNV', caller: null, annotationFormat: null }],
+        undefined,
+        { bedFile }
+      )
+
+      expect(isIpcError(result)).toBe(false)
+      expect(startMultiFileImport).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not enroll a BED preview result outside the selected VCF directories', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-sibling-bed-authority-'))
+    try {
+      const selectedDir = join(root, 'selected')
+      const externalDir = join(root, 'external')
+      const filePath = join(selectedDir, 'variants.vcf')
+      const bedFile = join(externalDir, 'regions.bed')
+      mkdirSync(selectedDir)
+      mkdirSync(externalDir)
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      writeFileSync(bedFile, 'chr1\t0\t10\n')
+      addAllowedImportPath(filePath)
+      vi.mocked(getVcfMultiPreview).mockResolvedValueOnce({
+        files: [],
+        siblingBedFiles: [bedFile],
+        suggestedCaseName: 'variants',
+        commonSamples: [],
+        detectedGenomeBuild: null
+      })
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      await invokeHandler(ipcMain, 'import:vcfMultiPreview', [filePath])
+
+      expect(isStrictlyEnrolledPath(bedFile)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not enroll a sibling BED result that no longer names a regular file', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-sibling-bed-authority-'))
+    try {
+      const filePath = join(root, 'variants.vcf')
+      const missingBed = join(root, 'removed-regions.bed')
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      addAllowedImportPath(filePath)
+      vi.mocked(getVcfMultiPreview).mockResolvedValueOnce({
+        files: [],
+        siblingBedFiles: [missingBed],
+        suggestedCaseName: 'variants',
+        commonSamples: [],
+        detectedGenomeBuild: null
+      })
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      await invokeHandler(ipcMain, 'import:vcfMultiPreview', [filePath])
+
+      expect(isStrictlyEnrolledPath(missingBed)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects dropped file path enrollment without a trusted preload token', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-drop-authority-'))
+    try {
+      const filePath = join(root, 'variants.vcf')
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      const enrolled = await invokeHandler(ipcMain, 'import:enrollDroppedFiles', [filePath])
+
+      expectInvalidParametersResult(enrolled)
+      expect(isStrictlyEnrolledPath(filePath)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('enrolls normalized VCF paths supplied by the trusted drop-provenance preload flow', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-drop-authority-'))
+    try {
+      const filePath = join(root, 'variants.vcf')
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      const registered = await invokeHandler(
+        ipcMain,
+        'import:registerDroppedFileEnrollmentToken',
+        TRUSTED_DROP_ENROLLMENT_TOKEN
+      )
+      expect(isIpcError(registered)).toBe(false)
+
+      const enrolled = await invokeHandler(ipcMain, 'import:enrollDroppedFiles', {
+        token: TRUSTED_DROP_ENROLLMENT_TOKEN,
+        filePaths: [filePath]
+      })
+
+      expect(enrolled).toEqual([filePath])
+      expect(isStrictlyEnrolledPath(filePath)).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not enroll unsupported, missing, relative, or non-normalized dropped paths', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-drop-authority-'))
+    try {
+      const unsupported = join(root, 'notes.txt')
+      const missing = join(root, 'missing.vcf')
+      const nonNormalized = `${root}/nested/../missing.vcf`
+      writeFileSync(unsupported, 'not a VCF')
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+      await invokeHandler(
+        ipcMain,
+        'import:registerDroppedFileEnrollmentToken',
+        TRUSTED_DROP_ENROLLMENT_TOKEN
+      )
+
+      const enrolled = await invokeHandler(ipcMain, 'import:enrollDroppedFiles', {
+        token: TRUSTED_DROP_ENROLLMENT_TOKEN,
+        filePaths: [unsupported, missing, 'relative.vcf', nonNormalized]
+      })
+
+      expect(enrolled).toEqual([])
+      expect(isStrictlyEnrolledPath(unsupported)).toBe(false)
+      expect(isStrictlyEnrolledPath(missing)).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/tests/main/ipc/handlers/import.test.ts
+++ b/tests/main/ipc/handlers/import.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
@@ -21,6 +24,12 @@ vi.mock('../../../../src/main/ipc/handlers/import-logic', () => ({
   startMultiFileImport: vi.fn()
 }))
 
+vi.mock('../../../../src/main/ipc/utils/settings-io', () => ({
+  loadSettings: vi.fn().mockResolvedValue({}),
+  saveSettings: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { dialog } from 'electron'
 import { registerImportHandlers } from '../../../../src/main/ipc/handlers/import'
 import {
   getVcfMultiPreview,
@@ -28,7 +37,11 @@ import {
   startImport,
   startMultiFileImport
 } from '../../../../src/main/ipc/handlers/import-logic'
-import { __resetAllowlistForTests } from '../../../../src/main/security/import-path-allowlist'
+import {
+  __resetAllowlistForTests,
+  addAllowedImportPath,
+  isStrictlyEnrolledPath
+} from '../../../../src/main/security/import-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
 
@@ -78,6 +91,63 @@ function expectInvalidParametersResult(result: unknown): void {
   expect((result as { code: ErrorCode }).code).toBe(ErrorCode.INVALID_PARAMETERS)
 }
 
+const LEGACY_IMPORT_PATH_CHANNELS = [
+  'import:start',
+  'import:startMultiFile',
+  'import:vcfPreview',
+  'import:vcfMultiPreview'
+] as const
+
+type LegacyImportPathChannel = (typeof LEGACY_IMPORT_PATH_CHANNELS)[number]
+
+function argsForPath(channel: LegacyImportPathChannel, filePath: string): unknown[] {
+  switch (channel) {
+    case 'import:start':
+      return [filePath, 'Case A', undefined]
+    case 'import:startMultiFile':
+      return [
+        'Case A',
+        [{ filePath, variantType: 'SNV', caller: null, annotationFormat: null }],
+        undefined,
+        undefined
+      ]
+    case 'import:vcfPreview':
+      return [filePath]
+    case 'import:vcfMultiPreview':
+      return [[filePath]]
+  }
+}
+
+function expectPathConsumerCalled(channel: LegacyImportPathChannel): void {
+  switch (channel) {
+    case 'import:start':
+      expect(startImport).toHaveBeenCalledOnce()
+      return
+    case 'import:startMultiFile':
+      expect(startMultiFileImport).toHaveBeenCalledOnce()
+      return
+    case 'import:vcfPreview':
+      expect(getVcfPreview).toHaveBeenCalledOnce()
+      return
+    case 'import:vcfMultiPreview':
+      expect(getVcfMultiPreview).toHaveBeenCalledOnce()
+  }
+}
+
+function expectNoPathConsumerCalled(): void {
+  expect(startImport).not.toHaveBeenCalled()
+  expect(startMultiFileImport).not.toHaveBeenCalled()
+  expect(getVcfPreview).not.toHaveBeenCalled()
+  expect(getVcfMultiPreview).not.toHaveBeenCalled()
+}
+
+function clearPathConsumerMocks(): void {
+  vi.mocked(startImport).mockClear()
+  vi.mocked(startMultiFileImport).mockClear()
+  vi.mocked(getVcfPreview).mockClear()
+  vi.mocked(getVcfMultiPreview).mockClear()
+}
+
 describe('import IPC handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -114,6 +184,82 @@ describe('import IPC handlers', () => {
     expect(startImport).not.toHaveBeenCalled()
   })
 
+  it.each(
+    LEGACY_IMPORT_PATH_CHANNELS.flatMap((channel) => [
+      { channel, root: 'temp', filePath: join(tmpdir(), 'varlens-unenrolled', 'variants.vcf') },
+      { channel, root: 'home', filePath: join(homedir(), 'varlens-unenrolled', 'variants.vcf') }
+    ])
+  )('rejects an unenrolled $root path for $channel', async ({ channel, filePath }) => {
+    const ipcMain = makeIpcMain()
+    registerImportHandlers(makeDeps(ipcMain) as never)
+
+    const result = await invokeHandler(ipcMain, channel, ...argsForPath(channel, filePath))
+
+    expectInvalidParametersResult(result)
+    expectNoPathConsumerCalled()
+  })
+
+  it.each(LEGACY_IMPORT_PATH_CHANNELS)(
+    'accepts an explicitly enrolled path for %s',
+    async (channel) => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-import-authority-'))
+      try {
+        const filePath = join(root, 'variants.vcf')
+        writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+        addAllowedImportPath(filePath)
+        const ipcMain = makeIpcMain()
+        registerImportHandlers(makeDeps(ipcMain) as never)
+
+        const result = await invokeHandler(ipcMain, channel, ...argsForPath(channel, filePath))
+
+        expect(isIpcError(result)).toBe(false)
+        expectPathConsumerCalled(channel)
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  const symlinkIt = process.platform === 'win32' ? it.skip : it
+  symlinkIt.each(LEGACY_IMPORT_PATH_CHANNELS)(
+    'accepts a pinned symlink and rejects it after retargeting for %s',
+    async (channel) => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-import-authority-'))
+      try {
+        const targetA = join(root, 'a.vcf')
+        const targetB = join(root, 'b.vcf')
+        const selectedPath = join(root, 'selected.vcf')
+        writeFileSync(targetA, '##fileformat=VCFv4.2\n')
+        writeFileSync(targetB, '##fileformat=VCFv4.2\n')
+        symlinkSync(targetA, selectedPath)
+        addAllowedImportPath(selectedPath)
+        const ipcMain = makeIpcMain()
+        registerImportHandlers(makeDeps(ipcMain) as never)
+
+        const accepted = await invokeHandler(
+          ipcMain,
+          channel,
+          ...argsForPath(channel, selectedPath)
+        )
+        expect(isIpcError(accepted)).toBe(false)
+        expectPathConsumerCalled(channel)
+
+        clearPathConsumerMocks()
+        unlinkSync(selectedPath)
+        symlinkSync(targetB, selectedPath)
+        const rejected = await invokeHandler(
+          ipcMain,
+          channel,
+          ...argsForPath(channel, selectedPath)
+        )
+        expectInvalidParametersResult(rejected)
+        expectNoPathConsumerCalled()
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
   it.each(['relative.vcf', '/tmp/../etc/shadow'])(
     'returns INVALID_PARAMETERS when import:start receives non-normalized filePath %s',
     async (filePath) => {
@@ -148,13 +294,15 @@ describe('import IPC handlers', () => {
     const ipcMain = makeIpcMain()
     registerImportHandlers(makeDeps(ipcMain) as never)
 
+    const filePath = join(tmpdir(), 'variants.vcf')
+    addAllowedImportPath(filePath)
     const result = await invokeHandler(
       ipcMain,
       'import:startMultiFile',
       'Case A',
       [
         {
-          filePath: '/tmp/variants.vcf',
+          filePath,
           variantType: 'SNV',
           caller: null,
           annotationFormat: null
@@ -174,13 +322,16 @@ describe('import IPC handlers', () => {
       const ipcMain = makeIpcMain()
       registerImportHandlers(makeDeps(ipcMain) as never)
 
+      const filePath = join(tmpdir(), 'variants.vcf')
+      addAllowedImportPath(filePath)
+
       const result = await invokeHandler(
         ipcMain,
         'import:startMultiFile',
         'Case A',
         [
           {
-            filePath: '/tmp/variants.vcf',
+            filePath,
             variantType: 'SNV',
             caller: null,
             annotationFormat: null
@@ -194,6 +345,101 @@ describe('import IPC handlers', () => {
       expect(startMultiFileImport).not.toHaveBeenCalled()
     }
   )
+
+  it.each([
+    join(tmpdir(), 'varlens-unenrolled', 'regions.bed'),
+    join(homedir(), 'varlens-unenrolled', 'regions.bed')
+  ])('rejects an unenrolled BED path regardless of its filesystem root', async (bedFile) => {
+    const ipcMain = makeIpcMain()
+    registerImportHandlers(makeDeps(ipcMain) as never)
+    const filePath = join(tmpdir(), 'dialog-enrolled.vcf')
+    addAllowedImportPath(filePath)
+
+    const result = await invokeHandler(
+      ipcMain,
+      'import:startMultiFile',
+      'Case A',
+      [{ filePath, variantType: 'SNV', caller: null, annotationFormat: null }],
+      undefined,
+      { bedFile }
+    )
+
+    expectInvalidParametersResult(result)
+    expect(startMultiFileImport).not.toHaveBeenCalled()
+  })
+
+  it('accepts an explicitly enrolled BED path for import:startMultiFile', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-import-bed-authority-'))
+    try {
+      const filePath = join(root, 'variants.vcf')
+      const bedFile = join(root, 'regions.bed')
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      writeFileSync(bedFile, 'chr1\t0\t10\n')
+      addAllowedImportPath(filePath)
+      addAllowedImportPath(bedFile)
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'import:startMultiFile',
+        'Case A',
+        [{ filePath, variantType: 'SNV', caller: null, annotationFormat: null }],
+        undefined,
+        { bedFile }
+      )
+
+      expect(isIpcError(result)).toBe(false)
+      expect(startMultiFileImport).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  symlinkIt('pins an enrolled BED symlink used by import:startMultiFile', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-import-bed-authority-'))
+    try {
+      const filePath = join(root, 'variants.vcf')
+      const targetA = join(root, 'a.bed')
+      const targetB = join(root, 'b.bed')
+      const bedFile = join(root, 'selected.bed')
+      writeFileSync(filePath, '##fileformat=VCFv4.2\n')
+      writeFileSync(targetA, 'chr1\t0\t10\n')
+      writeFileSync(targetB, 'chr2\t0\t10\n')
+      symlinkSync(targetA, bedFile)
+      addAllowedImportPath(filePath)
+      addAllowedImportPath(bedFile)
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      const accepted = await invokeHandler(
+        ipcMain,
+        'import:startMultiFile',
+        'Case A',
+        [{ filePath, variantType: 'SNV', caller: null, annotationFormat: null }],
+        undefined,
+        { bedFile }
+      )
+      expect(isIpcError(accepted)).toBe(false)
+      expect(startMultiFileImport).toHaveBeenCalledOnce()
+
+      clearPathConsumerMocks()
+      unlinkSync(bedFile)
+      symlinkSync(targetB, bedFile)
+      const rejected = await invokeHandler(
+        ipcMain,
+        'import:startMultiFile',
+        'Case A',
+        [{ filePath, variantType: 'SNV', caller: null, annotationFormat: null }],
+        undefined,
+        { bedFile }
+      )
+      expectInvalidParametersResult(rejected)
+      expect(startMultiFileImport).not.toHaveBeenCalled()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
 
   it('returns INVALID_PARAMETERS when import:vcfPreview receives an unallowed filePath', async () => {
     const ipcMain = makeIpcMain()
@@ -216,5 +462,29 @@ describe('import IPC handlers', () => {
 
     expectInvalidParametersResult(result)
     expect(getVcfMultiPreview).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['import:selectFile', 'selected.vcf'],
+    ['import:selectFiles', 'selected.vcf'],
+    ['import:selectBedFile', 'selected.bed']
+  ])('%s enrolls each explicitly selected file', async (channel, fileName) => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-import-selector-'))
+    try {
+      const filePath = join(root, fileName)
+      writeFileSync(filePath, '')
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [filePath]
+      } as never)
+      const ipcMain = makeIpcMain()
+      registerImportHandlers(makeDeps(ipcMain) as never)
+
+      await invokeHandler(ipcMain, channel)
+
+      expect(isStrictlyEnrolledPath(filePath)).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/main/ipc/handlers/shell.test.ts
+++ b/tests/main/ipc/handlers/shell.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('electron', () => ({
@@ -23,6 +24,10 @@ import {
   __resetAllowlistForTests,
   addAllowedImportPath
 } from '../../../../src/main/security/import-path-allowlist'
+import {
+  __resetDatabasePathAllowlistForTests,
+  addAllowedDatabasePath
+} from '../../../../src/main/security/database-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
 
@@ -55,6 +60,7 @@ describe('shell IPC handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     __resetAllowlistForTests()
+    __resetDatabasePathAllowlistForTests()
   })
 
   it('returns an IPC error when shell:updateUserDomains receives more than 100 domains', async () => {
@@ -79,7 +85,7 @@ describe('shell IPC handlers', () => {
       const result = await invokeHandler(
         ipcMain,
         'shell:showItemInFolder',
-        '/some/other/mount/unrelated-export.xlsx'
+        resolve('external', 'unrelated-export.xlsx')
       )
 
       expect(isIpcError(result)).toBe(true)
@@ -89,13 +95,35 @@ describe('shell IPC handlers', () => {
     it('accepts a path enrolled via a dialog this session (e.g. an export save location)', async () => {
       const ipcMain = makeIpcMain()
       registerShellHandlers({ ipcMain } as never)
-      const filePath = '/some/other/mount/case1_variants.xlsx'
+      const filePath = resolve('external', 'case1_variants.xlsx')
       addAllowedImportPath(filePath)
 
       const result = await invokeHandler(ipcMain, 'shell:showItemInFolder', filePath)
 
       expect(isIpcError(result)).toBe(false)
       expect(shell.showItemInFolder).toHaveBeenCalledWith(filePath)
+    })
+
+    it('accepts database dialog, recent, and active path authority', async () => {
+      const selectedPath = resolve('external', 'selected.db')
+      const recentPath = resolve('external', 'recent.db')
+      const activePath = resolve('external', 'active.db')
+      addAllowedDatabasePath(selectedPath)
+
+      for (const filePath of [selectedPath, recentPath, activePath]) {
+        const ipcMain = makeIpcMain()
+        registerShellHandlers({
+          ipcMain,
+          getDbManager: () => ({
+            getCurrentPath: () => activePath,
+            getRecentDatabases: () => [{ path: recentPath }]
+          })
+        } as never)
+
+        const result = await invokeHandler(ipcMain, 'shell:showItemInFolder', filePath)
+        expect(isIpcError(result)).toBe(false)
+        expect(shell.showItemInFolder).toHaveBeenCalledWith(filePath)
+      }
     })
 
     it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {

--- a/tests/main/ipc/handlers/shell.test.ts
+++ b/tests/main/ipc/handlers/shell.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolve } from 'node:path'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('electron', () => ({
@@ -17,17 +16,8 @@ vi.mock('../../../../src/main/utils/url-validation', () => ({
   isUrlSafeForExternal: vi.fn(() => true)
 }))
 
-import { shell } from 'electron'
 import { registerShellHandlers } from '../../../../src/main/ipc/handlers/shell'
 import { setUserDomains } from '../../../../src/main/utils/url-validation'
-import {
-  __resetAllowlistForTests,
-  addAllowedImportPath
-} from '../../../../src/main/security/import-path-allowlist'
-import {
-  __resetDatabasePathAllowlistForTests,
-  addAllowedDatabasePath
-} from '../../../../src/main/security/database-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
 
@@ -59,8 +49,6 @@ async function invokeHandler(
 describe('shell IPC handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    __resetAllowlistForTests()
-    __resetDatabasePathAllowlistForTests()
   })
 
   it('returns an IPC error when shell:updateUserDomains receives more than 100 domains', async () => {
@@ -77,69 +65,10 @@ describe('shell IPC handlers', () => {
     expect(setUserDomains).not.toHaveBeenCalled()
   })
 
-  describe('shell:showItemInFolder', () => {
-    it('rejects a path with no dialog authority', async () => {
-      const ipcMain = makeIpcMain()
-      registerShellHandlers({ ipcMain } as never)
+  it('does not expose a generic file-reveal channel', () => {
+    const ipcMain = makeIpcMain()
+    registerShellHandlers({ ipcMain } as never)
 
-      const result = await invokeHandler(
-        ipcMain,
-        'shell:showItemInFolder',
-        resolve('external', 'unrelated-export.xlsx')
-      )
-
-      expect(isIpcError(result)).toBe(true)
-      expect(shell.showItemInFolder).not.toHaveBeenCalled()
-    })
-
-    it('accepts a path enrolled via a dialog this session (e.g. an export save location)', async () => {
-      const ipcMain = makeIpcMain()
-      registerShellHandlers({ ipcMain } as never)
-      const filePath = resolve('external', 'case1_variants.xlsx')
-      addAllowedImportPath(filePath)
-
-      const result = await invokeHandler(ipcMain, 'shell:showItemInFolder', filePath)
-
-      expect(isIpcError(result)).toBe(false)
-      expect(shell.showItemInFolder).toHaveBeenCalledWith(filePath)
-    })
-
-    it('accepts database dialog, recent, and active path authority', async () => {
-      const selectedPath = resolve('external', 'selected.db')
-      const recentPath = resolve('external', 'recent.db')
-      const activePath = resolve('external', 'active.db')
-      addAllowedDatabasePath(selectedPath)
-
-      for (const filePath of [selectedPath, recentPath, activePath]) {
-        const ipcMain = makeIpcMain()
-        registerShellHandlers({
-          ipcMain,
-          getDbManager: () => ({
-            getCurrentPath: () => activePath,
-            getRecentDatabases: () => [{ path: recentPath }]
-          })
-        } as never)
-
-        const result = await invokeHandler(ipcMain, 'shell:showItemInFolder', filePath)
-        expect(isIpcError(result)).toBe(false)
-        expect(shell.showItemInFolder).toHaveBeenCalledWith(filePath)
-      }
-    })
-
-    it('rejects a home path that was never dialog-enrolled', async () => {
-      // Filesystem location is not authority: living under the mocked home
-      // root must never substitute for explicit user selection.
-      const ipcMain = makeIpcMain()
-      registerShellHandlers({ ipcMain } as never)
-
-      const result = await invokeHandler(
-        ipcMain,
-        'shell:showItemInFolder',
-        '/nonexistent-electron-app-path/leaked-file.xlsx'
-      )
-
-      expect(isIpcError(result)).toBe(true)
-      expect(shell.showItemInFolder).not.toHaveBeenCalled()
-    })
+    expect(ipcMain.handle).not.toHaveBeenCalledWith('shell:showItemInFolder', expect.any(Function))
   })
 })

--- a/tests/main/ipc/handlers/shell.test.ts
+++ b/tests/main/ipc/handlers/shell.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ErrorCode, isIpcError } from '../../../../src/shared/types/errors'
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/nonexistent-electron-app-path')
+  },
   shell: {
     openExternal: vi.fn(),
     showItemInFolder: vi.fn()
@@ -13,8 +16,13 @@ vi.mock('../../../../src/main/utils/url-validation', () => ({
   isUrlSafeForExternal: vi.fn(() => true)
 }))
 
+import { shell } from 'electron'
 import { registerShellHandlers } from '../../../../src/main/ipc/handlers/shell'
 import { setUserDomains } from '../../../../src/main/utils/url-validation'
+import {
+  __resetAllowlistForTests,
+  addAllowedImportPath
+} from '../../../../src/main/security/import-path-allowlist'
 
 type HandlerCallback = (event: unknown, ...args: unknown[]) => Promise<unknown>
 
@@ -46,6 +54,7 @@ async function invokeHandler(
 describe('shell IPC handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    __resetAllowlistForTests()
   })
 
   it('returns an IPC error when shell:updateUserDomains receives more than 100 domains', async () => {
@@ -60,5 +69,33 @@ describe('shell IPC handlers', () => {
       expect(result.code).toBe(ErrorCode.UNKNOWN)
     }
     expect(setUserDomains).not.toHaveBeenCalled()
+  })
+
+  describe('shell:showItemInFolder', () => {
+    it('rejects a path with no dialog authority', async () => {
+      const ipcMain = makeIpcMain()
+      registerShellHandlers({ ipcMain } as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'shell:showItemInFolder',
+        '/some/other/mount/unrelated-export.xlsx'
+      )
+
+      expect(isIpcError(result)).toBe(true)
+      expect(shell.showItemInFolder).not.toHaveBeenCalled()
+    })
+
+    it('accepts a path enrolled via a dialog this session (e.g. an export save location)', async () => {
+      const ipcMain = makeIpcMain()
+      registerShellHandlers({ ipcMain } as never)
+      const filePath = '/some/other/mount/case1_variants.xlsx'
+      addAllowedImportPath(filePath)
+
+      const result = await invokeHandler(ipcMain, 'shell:showItemInFolder', filePath)
+
+      expect(isIpcError(result)).toBe(false)
+      expect(shell.showItemInFolder).toHaveBeenCalledWith(filePath)
+    })
   })
 })

--- a/tests/main/ipc/handlers/shell.test.ts
+++ b/tests/main/ipc/handlers/shell.test.ts
@@ -97,5 +97,23 @@ describe('shell IPC handlers', () => {
       expect(isIpcError(result)).toBe(false)
       expect(shell.showItemInFolder).toHaveBeenCalledWith(filePath)
     })
+
+    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
+      // isAllowedImportPath grants app.getPath('home')/userData/temp for the
+      // original import flow; this gate must use the STRICT check so a path
+      // merely living under the mocked "home" root (but never picked via a
+      // dialog this session) is still rejected.
+      const ipcMain = makeIpcMain()
+      registerShellHandlers({ ipcMain } as never)
+
+      const result = await invokeHandler(
+        ipcMain,
+        'shell:showItemInFolder',
+        '/nonexistent-electron-app-path/leaked-file.xlsx'
+      )
+
+      expect(isIpcError(result)).toBe(true)
+      expect(shell.showItemInFolder).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/main/ipc/handlers/shell.test.ts
+++ b/tests/main/ipc/handlers/shell.test.ts
@@ -126,11 +126,9 @@ describe('shell IPC handlers', () => {
       }
     })
 
-    it('rejects a path under the automatic home root that was never dialog-enrolled (F-path)', async () => {
-      // isAllowedImportPath grants app.getPath('home')/userData/temp for the
-      // original import flow; this gate must use the STRICT check so a path
-      // merely living under the mocked "home" root (but never picked via a
-      // dialog this session) is still rejected.
+    it('rejects a home path that was never dialog-enrolled', async () => {
+      // Filesystem location is not authority: living under the mocked home
+      // root must never substitute for explicit user selection.
       const ipcMain = makeIpcMain()
       registerShellHandlers({ ipcMain } as never)
 

--- a/tests/main/security/database-path-allowlist.test.ts
+++ b/tests/main/security/database-path-allowlist.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  __resetDatabasePathAllowlistForTests,
+  addAllowedDatabasePath,
+  isStrictlyEnrolledDatabasePath
+} from '../../../src/main/security/database-path-allowlist'
+
+describe('database-path-allowlist', () => {
+  beforeEach(() => __resetDatabasePathAllowlistForTests())
+
+  const symlinkIt = process.platform === 'win32' ? it.skip : it
+
+  symlinkIt('rejects an enrolled symlink after its target is changed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'varlens-db-authority-'))
+    try {
+      const targetA = join(root, 'a.db')
+      const targetB = join(root, 'b.db')
+      const selected = join(root, 'selected.db')
+      writeFileSync(targetA, 'A')
+      writeFileSync(targetB, 'B')
+      symlinkSync(targetA, selected)
+
+      addAllowedDatabasePath(selected)
+      expect(isStrictlyEnrolledDatabasePath(selected)).toBe(true)
+
+      rmSync(selected)
+      symlinkSync(targetB, selected)
+      expect(isStrictlyEnrolledDatabasePath(selected)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/main/security/import-path-allowlist.test.ts
+++ b/tests/main/security/import-path-allowlist.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import {
   addAllowedImportPath,
   isAllowedImportPath,
+  isStrictlyEnrolledPath,
   __resetAllowlistForTests
 } from '../../../src/main/security/import-path-allowlist'
 
@@ -60,5 +61,64 @@ describe('import-path-allowlist', () => {
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
+  })
+
+  // F-path hardening (Codex-high finding): isAllowedImportPath's automatic
+  // home/userData/temp roots are intentionally permissive for the original
+  // import.ts flow, but the DB/BED/batch/shell gates need a strict
+  // "dialog-enrolled this session" boundary that does not inherit that
+  // grant. isStrictlyEnrolledPath is that boundary.
+  describe('isStrictlyEnrolledPath', () => {
+    it('rejects a path that isAllowedImportPath only accepts via the automatic temp root', () => {
+      // Proves the two predicates diverge: isAllowedImportPath grants the
+      // automatic root, isStrictlyEnrolledPath must not inherit that grant.
+      expect(isAllowedImportPath('/tmp/inside-tmp.bed')).toBe(true)
+      expect(isStrictlyEnrolledPath('/tmp/inside-tmp.bed')).toBe(false)
+    })
+
+    it('rejects /etc/passwd', () => {
+      expect(isStrictlyEnrolledPath('/etc/passwd')).toBe(false)
+    })
+
+    it('rejects relative paths', () => {
+      expect(isStrictlyEnrolledPath('relative.bed')).toBe(false)
+    })
+
+    it('rejects non-normalized absolute paths containing traversal', () => {
+      expect(isStrictlyEnrolledPath('/tmp/../etc/shadow')).toBe(false)
+    })
+
+    it('accepts a previously-registered dialog path', () => {
+      addAllowedImportPath('/some/custom/mount/file.vcf')
+      expect(isStrictlyEnrolledPath('/some/custom/mount/file.vcf')).toBe(true)
+    })
+
+    symlinkIt('rejects an existing temp symlink that was never dialog-enrolled', () => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
+      try {
+        const linkPath = join(root, 'passwd-link.vcf')
+        symlinkSync('/etc/passwd', linkPath)
+
+        expect(isStrictlyEnrolledPath(linkPath)).toBe(false)
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    symlinkIt('accepts a dialog-registered symlink and its resolved target', () => {
+      const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
+      try {
+        const linkPath = join(root, 'passwd-link.vcf')
+        symlinkSync('/etc/passwd', linkPath)
+        const targetPath = realpathSync.native(linkPath)
+
+        addAllowedImportPath(linkPath)
+
+        expect(isStrictlyEnrolledPath(linkPath)).toBe(true)
+        expect(isStrictlyEnrolledPath(targetPath)).toBe(true)
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
   })
 })

--- a/tests/main/security/import-path-allowlist.test.ts
+++ b/tests/main/security/import-path-allowlist.test.ts
@@ -1,10 +1,9 @@
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join, parse, resolve, sep } from 'node:path'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { describe, it, expect, beforeEach } from 'vitest'
 import {
   addAllowedImportPath,
-  isAllowedImportPath,
   isStrictlyEnrolledPath,
   __resetAllowlistForTests
 } from '../../../src/main/security/import-path-allowlist'
@@ -14,40 +13,44 @@ describe('import-path-allowlist', () => {
 
   const symlinkIt = process.platform === 'win32' ? it.skip : it
   const untrustedPath = join(parse(process.cwd()).root, 'varlens-untrusted', 'file.vcf')
-  const automaticTempPath = join(tmpdir(), 'inside-tmp.bed')
+  const unenrolledTempPath = join(tmpdir(), 'inside-tmp.bed')
 
-  it('rejects a path outside the automatic roots', () => {
-    expect(isAllowedImportPath(untrustedPath)).toBe(false)
+  it('rejects a path that was never enrolled', () => {
+    expect(isStrictlyEnrolledPath(untrustedPath)).toBe(false)
   })
 
-  it('rejects relative paths even when they resolve under an automatic root', () => {
-    expect(isAllowedImportPath('relative.bed')).toBe(false)
+  it('rejects relative paths even when they resolve under temp', () => {
+    expect(isStrictlyEnrolledPath('relative.bed')).toBe(false)
   })
 
   it('rejects non-normalized absolute paths containing traversal', () => {
-    expect(isAllowedImportPath(`${tmpdir()}${sep}..${sep}varlens-shadow`)).toBe(false)
+    expect(isStrictlyEnrolledPath(`${tmpdir()}${sep}..${sep}varlens-shadow`)).toBe(false)
+  })
+
+  it.each([
+    ['relative', 'relative.bed', resolve('relative.bed')],
+    [
+      'non-normalized absolute',
+      `${tmpdir()}${sep}..${sep}varlens-shadow`,
+      resolve(`${tmpdir()}${sep}..${sep}varlens-shadow`)
+    ]
+  ])('does not enroll a %s path through its normalized alias', (_kind, candidate, alias) => {
+    addAllowedImportPath(candidate)
+
+    expect(isStrictlyEnrolledPath(alias)).toBe(false)
   })
 
   it('accepts a previously-registered dialog path', () => {
     const filePath = resolve(tmpdir(), 'varlens-external', 'file.vcf')
     addAllowedImportPath(filePath)
-    expect(isAllowedImportPath(filePath)).toBe(true)
+    expect(isStrictlyEnrolledPath(filePath)).toBe(true)
   })
 
-  it('accepts paths under app.getPath(temp) via the env-fallback', () => {
-    expect(isAllowedImportPath(automaticTempPath)).toBe(true)
-  })
-
-  symlinkIt('rejects an existing temp symlink that resolves outside allowed roots', () => {
-    const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
-    try {
-      const linkPath = join(root, 'passwd-link.vcf')
-      symlinkSync('/etc/passwd', linkPath)
-
-      expect(isAllowedImportPath(linkPath)).toBe(false)
-    } finally {
-      rmSync(root, { recursive: true, force: true })
-    }
+  it.each([
+    ['temp', unenrolledTempPath],
+    ['home', join(homedir(), 'varlens-unenrolled', 'inside-home.vcf')]
+  ])('rejects an unenrolled path under %s', (_root, filePath) => {
+    expect(isStrictlyEnrolledPath(filePath)).toBe(false)
   })
 
   symlinkIt('rejects a dialog-registered symlink after its target is changed', () => {
@@ -61,78 +64,13 @@ describe('import-path-allowlist', () => {
       symlinkSync(targetA, linkPath)
 
       addAllowedImportPath(linkPath)
-      expect(isAllowedImportPath(linkPath)).toBe(true)
+      expect(isStrictlyEnrolledPath(linkPath)).toBe(true)
 
       rmSync(linkPath)
       symlinkSync(targetB, linkPath)
-      expect(isAllowedImportPath(linkPath)).toBe(false)
+      expect(isStrictlyEnrolledPath(linkPath)).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
-  })
-
-  // F-path hardening (Codex-high finding): isAllowedImportPath's automatic
-  // home/userData/temp roots are intentionally permissive for the original
-  // import.ts flow, but the DB/BED/batch/shell gates need a strict
-  // "dialog-enrolled this session" boundary that does not inherit that
-  // grant. isStrictlyEnrolledPath is that boundary.
-  describe('isStrictlyEnrolledPath', () => {
-    it('rejects a path that isAllowedImportPath only accepts via the automatic temp root', () => {
-      // Proves the two predicates diverge: isAllowedImportPath grants the
-      // automatic root, isStrictlyEnrolledPath must not inherit that grant.
-      expect(isAllowedImportPath(automaticTempPath)).toBe(true)
-      expect(isStrictlyEnrolledPath(automaticTempPath)).toBe(false)
-    })
-
-    it('rejects a path outside the authority set', () => {
-      expect(isStrictlyEnrolledPath(untrustedPath)).toBe(false)
-    })
-
-    it('rejects relative paths', () => {
-      expect(isStrictlyEnrolledPath('relative.bed')).toBe(false)
-    })
-
-    it('rejects non-normalized absolute paths containing traversal', () => {
-      expect(isStrictlyEnrolledPath(`${tmpdir()}${sep}..${sep}varlens-shadow`)).toBe(false)
-    })
-
-    it('accepts a previously-registered dialog path', () => {
-      const filePath = resolve(tmpdir(), 'varlens-external', 'file.vcf')
-      addAllowedImportPath(filePath)
-      expect(isStrictlyEnrolledPath(filePath)).toBe(true)
-    })
-
-    symlinkIt('rejects an existing temp symlink that was never dialog-enrolled', () => {
-      const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
-      try {
-        const linkPath = join(root, 'passwd-link.vcf')
-        symlinkSync('/etc/passwd', linkPath)
-
-        expect(isStrictlyEnrolledPath(linkPath)).toBe(false)
-      } finally {
-        rmSync(root, { recursive: true, force: true })
-      }
-    })
-
-    symlinkIt('rejects a dialog-registered symlink after its target is changed', () => {
-      const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
-      try {
-        const targetA = join(root, 'a.vcf')
-        const targetB = join(root, 'b.vcf')
-        const linkPath = join(root, 'selected.vcf')
-        writeFileSync(targetA, 'A')
-        writeFileSync(targetB, 'B')
-        symlinkSync(targetA, linkPath)
-
-        addAllowedImportPath(linkPath)
-        expect(isStrictlyEnrolledPath(linkPath)).toBe(true)
-
-        rmSync(linkPath)
-        symlinkSync(targetB, linkPath)
-        expect(isStrictlyEnrolledPath(linkPath)).toBe(false)
-      } finally {
-        rmSync(root, { recursive: true, force: true })
-      }
-    })
   })
 })

--- a/tests/main/security/import-path-allowlist.test.ts
+++ b/tests/main/security/import-path-allowlist.test.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { join, parse, resolve, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 import { describe, it, expect, beforeEach } from 'vitest'
 import {
@@ -13,9 +13,11 @@ describe('import-path-allowlist', () => {
   beforeEach(() => __resetAllowlistForTests())
 
   const symlinkIt = process.platform === 'win32' ? it.skip : it
+  const untrustedPath = join(parse(process.cwd()).root, 'varlens-untrusted', 'file.vcf')
+  const automaticTempPath = join(tmpdir(), 'inside-tmp.bed')
 
-  it('rejects /etc/passwd', () => {
-    expect(isAllowedImportPath('/etc/passwd')).toBe(false)
+  it('rejects a path outside the automatic roots', () => {
+    expect(isAllowedImportPath(untrustedPath)).toBe(false)
   })
 
   it('rejects relative paths even when they resolve under an automatic root', () => {
@@ -23,16 +25,17 @@ describe('import-path-allowlist', () => {
   })
 
   it('rejects non-normalized absolute paths containing traversal', () => {
-    expect(isAllowedImportPath('/tmp/../etc/shadow')).toBe(false)
+    expect(isAllowedImportPath(`${tmpdir()}${sep}..${sep}varlens-shadow`)).toBe(false)
   })
 
   it('accepts a previously-registered dialog path', () => {
-    addAllowedImportPath('/some/custom/mount/file.vcf')
-    expect(isAllowedImportPath('/some/custom/mount/file.vcf')).toBe(true)
+    const filePath = resolve(tmpdir(), 'varlens-external', 'file.vcf')
+    addAllowedImportPath(filePath)
+    expect(isAllowedImportPath(filePath)).toBe(true)
   })
 
   it('accepts paths under app.getPath(temp) via the env-fallback', () => {
-    expect(isAllowedImportPath('/tmp/inside-tmp.bed')).toBe(true)
+    expect(isAllowedImportPath(automaticTempPath)).toBe(true)
   })
 
   symlinkIt('rejects an existing temp symlink that resolves outside allowed roots', () => {
@@ -47,17 +50,22 @@ describe('import-path-allowlist', () => {
     }
   })
 
-  symlinkIt('accepts a dialog-registered symlink and its resolved target', () => {
+  symlinkIt('rejects a dialog-registered symlink after its target is changed', () => {
     const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
     try {
-      const linkPath = join(root, 'passwd-link.vcf')
-      symlinkSync('/etc/passwd', linkPath)
-      const targetPath = realpathSync.native(linkPath)
+      const targetA = join(root, 'a.vcf')
+      const targetB = join(root, 'b.vcf')
+      const linkPath = join(root, 'selected.vcf')
+      writeFileSync(targetA, 'A')
+      writeFileSync(targetB, 'B')
+      symlinkSync(targetA, linkPath)
 
       addAllowedImportPath(linkPath)
-
       expect(isAllowedImportPath(linkPath)).toBe(true)
-      expect(isAllowedImportPath(targetPath)).toBe(true)
+
+      rmSync(linkPath)
+      symlinkSync(targetB, linkPath)
+      expect(isAllowedImportPath(linkPath)).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -72,12 +80,12 @@ describe('import-path-allowlist', () => {
     it('rejects a path that isAllowedImportPath only accepts via the automatic temp root', () => {
       // Proves the two predicates diverge: isAllowedImportPath grants the
       // automatic root, isStrictlyEnrolledPath must not inherit that grant.
-      expect(isAllowedImportPath('/tmp/inside-tmp.bed')).toBe(true)
-      expect(isStrictlyEnrolledPath('/tmp/inside-tmp.bed')).toBe(false)
+      expect(isAllowedImportPath(automaticTempPath)).toBe(true)
+      expect(isStrictlyEnrolledPath(automaticTempPath)).toBe(false)
     })
 
-    it('rejects /etc/passwd', () => {
-      expect(isStrictlyEnrolledPath('/etc/passwd')).toBe(false)
+    it('rejects a path outside the authority set', () => {
+      expect(isStrictlyEnrolledPath(untrustedPath)).toBe(false)
     })
 
     it('rejects relative paths', () => {
@@ -85,12 +93,13 @@ describe('import-path-allowlist', () => {
     })
 
     it('rejects non-normalized absolute paths containing traversal', () => {
-      expect(isStrictlyEnrolledPath('/tmp/../etc/shadow')).toBe(false)
+      expect(isStrictlyEnrolledPath(`${tmpdir()}${sep}..${sep}varlens-shadow`)).toBe(false)
     })
 
     it('accepts a previously-registered dialog path', () => {
-      addAllowedImportPath('/some/custom/mount/file.vcf')
-      expect(isStrictlyEnrolledPath('/some/custom/mount/file.vcf')).toBe(true)
+      const filePath = resolve(tmpdir(), 'varlens-external', 'file.vcf')
+      addAllowedImportPath(filePath)
+      expect(isStrictlyEnrolledPath(filePath)).toBe(true)
     })
 
     symlinkIt('rejects an existing temp symlink that was never dialog-enrolled', () => {
@@ -105,17 +114,22 @@ describe('import-path-allowlist', () => {
       }
     })
 
-    symlinkIt('accepts a dialog-registered symlink and its resolved target', () => {
+    symlinkIt('rejects a dialog-registered symlink after its target is changed', () => {
       const root = mkdtempSync(join(tmpdir(), 'varlens-allowlist-'))
       try {
-        const linkPath = join(root, 'passwd-link.vcf')
-        symlinkSync('/etc/passwd', linkPath)
-        const targetPath = realpathSync.native(linkPath)
+        const targetA = join(root, 'a.vcf')
+        const targetB = join(root, 'b.vcf')
+        const linkPath = join(root, 'selected.vcf')
+        writeFileSync(targetA, 'A')
+        writeFileSync(targetB, 'B')
+        symlinkSync(targetA, linkPath)
 
         addAllowedImportPath(linkPath)
-
         expect(isStrictlyEnrolledPath(linkPath)).toBe(true)
-        expect(isStrictlyEnrolledPath(targetPath)).toBe(true)
+
+        rmSync(linkPath)
+        symlinkSync(targetB, linkPath)
+        expect(isStrictlyEnrolledPath(linkPath)).toBe(false)
       } finally {
         rmSync(root, { recursive: true, force: true })
       }

--- a/tests/main/utils/url-validation.test.ts
+++ b/tests/main/utils/url-validation.test.ts
@@ -59,6 +59,13 @@ describe('isDomainAllowed', () => {
     expect(isDomainAllowed('evil.com')).toBe(false)
     expect(isDomainAllowed('valid.org')).toBe(true)
   })
+
+  it('excludes user-configured domains when includeUserDomains is false (S1)', () => {
+    setUserDomains(['mylab.org'])
+    expect(isDomainAllowed('mylab.org')).toBe(true)
+    expect(isDomainAllowed('mylab.org', { includeUserDomains: false })).toBe(false)
+    expect(isDomainAllowed('github.com', { includeUserDomains: false })).toBe(true)
+  })
 })
 
 describe('isUrlSafeForExternal', () => {
@@ -88,5 +95,36 @@ describe('isUrlSafeForExternal', () => {
 
   it('rejects malformed URL', () => {
     expect(isUrlSafeForExternal('not a url')).toBe(false)
+  })
+
+  it('narrows github.io to the docs subdomain only (S5)', () => {
+    expect(isUrlSafeForExternal('https://attacker.github.io/x')).toBe(false)
+    expect(isUrlSafeForExternal('https://berntpopp.github.io/varlens')).toBe(true)
+  })
+
+  describe('renderer-added domains gate openExternal only (S1)', () => {
+    it('allows a user-added domain by default (openExternal path)', () => {
+      setUserDomains(['evil.com'])
+      expect(isUrlSafeForExternal('https://evil.com')).toBe(true)
+    })
+
+    it('denies a user-added domain when includeUserDomains is false (window-open path)', () => {
+      setUserDomains(['evil.com'])
+      expect(isUrlSafeForExternal('https://evil.com', { includeUserDomains: false })).toBe(false)
+    })
+
+    it('still allows a built-in domain when includeUserDomains is false', () => {
+      setUserDomains(['evil.com'])
+      expect(isUrlSafeForExternal('https://github.com/repo', { includeUserDomains: false })).toBe(
+        true
+      )
+    })
+
+    it('keeps the https-only gate when includeUserDomains is false', () => {
+      setUserDomains(['evil.com'])
+      expect(isUrlSafeForExternal('http://github.com/repo', { includeUserDomains: false })).toBe(
+        false
+      )
+    })
   })
 })

--- a/tests/main/window-navigation-policy.test.ts
+++ b/tests/main/window-navigation-policy.test.ts
@@ -1,28 +1,58 @@
 import { describe, expect, it } from 'vitest'
 import { isMainWindowNavigationAllowed } from '../../src/main/window-navigation-policy'
 
+const APP_DOC_URL = 'file:///app/renderer/index.html'
+
 describe('main window navigation policy', () => {
-  it('allows navigation within the development renderer URL', () => {
+  it('allows navigation within the development renderer origin', () => {
     expect(
       isMainWindowNavigationAllowed(
         'http://localhost:5173/assets/index.js',
-        'http://localhost:5173'
+        'http://localhost:5173',
+        APP_DOC_URL
       )
     ).toBe(true)
   })
 
-  it('allows file URLs for the packaged renderer', () => {
-    expect(isMainWindowNavigationAllowed('file:///app/renderer/index.html', undefined)).toBe(true)
+  it('allows navigation to the exact packaged app document', () => {
+    expect(isMainWindowNavigationAllowed(APP_DOC_URL, undefined, APP_DOC_URL)).toBe(true)
+  })
+
+  it('blocks navigation to an arbitrary local file (S2)', () => {
+    expect(
+      isMainWindowNavigationAllowed('file:///tmp/evil.html', undefined, APP_DOC_URL)
+    ).toBe(false)
+    expect(
+      isMainWindowNavigationAllowed('file:///etc/passwd', undefined, APP_DOC_URL)
+    ).toBe(false)
+  })
+
+  it('blocks a dev-origin spoof that merely starts with the renderer URL (S2)', () => {
+    // http://localhost:5173.evil.com starts with 'http://localhost:5173' as a
+    // string, but is a different WHATWG origin entirely.
+    expect(
+      isMainWindowNavigationAllowed(
+        'http://localhost:5173.evil.com/assets/index.js',
+        'http://localhost:5173',
+        APP_DOC_URL
+      )
+    ).toBe(false)
   })
 
   it('blocks non-file URLs when no development renderer URL is configured', () => {
-    expect(isMainWindowNavigationAllowed('https://example.com', undefined)).toBe(false)
-    expect(isMainWindowNavigationAllowed('https://example.com', '')).toBe(false)
-  })
-
-  it('blocks external URLs outside the development renderer URL', () => {
-    expect(isMainWindowNavigationAllowed('https://example.com', 'http://localhost:5173')).toBe(
+    expect(isMainWindowNavigationAllowed('https://example.com', undefined, APP_DOC_URL)).toBe(
       false
     )
+    expect(isMainWindowNavigationAllowed('https://example.com', '', APP_DOC_URL)).toBe(false)
+  })
+
+  it('blocks external URLs outside the development renderer origin', () => {
+    expect(
+      isMainWindowNavigationAllowed('https://example.com', 'http://localhost:5173', APP_DOC_URL)
+    ).toBe(false)
+  })
+
+  it('blocks malformed URLs', () => {
+    expect(isMainWindowNavigationAllowed('not a url', undefined, APP_DOC_URL)).toBe(false)
   })
 })

--- a/tests/main/window-navigation-policy.test.ts
+++ b/tests/main/window-navigation-policy.test.ts
@@ -19,12 +19,10 @@ describe('main window navigation policy', () => {
   })
 
   it('blocks navigation to an arbitrary local file (S2)', () => {
-    expect(
-      isMainWindowNavigationAllowed('file:///tmp/evil.html', undefined, APP_DOC_URL)
-    ).toBe(false)
-    expect(
-      isMainWindowNavigationAllowed('file:///etc/passwd', undefined, APP_DOC_URL)
-    ).toBe(false)
+    expect(isMainWindowNavigationAllowed('file:///tmp/evil.html', undefined, APP_DOC_URL)).toBe(
+      false
+    )
+    expect(isMainWindowNavigationAllowed('file:///etc/passwd', undefined, APP_DOC_URL)).toBe(false)
   })
 
   it('blocks a dev-origin spoof that merely starts with the renderer URL (S2)', () => {
@@ -40,9 +38,7 @@ describe('main window navigation policy', () => {
   })
 
   it('blocks non-file URLs when no development renderer URL is configured', () => {
-    expect(isMainWindowNavigationAllowed('https://example.com', undefined, APP_DOC_URL)).toBe(
-      false
-    )
+    expect(isMainWindowNavigationAllowed('https://example.com', undefined, APP_DOC_URL)).toBe(false)
     expect(isMainWindowNavigationAllowed('https://example.com', '', APP_DOC_URL)).toBe(false)
   })
 

--- a/tests/main/window-navigation-policy.test.ts
+++ b/tests/main/window-navigation-policy.test.ts
@@ -25,6 +25,25 @@ describe('main window navigation policy', () => {
     expect(isMainWindowNavigationAllowed('file:///etc/passwd', undefined, APP_DOC_URL)).toBe(false)
   })
 
+  it('blocks a remote file authority even when its pathname matches the app document', () => {
+    expect(
+      isMainWindowNavigationAllowed(
+        'file://attacker/app/renderer/index.html',
+        undefined,
+        APP_DOC_URL
+      )
+    ).toBe(false)
+  })
+
+  it('allows router fragments but rejects query-bearing packaged document URLs', () => {
+    expect(isMainWindowNavigationAllowed(`${APP_DOC_URL}#/variants`, undefined, APP_DOC_URL)).toBe(
+      true
+    )
+    expect(isMainWindowNavigationAllowed(`${APP_DOC_URL}?next=evil`, undefined, APP_DOC_URL)).toBe(
+      false
+    )
+  })
+
   it('blocks a dev-origin spoof that merely starts with the renderer URL (S2)', () => {
     // http://localhost:5173.evil.com starts with 'http://localhost:5173' as a
     // string, but is a different WHATWG origin entirely.

--- a/tests/renderer/components/BatchImportDialog.test.ts
+++ b/tests/renderer/components/BatchImportDialog.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+import BatchImportDialog from '../../../src/renderer/src/components/BatchImportDialog.vue'
+import { createMockApi, type MockApi } from '../../utils/mock-api'
+
+const vuetify = createVuetify({ components, directives })
+
+describe('BatchImportDialog ZIP ownership', () => {
+  let wrapper: VueWrapper<InstanceType<typeof BatchImportDialog>>
+  let mockApi: MockApi
+
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    mockApi = createMockApi()
+    window.api = mockApi as unknown as typeof window.api
+    wrapper = mount(BatchImportDialog, {
+      global: { plugins: [vuetify, pinia] },
+      attachTo: document.body
+    })
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('releases the exact ZIP extraction as soon as its import reaches a terminal result', async () => {
+    mockApi.batchImport.selectZip.mockResolvedValue({
+      filePath: '/selected/cases.zip',
+      isEncrypted: false
+    })
+    mockApi.batchImport.extractZip.mockResolvedValue({
+      files: ['/tmp/extraction/case.json'],
+      errors: [],
+      extractionId: 'extraction-owned-by-dialog'
+    })
+    mockApi.batchImport.checkDuplicates.mockResolvedValue({
+      files: [
+        {
+          filePath: '/tmp/extraction/case.json',
+          fileName: 'case.json',
+          caseName: 'case',
+          isDuplicate: false
+        }
+      ],
+      duplicateCount: 0
+    })
+    mockApi.batchImport.start.mockResolvedValue({
+      succeeded: 1,
+      failed: 0,
+      skipped: 0,
+      cancelled: false,
+      details: []
+    })
+
+    await wrapper.vm.show('zip')
+    await flushPromises()
+    const startButton = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Start Import')
+    )
+    expect(startButton).toBeDefined()
+    startButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledTimes(1)
+    expect(mockApi.batchImport.cleanupZipTemp).toHaveBeenCalledWith('extraction-owned-by-dialog')
+  })
+})

--- a/tests/renderer/components/VcfImportDialog.test.ts
+++ b/tests/renderer/components/VcfImportDialog.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+import VcfImportDialog from '../../../src/renderer/src/components/import/VcfImportDialog.vue'
+import { AppStateKey, createAppState } from '../../../src/renderer/src/composables/useAppState'
+import { createMockApi, type MockApi } from '../../utils/mock-api'
+
+const vuetify = createVuetify({ components, directives })
+
+function dispatchFileDrop(target: Element, files: File[]): void {
+  const event = new Event('drop', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', { value: { files } })
+  target.dispatchEvent(event)
+}
+
+describe('VcfImportDialog dropped-file provenance', () => {
+  let wrapper: VueWrapper<InstanceType<typeof VcfImportDialog>>
+  let mockApi: MockApi
+
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    mockApi = createMockApi()
+    window.api = mockApi as unknown as typeof window.api
+    wrapper = mount(VcfImportDialog, {
+      props: { open: true },
+      global: {
+        plugins: [vuetify, pinia],
+        provide: { [AppStateKey as symbol]: createAppState() }
+      },
+      attachTo: document.body
+    })
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('enrolls genuine dropped Files before sending their returned paths to preview', async () => {
+    const droppedFile = new File(['##fileformat=VCFv4.2\n'], 'sample.vcf')
+    mockApi.import.enrollDroppedFiles.mockResolvedValue(['/trusted/sample.vcf'])
+    mockApi.import.vcfMultiPreview.mockResolvedValue({
+      files: [],
+      siblingBedFiles: [],
+      suggestedCaseName: 'sample'
+    })
+    await flushPromises()
+
+    const dropZone = document.body.querySelector('.drop-zone')
+    expect(dropZone).not.toBeNull()
+    dispatchFileDrop(dropZone!, [droppedFile])
+    await flushPromises()
+
+    expect(mockApi.import.enrollDroppedFiles).toHaveBeenCalledWith([droppedFile])
+    expect(mockApi.import.vcfMultiPreview).toHaveBeenCalledWith(['/trusted/sample.vcf'])
+  })
+
+  it('shows a recoverable error when dropped-file provenance enrollment fails', async () => {
+    const droppedFile = new File(['##fileformat=VCFv4.2\n'], 'sample.vcf')
+    mockApi.import.enrollDroppedFiles.mockRejectedValue(new Error('native path unavailable'))
+    await flushPromises()
+
+    const dropZone = document.body.querySelector('.drop-zone')
+    expect(dropZone).not.toBeNull()
+    dispatchFileDrop(dropZone!, [droppedFile])
+    await flushPromises()
+
+    expect(document.body.textContent).toContain('File drop failed: native path unavailable')
+    expect(mockApi.import.vcfMultiPreview).not.toHaveBeenCalled()
+  })
+})

--- a/tests/renderer/composables/useZipExtractionLifecycle.test.ts
+++ b/tests/renderer/composables/useZipExtractionLifecycle.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ErrorCode } from '../../../src/shared/types/errors'
+import { useZipExtractionLifecycle } from '../../../src/renderer/src/composables/useZipExtractionLifecycle'
+
+describe('useZipExtractionLifecycle', () => {
+  it('cleans each owned extraction exactly once across concurrent cleanup calls', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const cleanupZipTemp = vi.fn(async () => {
+      await gate
+    })
+    const lifecycle = useZipExtractionLifecycle(cleanupZipTemp)
+    lifecycle.track('extraction-1')
+
+    const first = lifecycle.cleanup()
+    const second = lifecycle.cleanup()
+    expect(cleanupZipTemp).toHaveBeenCalledOnce()
+    expect(cleanupZipTemp).toHaveBeenCalledWith('extraction-1')
+
+    release()
+    await Promise.all([first, second])
+    await lifecycle.cleanup()
+    expect(cleanupZipTemp).toHaveBeenCalledOnce()
+  })
+
+  it('retains failed ownership so a later cleanup can retry it', async () => {
+    const cleanupZipTemp = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: ErrorCode.UNKNOWN,
+        message: 'transport failed',
+        userMessage: 'Cleanup failed'
+      })
+      .mockResolvedValueOnce(undefined)
+    const lifecycle = useZipExtractionLifecycle(cleanupZipTemp)
+    lifecycle.track('extraction-1')
+
+    await expect(lifecycle.cleanup()).rejects.toMatchObject({ code: ErrorCode.UNKNOWN })
+    await expect(lifecycle.cleanup()).resolves.toBeUndefined()
+
+    expect(cleanupZipTemp).toHaveBeenCalledTimes(2)
+    expect(cleanupZipTemp).toHaveBeenNthCalledWith(2, 'extraction-1')
+  })
+
+  it('does not lose a newer extraction tracked while an older cleanup is pending', async () => {
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const cleanupZipTemp = vi.fn(async (extractionId: string) => {
+      if (extractionId === 'extraction-1') await firstGate
+    })
+    const lifecycle = useZipExtractionLifecycle(cleanupZipTemp)
+    lifecycle.track('extraction-1')
+
+    const firstCleanup = lifecycle.cleanup()
+    lifecycle.track('extraction-2')
+    const secondCleanup = lifecycle.cleanup()
+    await Promise.resolve()
+    expect(cleanupZipTemp).toHaveBeenCalledWith('extraction-2')
+    releaseFirst()
+    await Promise.all([firstCleanup, secondCleanup])
+
+    expect(cleanupZipTemp).toHaveBeenCalledTimes(2)
+    expect(cleanupZipTemp).toHaveBeenCalledWith('extraction-1')
+    expect(cleanupZipTemp).toHaveBeenCalledWith('extraction-2')
+  })
+})

--- a/tests/shared/ipc/domains/batch-import.test.ts
+++ b/tests/shared/ipc/domains/batch-import.test.ts
@@ -52,7 +52,8 @@ describe('batch-import preload domain behavior', () => {
       })
       .mockResolvedValueOnce({
         files: ['/extracted/file1.json', '/extracted/file2.json'],
-        errors: []
+        errors: [],
+        extractionId: 'extraction-1'
       })
       .mockResolvedValueOnce(undefined)
 
@@ -98,7 +99,7 @@ describe('batch-import preload domain behavior', () => {
       errors: []
     })
 
-    await expect(api.cleanupZipTemp()).resolves.toBeUndefined()
+    await expect(api.cleanupZipTemp('extraction-1')).resolves.toBeUndefined()
 
     expect(invoke).toHaveBeenNthCalledWith(1, 'batch-import:selectFiles')
     expect(invoke).toHaveBeenNthCalledWith(2, 'batch-import:selectFolder')
@@ -129,7 +130,7 @@ describe('batch-import preload domain behavior', () => {
       '/path/to/archive.zip',
       undefined
     )
-    expect(invoke).toHaveBeenNthCalledWith(9, 'batch-import:cleanupZipTemp')
+    expect(invoke).toHaveBeenNthCalledWith(9, 'batch-import:cleanupZipTemp', 'extraction-1')
   })
 
   it('preload index preserves batch-import transport results when exposing window.api', async () => {
@@ -187,7 +188,7 @@ describe('batch-import preload domain behavior', () => {
         cancel: () => Promise<unknown>
         selectZip: () => Promise<unknown>
         testZipPassword: (zipPath: string, password: string) => Promise<unknown>
-        cleanupZipTemp: () => Promise<unknown>
+        cleanupZipTemp: (extractionId: string) => Promise<unknown>
       }
     }
 
@@ -206,7 +207,7 @@ describe('batch-import preload domain behavior', () => {
       code: ErrorCode.WRONG_PASSWORD,
       message: 'Password test failed'
     })
-    await expect(api.batchImport.cleanupZipTemp()).resolves.toBeUndefined()
+    await expect(api.batchImport.cleanupZipTemp('extraction-2')).resolves.toBeUndefined()
 
     expect(invoke).toHaveBeenCalledWith('batch-import:selectFiles')
     expect(invoke).toHaveBeenCalledWith('batch-import:selectFolder')
@@ -214,6 +215,6 @@ describe('batch-import preload domain behavior', () => {
     expect(invoke).toHaveBeenCalledWith('batch-import:cancel')
     expect(invoke).toHaveBeenCalledWith('batch-import:selectZip')
     expect(invoke).toHaveBeenCalledWith('batch-import:testZipPassword', '/archive.zip', 'pwd')
-    expect(invoke).toHaveBeenCalledWith('batch-import:cleanupZipTemp')
+    expect(invoke).toHaveBeenCalledWith('batch-import:cleanupZipTemp', 'extraction-2')
   })
 })

--- a/tests/shared/ipc/domains/export.test.ts
+++ b/tests/shared/ipc/domains/export.test.ts
@@ -23,6 +23,7 @@ describe('export preload domain behavior', () => {
         success: true,
         filePath: '/tmp/cohort.xlsx'
       })
+      .mockResolvedValueOnce({ success: true })
 
     vi.doMock('electron', () => ({
       ipcRenderer: { invoke }
@@ -42,6 +43,7 @@ describe('export preload domain behavior', () => {
       success: true,
       filePath: '/tmp/cohort.xlsx'
     })
+    await expect(api.revealInFolder('/tmp/cohort.xlsx')).resolves.toEqual({ success: true })
 
     expect(invoke).toHaveBeenNthCalledWith(
       1,
@@ -57,6 +59,7 @@ describe('export preload domain behavior', () => {
       limit: 50,
       offset: 0
     })
+    expect(invoke).toHaveBeenNthCalledWith(3, 'export:revealInFolder', '/tmp/cohort.xlsx')
   })
 
   it('preload index preserves export transport results when exposing window.api', async () => {

--- a/tests/shared/ipc/domains/import.test.ts
+++ b/tests/shared/ipc/domains/import.test.ts
@@ -43,8 +43,14 @@ describe('import preload domain behavior', () => {
       })
       .mockResolvedValueOnce(undefined)
 
+    const droppedFile = { name: 'dropped.vcf' } as File
+    const rawString = '/renderer/supplied.vcf'
+    const getPathForFile = vi.fn((file: File) =>
+      file === droppedFile ? '/trusted/dropped.vcf' : ''
+    )
     vi.doMock('electron', () => ({
-      ipcRenderer: { invoke }
+      ipcRenderer: { invoke },
+      webUtils: { getPathForFile }
     }))
 
     const { createImportApi } = await import('../../../../src/preload/domains/import')
@@ -79,6 +85,20 @@ describe('import preload domain behavior', () => {
     })
 
     await expect(api.cancel()).resolves.toBeUndefined()
+
+    await api.enrollDroppedFiles([droppedFile, rawString as unknown as File])
+    expect(getPathForFile).toHaveBeenCalledWith(droppedFile)
+    const droppedFileEnrollmentToken = invoke.mock.calls[8]?.[1]
+    expect(droppedFileEnrollmentToken).toEqual(expect.any(String))
+    expect(invoke).toHaveBeenNthCalledWith(
+      9,
+      'import:registerDroppedFileEnrollmentToken',
+      droppedFileEnrollmentToken
+    )
+    expect(invoke).toHaveBeenNthCalledWith(10, 'import:enrollDroppedFiles', {
+      token: droppedFileEnrollmentToken,
+      filePaths: ['/trusted/dropped.vcf']
+    })
 
     expect(invoke).toHaveBeenNthCalledWith(1, 'import:selectFile')
     expect(invoke).toHaveBeenNthCalledWith(2, 'import:selectFiles')

--- a/tests/utils/mock-api.ts
+++ b/tests/utils/mock-api.ts
@@ -154,7 +154,35 @@ export function createMockApi(): MockApi {
 
     import: {
       selectFile: vi.fn().mockResolvedValue(null),
+      selectFiles: vi.fn().mockResolvedValue([]),
+      selectBedFile: vi.fn().mockResolvedValue(null),
+      enrollDroppedFiles: vi.fn().mockResolvedValue([]),
       start: vi.fn().mockResolvedValue({ success: true }),
+      startMultiFile: vi.fn().mockResolvedValue({
+        caseId: 1,
+        totalVariants: 0,
+        totalSkipped: 0,
+        files: [],
+        elapsed: 0
+      }),
+      vcfPreview: vi.fn().mockResolvedValue({
+        fileformat: 'VCFv4.2',
+        samples: [],
+        variantCountEstimate: 0,
+        annotationType: 'none',
+        detectedGenomeBuild: null,
+        infoFields: [],
+        callerName: null,
+        callerVersion: null,
+        defaultVariantType: 'snv',
+        filePath: '/tmp/mock.vcf',
+        fileSize: 0
+      }),
+      vcfMultiPreview: vi.fn().mockResolvedValue({
+        files: [],
+        siblingBedFiles: [],
+        suggestedCaseName: 'Mock case'
+      }),
       onProgress: vi.fn(() => vi.fn()), // Returns cleanup function
       cancel: vi.fn().mockResolvedValue(undefined)
     },
@@ -166,13 +194,13 @@ export function createMockApi(): MockApi {
 
     export: {
       variants: vi.fn().mockResolvedValue({ success: true }),
-      cohort: vi.fn().mockResolvedValue({ success: true })
+      cohort: vi.fn().mockResolvedValue({ success: true }),
+      revealInFolder: vi.fn().mockResolvedValue({ success: false })
     },
 
     shell: {
       openExternal: vi.fn().mockResolvedValue(undefined),
-      updateDomains: vi.fn().mockResolvedValue(undefined),
-      showItemInFolder: vi.fn().mockResolvedValue(undefined)
+      updateDomains: vi.fn().mockResolvedValue(undefined)
     },
 
     database: {
@@ -207,7 +235,9 @@ export function createMockApi(): MockApi {
       cancel: vi.fn().mockResolvedValue(undefined),
       selectZip: vi.fn().mockResolvedValue(null),
       testZipPassword: vi.fn().mockResolvedValue({ valid: true }),
-      extractZip: vi.fn().mockResolvedValue([]),
+      extractZip: vi
+        .fn()
+        .mockResolvedValue({ files: [], errors: [], extractionId: 'mock-extraction' }),
       cleanupZipTemp: vi.fn().mockResolvedValue(undefined),
       onProgress: vi.fn(() => vi.fn()), // Returns cleanup function
       onComplete: vi.fn(() => vi.fn()) // Returns cleanup function

--- a/tests/web-gate/handler-seam.test.ts
+++ b/tests/web-gate/handler-seam.test.ts
@@ -22,7 +22,7 @@ const TASK_TYPES_PATH = 'src/web/server/task-types.ts'
 const WEB_ROUTES_DIR = 'src/web/server/routes'
 
 const FLAT_HANDLERS = new Set(['shell', 'shortlist', 'system', 'updater'])
-const SHARED_DOMAIN_HELPERS = new Set(['import-schemas'])
+const SHARED_DOMAIN_HELPERS = new Set(['batch-import-schemas', 'import-schemas', 'jobs-schemas'])
 const ROUTE_OVERRIDE_LOGIC_EXCEPTIONS: Record<string, string> = {
   'analysis-groups.ts': 'thin storage-executor adapters with web-only argument validation',
   'audit-log.ts': 'admin-gated audit-trail read adapters over the storage read executor',

--- a/tests/web-gate/web-client-api.test.ts
+++ b/tests/web-gate/web-client-api.test.ts
@@ -10,8 +10,12 @@ interface TestApi {
     onProgress: (callback: (progress: unknown) => void) => () => void
     selectFile: () => Promise<string | null>
     selectBedFile: () => Promise<string | null>
+    enrollDroppedFiles: (files: readonly File[]) => Promise<string[]>
     cancel: () => Promise<void>
     start: (...args: unknown[]) => Promise<unknown>
+  }
+  export: {
+    revealInFolder: (filePath: string) => Promise<{ success: boolean }>
   }
   batchImport: {
     onProgress: (callback: (progress: unknown) => void) => () => void
@@ -508,6 +512,31 @@ describe('web client api', () => {
 
     expect(input.accept).toBe('.bed,.bed.gz,.gz')
     expect(input.multiple).toBe(false)
+  })
+
+  test('import.enrollDroppedFiles uploads the exact dropped Files and returns user-scoped refs', async () => {
+    const first = new File(['##fileformat=VCFv4.2\n'], 'case-a.vcf')
+    const second = new File(['compressed'], 'case-b.vcf.gz')
+    resetMockXhr()
+    vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest)
+
+    const api = createApi() as unknown as TestApi
+    await expect(api.import.enrollDroppedFiles([first, second])).resolves.toEqual([
+      'web-upload:upload-case-a.vcf/case-a.vcf',
+      'web-upload:upload-case-b.vcf.gz/case-b.vcf.gz'
+    ])
+
+    expect(MockXMLHttpRequest.instances).toHaveLength(2)
+  })
+
+  test('export.revealInFolder is an explicit unsupported web capability', async () => {
+    const fetchMock = mockFetch({ ok: true, status: 200, statusText: 'OK', body: '{}' })
+    const api = createApi() as unknown as TestApi
+
+    await expect(api.export.revealInFolder('/server/export.xlsx')).resolves.toEqual({
+      success: false
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   test('batchImport.selectFolder enables directory picking and uploads all selected files', async () => {


### PR DESCRIPTION
## Summary

Hardens URL/navigation and filesystem-path handling (findings S1, S2, S3, S5, S6 + Codex F-03/F-06). VarLens is offline and single-user, so the renderer is effectively the trust boundary — these are defense-in-depth gates that stop a compromised renderer from navigating to arbitrary local files, widening the window-open allowlist, or reading/opening arbitrary filesystem paths.

**PR-F** of the staged security & bug remediation.

## What changed

**Navigation & external URLs (S1, S2, S5):**
- `will-navigate` now allows only the **exact packaged app document** (decoded file pathname) plus the **dev origin** (WHATWG `URL.origin` comparison) — arbitrary `file://` and `http://localhost:5173.evil.com`-style origin spoofs are denied. (In this app the main frame has no legitimate navigation trigger — memory-history router, no raw anchors — so this is pure defense-in-depth.)
- Renderer-added external-URL domains (`shell:updateUserDomains`) now gate `shell.openExternal` **only**, never `setWindowOpenHandler`.
- `github.io` narrowed to `berntpopp.github.io`. The `https:`-only external gate is unchanged.

**Filesystem path authority (S3, S6, F-03/F-06):**
- New **dialog-origin authority**: `database:open/create/showInFolder/removeRecent` accept a path only if it was dialog-selected, in the recent-DB list, or the active DB. `region-files:importBed`, all `batch-import:*` channels, and `shell:showItemInFolder` require the path to have been **explicitly enrolled** by a real dialog handler (`selectFile`/`selectSaveLocation`/`selectBedFile`/`selectFiles`/`selectFolder`/`selectZip`/export). ZIP-extracted temp files are enrolled at extraction time.
- Crucially, these gates use a **strict** enrollment check that does NOT inherit the import allowlist's permissive home/userData/temp auto-roots — so an unenrolled path under the user's home dir is rejected (the original `import.ts` flow keeps the permissive gate by design).
- Added Zod validation to the previously-unvalidated `batch-import:*` and `jobs:list/get/progress` args.

Startup auto-open of the default DB opens a fixed `userData` path directly on the `DatabaseManager` (not through the IPC gate), so no legitimate open is ever locked out.

## Reviews

- **Codex-high (whole-branch gate):** first pass NO-GO caught that reusing the permissive `isAllowedImportPath` (auto-allows anything under home/temp) defeated the dialog-origin intent — fixed with a strict `isStrictlyEnrolledPath` for the DB/BED/batch/shell gates — then **GO**, with every legitimate flow (dialog/recent/active/startup/export/import) confirmed still working.
- Per-task reviews (Opus on the path-authority task): traced every DB-open flow to confirm no lockout; F-nav reviewer confirmed the navigation tightening can't break normal use.

## Verification

- `make test` (`--project main`): **2857 passing**; `make typecheck` clean; `make ci-startup-smoke` passed (real app document still loads after the navigation tightening).
- Tests assert both reject (unenrolled out-of-root paths, arbitrary domains) and accept (dialog-enrolled paths, real dev/app origins) behavior; a real `adm-zip` extract→start test proves ZIP temp enrollment.

## Follow-ups (tracked, non-blocking)

- Hoist the duplicated `appDocUrl`/`loadFile` path expression in `index.ts` into one const (fails closed if they diverge).
- `startup-large-db.e2e.ts` (manual, non-CI benchmark) opens a raw DB path bypassing the dialog and now needs a recent-list seed before its next manual run.

Part of the security & bug remediation series (PRs A–E: #306–#310; PRs G–I to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmqdEMGjqVhTX8EKr6QxoH
