### PR TITLE
feat(db): encryption-by-default — envelope key-store, reversible migration, recovery (S8-enc) [PR-I]

### DIFF
--- a/.planning/plans/2026-07-13-pr314-key-lifecycle-hardening-plan.md
+++ b/.planning/plans/2026-07-13-pr314-key-lifecycle-hardening-plan.md
@@ -1,0 +1,9 @@
+# PR 314 key-lifecycle hardening implementation plan
+
+1. Add focused failing tests for `basic_text`, deferred recovery enrollment, initial sidecar failure, verified-session passphrase rotation, managed deletion cleanup/recreate, sidecar bounds, and renderer semantics.
+2. Harden `DbKeyStore` capability detection and add the verified-DEK passphrase replacement seam.
+3. Defer lifecycle recovery mutations until database verification and fail passphrase-only provisioning closed.
+4. Clean key artifacts during deletion and validate sidecar input bounds.
+5. Align mock API and renderer recovery controls with the backend contract.
+6. Run focused Vitest suites, typecheck, agent-check, review the diff for secret handling and crash durability, then commit without pushing.
+

--- a/.planning/plans/2026-07-13-pr314-key-lifecycle-hardening-plan.md
+++ b/.planning/plans/2026-07-13-pr314-key-lifecycle-hardening-plan.md
@@ -6,4 +6,5 @@
 4. Clean key artifacts during deletion and validate sidecar input bounds.
 5. Align mock API and renderer recovery controls with the backend contract.
 6. Run focused Vitest suites, typecheck, agent-check, review the diff for secret handling and crash durability, then commit without pushing.
-
+7. Add failing tests for pending migration reconciliation, post-swap reopen failure, optional-sidecar visibility, streaming content hashes, and backup/delete durability.
+8. Implement pending-key activation/removal at verified open boundaries, stream content hashing, and harden migration durability and result reporting.

--- a/.planning/specs/2026-07-13-pr314-key-lifecycle-hardening.md
+++ b/.planning/specs/2026-07-13-pr314-key-lifecycle-hardening.md
@@ -13,6 +13,10 @@ Close the key-lifecycle and recovery-sidecar security gaps found during PR 314 r
 - Deleting a managed database removes its registry mapping and recovery sidecar after the database file is deleted, allowing the path to be recreated.
 - Recovery sidecars are bounded and every decoded cryptographic field has its exact expected size.
 - Renderer visibility and error states reflect whether a database is actually key-managed and whether portable recovery was written.
+- Plaintext migration keys remain `pending` until the encrypted file is reopened successfully. A later verified encrypted open activates the entry; a later verified plaintext open removes the abandoned pending entry.
+- Migration verification streams table rows instead of materializing WGS-sized tables in memory.
+- Once the encrypted swap has completed, an application reopen failure never attempts to reinterpret the encrypted file as plaintext.
+- Plaintext backups and their deletion receive the same file/directory durability treatment as key-registry and sidecar writes.
 
 ## Design
 
@@ -20,5 +24,6 @@ Keep the existing `DbKeyStore` and handler boundaries. Add a single secure-stora
 
 Passphrase-only provisioning is transactional at the orchestration boundary: if sidecar persistence fails, remove the new registry entry and sidecar and do not create or migrate the database. Existing managed databases remain usable if a replacement sidecar write fails, so that operation returns partial failure and the UI keeps the dialog open with a recovery warning.
 
-Deletion cleanup occurs only after the primary database unlink succeeds. Sidecar parsing rejects files larger than 64 KiB, noncanonical base64, and decoded fields whose sizes differ from the encryption format.
+Migration provisioning uses pending registry entries. The low-level migration removes them on any pre-swap/rollback failure. A successful encrypted reopen activates the entry. On a later launch/open, plaintext detection proves a pending migration never swapped and permits safe removal; encrypted verification proves the swap completed and permits activation. Legacy registry entries without a state field are active.
 
+Deletion cleanup occurs only after the primary database unlink succeeds. Sidecar parsing rejects files larger than 64 KiB, noncanonical base64, and decoded fields whose sizes differ from the encryption format.

--- a/.planning/specs/2026-07-13-pr314-key-lifecycle-hardening.md
+++ b/.planning/specs/2026-07-13-pr314-key-lifecycle-hardening.md
@@ -1,0 +1,24 @@
+# PR 314 key-lifecycle hardening
+
+## Goal
+
+Close the key-lifecycle and recovery-sidecar security gaps found during PR 314 review without broadening the encryption architecture.
+
+## Invariants
+
+- Electron `safeStorage` is usable for managed keys only when encryption is available and the selected backend is not Linux `basic_text`.
+- Password resolution is read-only. Registry enrollment or path repointing happens only after SQLite accepts the recovered DEK.
+- A passphrase-only create or plaintext migration succeeds only when both registry and portable recovery sidecar are durable.
+- Recovery-passphrase replacement uses the DEK from the already-open, verified database session and reports a sidecar replacement failure explicitly.
+- Deleting a managed database removes its registry mapping and recovery sidecar after the database file is deleted, allowing the path to be recreated.
+- Recovery sidecars are bounded and every decoded cryptographic field has its exact expected size.
+- Renderer visibility and error states reflect whether a database is actually key-managed and whether portable recovery was written.
+
+## Design
+
+Keep the existing `DbKeyStore` and handler boundaries. Add a single secure-storage capability check, represent sidecar recovery as a deferred action returned by password resolution, and add a narrowly named key-store method that writes a new passphrase wrap for a caller-supplied verified DEK. The lifecycle handler is the authority for that DEK because it obtains it from the current open `DatabaseService`.
+
+Passphrase-only provisioning is transactional at the orchestration boundary: if sidecar persistence fails, remove the new registry entry and sidecar and do not create or migrate the database. Existing managed databases remain usable if a replacement sidecar write fails, so that operation returns partial failure and the UI keeps the dialog open with a recovery warning.
+
+Deletion cleanup occurs only after the primary database unlink succeeds. Sidecar parsing rejects files larger than 64 KiB, noncanonical base64, and decoded fields whose sizes differ from the encryption format.
+

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,7 +51,8 @@ export default defineConfig({
             { text: 'Introduction', link: '/guide/introduction' },
             { text: 'App Layout', link: '/guide/app-layout' },
             { text: 'Installation', link: '/guide/installation' },
-            { text: 'Importing Data', link: '/guide/importing-data' }
+            { text: 'Importing Data', link: '/guide/importing-data' },
+            { text: 'Database Encryption', link: '/guide/database-encryption' }
           ]
         }
       ],

--- a/docs/guide/database-encryption.md
+++ b/docs/guide/database-encryption.md
@@ -1,0 +1,101 @@
+# Database Encryption
+
+VarLens stores your variant data in a local SQLite database. **New databases are
+encrypted at rest by default** so that a copy of the database file alone — on a
+lost laptop, a stolen drive, or an unattended backup — cannot be read without the
+key.
+
+## What encryption protects against (and what it doesn't)
+
+**Protects against — offline file theft.** If someone obtains only your database
+file (`.db`), they cannot open it or read any case, variant, or phenotype data
+without the encryption key. The file is encrypted with AES using
+[SQLCipher](https://www.zetetic.net/sqlcipher/)-compatible page encryption.
+
+**Does _not_ protect against** a running, unlocked VarLens on your machine, malware
+running as your user account, or anyone who has both the database file **and** your
+key (or your recovery passphrase). Encryption-at-rest is one layer, not a
+substitute for OS-level account security.
+
+## How the key is stored, per platform
+
+By default VarLens generates a random per-database key and stores it using the
+operating system's secure credential store (Electron `safeStorage`):
+
+| Platform | Key protected by |
+| --- | --- |
+| **macOS** | Keychain |
+| **Windows** | DPAPI (your Windows user account) |
+| **Linux (desktop)** | GNOME Keyring / KDE Wallet (via libsecret / kwallet) |
+
+When a secure store is available, encryption is fully transparent — you never see a
+password prompt; VarLens unlocks the database automatically on your machine.
+
+### The honest Linux caveat
+
+On a Linux system **without** a desktop keyring (a headless server, a minimal
+install, some container environments), the OS secure store is unavailable. VarLens
+**detects this** — it never silently pretends to encrypt with a throw-away key.
+Instead, when you create a database on such a system, VarLens asks you to **set a
+database password**, and the key is derived from that password (via scrypt). Your
+password is never stored insecurely; you enter it when opening the database.
+
+## Recovery: set a passphrase before you move or back up a database
+
+::: warning IMPORTANT — the transparent key does not travel
+A transparently-managed key lives **only** in your machine's OS keyring. It is
+**not** inside the database file and is **not** copied when you copy the `.db`
+file. That means, unless you have set a recovery passphrase:
+
+- **Reinstalling your OS, resetting your keychain, or wiping your user profile
+  destroys the key — and the encrypted data becomes permanently unrecoverable.**
+- **Copying the database to another computer** will fail to open there, because the
+  new machine's keyring does not have the key.
+:::
+
+To keep your data recoverable and portable, **set a recovery passphrase**:
+
+1. Open the database.
+2. Use **Set a database password / recovery passphrase**.
+3. Store that passphrase somewhere safe (a password manager).
+
+A recovery passphrase wraps the same database key, so the database can then be
+opened on any machine — or after a keyring loss — by entering the passphrase. Set
+one **before** backing up or transferring a database.
+
+## Encrypting an existing (unencrypted) database
+
+Databases created before encryption-by-default remain readable and are **not**
+changed until you choose to encrypt them. When you open an unencrypted database,
+VarLens offers a one-time **Encrypt this database** migration. The migration is
+designed to be safe:
+
+1. It builds a fully **encrypted copy** and verifies its integrity **before**
+   touching your original.
+2. It writes a **plaintext backup** of your original and verifies that backup can
+   be opened.
+3. Only then does it atomically swap the encrypted database into place.
+4. If **any** step fails, it rolls back — you are never left without a working
+   database.
+
+You are prompted for consent first, and encouraged to set a recovery passphrase as
+part of the migration.
+
+::: warning Delete the plaintext backup when you're done
+The migration keeps a `…plaintext-backup-…` file next to your database so you can
+roll back if needed. That backup is **unencrypted** — it contains a full readable
+copy of your data. Once you've confirmed the encrypted database opens correctly,
+use **Delete plaintext backup** to remove it, or delete it yourself. Leaving it in
+place defeats the purpose of encrypting.
+:::
+
+## Summary
+
+- New databases are **encrypted at rest by default**.
+- The key is protected by your OS keyring where available; otherwise VarLens asks
+  you to set a password (and never fakes encryption).
+- **Set a recovery passphrase** before moving or backing up a database — the
+  transparent key does not travel with the file, and losing it means losing the
+  data.
+- Existing unencrypted databases can be encrypted with a consented, backed-up,
+  reversible migration; delete the plaintext backup afterward.

--- a/docs/guide/database-encryption.md
+++ b/docs/guide/database-encryption.md
@@ -56,12 +56,18 @@ file. That means, unless you have set a recovery passphrase:
 To keep your data recoverable and portable, **set a recovery passphrase**:
 
 1. Open the database.
-2. Use **Set a database password / recovery passphrase**.
+2. From the database menu, use **Set Recovery Passphrase...**.
 3. Store that passphrase somewhere safe (a password manager).
 
 A recovery passphrase wraps the same database key, so the database can then be
 opened on any machine — or after a keyring loss — by entering the passphrase. Set
 one **before** backing up or transferring a database.
+
+Setting a recovery passphrase also writes a small `<db>.varlens-recovery.json`
+sidecar file next to your database. Portability requires copying **both** the
+`.db` file **and** its `.varlens-recovery.json` sidecar, plus knowing the
+passphrase — copying the `.db` file alone is not enough, even with a recovery
+passphrase set.
 
 ## Encrypting an existing (unencrypted) database
 
@@ -96,6 +102,6 @@ place defeats the purpose of encrypting.
   you to set a password (and never fakes encryption).
 - **Set a recovery passphrase** before moving or backing up a database — the
   transparent key does not travel with the file, and losing it means losing the
-  data.
+  data. Bring the `.varlens-recovery.json` sidecar along with the `.db` file.
 - Existing unencrypted databases can be encrypted with a consented, backed-up,
   reversible migration; delete the plaintext backup afterward.

--- a/docs/guide/database-encryption.md
+++ b/docs/guide/database-encryption.md
@@ -9,8 +9,8 @@ key.
 
 **Protects against — offline file theft.** If someone obtains only your database
 file (`.db`), they cannot open it or read any case, variant, or phenotype data
-without the encryption key. The file is encrypted with AES using
-[SQLCipher](https://www.zetetic.net/sqlcipher/)-compatible page encryption.
+without the encryption key. The database pages are protected by SQLite3 Multiple
+Ciphers using its default `sqleet` cipher (ChaCha20-Poly1305).
 
 **Does _not_ protect against** a running, unlocked VarLens on your machine, malware
 running as your user account, or anyone who has both the database file **and** your

--- a/src/main/database/db-key-passphrase.ts
+++ b/src/main/database/db-key-passphrase.ts
@@ -1,0 +1,45 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto'
+
+/** AES-256-GCM passphrase wrap of a DEK. All fields are base64-encoded. */
+export interface PassphraseWrap {
+  saltB64: string
+  ivB64: string
+  ctB64: string
+  tagB64: string
+}
+
+/** scrypt cost parameters. N=16384, r=8, p=1 derives ~16 MiB. */
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const
+const SCRYPT_KEY_LENGTH = 32
+const GCM_IV_LENGTH = 12
+const PASSPHRASE_SALT_LENGTH = 16
+
+export function wrapPassphrase(dek: string, passphrase: string): PassphraseWrap {
+  const salt = randomBytes(PASSPHRASE_SALT_LENGTH)
+  const iv = randomBytes(GCM_IV_LENGTH)
+  const derivedKey = scryptSync(passphrase, salt, SCRYPT_KEY_LENGTH, SCRYPT_PARAMS)
+  const cipher = createCipheriv('aes-256-gcm', derivedKey, iv)
+  const ct = Buffer.concat([cipher.update(dek, 'utf8'), cipher.final()])
+  return {
+    saltB64: salt.toString('base64'),
+    ivB64: iv.toString('base64'),
+    ctB64: ct.toString('base64'),
+    tagB64: cipher.getAuthTag().toString('base64')
+  }
+}
+
+/** Null on a wrong passphrase, GCM auth failure, or malformed wrap. */
+export function unwrapPassphrase(wrap: PassphraseWrap, passphrase: string): string | null {
+  try {
+    const salt = Buffer.from(wrap.saltB64, 'base64')
+    const iv = Buffer.from(wrap.ivB64, 'base64')
+    const ct = Buffer.from(wrap.ctB64, 'base64')
+    const tag = Buffer.from(wrap.tagB64, 'base64')
+    const derivedKey = scryptSync(passphrase, salt, SCRYPT_KEY_LENGTH, SCRYPT_PARAMS)
+    const decipher = createDecipheriv('aes-256-gcm', derivedKey, iv)
+    decipher.setAuthTag(tag)
+    return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8')
+  } catch {
+    return null
+  }
+}

--- a/src/main/database/db-key-registry.ts
+++ b/src/main/database/db-key-registry.ts
@@ -25,7 +25,6 @@ export function isValidKeyRegistryShape(value: unknown): value is KeyRegistry {
 
   for (const [keyId, entry] of Object.entries(registry.keys)) {
     if (keyId === '' || !isValidKeyEntry(entry)) return false
-    if (registry.pathIndex[entry.path] !== keyId) return false
   }
 
   for (const [dbPath, keyId] of Object.entries(registry.pathIndex)) {

--- a/src/main/database/db-key-registry.ts
+++ b/src/main/database/db-key-registry.ts
@@ -1,0 +1,32 @@
+import type { PassphraseWrap } from './db-key-passphrase'
+
+/** One on-disk registry entry and its wrapping state. */
+export interface KeyEntry {
+  path: string
+  /** Missing means active for registries created before migration journaling. */
+  state?: 'pending' | 'active'
+  safeWrap?: string
+  passWrap?: PassphraseWrap
+}
+
+export interface KeyRegistry {
+  keys: Record<string, KeyEntry | undefined>
+  pathIndex: Record<string, string | undefined>
+}
+
+export function emptyKeyRegistry(): KeyRegistry {
+  return { keys: {}, pathIndex: {} }
+}
+
+export function isValidKeyRegistryShape(value: unknown): value is KeyRegistry {
+  if (value === null || typeof value !== 'object') return false
+  const registry = value as { keys?: unknown; pathIndex?: unknown }
+  return (
+    typeof registry.keys === 'object' &&
+    registry.keys !== null &&
+    !Array.isArray(registry.keys) &&
+    typeof registry.pathIndex === 'object' &&
+    registry.pathIndex !== null &&
+    !Array.isArray(registry.pathIndex)
+  )
+}

--- a/src/main/database/db-key-registry.ts
+++ b/src/main/database/db-key-registry.ts
@@ -21,12 +21,42 @@ export function emptyKeyRegistry(): KeyRegistry {
 export function isValidKeyRegistryShape(value: unknown): value is KeyRegistry {
   if (value === null || typeof value !== 'object') return false
   const registry = value as { keys?: unknown; pathIndex?: unknown }
+  if (!isRecord(registry.keys) || !isRecord(registry.pathIndex)) return false
+
+  for (const [keyId, entry] of Object.entries(registry.keys)) {
+    if (keyId === '' || !isValidKeyEntry(entry)) return false
+    if (registry.pathIndex[entry.path] !== keyId) return false
+  }
+
+  for (const [dbPath, keyId] of Object.entries(registry.pathIndex)) {
+    if (dbPath === '' || typeof keyId !== 'string') return false
+    const entry = registry.keys[keyId]
+    if (!isValidKeyEntry(entry) || entry.path !== dbPath) return false
+  }
+
+  return true
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isValidKeyEntry(value: unknown): value is KeyEntry {
+  if (!isRecord(value) || typeof value.path !== 'string' || value.path === '') return false
+  if (value.state !== undefined && value.state !== 'pending' && value.state !== 'active') {
+    return false
+  }
+  if (value.safeWrap !== undefined && typeof value.safeWrap !== 'string') return false
+  if (value.passWrap !== undefined && !isValidPassphraseWrap(value.passWrap)) return false
+  return value.safeWrap !== undefined || value.passWrap !== undefined
+}
+
+function isValidPassphraseWrap(value: unknown): value is PassphraseWrap {
   return (
-    typeof registry.keys === 'object' &&
-    registry.keys !== null &&
-    !Array.isArray(registry.keys) &&
-    typeof registry.pathIndex === 'object' &&
-    registry.pathIndex !== null &&
-    !Array.isArray(registry.pathIndex)
+    isRecord(value) &&
+    typeof value.saltB64 === 'string' &&
+    typeof value.ivB64 === 'string' &&
+    typeof value.ctB64 === 'string' &&
+    typeof value.tagB64 === 'string'
   )
 }

--- a/src/main/database/db-key-store-instance.ts
+++ b/src/main/database/db-key-store-instance.ts
@@ -1,0 +1,26 @@
+/**
+ * Lazily-constructed `DbKeyStore` singleton, scoped to Electron's userData
+ * directory and backed by the real OS keyring via `safeStorage`.
+ *
+ * Kept as its own module (rather than inlined in the IPC handler layer, next
+ * to `getDefaultPostgresProfileStore`'s pattern in `handlers/database.ts`)
+ * so main-process code that would otherwise stay Electron-free -- notably
+ * `database/startup.ts`, which is unit-tested without mocking `electron` --
+ * can receive a `DbKeyStore` from its caller instead of importing this
+ * module directly.
+ */
+import { app, safeStorage } from 'electron'
+import { join } from 'path'
+import { DbKeyStore, DEFAULT_DB_KEY_REGISTRY_FILENAME } from './db-key-store'
+
+let instance: DbKeyStore | null = null
+
+export function getDbKeyStore(): DbKeyStore {
+  if (instance === null) {
+    instance = new DbKeyStore({
+      registryPath: join(app.getPath('userData'), DEFAULT_DB_KEY_REGISTRY_FILENAME),
+      safeStorage
+    })
+  }
+  return instance
+}

--- a/src/main/database/db-key-store-instance.ts
+++ b/src/main/database/db-key-store-instance.ts
@@ -12,14 +12,24 @@
 import { app, safeStorage } from 'electron'
 import { join } from 'path'
 import { DbKeyStore, DEFAULT_DB_KEY_REGISTRY_FILENAME } from './db-key-store'
+import type { SafeStorageLike } from './db-key-store'
 
 let instance: DbKeyStore | null = null
+
+const electronSafeStorage: SafeStorageLike = {
+  isEncryptionAvailable: () => safeStorage.isEncryptionAvailable(),
+  ...(process.platform === 'linux'
+    ? { getSelectedStorageBackend: () => safeStorage.getSelectedStorageBackend() }
+    : {}),
+  encryptString: (plainText) => safeStorage.encryptString(plainText),
+  decryptString: (encrypted) => safeStorage.decryptString(encrypted)
+}
 
 export function getDbKeyStore(): DbKeyStore {
   if (instance === null) {
     instance = new DbKeyStore({
       registryPath: join(app.getPath('userData'), DEFAULT_DB_KEY_REGISTRY_FILENAME),
-      safeStorage
+      safeStorage: electronSafeStorage
     })
   }
   return instance

--- a/src/main/database/db-key-store-types.ts
+++ b/src/main/database/db-key-store-types.ts
@@ -1,0 +1,30 @@
+/** Injectable subset of Electron's safeStorage API. */
+export interface SafeStorageLike {
+  isEncryptionAvailable(): boolean
+  getSelectedStorageBackend?(): string
+  encryptString(plainText: string): Buffer
+  decryptString(encrypted: Buffer): string
+}
+
+export type CreateManagedKeyResult =
+  | { ok: true; keyId: string; dek: string }
+  | { ok: false; reason: 'safe-storage-unavailable' | 'path-already-keyed' }
+
+export type WrapNewDekWithPassphraseResult =
+  | { ok: true; keyId: string; dek: string; sidecarWritten: boolean }
+  | { ok: false; reason: 'path-already-keyed' }
+
+export type ResolveKeyResult =
+  { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'needs-passphrase' }
+
+export type ResolveKeyWithPassphraseResult =
+  { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'wrong-passphrase' }
+
+export type ResolveKeyWithPassphraseFromSidecarResult =
+  { ok: true; dek: string } | { ok: false; reason: 'wrong-passphrase' }
+
+export type SetPassphraseResult =
+  { ok: true; sidecarWritten: boolean } | { ok: false; reason: 'not-found' | 'cannot-resolve-dek' }
+
+export type EnrollRecoveredKeyResult =
+  { ok: true; keyId: string } | { ok: false; reason: 'path-already-keyed' }

--- a/src/main/database/db-key-store-types.ts
+++ b/src/main/database/db-key-store-types.ts
@@ -26,5 +26,4 @@ export type ResolveKeyWithPassphraseFromSidecarResult =
 export type SetPassphraseResult =
   { ok: true; sidecarWritten: boolean } | { ok: false; reason: 'not-found' | 'cannot-resolve-dek' }
 
-export type EnrollRecoveredKeyResult =
-  { ok: true; keyId: string } | { ok: false; reason: 'path-already-keyed' }
+export type EnrollRecoveredKeyResult = { ok: true; keyId: string }

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -417,3 +417,13 @@ export class DbKeyStore {
     renameSync(tmpPath, this.registryPath)
   }
 }
+
+/**
+ * The subset of `DbKeyStore` consumed by the DB create/open flow
+ * (`database-logic.ts`, `database/startup.ts`). Narrowed so those modules
+ * can accept an injected fake in tests without depending on the full class.
+ */
+export type DbKeyStoreLike = Pick<
+  DbKeyStore,
+  'createManagedKey' | 'wrapNewDekWithPassphrase' | 'resolveKeyForPath' | 'resolveKeyWithPassphrase'
+>

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -561,15 +561,19 @@ export type DbKeyStoreLike = Pick<
 >
 
 /**
- * Adds `setPassphrase` on top of `DbKeyStoreLike` -- consumed by the
- * plaintext-to-encrypted migration orchestration (task I2b), which offers a
- * recovery passphrase on a freshly-minted managed key so keyring loss can't
- * make the migrated data unrecoverable. Kept separate from `DbKeyStoreLike`
- * so existing consumers of that narrower type (e.g. `database/startup.ts`'s
- * hand-rolled "unavailable" fake) don't need to implement a method they
- * never call.
+ * Adds `setPassphrase` and `getKeyIdForPath` on top of `DbKeyStoreLike`.
+ * `setPassphrase` alone is consumed by the plaintext-to-encrypted migration
+ * orchestration (task I2b), which offers a recovery passphrase on a
+ * freshly-minted managed key so keyring loss can't make the migrated data
+ * unrecoverable. Both together are consumed by the `setRecoveryPassphrase`
+ * IPC action (`database-lifecycle-logic.ts`), which resolves an already-open
+ * database's `keyId` from its path before calling `setPassphrase` on it.
+ * Kept separate from `DbKeyStoreLike` so existing consumers of that narrower
+ * type (e.g. `database/startup.ts`'s hand-rolled "unavailable" fake) don't
+ * need to implement methods they never call.
  */
-export type DbKeyStoreWithPassphraseLike = DbKeyStoreLike & Pick<DbKeyStore, 'setPassphrase'>
+export type DbKeyStoreWithPassphraseLike = DbKeyStoreLike &
+  Pick<DbKeyStore, 'setPassphrase' | 'getKeyIdForPath'>
 
 /**
  * Consumed by `openDatabase`'s recovery-sidecar flow: transparent resolve,

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -1,0 +1,400 @@
+/**
+ * DbKeyStore — envelope-encryption key-lifecycle store for the SQLCipher DEK.
+ *
+ * Design (see .superpowers/sdd/task-I1-brief.md for the full rationale):
+ * - The DEK (data-encryption key) is a random 32-byte value, hex-encoded
+ *   (64 lowercase hex chars). It IS the SQLCipher `PRAGMA key` value. A
+ *   database is always encrypted with a stable random DEK — the DEK itself
+ *   never changes; only how it is *wrapped* changes.
+ * - The DEK is wrapped (either or both):
+ *     - safeStorage wrap (transparent): `safeStorage.encryptString(dekHex)`,
+ *       stored base64-encoded. OS-keyring-protected; only usable on the
+ *       machine/profile that created it.
+ *     - passphrase wrap (portable): AES-256-GCM encryption of the dekHex
+ *       using a key derived from the passphrase via scrypt. Portable across
+ *       machines because it only depends on the user knowing the passphrase.
+ * - A registry JSON file maps `keyId -> { path, safeWrap?, passWrap? }` plus
+ *   a reverse `path -> keyId` index. Switching keyring<->passphrase is just
+ *   re-wrapping the SAME DEK — never a DB rekey.
+ * - This module does NOT touch any DB open/create flow. It is a pure,
+ *   injectable key-lifecycle store consumed by later tasks.
+ *
+ * Security notes:
+ * - `safeStorage` is injected (constructor param), never imported from
+ *   `electron` in this file, so the crypto logic is unit-testable with a
+ *   fake and has no Electron runtime dependency.
+ * - Only Node's built-in `crypto` is used (no new dependencies).
+ * - The DEK, a passphrase, and any wrap material are NEVER logged or placed
+ *   in a thrown error message. Recoverable failure modes are returned as
+ *   typed result objects instead of throwing.
+ * - A hex-encoded DEK (charset `0-9a-f`) can never start with `x` or `X`,
+ *   so it can never collide with SQLCipher's `x'<hex>'` hex-literal PRAGMA
+ *   syntax. `assertNotHexLiteralKey` is still called defensively on every
+ *   newly generated DEK — see `sqlcipher-key-guard.ts`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import { dirname } from 'path'
+import { createCipheriv, createDecipheriv, randomBytes, randomUUID, scryptSync } from 'crypto'
+import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
+import { mainLogger } from '../services/MainLogger'
+
+/** Default registry filename, intended to live under Electron's `userData` dir. */
+export const DEFAULT_DB_KEY_REGISTRY_FILENAME = 'varlens-db-keys.json'
+
+/**
+ * The subset of Electron's `safeStorage` API this store depends on.
+ * Injected so the store can be unit-tested without Electron.
+ */
+export interface SafeStorageLike {
+  isEncryptionAvailable(): boolean
+  encryptString(plainText: string): Buffer
+  decryptString(encrypted: Buffer): string
+}
+
+/** AES-256-GCM passphrase wrap of a DEK. All fields are base64-encoded. */
+interface PassphraseWrap {
+  saltB64: string
+  ivB64: string
+  ctB64: string
+  tagB64: string
+}
+
+/** One registry entry: where the DB lives and how its DEK is wrapped. */
+interface KeyEntry {
+  path: string
+  /** base64 of `safeStorage.encryptString(dekHex)`. Present when a keyring wrap exists. */
+  safeWrap?: string
+  /** Present when a passphrase wrap exists. */
+  passWrap?: PassphraseWrap
+}
+
+/**
+ * On-disk registry shape. Values are typed as possibly-`undefined` because
+ * plain `Record<K, V>` indexing does not reflect that a lookup by an
+ * arbitrary key can miss — this project does not enable
+ * `noUncheckedIndexedAccess`, so the optionality is spelled out explicitly.
+ */
+interface Registry {
+  keys: Record<string, KeyEntry | undefined>
+  pathIndex: Record<string, string | undefined>
+}
+
+export type CreateManagedKeyResult =
+  { ok: true; keyId: string; dek: string } | { ok: false; reason: 'safe-storage-unavailable' }
+
+export type ResolveKeyResult =
+  { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'needs-passphrase' }
+
+export type ResolveKeyWithPassphraseResult =
+  { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'wrong-passphrase' }
+
+export type SetPassphraseResult =
+  { ok: true } | { ok: false; reason: 'not-found' | 'cannot-resolve-dek' }
+
+/** scrypt cost parameters. N=16384, r=8, p=1 derives ~16 MiB, under Node's default 32 MiB maxmem. */
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const
+const SCRYPT_KEY_LENGTH = 32
+const GCM_IV_LENGTH = 12
+const PASSPHRASE_SALT_LENGTH = 16
+const DEK_BYTE_LENGTH = 32
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
+function emptyRegistry(): Registry {
+  return { keys: {}, pathIndex: {} }
+}
+
+function isValidRegistryShape(value: unknown): value is Registry {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as { keys?: unknown; pathIndex?: unknown }
+  return (
+    typeof v.keys === 'object' &&
+    v.keys !== null &&
+    !Array.isArray(v.keys) &&
+    typeof v.pathIndex === 'object' &&
+    v.pathIndex !== null &&
+    !Array.isArray(v.pathIndex)
+  )
+}
+
+/**
+ * Generate a fresh 64-hex-char DEK. Hex chars are `0-9a-f`, so the result
+ * can never start with `x`/`X` and can never be mistaken for SQLCipher's
+ * `x'<hex>'` hex-literal PRAGMA syntax — asserted defensively regardless.
+ */
+function generateDek(): string {
+  const dek = randomBytes(DEK_BYTE_LENGTH).toString('hex')
+  assertNotHexLiteralKey(dek)
+  return dek
+}
+
+function wrapPassphrase(dek: string, passphrase: string): PassphraseWrap {
+  const salt = randomBytes(PASSPHRASE_SALT_LENGTH)
+  const iv = randomBytes(GCM_IV_LENGTH)
+  const derivedKey = scryptSync(passphrase, salt, SCRYPT_KEY_LENGTH, SCRYPT_PARAMS)
+  const cipher = createCipheriv('aes-256-gcm', derivedKey, iv)
+  const ct = Buffer.concat([cipher.update(dek, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return {
+    saltB64: salt.toString('base64'),
+    ivB64: iv.toString('base64'),
+    ctB64: ct.toString('base64'),
+    tagB64: tag.toString('base64')
+  }
+}
+
+/** Returns the unwrapped DEK, or null on a wrong passphrase (GCM auth failure) or malformed wrap. */
+function unwrapPassphrase(wrap: PassphraseWrap, passphrase: string): string | null {
+  try {
+    const salt = Buffer.from(wrap.saltB64, 'base64')
+    const iv = Buffer.from(wrap.ivB64, 'base64')
+    const ct = Buffer.from(wrap.ctB64, 'base64')
+    const tag = Buffer.from(wrap.tagB64, 'base64')
+    const derivedKey = scryptSync(passphrase, salt, SCRYPT_KEY_LENGTH, SCRYPT_PARAMS)
+    const decipher = createDecipheriv('aes-256-gcm', derivedKey, iv)
+    decipher.setAuthTag(tag)
+    const pt = Buffer.concat([decipher.update(ct), decipher.final()])
+    return pt.toString('utf8')
+  } catch {
+    // GCM auth failure (wrong passphrase) or malformed wrap material.
+    // Never surface crypto internals — the caller only needs "it failed".
+    return null
+  }
+}
+
+/**
+ * Envelope-encryption key-lifecycle store for SQLCipher DEKs.
+ *
+ * Every method reads the registry fresh from disk and writes it back after
+ * mutating, so multiple `DbKeyStore` instances over the same `registryPath`
+ * stay consistent (see the "Registry persistence" test case).
+ */
+export class DbKeyStore {
+  private readonly registryPath: string
+  private readonly safeStorage: SafeStorageLike
+
+  constructor(options: { registryPath: string; safeStorage: SafeStorageLike }) {
+    this.registryPath = options.registryPath
+    this.safeStorage = options.safeStorage
+  }
+
+  /**
+   * Create a new managed (keyring-wrapped) DEK for `dbPath`.
+   * Fails with a typed result (never throws) when safeStorage is unavailable,
+   * so the caller can fall back to `wrapNewDekWithPassphrase`.
+   */
+  createManagedKey(dbPath: string): CreateManagedKeyResult {
+    if (!this.safeStorage.isEncryptionAvailable()) {
+      return { ok: false, reason: 'safe-storage-unavailable' }
+    }
+
+    const dek = generateDek()
+    let safeWrap: string
+    try {
+      safeWrap = this.safeStorage.encryptString(dek).toString('base64')
+    } catch (e) {
+      mainLogger.warn(
+        `safeStorage.encryptString failed while creating a managed key: ${errorMessage(e)}`,
+        'DbKeyStore'
+      )
+      return { ok: false, reason: 'safe-storage-unavailable' }
+    }
+
+    const keyId = randomUUID()
+    const registry = this.load()
+    registry.keys[keyId] = { path: dbPath, safeWrap }
+    registry.pathIndex[dbPath] = keyId
+    this.save(registry)
+
+    return { ok: true, keyId, dek }
+  }
+
+  /**
+   * The no-keyring create path: generate a DEK, wrap it with ONLY a
+   * passphrase (no safeWrap), and map `dbPath` to it. Always succeeds —
+   * unlike `createManagedKey`, it has no safeStorage dependency.
+   */
+  wrapNewDekWithPassphrase(dbPath: string, passphrase: string): { keyId: string; dek: string } {
+    const dek = generateDek()
+    const keyId = randomUUID()
+    const passWrap = wrapPassphrase(dek, passphrase)
+
+    const registry = this.load()
+    registry.keys[keyId] = { path: dbPath, passWrap }
+    registry.pathIndex[dbPath] = keyId
+    this.save(registry)
+
+    return { keyId, dek }
+  }
+
+  /**
+   * Resolve the DEK for `dbPath` transparently (via an existing safeStorage
+   * wrap). Returns `needs-passphrase` — never a wrong key — when the entry
+   * only has a passphrase wrap, or when safeStorage cannot unwrap it right
+   * now (e.g. moved to a machine without the original OS keyring).
+   */
+  resolveKeyForPath(dbPath: string): ResolveKeyResult {
+    const registry = this.load()
+    const keyId = registry.pathIndex[dbPath]
+    const entry = keyId === undefined ? undefined : registry.keys[keyId]
+    if (!entry) {
+      return { ok: false, reason: 'not-found' }
+    }
+
+    const dek = this.tryUnwrapWithSafeStorage(entry)
+    if (dek !== null) {
+      return { ok: true, dek }
+    }
+    return { ok: false, reason: 'needs-passphrase' }
+  }
+
+  /**
+   * Resolve the DEK for `dbPath` using a passphrase wrap. Distinguishes "no
+   * such path/entry" from "wrong passphrase" (GCM auth failure) — a wrong
+   * passphrase never returns a different, wrong key.
+   */
+  resolveKeyWithPassphrase(dbPath: string, passphrase: string): ResolveKeyWithPassphraseResult {
+    const registry = this.load()
+    const keyId = registry.pathIndex[dbPath]
+    const entry = keyId === undefined ? undefined : registry.keys[keyId]
+    if (!entry || entry.passWrap === undefined) {
+      return { ok: false, reason: 'not-found' }
+    }
+
+    const dek = unwrapPassphrase(entry.passWrap, passphrase)
+    if (dek === null) {
+      return { ok: false, reason: 'wrong-passphrase' }
+    }
+    return { ok: true, dek }
+  }
+
+  /**
+   * Add or replace the passphrase wrap for an existing DEK identified by
+   * `keyId`. The DEK is resolved internally via the entry's existing
+   * safeStorage wrap — this store never wraps a DEK it cannot itself
+   * resolve, so an unknown/unresolvable key never gets a passphrase wrap.
+   */
+  setPassphrase(keyId: string, passphrase: string): SetPassphraseResult {
+    const registry = this.load()
+    const entry = registry.keys[keyId]
+    if (!entry) {
+      return { ok: false, reason: 'not-found' }
+    }
+
+    const dek = this.tryUnwrapWithSafeStorage(entry)
+    if (dek === null) {
+      return { ok: false, reason: 'cannot-resolve-dek' }
+    }
+
+    entry.passWrap = wrapPassphrase(dek, passphrase)
+    this.save(registry)
+    return { ok: true }
+  }
+
+  /**
+   * Move/rename: repoint `keyId` at `newPath`. Any previous path mapping(s)
+   * for this key are removed so a stale path never resolves to the wrong
+   * key — the caller sees a typed miss instead.
+   */
+  updatePath(keyId: string, newPath: string): void {
+    const registry = this.load()
+    const entry = registry.keys[keyId]
+    if (!entry) {
+      mainLogger.warn(`updatePath called for unknown keyId`, 'DbKeyStore')
+      return
+    }
+
+    for (const [path, id] of Object.entries(registry.pathIndex)) {
+      if (id === keyId) delete registry.pathIndex[path]
+    }
+    entry.path = newPath
+    registry.pathIndex[newPath] = keyId
+    this.save(registry)
+  }
+
+  /** Delete a key's registry entry and its path mapping(s). */
+  removeKey(keyId: string): void {
+    const registry = this.load()
+    if (!registry.keys[keyId]) {
+      return
+    }
+    delete registry.keys[keyId]
+    for (const [path, id] of Object.entries(registry.pathIndex)) {
+      if (id === keyId) delete registry.pathIndex[path]
+    }
+    this.save(registry)
+  }
+
+  /** Attempt to unwrap `entry.safeWrap` via the injected safeStorage; null on any failure. */
+  private tryUnwrapWithSafeStorage(entry: KeyEntry): string | null {
+    if (entry.safeWrap === undefined || !this.safeStorage.isEncryptionAvailable()) {
+      return null
+    }
+    try {
+      const buf = Buffer.from(entry.safeWrap, 'base64')
+      return this.safeStorage.decryptString(buf)
+    } catch (e) {
+      mainLogger.warn(`safeStorage.decryptString failed: ${errorMessage(e)}`, 'DbKeyStore')
+      return null
+    }
+  }
+
+  /**
+   * Read the registry from disk. Tolerates a missing file (fresh install —
+   * treated as empty, no logging). Never throws on a corrupt file: it is
+   * preserved as `<registryPath>.bak` and a warning is logged, so keys are
+   * not silently lost even though this read returns an empty registry.
+   */
+  private load(): Registry {
+    if (!existsSync(this.registryPath)) {
+      return emptyRegistry()
+    }
+
+    let raw: string
+    try {
+      raw = readFileSync(this.registryPath, 'utf-8')
+    } catch (e) {
+      mainLogger.warn(`Failed to read key registry file: ${errorMessage(e)}`, 'DbKeyStore')
+      return emptyRegistry()
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      if (!isValidRegistryShape(parsed)) {
+        throw new Error('unexpected key registry shape')
+      }
+      return parsed
+    } catch (e) {
+      this.preserveCorruptBackup(raw)
+      mainLogger.warn(
+        `Key registry file was corrupt or invalid; treating as empty and preserving a backup at ${this.registryPath}.bak: ${errorMessage(e)}`,
+        'DbKeyStore'
+      )
+      return emptyRegistry()
+    }
+  }
+
+  private preserveCorruptBackup(raw: string): void {
+    try {
+      writeFileSync(`${this.registryPath}.bak`, raw, 'utf-8')
+    } catch (e) {
+      mainLogger.warn(
+        `Failed to preserve corrupt key registry backup: ${errorMessage(e)}`,
+        'DbKeyStore'
+      )
+    }
+  }
+
+  /** Write the registry to disk (mkdir -p + write-then-rename for atomicity). */
+  private save(registry: Registry): void {
+    const dir = dirname(this.registryPath)
+    mkdirSync(dir, { recursive: true })
+    const json = JSON.stringify(registry, null, 2)
+    const tmpPath = `${this.registryPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    writeFileSync(tmpPath, json, 'utf-8')
+    renameSync(tmpPath, this.registryPath)
+  }
+}

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -38,6 +38,7 @@ import { dirname } from 'path'
 import { createCipheriv, createDecipheriv, randomBytes, randomUUID, scryptSync } from 'crypto'
 import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
 import { mainLogger } from '../services/MainLogger'
+import { writeRecoverySidecar } from './recovery-sidecar'
 
 /** Default registry filename, intended to live under Electron's `userData` dir. */
 export const DEFAULT_DB_KEY_REGISTRY_FILENAME = 'varlens-db-keys.json'
@@ -53,7 +54,7 @@ export interface SafeStorageLike {
 }
 
 /** AES-256-GCM passphrase wrap of a DEK. All fields are base64-encoded. */
-interface PassphraseWrap {
+export interface PassphraseWrap {
   saltB64: string
   ivB64: string
   ctB64: string
@@ -85,7 +86,8 @@ export type CreateManagedKeyResult =
   | { ok: false; reason: 'safe-storage-unavailable' | 'path-already-keyed' }
 
 export type WrapNewDekWithPassphraseResult =
-  { ok: true; keyId: string; dek: string } | { ok: false; reason: 'path-already-keyed' }
+  | { ok: true; keyId: string; dek: string; sidecarWritten: boolean }
+  | { ok: false; reason: 'path-already-keyed' }
 
 export type ResolveKeyResult =
   { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'needs-passphrase' }
@@ -93,8 +95,19 @@ export type ResolveKeyResult =
 export type ResolveKeyWithPassphraseResult =
   { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'wrong-passphrase' }
 
+/**
+ * Result of resolving a DEK from a `PassphraseWrap` read directly from a
+ * recovery sidecar (no registry lookup involved). Never `'not-found'` --
+ * the caller already knows the sidecar exists before calling this.
+ */
+export type ResolveKeyWithPassphraseFromSidecarResult =
+  { ok: true; dek: string } | { ok: false; reason: 'wrong-passphrase' }
+
 export type SetPassphraseResult =
-  { ok: true } | { ok: false; reason: 'not-found' | 'cannot-resolve-dek' }
+  { ok: true; sidecarWritten: boolean } | { ok: false; reason: 'not-found' | 'cannot-resolve-dek' }
+
+export type EnrollRecoveredKeyResult =
+  { ok: true; keyId: string } | { ok: false; reason: 'path-already-keyed' }
 
 /** scrypt cost parameters. N=16384, r=8, p=1 derives ~16 MiB, under Node's default 32 MiB maxmem. */
 const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const
@@ -246,7 +259,9 @@ export class DbKeyStore {
     registry.pathIndex[dbPath] = keyId
     this.save(registry)
 
-    return { ok: true, keyId, dek }
+    const sidecarWritten = this.tryWriteRecoverySidecar(dbPath, passWrap)
+
+    return { ok: true, keyId, dek, sidecarWritten }
   }
 
   /**
@@ -291,6 +306,24 @@ export class DbKeyStore {
   }
 
   /**
+   * Resolve a DEK from a `PassphraseWrap` read directly from a recovery
+   * sidecar -- no registry or filesystem access here, purely a wrapper
+   * around `unwrapPassphrase`. AES-GCM's auth tag means a wrong passphrase
+   * can only ever produce `null` (never a different, plausible-looking
+   * wrong key), so this can only fail as `wrong-passphrase`.
+   */
+  resolveKeyWithPassphraseFromSidecar(
+    passWrap: PassphraseWrap,
+    passphrase: string
+  ): ResolveKeyWithPassphraseFromSidecarResult {
+    const dek = unwrapPassphrase(passWrap, passphrase)
+    if (dek === null) {
+      return { ok: false, reason: 'wrong-passphrase' }
+    }
+    return { ok: true, dek }
+  }
+
+  /**
    * Add or replace the passphrase wrap for an existing DEK identified by
    * `keyId`. The DEK is resolved internally via the entry's existing
    * safeStorage wrap — this store never wraps a DEK it cannot itself
@@ -310,7 +343,82 @@ export class DbKeyStore {
 
     entry.passWrap = wrapPassphrase(dek, passphrase)
     this.save(registry)
-    return { ok: true }
+    const sidecarWritten = this.tryWriteRecoverySidecar(entry.path, entry.passWrap)
+    return { ok: true, sidecarWritten }
+  }
+
+  /**
+   * Direct `pathIndex` lookup, with no attempt to resolve/unwrap the DEK.
+   * Consumed by the (separately implemented) `setRecoveryPassphrase` IPC
+   * action, which needs the `keyId` for an already-open database's path
+   * before it can call `setPassphrase`.
+   */
+  getKeyIdForPath(dbPath: string): string | null {
+    const registry = this.load()
+    return registry.pathIndex[dbPath] ?? null
+  }
+
+  /**
+   * Find a LOCAL registry entry whose safeStorage-wrapped DEK equals `dek`,
+   * regardless of which path it's currently mapped to. Powers the
+   * "same-machine move" self-heal: if a `.db` file (plus its recovery
+   * sidecar) was moved to a new path on a machine that ALREADY has a
+   * keyring entry for that exact DEK under the old path, this lets the
+   * caller repoint that existing entry via `updatePath` instead of minting
+   * a redundant, orphaned key. Returns `null` when nothing matches or
+   * safeStorage is unavailable.
+   */
+  findManagedKeyIdForDek(dek: string): string | null {
+    const registry = this.load()
+    for (const [keyId, entry] of Object.entries(registry.keys)) {
+      if (entry === undefined || entry.safeWrap === undefined) continue
+      if (this.tryUnwrapWithSafeStorage(entry) === dek) {
+        return keyId
+      }
+    }
+    return null
+  }
+
+  /**
+   * Enroll a DEK recovered from a portable sidecar as a brand-new registry
+   * entry for `dbPath`, so future opens on THIS machine are transparent.
+   * Guards `dbPath` being already keyed exactly like `createManagedKey`/
+   * `wrapNewDekWithPassphrase` do, to avoid orphaning an existing key.
+   * Best-effort ALSO adds a safeStorage wrap when available (non-fatal on
+   * failure — the passphrase wrap being enrolled is enough on its own).
+   * Does NOT re-write the sidecar: `passWrap` came FROM the sidecar, so it
+   * is already on disk, correct, and current.
+   */
+  enrollRecoveredKey(
+    dbPath: string,
+    dek: string,
+    passWrap: PassphraseWrap
+  ): EnrollRecoveredKeyResult {
+    const registry = this.load()
+    if (registry.pathIndex[dbPath] !== undefined) {
+      return { ok: false, reason: 'path-already-keyed' }
+    }
+
+    const keyId = randomUUID()
+    const entry: KeyEntry = { path: dbPath, passWrap }
+
+    if (this.safeStorage.isEncryptionAvailable()) {
+      try {
+        entry.safeWrap = this.safeStorage.encryptString(dek).toString('base64')
+      } catch (e) {
+        mainLogger.warn(
+          `safeStorage.encryptString failed while enrolling a recovered key (continuing with ` +
+            `the passphrase wrap alone): ${errorMessage(e)}`,
+          'DbKeyStore'
+        )
+      }
+    }
+
+    registry.keys[keyId] = entry
+    registry.pathIndex[dbPath] = keyId
+    this.save(registry)
+
+    return { ok: true, keyId }
   }
 
   /**
@@ -345,6 +453,26 @@ export class DbKeyStore {
       if (id === keyId) delete registry.pathIndex[path]
     }
     this.save(registry)
+  }
+
+  /**
+   * Best-effort write of a recovery sidecar alongside `dbPath`. Never
+   * throws: a failure here (disk full, read-only filesystem, …) must not
+   * fail the registry write it accompanies, so it is logged and reported
+   * back to the caller as `sidecarWritten: false` instead.
+   */
+  private tryWriteRecoverySidecar(dbPath: string, passWrap: PassphraseWrap): boolean {
+    try {
+      writeRecoverySidecar(dbPath, passWrap)
+      return true
+    } catch (e) {
+      mainLogger.warn(
+        `Failed to write recovery sidecar for the database at this path (portability recovery ` +
+          `will be unavailable if the registry is later lost): ${errorMessage(e)}`,
+        'DbKeyStore'
+      )
+      return false
+    }
   }
 
   /** Attempt to unwrap `entry.safeWrap` via the injected safeStorage; null on any failure. */
@@ -442,3 +570,23 @@ export type DbKeyStoreLike = Pick<
  * never call.
  */
 export type DbKeyStoreWithPassphraseLike = DbKeyStoreLike & Pick<DbKeyStore, 'setPassphrase'>
+
+/**
+ * Consumed by `openDatabase`'s recovery-sidecar flow: transparent resolve,
+ * registry-based and sidecar-based passphrase resolution, the same-machine
+ * move self-heal (`findManagedKeyIdForDek` + `updatePath`), and enrolling a
+ * brand-new local entry when a sidecar recovers a DEK this machine has never
+ * seen before (`enrollRecoveredKey`). Kept separate from `DbKeyStoreLike` so
+ * existing narrower consumers (e.g. `createDatabase`, `database/startup.ts`)
+ * don't need to implement methods they never call.
+ */
+export type DbKeyStoreWithRecoveryLike = Pick<
+  DbKeyStore,
+  | 'resolveKeyForPath'
+  | 'resolveKeyWithPassphrase'
+  | 'resolveKeyWithPassphraseFromSidecar'
+  | 'findManagedKeyIdForDek'
+  | 'enrollRecoveredKey'
+  | 'updatePath'
+  | 'removeKey'
+>

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -81,7 +81,11 @@ interface Registry {
 }
 
 export type CreateManagedKeyResult =
-  { ok: true; keyId: string; dek: string } | { ok: false; reason: 'safe-storage-unavailable' }
+  | { ok: true; keyId: string; dek: string }
+  | { ok: false; reason: 'safe-storage-unavailable' | 'path-already-keyed' }
+
+export type WrapNewDekWithPassphraseResult =
+  { ok: true; keyId: string; dek: string } | { ok: false; reason: 'path-already-keyed' }
 
 export type ResolveKeyResult =
   { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'needs-passphrase' }
@@ -184,9 +188,18 @@ export class DbKeyStore {
   /**
    * Create a new managed (keyring-wrapped) DEK for `dbPath`.
    * Fails with a typed result (never throws) when safeStorage is unavailable,
-   * so the caller can fall back to `wrapNewDekWithPassphrase`.
+   * so the caller can fall back to `wrapNewDekWithPassphrase`. Also fails
+   * with `path-already-keyed` when `dbPath` is already mapped to a key —
+   * minting a second DEK for an already-keyed path would repoint
+   * `pathIndex[dbPath]` at the new key and orphan the DEK the database was
+   * actually encrypted with, making the database unopenable.
    */
   createManagedKey(dbPath: string): CreateManagedKeyResult {
+    const registry = this.load()
+    if (registry.pathIndex[dbPath] !== undefined) {
+      return { ok: false, reason: 'path-already-keyed' }
+    }
+
     if (!this.safeStorage.isEncryptionAvailable()) {
       return { ok: false, reason: 'safe-storage-unavailable' }
     }
@@ -204,7 +217,6 @@ export class DbKeyStore {
     }
 
     const keyId = randomUUID()
-    const registry = this.load()
     registry.keys[keyId] = { path: dbPath, safeWrap }
     registry.pathIndex[dbPath] = keyId
     this.save(registry)
@@ -214,20 +226,27 @@ export class DbKeyStore {
 
   /**
    * The no-keyring create path: generate a DEK, wrap it with ONLY a
-   * passphrase (no safeWrap), and map `dbPath` to it. Always succeeds —
-   * unlike `createManagedKey`, it has no safeStorage dependency.
+   * passphrase (no safeWrap), and map `dbPath` to it. Fails with a typed
+   * result (never throws) when `dbPath` is already mapped to a key —
+   * minting a second DEK for an already-keyed path would repoint
+   * `pathIndex[dbPath]` at the new key and orphan the DEK the database was
+   * actually encrypted with, making the database unopenable.
    */
-  wrapNewDekWithPassphrase(dbPath: string, passphrase: string): { keyId: string; dek: string } {
+  wrapNewDekWithPassphrase(dbPath: string, passphrase: string): WrapNewDekWithPassphraseResult {
+    const registry = this.load()
+    if (registry.pathIndex[dbPath] !== undefined) {
+      return { ok: false, reason: 'path-already-keyed' }
+    }
+
     const dek = generateDek()
     const keyId = randomUUID()
     const passWrap = wrapPassphrase(dek, passphrase)
 
-    const registry = this.load()
     registry.keys[keyId] = { path: dbPath, passWrap }
     registry.pathIndex[dbPath] = keyId
     this.save(registry)
 
-    return { keyId, dek }
+    return { ok: true, keyId, dek }
   }
 
   /**

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -41,92 +41,33 @@ import { mainLogger } from '../services/MainLogger'
 import { writeRecoverySidecar } from './recovery-sidecar'
 import { fsyncContainingDirectory, fsyncFile } from './fs-durability'
 import { unwrapPassphrase, wrapPassphrase, type PassphraseWrap } from './db-key-passphrase'
+import type {
+  CreateManagedKeyResult,
+  EnrollRecoveredKeyResult,
+  ResolveKeyResult,
+  ResolveKeyWithPassphraseFromSidecarResult,
+  ResolveKeyWithPassphraseResult,
+  SafeStorageLike,
+  SetPassphraseResult,
+  WrapNewDekWithPassphraseResult
+} from './db-key-store-types'
+import {
+  emptyKeyRegistry,
+  isValidKeyRegistryShape,
+  type KeyEntry,
+  type KeyRegistry
+} from './db-key-registry'
 
 export type { PassphraseWrap } from './db-key-passphrase'
+export type * from './db-key-store-types'
 
 /** Default registry filename, intended to live under Electron's `userData` dir. */
 export const DEFAULT_DB_KEY_REGISTRY_FILENAME = 'varlens-db-keys.json'
-
-/**
- * The subset of Electron's `safeStorage` API this store depends on.
- * Injected so the store can be unit-tested without Electron.
- */
-export interface SafeStorageLike {
-  isEncryptionAvailable(): boolean
-  getSelectedStorageBackend?(): string
-  encryptString(plainText: string): Buffer
-  decryptString(encrypted: Buffer): string
-}
-
-/** One registry entry: where the DB lives and how its DEK is wrapped. */
-interface KeyEntry {
-  path: string
-  /** base64 of `safeStorage.encryptString(dekHex)`. Present when a keyring wrap exists. */
-  safeWrap?: string
-  /** Present when a passphrase wrap exists. */
-  passWrap?: PassphraseWrap
-}
-
-/**
- * On-disk registry shape. Values are typed as possibly-`undefined` because
- * plain `Record<K, V>` indexing does not reflect that a lookup by an
- * arbitrary key can miss — this project does not enable
- * `noUncheckedIndexedAccess`, so the optionality is spelled out explicitly.
- */
-interface Registry {
-  keys: Record<string, KeyEntry | undefined>
-  pathIndex: Record<string, string | undefined>
-}
-
-export type CreateManagedKeyResult =
-  | { ok: true; keyId: string; dek: string }
-  | { ok: false; reason: 'safe-storage-unavailable' | 'path-already-keyed' }
-
-export type WrapNewDekWithPassphraseResult =
-  | { ok: true; keyId: string; dek: string; sidecarWritten: boolean }
-  | { ok: false; reason: 'path-already-keyed' }
-
-export type ResolveKeyResult =
-  { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'needs-passphrase' }
-
-export type ResolveKeyWithPassphraseResult =
-  { ok: true; dek: string } | { ok: false; reason: 'not-found' | 'wrong-passphrase' }
-
-/**
- * Result of resolving a DEK from a `PassphraseWrap` read directly from a
- * recovery sidecar (no registry lookup involved). Never `'not-found'` --
- * the caller already knows the sidecar exists before calling this.
- */
-export type ResolveKeyWithPassphraseFromSidecarResult =
-  { ok: true; dek: string } | { ok: false; reason: 'wrong-passphrase' }
-
-export type SetPassphraseResult =
-  { ok: true; sidecarWritten: boolean } | { ok: false; reason: 'not-found' | 'cannot-resolve-dek' }
-
-export type EnrollRecoveredKeyResult =
-  { ok: true; keyId: string } | { ok: false; reason: 'path-already-keyed' }
 
 const DEK_BYTE_LENGTH = 32
 
 function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
-}
-
-function emptyRegistry(): Registry {
-  return { keys: {}, pathIndex: {} }
-}
-
-function isValidRegistryShape(value: unknown): value is Registry {
-  if (value === null || typeof value !== 'object') return false
-  const v = value as { keys?: unknown; pathIndex?: unknown }
-  return (
-    typeof v.keys === 'object' &&
-    v.keys !== null &&
-    !Array.isArray(v.keys) &&
-    typeof v.pathIndex === 'object' &&
-    v.pathIndex !== null &&
-    !Array.isArray(v.pathIndex)
-  )
 }
 
 /**
@@ -166,6 +107,18 @@ export class DbKeyStore {
    * actually encrypted with, making the database unopenable.
    */
   createManagedKey(dbPath: string): CreateManagedKeyResult {
+    return this.createManagedKeyWithState(dbPath, 'active')
+  }
+
+  /** Mint a managed key that is not authoritative until a verified encrypted open activates it. */
+  createPendingManagedKey(dbPath: string): CreateManagedKeyResult {
+    return this.createManagedKeyWithState(dbPath, 'pending')
+  }
+
+  private createManagedKeyWithState(
+    dbPath: string,
+    state: 'pending' | 'active'
+  ): CreateManagedKeyResult {
     const registry = this.load()
     if (registry.pathIndex[dbPath] !== undefined) {
       return { ok: false, reason: 'path-already-keyed' }
@@ -188,7 +141,7 @@ export class DbKeyStore {
     }
 
     const keyId = randomUUID()
-    registry.keys[keyId] = { path: dbPath, safeWrap }
+    registry.keys[keyId] = { path: dbPath, safeWrap, state }
     registry.pathIndex[dbPath] = keyId
     this.save(registry)
 
@@ -204,6 +157,22 @@ export class DbKeyStore {
    * actually encrypted with, making the database unopenable.
    */
   wrapNewDekWithPassphrase(dbPath: string, passphrase: string): WrapNewDekWithPassphraseResult {
+    return this.wrapNewDekWithPassphraseAndState(dbPath, passphrase, 'active')
+  }
+
+  /** Passphrase-only counterpart to `createPendingManagedKey`. */
+  wrapNewPendingDekWithPassphrase(
+    dbPath: string,
+    passphrase: string
+  ): WrapNewDekWithPassphraseResult {
+    return this.wrapNewDekWithPassphraseAndState(dbPath, passphrase, 'pending')
+  }
+
+  private wrapNewDekWithPassphraseAndState(
+    dbPath: string,
+    passphrase: string,
+    state: 'pending' | 'active'
+  ): WrapNewDekWithPassphraseResult {
     const registry = this.load()
     if (registry.pathIndex[dbPath] !== undefined) {
       return { ok: false, reason: 'path-already-keyed' }
@@ -213,7 +182,7 @@ export class DbKeyStore {
     const keyId = randomUUID()
     const passWrap = wrapPassphrase(dek, passphrase)
 
-    registry.keys[keyId] = { path: dbPath, passWrap }
+    registry.keys[keyId] = { path: dbPath, passWrap, state }
     registry.pathIndex[dbPath] = keyId
     this.save(registry)
 
@@ -335,6 +304,24 @@ export class DbKeyStore {
   getKeyIdForPath(dbPath: string): string | null {
     const registry = this.load()
     return registry.pathIndex[dbPath] ?? null
+  }
+
+  /** Pending is explicit; legacy entries without a state are active. */
+  getKeyStateForPath(dbPath: string): 'pending' | 'active' | null {
+    const registry = this.load()
+    const keyId = registry.pathIndex[dbPath]
+    const entry = keyId === undefined ? undefined : registry.keys[keyId]
+    if (entry === undefined) return null
+    return entry.state ?? 'active'
+  }
+
+  /** Mark a pending key authoritative after SQLite has accepted its DEK. */
+  activateKey(keyId: string): void {
+    const registry = this.load()
+    const entry = registry.keys[keyId]
+    if (entry === undefined || entry.state !== 'pending') return
+    entry.state = 'active'
+    this.save(registry)
   }
 
   /**
@@ -490,9 +477,9 @@ export class DbKeyStore {
    * preserved as `<registryPath>.bak` and a warning is logged, so keys are
    * not silently lost even though this read returns an empty registry.
    */
-  private load(): Registry {
+  private load(): KeyRegistry {
     if (!existsSync(this.registryPath)) {
-      return emptyRegistry()
+      return emptyKeyRegistry()
     }
 
     let raw: string
@@ -500,12 +487,12 @@ export class DbKeyStore {
       raw = readFileSync(this.registryPath, 'utf-8')
     } catch (e) {
       mainLogger.warn(`Failed to read key registry file: ${errorMessage(e)}`, 'DbKeyStore')
-      return emptyRegistry()
+      return emptyKeyRegistry()
     }
 
     try {
       const parsed: unknown = JSON.parse(raw)
-      if (!isValidRegistryShape(parsed)) {
+      if (!isValidKeyRegistryShape(parsed)) {
         throw new Error('unexpected key registry shape')
       }
       return parsed
@@ -515,7 +502,7 @@ export class DbKeyStore {
         `Key registry file was corrupt or invalid; treating as empty and preserving a backup at ${this.registryPath}.bak: ${errorMessage(e)}`,
         'DbKeyStore'
       )
-      return emptyRegistry()
+      return emptyKeyRegistry()
     }
   }
 
@@ -531,7 +518,7 @@ export class DbKeyStore {
   }
 
   /** Write registry to disk (mkdir -p + write-temp + fsync + rename + best-effort dir fsync). */
-  private save(registry: Registry): void {
+  private save(registry: KeyRegistry): void {
     const dir = dirname(this.registryPath)
     mkdirSync(dir, { recursive: true })
     const json = JSON.stringify(registry, null, 2)
@@ -570,7 +557,16 @@ export type DbKeyStoreLike = Pick<
  * need to implement methods they never call.
  */
 export type DbKeyStoreWithPassphraseLike = DbKeyStoreLike &
-  Pick<DbKeyStore, 'setPassphrase' | 'setPassphraseForVerifiedDek' | 'getKeyIdForPath'>
+  Pick<
+    DbKeyStore,
+    | 'setPassphrase'
+    | 'setPassphraseForVerifiedDek'
+    | 'getKeyIdForPath'
+    | 'getKeyStateForPath'
+    | 'activateKey'
+    | 'createPendingManagedKey'
+    | 'wrapNewPendingDekWithPassphrase'
+  >
 
 /**
  * Consumed by `openDatabase`'s recovery-sidecar flow: transparent resolve,
@@ -591,4 +587,6 @@ export type DbKeyStoreWithRecoveryLike = Pick<
   | 'updatePath'
   | 'removeKey'
   | 'getKeyIdForPath'
+  | 'getKeyStateForPath'
+  | 'activateKey'
 >

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -35,11 +35,14 @@
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
 import { dirname } from 'path'
-import { createCipheriv, createDecipheriv, randomBytes, randomUUID, scryptSync } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
 import { mainLogger } from '../services/MainLogger'
 import { writeRecoverySidecar } from './recovery-sidecar'
 import { fsyncContainingDirectory, fsyncFile } from './fs-durability'
+import { unwrapPassphrase, wrapPassphrase, type PassphraseWrap } from './db-key-passphrase'
+
+export type { PassphraseWrap } from './db-key-passphrase'
 
 /** Default registry filename, intended to live under Electron's `userData` dir. */
 export const DEFAULT_DB_KEY_REGISTRY_FILENAME = 'varlens-db-keys.json'
@@ -50,16 +53,9 @@ export const DEFAULT_DB_KEY_REGISTRY_FILENAME = 'varlens-db-keys.json'
  */
 export interface SafeStorageLike {
   isEncryptionAvailable(): boolean
+  getSelectedStorageBackend?(): string
   encryptString(plainText: string): Buffer
   decryptString(encrypted: Buffer): string
-}
-
-/** AES-256-GCM passphrase wrap of a DEK. All fields are base64-encoded. */
-export interface PassphraseWrap {
-  saltB64: string
-  ivB64: string
-  ctB64: string
-  tagB64: string
 }
 
 /** One registry entry: where the DB lives and how its DEK is wrapped. */
@@ -110,11 +106,6 @@ export type SetPassphraseResult =
 export type EnrollRecoveredKeyResult =
   { ok: true; keyId: string } | { ok: false; reason: 'path-already-keyed' }
 
-/** scrypt cost parameters. N=16384, r=8, p=1 derives ~16 MiB, under Node's default 32 MiB maxmem. */
-const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const
-const SCRYPT_KEY_LENGTH = 32
-const GCM_IV_LENGTH = 12
-const PASSPHRASE_SALT_LENGTH = 16
 const DEK_BYTE_LENGTH = 32
 
 function errorMessage(e: unknown): string {
@@ -149,40 +140,6 @@ function generateDek(): string {
   return dek
 }
 
-function wrapPassphrase(dek: string, passphrase: string): PassphraseWrap {
-  const salt = randomBytes(PASSPHRASE_SALT_LENGTH)
-  const iv = randomBytes(GCM_IV_LENGTH)
-  const derivedKey = scryptSync(passphrase, salt, SCRYPT_KEY_LENGTH, SCRYPT_PARAMS)
-  const cipher = createCipheriv('aes-256-gcm', derivedKey, iv)
-  const ct = Buffer.concat([cipher.update(dek, 'utf8'), cipher.final()])
-  const tag = cipher.getAuthTag()
-  return {
-    saltB64: salt.toString('base64'),
-    ivB64: iv.toString('base64'),
-    ctB64: ct.toString('base64'),
-    tagB64: tag.toString('base64')
-  }
-}
-
-/** Returns the unwrapped DEK, or null on a wrong passphrase (GCM auth failure) or malformed wrap. */
-function unwrapPassphrase(wrap: PassphraseWrap, passphrase: string): string | null {
-  try {
-    const salt = Buffer.from(wrap.saltB64, 'base64')
-    const iv = Buffer.from(wrap.ivB64, 'base64')
-    const ct = Buffer.from(wrap.ctB64, 'base64')
-    const tag = Buffer.from(wrap.tagB64, 'base64')
-    const derivedKey = scryptSync(passphrase, salt, SCRYPT_KEY_LENGTH, SCRYPT_PARAMS)
-    const decipher = createDecipheriv('aes-256-gcm', derivedKey, iv)
-    decipher.setAuthTag(tag)
-    const pt = Buffer.concat([decipher.update(ct), decipher.final()])
-    return pt.toString('utf8')
-  } catch {
-    // GCM auth failure (wrong passphrase) or malformed wrap material.
-    // Never surface crypto internals — the caller only needs "it failed".
-    return null
-  }
-}
-
 /**
  * Envelope-encryption key-lifecycle store for SQLCipher DEKs.
  *
@@ -214,7 +171,7 @@ export class DbKeyStore {
       return { ok: false, reason: 'path-already-keyed' }
     }
 
-    if (!this.safeStorage.isEncryptionAvailable()) {
+    if (!this.isSecureStorageAvailable()) {
       return { ok: false, reason: 'safe-storage-unavailable' }
     }
 
@@ -348,6 +305,27 @@ export class DbKeyStore {
     return { ok: true, sidecarWritten }
   }
 
+  /** Replace a passphrase wrap using the caller's already-verified session DEK. */
+  setPassphraseForVerifiedDek(
+    keyId: string,
+    verifiedDek: string,
+    passphrase: string
+  ): SetPassphraseResult {
+    const registry = this.load()
+    const entry = registry.keys[keyId]
+    if (!entry) {
+      return { ok: false, reason: 'not-found' }
+    }
+    if (!/^[0-9a-f]{64}$/.test(verifiedDek)) {
+      return { ok: false, reason: 'cannot-resolve-dek' }
+    }
+
+    entry.passWrap = wrapPassphrase(verifiedDek, passphrase)
+    this.save(registry)
+    const sidecarWritten = this.tryWriteRecoverySidecar(entry.path, entry.passWrap)
+    return { ok: true, sidecarWritten }
+  }
+
   /**
    * Direct `pathIndex` lookup, with no attempt to resolve/unwrap the DEK.
    * Consumed by the (separately implemented) `setRecoveryPassphrase` IPC
@@ -403,7 +381,7 @@ export class DbKeyStore {
     const keyId = randomUUID()
     const entry: KeyEntry = { path: dbPath, passWrap }
 
-    if (this.safeStorage.isEncryptionAvailable()) {
+    if (this.isSecureStorageAvailable()) {
       try {
         entry.safeWrap = this.safeStorage.encryptString(dek).toString('base64')
       } catch (e) {
@@ -478,7 +456,7 @@ export class DbKeyStore {
 
   /** Attempt to unwrap `entry.safeWrap` via the injected safeStorage; null on any failure. */
   private tryUnwrapWithSafeStorage(entry: KeyEntry): string | null {
-    if (entry.safeWrap === undefined || !this.safeStorage.isEncryptionAvailable()) {
+    if (entry.safeWrap === undefined || !this.isSecureStorageAvailable()) {
       return null
     }
     try {
@@ -487,6 +465,22 @@ export class DbKeyStore {
     } catch (e) {
       mainLogger.warn(`safeStorage.decryptString failed: ${errorMessage(e)}`, 'DbKeyStore')
       return null
+    }
+  }
+
+  /** Electron's Linux `basic_text` backend is obfuscation, not secure storage. */
+  private isSecureStorageAvailable(): boolean {
+    try {
+      return (
+        this.safeStorage.isEncryptionAvailable() &&
+        this.safeStorage.getSelectedStorageBackend?.() !== 'basic_text'
+      )
+    } catch (e) {
+      mainLogger.warn(
+        `Failed to determine secure storage availability: ${errorMessage(e)}`,
+        'DbKeyStore'
+      )
+      return false
     }
   }
 
@@ -576,7 +570,7 @@ export type DbKeyStoreLike = Pick<
  * need to implement methods they never call.
  */
 export type DbKeyStoreWithPassphraseLike = DbKeyStoreLike &
-  Pick<DbKeyStore, 'setPassphrase' | 'getKeyIdForPath'>
+  Pick<DbKeyStore, 'setPassphrase' | 'setPassphraseForVerifiedDek' | 'getKeyIdForPath'>
 
 /**
  * Consumed by `openDatabase`'s recovery-sidecar flow: transparent resolve,

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -487,7 +487,9 @@ export class DbKeyStore {
       raw = readFileSync(this.registryPath, 'utf-8')
     } catch (e) {
       mainLogger.warn(`Failed to read key registry file: ${errorMessage(e)}`, 'DbKeyStore')
-      throw new Error('The database key registry could not be read; no key changes were made')
+      throw new Error('The database key registry could not be read; no key changes were made', {
+        cause: e
+      })
     }
 
     try {
@@ -502,7 +504,9 @@ export class DbKeyStore {
         `Key registry file was corrupt or invalid; refusing to replace it and preserving a backup at ${this.registryPath}.bak: ${errorMessage(e)}`,
         'DbKeyStore'
       )
-      throw new Error('The database key registry is corrupt or invalid; no key changes were made')
+      throw new Error('The database key registry is corrupt or invalid; no key changes were made', {
+        cause: e
+      })
     }
   }
 

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -431,3 +431,14 @@ export type DbKeyStoreLike = Pick<
   | 'resolveKeyWithPassphrase'
   | 'removeKey'
 >
+
+/**
+ * Adds `setPassphrase` on top of `DbKeyStoreLike` -- consumed by the
+ * plaintext-to-encrypted migration orchestration (task I2b), which offers a
+ * recovery passphrase on a freshly-minted managed key so keyring loss can't
+ * make the migrated data unrecoverable. Kept separate from `DbKeyStoreLike`
+ * so existing consumers of that narrower type (e.g. `database/startup.ts`'s
+ * hand-rolled "unavailable" fake) don't need to implement a method they
+ * never call.
+ */
+export type DbKeyStoreWithPassphraseLike = DbKeyStoreLike & Pick<DbKeyStore, 'setPassphrase'>

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -487,9 +487,9 @@ export class DbKeyStore {
       raw = readFileSync(this.registryPath, 'utf-8')
     } catch (e) {
       mainLogger.warn(`Failed to read key registry file: ${errorMessage(e)}`, 'DbKeyStore')
-      throw new Error('The database key registry could not be read; no key changes were made', {
-        cause: e
-      })
+      const error = new Error('The database key registry could not be read; no key changes were made')
+      ;(error as Error & { cause?: unknown }).cause = e
+      throw error
     }
 
     try {
@@ -504,9 +504,11 @@ export class DbKeyStore {
         `Key registry file was corrupt or invalid; refusing to replace it and preserving a backup at ${this.registryPath}.bak: ${errorMessage(e)}`,
         'DbKeyStore'
       )
-      throw new Error('The database key registry is corrupt or invalid; no key changes were made', {
-        cause: e
-      })
+      const error = new Error(
+        'The database key registry is corrupt or invalid; no key changes were made'
+      )
+      ;(error as Error & { cause?: unknown }).cause = e
+      throw error
     }
   }
 

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -487,7 +487,9 @@ export class DbKeyStore {
       raw = readFileSync(this.registryPath, 'utf-8')
     } catch (e) {
       mainLogger.warn(`Failed to read key registry file: ${errorMessage(e)}`, 'DbKeyStore')
-      const error = new Error('The database key registry could not be read; no key changes were made')
+      const error = new Error(
+        'The database key registry could not be read; no key changes were made'
+      )
       ;(error as Error & { cause?: unknown }).cause = e
       throw error
     }

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -348,8 +348,10 @@ export class DbKeyStore {
   /**
    * Enroll a DEK recovered from a portable sidecar as a brand-new registry
    * entry for `dbPath`, so future opens on THIS machine are transparent.
-   * Guards `dbPath` being already keyed exactly like `createManagedKey`/
-   * `wrapNewDekWithPassphrase` do, to avoid orphaning an existing key.
+   * The caller must first prove SQLite accepts `dek`. That verification makes
+   * a pre-existing mapping at this path stale: the new entry replaces only
+   * `pathIndex[dbPath]`, while the displaced wrapped key remains in `keys` so
+   * a moved copy of the old database is still recoverable by DEK lookup.
    * Best-effort ALSO adds a safeStorage wrap when available (non-fatal on
    * failure — the passphrase wrap being enrolled is enough on its own).
    * Does NOT re-write the sidecar: `passWrap` came FROM the sidecar, so it
@@ -361,9 +363,6 @@ export class DbKeyStore {
     passWrap: PassphraseWrap
   ): EnrollRecoveredKeyResult {
     const registry = this.load()
-    if (registry.pathIndex[dbPath] !== undefined) {
-      return { ok: false, reason: 'path-already-keyed' }
-    }
 
     const keyId = randomUUID()
     const entry: KeyEntry = { path: dbPath, passWrap }

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -425,5 +425,9 @@ export class DbKeyStore {
  */
 export type DbKeyStoreLike = Pick<
   DbKeyStore,
-  'createManagedKey' | 'wrapNewDekWithPassphrase' | 'resolveKeyForPath' | 'resolveKeyWithPassphrase'
+  | 'createManagedKey'
+  | 'wrapNewDekWithPassphrase'
+  | 'resolveKeyForPath'
+  | 'resolveKeyWithPassphrase'
+  | 'removeKey'
 >

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -39,6 +39,7 @@ import { createCipheriv, createDecipheriv, randomBytes, randomUUID, scryptSync }
 import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
 import { mainLogger } from '../services/MainLogger'
 import { writeRecoverySidecar } from './recovery-sidecar'
+import { fsyncContainingDirectory, fsyncFile } from './fs-durability'
 
 /** Default registry filename, intended to live under Electron's `userData` dir. */
 export const DEFAULT_DB_KEY_REGISTRY_FILENAME = 'varlens-db-keys.json'
@@ -535,14 +536,16 @@ export class DbKeyStore {
     }
   }
 
-  /** Write the registry to disk (mkdir -p + write-then-rename for atomicity). */
+  /** Write registry to disk (mkdir -p + write-temp + fsync + rename + best-effort dir fsync). */
   private save(registry: Registry): void {
     const dir = dirname(this.registryPath)
     mkdirSync(dir, { recursive: true })
     const json = JSON.stringify(registry, null, 2)
     const tmpPath = `${this.registryPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
     writeFileSync(tmpPath, json, 'utf-8')
+    fsyncFile(tmpPath)
     renameSync(tmpPath, this.registryPath)
+    fsyncContainingDirectory(this.registryPath)
   }
 }
 
@@ -593,4 +596,5 @@ export type DbKeyStoreWithRecoveryLike = Pick<
   | 'enrollRecoveredKey'
   | 'updatePath'
   | 'removeKey'
+  | 'getKeyIdForPath'
 >

--- a/src/main/database/db-key-store.ts
+++ b/src/main/database/db-key-store.ts
@@ -472,10 +472,10 @@ export class DbKeyStore {
   }
 
   /**
-   * Read the registry from disk. Tolerates a missing file (fresh install —
-   * treated as empty, no logging). Never throws on a corrupt file: it is
-   * preserved as `<registryPath>.bak` and a warning is logged, so keys are
-   * not silently lost even though this read returns an empty registry.
+   * Read the registry from disk. A missing file is a fresh install and is
+   * treated as empty. An existing unreadable or invalid registry fails
+   * closed: returning an empty registry would let the next mutation replace
+   * the only copy of every wrapped database key.
    */
   private load(): KeyRegistry {
     if (!existsSync(this.registryPath)) {
@@ -487,7 +487,7 @@ export class DbKeyStore {
       raw = readFileSync(this.registryPath, 'utf-8')
     } catch (e) {
       mainLogger.warn(`Failed to read key registry file: ${errorMessage(e)}`, 'DbKeyStore')
-      return emptyKeyRegistry()
+      throw new Error('The database key registry could not be read; no key changes were made')
     }
 
     try {
@@ -499,10 +499,10 @@ export class DbKeyStore {
     } catch (e) {
       this.preserveCorruptBackup(raw)
       mainLogger.warn(
-        `Key registry file was corrupt or invalid; treating as empty and preserving a backup at ${this.registryPath}.bak: ${errorMessage(e)}`,
+        `Key registry file was corrupt or invalid; refusing to replace it and preserving a backup at ${this.registryPath}.bak: ${errorMessage(e)}`,
         'DbKeyStore'
       )
-      return emptyKeyRegistry()
+      throw new Error('The database key registry is corrupt or invalid; no key changes were made')
     }
   }
 

--- a/src/main/database/fs-durability.ts
+++ b/src/main/database/fs-durability.ts
@@ -1,0 +1,49 @@
+/**
+ * fs-durability.ts -- small fsync helpers for making an atomic
+ * write-temp-then-rename durable across a crash/power-loss.
+ *
+ * Mirrors the pattern `plaintext-migration.ts` already uses for its step-6
+ * atomic swap. Shared by `db-key-store.ts` (registry writes) and
+ * `recovery-sidecar.ts` (sidecar writes) -- both persist the wrapped DEK an
+ * encrypted database depends on, so a crash between "file exists" and "bytes
+ * durable on disk" must not be able to leave a wrapped key unrecoverable.
+ */
+
+import { closeSync, fsyncSync, openSync } from 'fs'
+import { dirname } from 'path'
+
+/**
+ * Fsync a regular file so its bytes are durably on disk before a caller's
+ * atomic rename depends on them. Real failures propagate -- the caller
+ * decides whether that's fatal to the write it's protecting.
+ */
+export function fsyncFile(filePath: string): void {
+  const fd = openSync(filePath, 'r')
+  try {
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+}
+
+/**
+ * Best-effort fsync of the directory containing `filePath`, so the
+ * just-renamed directory entry is itself durable, not only the file's
+ * contents. Some platforms/filesystems (notably Windows) cannot open/fsync a
+ * directory handle at all -- that failure, and any other failure here, is
+ * intentionally swallowed: the rename itself has already succeeded by the
+ * time this runs, so failing the caller over this extra durability nicety
+ * would be worse than the gap it narrows.
+ */
+export function fsyncContainingDirectory(filePath: string): void {
+  try {
+    const fd = openSync(dirname(filePath), 'r')
+    try {
+      fsyncSync(fd)
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    // Expected on platforms that don't support directory fsync.
+  }
+}

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -9,6 +9,7 @@ import { DatabaseManager } from '../services/DatabaseManager'
 import { RecentDatabasesService } from '../services/RecentDatabasesService'
 import { app } from 'electron'
 import { join } from 'path'
+import { getDbKeyStore } from './db-key-store-instance'
 import { openConfiguredDatabase } from './startup'
 
 // Singleton instance of DatabaseManager
@@ -31,7 +32,8 @@ export async function initDatabaseManager(): Promise<DatabaseManager> {
 
     await openConfiguredDatabase(databaseManager, {
       env: process.env,
-      userDataPath: app.getPath('userData')
+      userDataPath: app.getPath('userData'),
+      keyStore: getDbKeyStore()
     })
   }
   return databaseManager

--- a/src/main/database/plaintext-migration-signal.ts
+++ b/src/main/database/plaintext-migration-signal.ts
@@ -1,0 +1,135 @@
+/**
+ * plaintext-migration-signal.ts -- content-signal computation for
+ * `plaintext-migration.ts`.
+ *
+ * Split out of `plaintext-migration.ts` to keep that file under the repo's
+ * LLM-sustainable size guideline; this module has one reason to change:
+ * "how do we prove two SQLite files hold the same logical data." It knows
+ * nothing about migration steps, rollback, or key-store lifecycle.
+ */
+
+import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
+import { createHash } from 'crypto'
+
+/** A structural + content fingerprint of a SQLite database's user tables. */
+export interface ContentSignal {
+  userVersion: number
+  tableRowCounts: Record<string, number>
+  /** Per-table content hash -- see `computeTableContentHash` for the approach. */
+  tableContentHashes: Record<string, string>
+}
+
+function quoteIdentifier(name: string): string {
+  return name.replace(/"/g, '""')
+}
+
+/**
+ * Content hash for one table: a SHA-256 over every row's values, ordered
+ * deterministically and type-tagged so e.g. the integer `1`, the text `'1'`,
+ * and `NULL` can never collide.
+ *
+ * APPROACH (documented per the I2b hardening review -- a same-cardinality
+ * content divergence, e.g. an UPDATE that changes a value without changing
+ * row count, is exactly what a plain `COUNT(*)` cannot catch):
+ *   - Row order: `ORDER BY rowid` when the table has one -- cheap (a normal
+ *     table scan needs no explicit sort) and correct for this module's only
+ *     use case, comparing files that started life as byte-identical copies
+ *     of one another (the original, its encrypting candidate, and its
+ *     backup), so rowid order is guaranteed to line up across all three.
+ *     Falls back to ordering by every column for `WITHOUT ROWID` tables,
+ *     which have no rowid.
+ *   - Per value: a self-describing, LENGTH-PREFIXED frame
+ *     (`<tag>:<byteLength>:<bytes>`, tag one of `N` null / `B` blob /
+ *     `F` number / `T` text). Length-prefixing (rather than a delimiter
+ *     character) makes the concatenated byte stream unambiguous regardless
+ *     of what bytes a value itself contains -- no in-band separator can ever
+ *     be confused with real data, and a table's fixed column count per row
+ *     makes the whole per-table stream self-delimiting without needing an
+ *     explicit row separator either. This is a logical-content hash, not a
+ *     byte-perfect binary one (e.g. INTEGER `1` and REAL `1.0` both
+ *     stringify to `'1'`) -- an acceptable tradeoff for a same-machine,
+ *     same-SQLite-build migration integrity check, not a general-purpose
+ *     content-addressing scheme.
+ *   - Cost: one full table scan per table, the same asymptotic cost as the
+ *     pre-existing `COUNT(*)` pass this augments -- just a heavier per-row
+ *     constant (hashing instead of counting).
+ */
+function computeTableContentHash(db: DatabaseType, tableName: string, columns: string[]): string {
+  const quotedTable = quoteIdentifier(tableName)
+  const columnList = columns.map((c) => `"${quoteIdentifier(c)}"`).join(', ')
+
+  let rows: Array<Record<string, unknown>>
+  try {
+    rows = db.prepare(`SELECT ${columnList} FROM "${quotedTable}" ORDER BY rowid`).all() as Array<
+      Record<string, unknown>
+    >
+  } catch {
+    // WITHOUT ROWID tables have no rowid -- fall back to ordering by every
+    // column so row order is still deterministic.
+    rows = db
+      .prepare(`SELECT ${columnList} FROM "${quotedTable}" ORDER BY ${columnList}`)
+      .all() as Array<Record<string, unknown>>
+  }
+
+  const hash = createHash('sha256')
+  for (const row of rows) {
+    for (const col of columns) {
+      hashOneValue(hash, row[col])
+    }
+  }
+  return hash.digest('hex')
+}
+
+/** Feed one SQLite value into `hash` as a length-prefixed frame -- see `computeTableContentHash`. */
+function hashOneValue(hash: ReturnType<typeof createHash>, value: unknown): void {
+  if (value === null || value === undefined) {
+    hash.update('N:0:')
+    return
+  }
+  const isBlob = Buffer.isBuffer(value)
+  const bytes = isBlob ? value : Buffer.from(String(value), 'utf8')
+  const tag = isBlob ? 'B' : typeof value === 'number' || typeof value === 'bigint' ? 'F' : 'T'
+  hash.update(`${tag}:${bytes.length}:`)
+  hash.update(bytes)
+}
+
+/** Compute a `ContentSignal` for every user table on an already-open connection. */
+export function computeContentSignal(db: DatabaseType): ContentSignal {
+  const tables = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+    .all() as Array<{ name: string }>
+
+  const tableRowCounts: Record<string, number> = {}
+  const tableContentHashes: Record<string, string> = {}
+  for (const { name } of tables) {
+    const row = db.prepare(`SELECT COUNT(*) as c FROM "${quoteIdentifier(name)}"`).get() as {
+      c: number
+    }
+    tableRowCounts[name] = row.c
+
+    const columns = (
+      db.prepare(`PRAGMA table_info("${quoteIdentifier(name)}")`).all() as Array<{ name: string }>
+    ).map((c) => c.name)
+    tableContentHashes[name] = computeTableContentHash(db, name, columns)
+  }
+
+  const userVersion = db.pragma('user_version', { simple: true }) as number
+  return { userVersion, tableRowCounts, tableContentHashes }
+}
+
+/** Two signals match iff `user_version`, every table's row count, AND every table's content hash agree. */
+export function signalsMatch(a: ContentSignal, b: ContentSignal): boolean {
+  if (a.userVersion !== b.userVersion) {
+    return false
+  }
+  const aKeys = Object.keys(a.tableRowCounts)
+  const bKeys = Object.keys(b.tableRowCounts)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every(
+    (key) =>
+      a.tableRowCounts[key] === b.tableRowCounts[key] &&
+      a.tableContentHashes[key] === b.tableContentHashes[key]
+  )
+}

--- a/src/main/database/plaintext-migration-signal.ts
+++ b/src/main/database/plaintext-migration-signal.ts
@@ -54,22 +54,19 @@ function quoteIdentifier(name: string): string {
  *     pre-existing `COUNT(*)` pass this augments -- just a heavier per-row
  *     constant (hashing instead of counting).
  */
-function computeTableContentHash(db: DatabaseType, tableName: string, columns: string[]): string {
+function computeTableContentHash(
+  db: DatabaseType,
+  tableName: string,
+  columns: string[],
+  withoutRowid: boolean
+): string {
   const quotedTable = quoteIdentifier(tableName)
   const columnList = columns.map((c) => `"${quoteIdentifier(c)}"`).join(', ')
 
-  let rows: Array<Record<string, unknown>>
-  try {
-    rows = db.prepare(`SELECT ${columnList} FROM "${quotedTable}" ORDER BY rowid`).all() as Array<
-      Record<string, unknown>
-    >
-  } catch {
-    // WITHOUT ROWID tables have no rowid -- fall back to ordering by every
-    // column so row order is still deterministic.
-    rows = db
-      .prepare(`SELECT ${columnList} FROM "${quotedTable}" ORDER BY ${columnList}`)
-      .all() as Array<Record<string, unknown>>
-  }
+  const orderBy = withoutRowid ? columnList : 'rowid'
+  const rows = db
+    .prepare(`SELECT ${columnList} FROM "${quotedTable}" ORDER BY ${orderBy}`)
+    .iterate() as Iterable<Record<string, unknown>>
 
   const hash = createHash('sha256')
   for (const row of rows) {
@@ -96,12 +93,14 @@ function hashOneValue(hash: ReturnType<typeof createHash>, value: unknown): void
 /** Compute a `ContentSignal` for every user table on an already-open connection. */
 export function computeContentSignal(db: DatabaseType): ContentSignal {
   const tables = db
-    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
-    .all() as Array<{ name: string }>
+    .prepare(
+      `SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`
+    )
+    .all() as Array<{ name: string; sql: string | null }>
 
   const tableRowCounts: Record<string, number> = {}
   const tableContentHashes: Record<string, string> = {}
-  for (const { name } of tables) {
+  for (const { name, sql } of tables) {
     const row = db.prepare(`SELECT COUNT(*) as c FROM "${quoteIdentifier(name)}"`).get() as {
       c: number
     }
@@ -110,7 +109,12 @@ export function computeContentSignal(db: DatabaseType): ContentSignal {
     const columns = (
       db.prepare(`PRAGMA table_info("${quoteIdentifier(name)}")`).all() as Array<{ name: string }>
     ).map((c) => c.name)
-    tableContentHashes[name] = computeTableContentHash(db, name, columns)
+    tableContentHashes[name] = computeTableContentHash(
+      db,
+      name,
+      columns,
+      /\bWITHOUT\s+ROWID\b/i.test(sql ?? '')
+    )
   }
 
   const userVersion = db.pragma('user_version', { simple: true }) as number

--- a/src/main/database/plaintext-migration.ts
+++ b/src/main/database/plaintext-migration.ts
@@ -69,18 +69,8 @@
 
 import Database from 'better-sqlite3-multiple-ciphers'
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
-import {
-  existsSync,
-  copyFileSync,
-  renameSync,
-  unlinkSync,
-  statSync,
-  openSync,
-  closeSync,
-  fsyncSync
-} from 'fs'
+import { existsSync, copyFileSync, renameSync, unlinkSync, statSync } from 'fs'
 import { randomUUID } from 'crypto'
-import { dirname } from 'path'
 import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
 import { isNotADatabaseError } from './sqlite-error'
 import type { DbKeyStoreLike } from './db-key-store'
@@ -89,6 +79,7 @@ import {
   signalsMatch,
   type ContentSignal
 } from './plaintext-migration-signal'
+import { fsyncContainingDirectory, fsyncFile } from './fs-durability'
 
 export type { ContentSignal }
 
@@ -284,38 +275,6 @@ function copySidecarsIfPresent(fromPath: string, toPath: string): void {
  * rename that makes it `path` -- a failure here is treated as a real,
  * proceed-blocking error (see the step-6 call site), not best-effort.
  */
-function fsyncFile(filePath: string): void {
-  const fd = openSync(filePath, 'r')
-  try {
-    fsyncSync(fd)
-  } finally {
-    closeSync(fd)
-  }
-}
-
-/**
- * Best-effort fsync of the directory containing `filePath`, so the
- * just-renamed directory entry is itself durable, not only the file's
- * contents. Some platforms (notably Windows) cannot open/fsync a directory
- * handle at all -- that failure (and any other failure here) is expected and
- * intentionally swallowed: by the time this runs, `renameSync` has already
- * succeeded, so failing the whole migration over this extra durability nicety
- * would trigger an unnecessary backup-restore for a non-data-loss condition.
- */
-function fsyncContainingDirectory(filePath: string): void {
-  try {
-    const fd = openSync(dirname(filePath), 'r')
-    try {
-      fsyncSync(fd)
-    } finally {
-      closeSync(fd)
-    }
-  } catch {
-    // Expected on platforms that don't support directory fsync; best-effort
-    // everywhere else. The rename itself already completed either way.
-  }
-}
-
 /**
  * Migrate a plaintext SQLite database at `path` to encrypted-at-rest with
  * `dek`, following the algorithm documented at the top of this file. Throws
@@ -402,6 +361,8 @@ export function migratePlaintextToEncrypted(
   try {
     copyFileSync(path, backupPath)
     copySidecarsIfPresent(path, backupPath)
+    fsyncFile(backupPath)
+    fsyncContainingDirectory(backupPath)
     afterBackupCopy(backupPath)
     const stat = statSync(backupPath)
     if (stat.size === 0) {
@@ -467,6 +428,8 @@ function rollbackAfterSwap(
   try {
     copyFileSync(backupPath, path)
     copySidecarsIfPresent(backupPath, path)
+    fsyncFile(path)
+    fsyncContainingDirectory(path)
   } catch (restoreError) {
     keyStore.removeKey(keyId)
     throw new PlaintextMigrationError(

--- a/src/main/database/plaintext-migration.ts
+++ b/src/main/database/plaintext-migration.ts
@@ -16,9 +16,11 @@
  *      typed no-op error -- nothing is written.
  *   2. CHECKPOINT the original's WAL (if any) so its main `.db` file is a
  *      complete, self-contained snapshot, and capture a content signal
- *      (row counts per table + `user_version`). This makes every later
- *      byte-copy of `path` correct without also copying `-wal`/`-shm`
- *      sidecars.
+ *      (row counts + a per-table content hash, per table, plus
+ *      `user_version`). The WAL checkpoint (`PRAGMA journal_mode = DELETE`)
+ *      return value is asserted -- a candidate/backup byte-copy of `path` is
+ *      only correct without also copying `-wal`/`-shm` sidecars if this
+ *      pragma actually took effect.
  *   3. Produce an ENCRYPTED CANDIDATE at a new temp file:
  *        - byte-copy `path` -> `<path>.encrypting-<nonce>.tmp`
  *        - `PRAGMA rekey` the COPY in place with the DEK.
@@ -41,10 +43,19 @@
  *      error; the candidate is deleted and the ORIGINAL is untouched.
  *   5. BACKUP the original: byte-copy `path` -> a timestamped
  *      `<path>.plaintext-backup-<ts>` file (plus `-wal`/`-shm` sidecars, if
- *      any still exist). Verified to exist with a non-zero size -- this
- *      backup MUST exist before the swap in step 6.
- *   6. ATOMIC SWAP: `fs.renameSync(tmp, path)` -- same directory, atomic on
- *      POSIX/Windows.
+ *      any still exist), then OPEN the backup with NO key, require
+ *      `PRAGMA integrity_check` = `'ok'`, AND that its content signal
+ *      matches the ORIGINAL's -- all BEFORE the swap in step 6. A partial or
+ *      truncated backup copy is caught here, not discovered later during a
+ *      rollback that depends on it.
+ *   6. ATOMIC SWAP: fsync the candidate file, then `fs.renameSync(tmp,
+ *      path)` -- same directory, atomic on POSIX/Windows -- then
+ *      best-effort fsync the containing directory. CRASH RECOVERY: a
+ *      `*.plaintext-backup-*` sibling sitting next to an ENCRYPTED `path`
+ *      means a migration may not have durably completed (this step's
+ *      fsyncs, or step 7, or the caller's post-migration reopen, never
+ *      finished) -- that backup IS the recovery source: copy it back over
+ *      `path` to restore the plaintext original.
  *   7. POST-SWAP VERIFY: re-open `path` WITH the DEK and re-run the same
  *      check as step 4. This is normally redundant with step 4 (rename does
  *      not alter bytes), but it is the one place a failure means `path`'s
@@ -58,11 +69,28 @@
 
 import Database from 'better-sqlite3-multiple-ciphers'
 import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
-import { existsSync, copyFileSync, renameSync, unlinkSync, statSync } from 'fs'
+import {
+  existsSync,
+  copyFileSync,
+  renameSync,
+  unlinkSync,
+  statSync,
+  openSync,
+  closeSync,
+  fsyncSync
+} from 'fs'
 import { randomUUID } from 'crypto'
+import { dirname } from 'path'
 import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
 import { isNotADatabaseError } from './sqlite-error'
 import type { DbKeyStoreLike } from './db-key-store'
+import {
+  computeContentSignal,
+  signalsMatch,
+  type ContentSignal
+} from './plaintext-migration-signal'
+
+export type { ContentSignal }
 
 export type PlaintextMigrationFailureReason =
   'already-encrypted' | 'source-missing' | 'verification-failed' | 'swap-failed'
@@ -97,11 +125,6 @@ export interface MigratePlaintextToEncryptedResult {
   backupPath: string
 }
 
-interface ContentSignal {
-  userVersion: number
-  tableRowCounts: Record<string, number>
-}
-
 /**
  * Injectable seam so tests can fault-inject specifically the POST-swap
  * verification (step 7) without affecting the PRE-swap verification (step
@@ -110,51 +133,40 @@ interface ContentSignal {
  */
 export interface PlaintextMigrationDeps {
   verifyEncrypted?: (filePath: string, dek: string) => ContentSignal
+  /**
+   * Test-only hook invoked immediately after the plaintext backup file (and
+   * its sidecars) are written in step 5, before the backup is verified. Lets
+   * tests simulate a truncated/corrupted backup copy against the REAL
+   * verification logic below, without mocking the filesystem. No-op in
+   * production.
+   */
+  afterBackupCopy?: (backupPath: string) => void
+  /**
+   * Test-only hook invoked immediately after the encrypting candidate (step
+   * 3) is copied and rekeyed, before it is verified in step 4. Lets tests
+   * construct a same-cardinality content divergence (same row count,
+   * different values) against the REAL candidate file, so step 4's
+   * strengthened content signal can be proven to catch it via the real
+   * verification code path. No-op in production.
+   */
+  afterCandidateRekey?: (candidatePath: string, dek: string) => void
 }
 
 function quoteSqlLiteral(value: string): string {
   return value.split("'").join("''")
 }
 
-function quoteIdentifier(name: string): string {
-  return name.replace(/"/g, '""')
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function computeContentSignal(db: DatabaseType): ContentSignal {
-  const tables = db
-    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
-    .all() as Array<{ name: string }>
-
-  const tableRowCounts: Record<string, number> = {}
-  for (const { name } of tables) {
-    const row = db.prepare(`SELECT COUNT(*) as c FROM "${quoteIdentifier(name)}"`).get() as {
-      c: number
-    }
-    tableRowCounts[name] = row.c
-  }
-
-  const userVersion = db.pragma('user_version', { simple: true }) as number
-  return { userVersion, tableRowCounts }
-}
-
-function signalsMatch(a: ContentSignal, b: ContentSignal): boolean {
-  if (a.userVersion !== b.userVersion) {
-    return false
-  }
-  const aKeys = Object.keys(a.tableRowCounts)
-  const bKeys = Object.keys(b.tableRowCounts)
-  if (aKeys.length !== bKeys.length) {
-    return false
-  }
-  return aKeys.every((key) => a.tableRowCounts[key] === b.tableRowCounts[key])
-}
-
-/** Real implementation of the injectable verify seam (step 4 and step 7). */
-function realVerifyEncrypted(filePath: string, dek: string): ContentSignal {
+/**
+ * Real implementation of the injectable verify seam (step 4 and step 7).
+ * Exported (in addition to being the default) so tests can let ONE of the
+ * two `deps.verifyEncrypted` calls in a fault-injection test run for real,
+ * without duplicating the content-signal algorithm in test code.
+ */
+export function realVerifyEncrypted(filePath: string, dek: string): ContentSignal {
   const db = new Database(filePath)
   try {
     // CRITICAL: the key pragma must be the first pragma issued (matches
@@ -170,6 +182,25 @@ function realVerifyEncrypted(filePath: string, dek: string): ContentSignal {
     return computeContentSignal(db)
   } finally {
     db.close()
+  }
+}
+
+/**
+ * Assert that `PRAGMA journal_mode = DELETE` actually landed in `'delete'`
+ * mode, rather than trusting the pragma silently. SQLite always returns the
+ * RESULTING journal mode from this statement (whether or not the requested
+ * change took effect -- e.g. it cannot leave WAL mode while another
+ * connection still has the database open), so a truthful check is just
+ * comparing the returned value.
+ */
+function checkpointOutOfWalMode(db: DatabaseType, context: string): void {
+  const journalMode = db.pragma('journal_mode = DELETE', { simple: true }) as string
+  if (journalMode !== 'delete') {
+    throw new PlaintextMigrationError(
+      `Failed to checkpoint ${context} out of WAL mode (journal_mode is '${journalMode}', ` +
+        `expected 'delete') -- refusing to proceed with a possibly-incomplete snapshot`,
+      'verification-failed'
+    )
   }
 }
 
@@ -196,14 +227,36 @@ function assertPlaintextAndCaptureSignal(path: string): ContentSignal {
     throw error
   }
 
-  // Fold any pending WAL frames into the main file and drop WAL mode so a
-  // plain byte-copy of `path` afterward (both for the encrypting candidate
-  // and, later, for the plaintext backup) is a complete, self-contained
-  // snapshot -- no separate `-wal`/`-shm` sidecar needs to travel with it.
-  db.pragma('journal_mode = DELETE')
-  const signal = computeContentSignal(db)
-  db.close()
-  return signal
+  try {
+    // Fold any pending WAL frames into the main file and drop WAL mode so a
+    // plain byte-copy of `path` afterward (both for the encrypting candidate
+    // and, later, for the plaintext backup) is a complete, self-contained
+    // snapshot -- no separate `-wal`/`-shm` sidecar needs to travel with it.
+    // The candidate's and backup's completeness DEPEND on this pragma
+    // actually taking effect, so its return value is asserted, not trusted.
+    checkpointOutOfWalMode(db, 'the source database')
+    const signal = computeContentSignal(db)
+    return signal
+  } finally {
+    db.close()
+  }
+}
+
+/** Open a PLAINTEXT file with NO key, verify integrity, and return its content signal. */
+function realVerifyPlaintextBackup(filePath: string): ContentSignal {
+  const db = new Database(filePath)
+  try {
+    const integrity = db.pragma('integrity_check', { simple: true }) as string
+    if (integrity !== 'ok') {
+      throw new PlaintextMigrationError(
+        `Plaintext backup failed integrity_check (${integrity})`,
+        'verification-failed'
+      )
+    }
+    return computeContentSignal(db)
+  } finally {
+    db.close()
+  }
 }
 
 function cleanupFile(path: string): void {
@@ -227,6 +280,43 @@ function copySidecarsIfPresent(fromPath: string, toPath: string): void {
 }
 
 /**
+ * Fsync a regular file so its bytes are durably on disk before the atomic
+ * rename that makes it `path` -- a failure here is treated as a real,
+ * proceed-blocking error (see the step-6 call site), not best-effort.
+ */
+function fsyncFile(filePath: string): void {
+  const fd = openSync(filePath, 'r')
+  try {
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+}
+
+/**
+ * Best-effort fsync of the directory containing `filePath`, so the
+ * just-renamed directory entry is itself durable, not only the file's
+ * contents. Some platforms (notably Windows) cannot open/fsync a directory
+ * handle at all -- that failure (and any other failure here) is expected and
+ * intentionally swallowed: by the time this runs, `renameSync` has already
+ * succeeded, so failing the whole migration over this extra durability nicety
+ * would trigger an unnecessary backup-restore for a non-data-loss condition.
+ */
+function fsyncContainingDirectory(filePath: string): void {
+  try {
+    const fd = openSync(dirname(filePath), 'r')
+    try {
+      fsyncSync(fd)
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    // Expected on platforms that don't support directory fsync; best-effort
+    // everywhere else. The rename itself already completed either way.
+  }
+}
+
+/**
  * Migrate a plaintext SQLite database at `path` to encrypted-at-rest with
  * `dek`, following the algorithm documented at the top of this file. Throws
  * `PlaintextMigrationError` on any failure; on success returns the backup
@@ -239,11 +329,22 @@ export function migratePlaintextToEncrypted(
 ): MigratePlaintextToEncryptedResult {
   const { path, dek, keyId, keyStore } = params
   const verifyEncrypted = deps.verifyEncrypted ?? realVerifyEncrypted
+  const afterBackupCopy = deps.afterBackupCopy ?? (() => undefined)
+  const afterCandidateRekey = deps.afterCandidateRekey ?? (() => undefined)
 
   assertNotHexLiteralKey(dek)
 
   // Steps 1-2: precondition + checkpoint + capture the original's signal.
-  const originalSignal = assertPlaintextAndCaptureSignal(path)
+  // No stale key-store entry may survive ANY failure path -- including this
+  // earliest one (source missing / already encrypted / WAL checkpoint
+  // didn't take) -- so this is rolled back exactly like the later steps.
+  let originalSignal: ContentSignal
+  try {
+    originalSignal = assertPlaintextAndCaptureSignal(path)
+  } catch (error) {
+    keyStore.removeKey(keyId)
+    throw error
+  }
 
   const tmpPath = `${path}.encrypting-${randomUUID()}.tmp`
 
@@ -265,11 +366,12 @@ export function migratePlaintextToEncrypted(
     copyFileSync(path, tmpPath)
     const tmpDb = new Database(tmpPath)
     try {
-      tmpDb.pragma('journal_mode = DELETE') // rekey requires a non-WAL journal mode
+      checkpointOutOfWalMode(tmpDb, 'the encrypting candidate') // rekey requires a non-WAL journal mode
       tmpDb.pragma(`rekey='${quoteSqlLiteral(dek)}'`)
     } finally {
       tmpDb.close()
     }
+    afterCandidateRekey(tmpPath, dek)
   } catch (error) {
     return rollbackBeforeSwap(error)
   }
@@ -291,14 +393,26 @@ export function migratePlaintextToEncrypted(
     )
   }
 
-  // Step 5: back up the original -- this MUST exist before the swap.
+  // Step 5: back up the original, then VERIFY the backup is genuinely
+  // openable and complete -- BEFORE the swap depends on it. A silent
+  // partial/truncated copy accepted here would later be relied on by
+  // `rollbackAfterSwap` -- restoring from a corrupt backup is permanent data
+  // loss, so this must fail loudly, before the swap, not during a rollback.
   const backupPath = `${path}.plaintext-backup-${Date.now()}`
   try {
     copyFileSync(path, backupPath)
     copySidecarsIfPresent(path, backupPath)
+    afterBackupCopy(backupPath)
     const stat = statSync(backupPath)
     if (stat.size === 0) {
       throw new Error('Backup file was created but is empty')
+    }
+    const backupSignal = realVerifyPlaintextBackup(backupPath)
+    if (!signalsMatch(originalSignal, backupSignal)) {
+      throw new PlaintextMigrationError(
+        'Plaintext backup content does not match the original -- refusing to proceed',
+        'verification-failed'
+      )
     }
   } catch (error) {
     cleanupFile(backupPath)
@@ -306,11 +420,28 @@ export function migratePlaintextToEncrypted(
   }
 
   // Step 6: atomic swap.
+  //
+  // fsync the candidate's bytes to disk before the rename gates on them, and
+  // best-effort fsync the containing directory after the rename lands, to
+  // narrow the window in which a crash could leave a rename that "happened"
+  // in the page cache but never reached disk. CRASH RECOVERY: a
+  // `*.plaintext-backup-*` sibling sitting next to an ENCRYPTED `path` means
+  // a migration may not have durably completed (this step, step 7, or the
+  // caller's post-migration reopen never finished) -- that backup IS the
+  // recovery source; copy it back over `path` to restore the plaintext
+  // original.
+  try {
+    fsyncFile(tmpPath)
+  } catch (error) {
+    return rollbackBeforeSwap(error)
+  }
+
   try {
     renameSync(tmpPath, path)
   } catch (error) {
     return rollbackAfterSwap(path, backupPath, tmpPath, keyId, keyStore, error)
   }
+  fsyncContainingDirectory(path)
 
   // Step 7: post-swap verification. On failure, `path` has already changed
   // -- restore from the backup so the user is never left without a working DB.

--- a/src/main/database/plaintext-migration.ts
+++ b/src/main/database/plaintext-migration.ts
@@ -1,0 +1,357 @@
+/**
+ * plaintext-migration.ts -- consented, backed-up, REVERSIBLE migration of an
+ * existing PLAINTEXT SQLite database to encrypted-at-rest.
+ *
+ * See `.superpowers/sdd/task-I2b-brief.md` for the full design and safety
+ * rationale. This module is intentionally low-level and self-contained: it
+ * knows nothing about `DatabaseManager`/`DatabaseService` sessions or IPC --
+ * the orchestration layer (`src/main/ipc/handlers/database-migration-logic.ts`)
+ * closes/reopens the live app connection around a call to
+ * `migratePlaintextToEncrypted`.
+ *
+ * The algorithm, IN ORDER -- the safety guarantees depend on this order:
+ *
+ *   1. PRECONDITION: `path` exists and is genuinely plaintext (opening it
+ *      with NO key succeeds). An already-encrypted (or unreadable) DB is a
+ *      typed no-op error -- nothing is written.
+ *   2. CHECKPOINT the original's WAL (if any) so its main `.db` file is a
+ *      complete, self-contained snapshot, and capture a content signal
+ *      (row counts per table + `user_version`). This makes every later
+ *      byte-copy of `path` correct without also copying `-wal`/`-shm`
+ *      sidecars.
+ *   3. Produce an ENCRYPTED CANDIDATE at a new temp file:
+ *        - byte-copy `path` -> `<path>.encrypting-<nonce>.tmp`
+ *        - `PRAGMA rekey` the COPY in place with the DEK.
+ *      NOTE: this repo's SQLite backend (`better-sqlite3-multiple-ciphers`,
+ *      which bundles `sqlite3mc` -- SQLite3 Multiple Ciphers -- rather than
+ *      upstream SQLCipher) does NOT implement SQLCipher's `sqlcipher_export()`
+ *      SQL function. This was verified directly: the string
+ *      "sqlcipher_export" appears nowhere in the vendored amalgamated
+ *      `sqlite3.c` nor in the compiled native addon's symbol table (checked
+ *      via `strings` on the built `.node` binary). `PRAGMA rekey` against an
+ *      in-place byte-copy is this repo's own proven encryption-conversion
+ *      mechanism -- see `tests/main/database/sqlcipher.test.ts` ("should
+ *      rekey from unencrypted to encrypted") -- and it gives the identical
+ *      safety property the brief's ATTACH+sqlcipher_export recipe was after:
+ *      the ORIGINAL file is never touched by this step, only a disposable
+ *      copy is.
+ *   4. VERIFY the candidate: open it WITH the DEK, require
+ *      `PRAGMA integrity_check` = `'ok'` AND that its content signal matches
+ *      the ORIGINAL's signal captured in step 2. Any failure here is a typed
+ *      error; the candidate is deleted and the ORIGINAL is untouched.
+ *   5. BACKUP the original: byte-copy `path` -> a timestamped
+ *      `<path>.plaintext-backup-<ts>` file (plus `-wal`/`-shm` sidecars, if
+ *      any still exist). Verified to exist with a non-zero size -- this
+ *      backup MUST exist before the swap in step 6.
+ *   6. ATOMIC SWAP: `fs.renameSync(tmp, path)` -- same directory, atomic on
+ *      POSIX/Windows.
+ *   7. POST-SWAP VERIFY: re-open `path` WITH the DEK and re-run the same
+ *      check as step 4. This is normally redundant with step 4 (rename does
+ *      not alter bytes), but it is the one place a failure means `path`'s
+ *      bytes have already changed -- so on failure here, restore the
+ *      ORIGINAL from the step-5 backup so the user is never left without a
+ *      working database.
+ *
+ * All failure paths funnel through `PlaintextMigrationError` and never log
+ * the DEK or any passphrase.
+ */
+
+import Database from 'better-sqlite3-multiple-ciphers'
+import type { Database as DatabaseType } from 'better-sqlite3-multiple-ciphers'
+import { existsSync, copyFileSync, renameSync, unlinkSync, statSync } from 'fs'
+import { randomUUID } from 'crypto'
+import { assertNotHexLiteralKey } from './sqlcipher-key-guard'
+import { isNotADatabaseError } from './sqlite-error'
+import type { DbKeyStoreLike } from './db-key-store'
+
+export type PlaintextMigrationFailureReason =
+  'already-encrypted' | 'source-missing' | 'verification-failed' | 'swap-failed'
+
+/** Typed error for every failure path of `migratePlaintextToEncrypted`. Never carries the DEK. */
+export class PlaintextMigrationError extends Error {
+  public readonly reason: PlaintextMigrationFailureReason
+
+  constructor(message: string, reason: PlaintextMigrationFailureReason, cause?: Error) {
+    super(message)
+    this.name = 'PlaintextMigrationError'
+    this.reason = reason
+    if (cause !== undefined) {
+      ;(this as Error & { cause?: Error }).cause = cause
+    }
+    Object.setPrototypeOf(this, PlaintextMigrationError.prototype)
+  }
+}
+
+export interface MigratePlaintextToEncryptedParams {
+  /** Path to the existing plaintext SQLite database. */
+  path: string
+  /** The SQLCipher DEK to encrypt with -- a hex string, never logged. */
+  dek: string
+  /** Key-store identity for `dek`, so a failed migration can roll back the registry entry. */
+  keyId: string
+  keyStore: Pick<DbKeyStoreLike, 'removeKey'>
+}
+
+export interface MigratePlaintextToEncryptedResult {
+  /** Path to the plaintext backup kept alongside `path` after a successful migration. */
+  backupPath: string
+}
+
+interface ContentSignal {
+  userVersion: number
+  tableRowCounts: Record<string, number>
+}
+
+/**
+ * Injectable seam so tests can fault-inject specifically the POST-swap
+ * verification (step 7) without affecting the PRE-swap verification (step
+ * 4), which must succeed for a test to exercise the swap at all. Defaults to
+ * the real implementation in production.
+ */
+export interface PlaintextMigrationDeps {
+  verifyEncrypted?: (filePath: string, dek: string) => ContentSignal
+}
+
+function quoteSqlLiteral(value: string): string {
+  return value.split("'").join("''")
+}
+
+function quoteIdentifier(name: string): string {
+  return name.replace(/"/g, '""')
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function computeContentSignal(db: DatabaseType): ContentSignal {
+  const tables = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+    .all() as Array<{ name: string }>
+
+  const tableRowCounts: Record<string, number> = {}
+  for (const { name } of tables) {
+    const row = db.prepare(`SELECT COUNT(*) as c FROM "${quoteIdentifier(name)}"`).get() as {
+      c: number
+    }
+    tableRowCounts[name] = row.c
+  }
+
+  const userVersion = db.pragma('user_version', { simple: true }) as number
+  return { userVersion, tableRowCounts }
+}
+
+function signalsMatch(a: ContentSignal, b: ContentSignal): boolean {
+  if (a.userVersion !== b.userVersion) {
+    return false
+  }
+  const aKeys = Object.keys(a.tableRowCounts)
+  const bKeys = Object.keys(b.tableRowCounts)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every((key) => a.tableRowCounts[key] === b.tableRowCounts[key])
+}
+
+/** Real implementation of the injectable verify seam (step 4 and step 7). */
+function realVerifyEncrypted(filePath: string, dek: string): ContentSignal {
+  const db = new Database(filePath)
+  try {
+    // CRITICAL: the key pragma must be the first pragma issued (matches
+    // `DatabaseService`'s constructor ordering).
+    db.pragma(`key='${quoteSqlLiteral(dek)}'`)
+    const integrity = db.pragma('integrity_check', { simple: true }) as string
+    if (integrity !== 'ok') {
+      throw new PlaintextMigrationError(
+        `Encrypted database failed integrity_check (${integrity})`,
+        'verification-failed'
+      )
+    }
+    return computeContentSignal(db)
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Precondition check (step 1) + WAL checkpoint (step 2, first half) + content
+ * signal capture (step 2, second half), all against one connection.
+ */
+function assertPlaintextAndCaptureSignal(path: string): ContentSignal {
+  if (!existsSync(path)) {
+    throw new PlaintextMigrationError(`No database file exists at ${path}`, 'source-missing')
+  }
+
+  const db = new Database(path)
+  try {
+    db.prepare('SELECT count(*) FROM sqlite_master').get()
+  } catch (error) {
+    db.close()
+    if (isNotADatabaseError(error)) {
+      throw new PlaintextMigrationError(
+        `Database at ${path} is already encrypted (or unreadable)`,
+        'already-encrypted'
+      )
+    }
+    throw error
+  }
+
+  // Fold any pending WAL frames into the main file and drop WAL mode so a
+  // plain byte-copy of `path` afterward (both for the encrypting candidate
+  // and, later, for the plaintext backup) is a complete, self-contained
+  // snapshot -- no separate `-wal`/`-shm` sidecar needs to travel with it.
+  db.pragma('journal_mode = DELETE')
+  const signal = computeContentSignal(db)
+  db.close()
+  return signal
+}
+
+function cleanupFile(path: string): void {
+  if (existsSync(path)) {
+    try {
+      unlinkSync(path)
+    } catch {
+      // Best-effort cleanup; the caller is already inside a failure path and
+      // must not throw a second, more confusing error over the first.
+    }
+  }
+}
+
+function copySidecarsIfPresent(fromPath: string, toPath: string): void {
+  for (const suffix of ['-wal', '-shm']) {
+    const from = `${fromPath}${suffix}`
+    if (existsSync(from)) {
+      copyFileSync(from, `${toPath}${suffix}`)
+    }
+  }
+}
+
+/**
+ * Migrate a plaintext SQLite database at `path` to encrypted-at-rest with
+ * `dek`, following the algorithm documented at the top of this file. Throws
+ * `PlaintextMigrationError` on any failure; on success returns the backup
+ * path so the caller can offer to delete it once the user confirms the
+ * encrypted database opens.
+ */
+export function migratePlaintextToEncrypted(
+  params: MigratePlaintextToEncryptedParams,
+  deps: PlaintextMigrationDeps = {}
+): MigratePlaintextToEncryptedResult {
+  const { path, dek, keyId, keyStore } = params
+  const verifyEncrypted = deps.verifyEncrypted ?? realVerifyEncrypted
+
+  assertNotHexLiteralKey(dek)
+
+  // Steps 1-2: precondition + checkpoint + capture the original's signal.
+  const originalSignal = assertPlaintextAndCaptureSignal(path)
+
+  const tmpPath = `${path}.encrypting-${randomUUID()}.tmp`
+
+  const rollbackBeforeSwap = (cause: unknown): never => {
+    cleanupFile(tmpPath)
+    keyStore.removeKey(keyId)
+    if (cause instanceof PlaintextMigrationError) {
+      throw cause
+    }
+    throw new PlaintextMigrationError(
+      `Failed to prepare an encrypted copy of the database: ${errorMessage(cause)}`,
+      'verification-failed',
+      cause instanceof Error ? cause : undefined
+    )
+  }
+
+  // Step 3: produce the encrypted candidate.
+  try {
+    copyFileSync(path, tmpPath)
+    const tmpDb = new Database(tmpPath)
+    try {
+      tmpDb.pragma('journal_mode = DELETE') // rekey requires a non-WAL journal mode
+      tmpDb.pragma(`rekey='${quoteSqlLiteral(dek)}'`)
+    } finally {
+      tmpDb.close()
+    }
+  } catch (error) {
+    return rollbackBeforeSwap(error)
+  }
+
+  // Step 4: verify the candidate before touching the original at all.
+  let candidateSignal: ContentSignal
+  try {
+    candidateSignal = verifyEncrypted(tmpPath, dek)
+  } catch (error) {
+    return rollbackBeforeSwap(error)
+  }
+
+  if (!signalsMatch(originalSignal, candidateSignal)) {
+    return rollbackBeforeSwap(
+      new PlaintextMigrationError(
+        'Encrypted database content does not match the original -- refusing to proceed',
+        'verification-failed'
+      )
+    )
+  }
+
+  // Step 5: back up the original -- this MUST exist before the swap.
+  const backupPath = `${path}.plaintext-backup-${Date.now()}`
+  try {
+    copyFileSync(path, backupPath)
+    copySidecarsIfPresent(path, backupPath)
+    const stat = statSync(backupPath)
+    if (stat.size === 0) {
+      throw new Error('Backup file was created but is empty')
+    }
+  } catch (error) {
+    cleanupFile(backupPath)
+    return rollbackBeforeSwap(error)
+  }
+
+  // Step 6: atomic swap.
+  try {
+    renameSync(tmpPath, path)
+  } catch (error) {
+    return rollbackAfterSwap(path, backupPath, tmpPath, keyId, keyStore, error)
+  }
+
+  // Step 7: post-swap verification. On failure, `path` has already changed
+  // -- restore from the backup so the user is never left without a working DB.
+  try {
+    verifyEncrypted(path, dek)
+  } catch (error) {
+    return rollbackAfterSwap(path, backupPath, tmpPath, keyId, keyStore, error)
+  }
+
+  return { backupPath }
+}
+
+function rollbackAfterSwap(
+  path: string,
+  backupPath: string,
+  tmpPath: string,
+  keyId: string,
+  keyStore: Pick<DbKeyStoreLike, 'removeKey'>,
+  cause: unknown
+): never {
+  cleanupFile(tmpPath)
+
+  try {
+    copyFileSync(backupPath, path)
+    copySidecarsIfPresent(backupPath, path)
+  } catch (restoreError) {
+    keyStore.removeKey(keyId)
+    throw new PlaintextMigrationError(
+      `Migration failed after the encrypted swap, AND restoring the original from backup ` +
+        `also failed. The plaintext backup is still intact at ${backupPath} -- restore it ` +
+        `manually. Swap failure: ${errorMessage(cause)}; restore failure: ${errorMessage(restoreError)}`,
+      'swap-failed',
+      restoreError instanceof Error ? restoreError : undefined
+    )
+  }
+
+  keyStore.removeKey(keyId)
+  throw new PlaintextMigrationError(
+    `Migration failed after the encrypted swap; the original plaintext database was restored ` +
+      `from backup and is unchanged: ${errorMessage(cause)}`,
+    'swap-failed',
+    cause instanceof Error ? cause : undefined
+  )
+}

--- a/src/main/database/recovery-sidecar.ts
+++ b/src/main/database/recovery-sidecar.ts
@@ -1,0 +1,100 @@
+/**
+ * recovery-sidecar.ts -- portable escrow of a DB's passphrase wrap, living
+ * next to the `.db` file itself.
+ *
+ * `DbKeyStore`'s registry (`userData/varlens-db-keys.json`) is keyed by
+ * absolute path and lives OUTSIDE the database file. That makes a
+ * passphrase-wrapped DEK non-portable in two ways this module fixes:
+ *   - copying the `.db` file to another machine leaves the registry (and
+ *     thus the passphrase wrap) behind -- the copy is unopenable even with
+ *     the correct passphrase.
+ *   - an OS reinstall or userData wipe destroys the registry -- same
+ *     failure, even on the ORIGINAL machine.
+ *
+ * The fix: whenever a passphrase wrap is created or replaced, ALSO persist
+ * that exact `PassphraseWrap` JSON to a sidecar file at
+ * `<dbPath>.varlens-recovery.json`, using the same "sidecar next to the
+ * database" convention `plaintext-migration.ts` already uses for
+ * `<path>.plaintext-backup-<ts>` and `<path>.encrypting-<nonce>.tmp`.
+ *
+ * The sidecar is safe to leave next to an encrypted database: without the
+ * passphrase it is scrypt+AES-256-GCM ciphertext and reveals nothing. It
+ * NEVER contains the DEK, a safeStorage wrap, or the raw passphrase -- only
+ * the `PassphraseWrap` fields plus a small version tag.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import { dirname } from 'path'
+import type { PassphraseWrap } from './db-key-store'
+
+/** Sidecar filename suffix, appended directly to the database's absolute path. */
+export const RECOVERY_SIDECAR_SUFFIX = '.varlens-recovery.json'
+
+/** On-disk shape of a recovery sidecar. Never carries the DEK or a safeStorage wrap. */
+export interface RecoverySidecar {
+  version: number
+  passWrap: PassphraseWrap
+}
+
+/** `<dbPath>.varlens-recovery.json` -- simple string concatenation, matching the repo convention. */
+export function recoverySidecarPathFor(dbPath: string): string {
+  return `${dbPath}${RECOVERY_SIDECAR_SUFFIX}`
+}
+
+export function recoverySidecarExists(dbPath: string): boolean {
+  return existsSync(recoverySidecarPathFor(dbPath))
+}
+
+function isValidPassphraseWrapShape(value: unknown): value is PassphraseWrap {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.saltB64 === 'string' &&
+    typeof v.ivB64 === 'string' &&
+    typeof v.ctB64 === 'string' &&
+    typeof v.tagB64 === 'string'
+  )
+}
+
+/**
+ * Atomic write (mkdir parent + write-to-tmp + rename), mirroring
+ * `DbKeyStore`'s private `save()` method. Real fs errors (disk full,
+ * permission denied, …) propagate -- the caller decides whether that's
+ * fatal; this is always called as a best-effort step alongside a registry
+ * write that has already succeeded.
+ */
+export function writeRecoverySidecar(dbPath: string, passWrap: PassphraseWrap): void {
+  const sidecarPath = recoverySidecarPathFor(dbPath)
+  mkdirSync(dirname(sidecarPath), { recursive: true })
+
+  const sidecar: RecoverySidecar = { version: 1, passWrap }
+  const json = JSON.stringify(sidecar, null, 2)
+  const tmpPath = `${sidecarPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  writeFileSync(tmpPath, json, 'utf-8')
+  renameSync(tmpPath, sidecarPath)
+}
+
+/**
+ * Tolerant read: a missing file returns `null`; corrupt/malformed JSON or a
+ * wrong shape also returns `null` -- this NEVER throws, since a sidecar is
+ * always an optional recovery aid, never a hard dependency.
+ */
+export function readRecoverySidecar(dbPath: string): RecoverySidecar | null {
+  const sidecarPath = recoverySidecarPathFor(dbPath)
+  if (!existsSync(sidecarPath)) {
+    return null
+  }
+
+  try {
+    const raw = readFileSync(sidecarPath, 'utf-8')
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object') return null
+    const v = parsed as { version?: unknown; passWrap?: unknown }
+    if (typeof v.version !== 'number' || !isValidPassphraseWrapShape(v.passWrap)) {
+      return null
+    }
+    return { version: v.version, passWrap: v.passWrap }
+  } catch {
+    return null
+  }
+}

--- a/src/main/database/recovery-sidecar.ts
+++ b/src/main/database/recovery-sidecar.ts
@@ -26,6 +26,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
 import { dirname } from 'path'
 import type { PassphraseWrap } from './db-key-store'
+import { fsyncContainingDirectory, fsyncFile } from './fs-durability'
 
 /** Sidecar filename suffix, appended directly to the database's absolute path. */
 export const RECOVERY_SIDECAR_SUFFIX = '.varlens-recovery.json'
@@ -62,6 +63,11 @@ function isValidPassphraseWrapShape(value: unknown): value is PassphraseWrap {
  * permission denied, …) propagate -- the caller decides whether that's
  * fatal; this is always called as a best-effort step alongside a registry
  * write that has already succeeded.
+ *
+ * Fsyncs the temp file's bytes to disk BEFORE the rename that makes them
+ * live, then best-effort fsyncs the containing directory after the rename --
+ * a crash between "file exists" and "bytes durable" must never be able to
+ * leave the portable recovery wrap unrecoverable. See `fs-durability.ts`.
  */
 export function writeRecoverySidecar(dbPath: string, passWrap: PassphraseWrap): void {
   const sidecarPath = recoverySidecarPathFor(dbPath)
@@ -71,7 +77,9 @@ export function writeRecoverySidecar(dbPath: string, passWrap: PassphraseWrap): 
   const json = JSON.stringify(sidecar, null, 2)
   const tmpPath = `${sidecarPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
   writeFileSync(tmpPath, json, 'utf-8')
+  fsyncFile(tmpPath)
   renameSync(tmpPath, sidecarPath)
+  fsyncContainingDirectory(sidecarPath)
 }
 
 /**

--- a/src/main/database/recovery-sidecar.ts
+++ b/src/main/database/recovery-sidecar.ts
@@ -23,13 +23,30 @@
  * the `PassphraseWrap` fields plus a small version tag.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from 'fs'
 import { dirname } from 'path'
-import type { PassphraseWrap } from './db-key-store'
+import type { PassphraseWrap } from './db-key-passphrase'
 import { fsyncContainingDirectory, fsyncFile } from './fs-durability'
 
 /** Sidecar filename suffix, appended directly to the database's absolute path. */
 export const RECOVERY_SIDECAR_SUFFIX = '.varlens-recovery.json'
+export const MAX_RECOVERY_SIDECAR_BYTES = 64 * 1024
+
+const PASSPHRASE_WRAP_FIELD_BYTES = {
+  saltB64: 16,
+  ivB64: 12,
+  ctB64: 64,
+  tagB64: 16
+} as const
 
 /** On-disk shape of a recovery sidecar. Never carries the DEK or a safeStorage wrap. */
 export interface RecoverySidecar {
@@ -46,15 +63,42 @@ export function recoverySidecarExists(dbPath: string): boolean {
   return existsSync(recoverySidecarPathFor(dbPath))
 }
 
+function isCanonicalBase64OfLength(value: unknown, expectedBytes: number): value is string {
+  if (typeof value !== 'string') return false
+  try {
+    const decoded = Buffer.from(value, 'base64')
+    return decoded.length === expectedBytes && decoded.toString('base64') === value
+  } catch {
+    return false
+  }
+}
+
 function isValidPassphraseWrapShape(value: unknown): value is PassphraseWrap {
   if (value === null || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   return (
-    typeof v.saltB64 === 'string' &&
-    typeof v.ivB64 === 'string' &&
-    typeof v.ctB64 === 'string' &&
-    typeof v.tagB64 === 'string'
+    isCanonicalBase64OfLength(v.saltB64, PASSPHRASE_WRAP_FIELD_BYTES.saltB64) &&
+    isCanonicalBase64OfLength(v.ivB64, PASSPHRASE_WRAP_FIELD_BYTES.ivB64) &&
+    isCanonicalBase64OfLength(v.ctB64, PASSPHRASE_WRAP_FIELD_BYTES.ctB64) &&
+    isCanonicalBase64OfLength(v.tagB64, PASSPHRASE_WRAP_FIELD_BYTES.tagB64)
   )
+}
+
+function readBoundedSidecar(sidecarPath: string): string | null {
+  const fd = openSync(sidecarPath, 'r')
+  try {
+    const buffer = Buffer.alloc(MAX_RECOVERY_SIDECAR_BYTES + 1)
+    let bytesRead = 0
+    while (bytesRead < buffer.length) {
+      const count = readSync(fd, buffer, bytesRead, buffer.length - bytesRead, null)
+      if (count === 0) break
+      bytesRead += count
+    }
+    if (bytesRead > MAX_RECOVERY_SIDECAR_BYTES) return null
+    return buffer.subarray(0, bytesRead).toString('utf8')
+  } finally {
+    closeSync(fd)
+  }
 }
 
 /**
@@ -82,6 +126,14 @@ export function writeRecoverySidecar(dbPath: string, passWrap: PassphraseWrap): 
   fsyncContainingDirectory(sidecarPath)
 }
 
+/** Remove a recovery sidecar and durably publish the directory entry change. */
+export function removeRecoverySidecar(dbPath: string): void {
+  const sidecarPath = recoverySidecarPathFor(dbPath)
+  if (!existsSync(sidecarPath)) return
+  unlinkSync(sidecarPath)
+  fsyncContainingDirectory(sidecarPath)
+}
+
 /**
  * Tolerant read: a missing file returns `null`; corrupt/malformed JSON or a
  * wrong shape also returns `null` -- this NEVER throws, since a sidecar is
@@ -94,11 +146,12 @@ export function readRecoverySidecar(dbPath: string): RecoverySidecar | null {
   }
 
   try {
-    const raw = readFileSync(sidecarPath, 'utf-8')
+    const raw = readBoundedSidecar(sidecarPath)
+    if (raw === null) return null
     const parsed: unknown = JSON.parse(raw)
     if (parsed === null || typeof parsed !== 'object') return null
     const v = parsed as { version?: unknown; passWrap?: unknown }
-    if (typeof v.version !== 'number' || !isValidPassphraseWrapShape(v.passWrap)) {
+    if (v.version !== 1 || !isValidPassphraseWrapShape(v.passWrap)) {
       return null
     }
     return { version: v.version, passWrap: v.passWrap }

--- a/src/main/database/sqlite-error.ts
+++ b/src/main/database/sqlite-error.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared detection for SQLite's SQLITE_NOTADB failure.
+ *
+ * SQLCipher-backed SQLite cannot distinguish "wrong or missing encryption
+ * key" from "genuinely corrupt/unreadable file" -- both produce the exact
+ * same error (code `SQLITE_NOTADB`, message `file is not a database`). Any
+ * file that trips this is treated as "needs a password so the caller can
+ * prompt"; a truly corrupt file just keeps failing on every attempted key,
+ * which is the same tradeoff every SQLCipher-based application makes.
+ *
+ * The error may arrive wrapped one level deep in a `DatabaseError` (see
+ * `DatabaseService`'s constructor, which wraps any pragma/init failure), so
+ * this checks both the error itself and its `.cause`.
+ */
+export function isNotADatabaseError(error: unknown): boolean {
+  return hasNotADatabaseSignature(error) || hasNotADatabaseSignature(getCause(error))
+}
+
+function getCause(error: unknown): unknown {
+  if (error !== null && typeof error === 'object' && 'cause' in error) {
+    return (error as { cause?: unknown }).cause
+  }
+  return undefined
+}
+
+function hasNotADatabaseSignature(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const code = (error as Error & { code?: unknown }).code
+  if (code === 'SQLITE_NOTADB') {
+    return true
+  }
+  return error.message.includes('file is not a database')
+}

--- a/src/main/database/startup.ts
+++ b/src/main/database/startup.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { Pool } from 'pg'
 
-import type { DbKeyStoreLike } from './db-key-store'
+import type { DbKeyStore, DbKeyStoreLike } from './db-key-store'
 import type { DatabaseManager } from '../services/DatabaseManager'
 import { mainLogger } from '../services/MainLogger'
 import {
@@ -13,6 +13,15 @@ import {
 import { PostgresStorageSession } from '../storage/postgres/PostgresStorageSession'
 import { PostgresMigrationRunner } from '../storage/postgres/migrations/PostgresMigrationRunner'
 import type { StorageSession } from '../storage/session'
+import { removeRecoverySidecar } from './recovery-sidecar'
+
+type StartupKeyStore = DbKeyStoreLike &
+  Partial<
+    Pick<
+      DbKeyStore,
+      'getKeyStateForPath' | 'getKeyIdForPath' | 'activateKey' | 'createPendingManagedKey'
+    >
+  >
 
 interface OpenConfiguredDatabaseOptions {
   env?: NodeJS.ProcessEnv
@@ -30,12 +39,12 @@ interface OpenConfiguredDatabaseOptions {
    * import) so it can be unit-tested without mocking `electron`. The real
    * app wires the actual singleton in from `database/index.ts`.
    */
-  keyStore?: DbKeyStoreLike
+  keyStore?: StartupKeyStore
   /** Injectable for tests; defaults to `fs.existsSync`. */
   fileExists?: (path: string) => boolean
 }
 
-function createUnavailableKeyStore(): DbKeyStoreLike {
+function createUnavailableKeyStore(): StartupKeyStore {
   return {
     createManagedKey: () => ({ ok: false, reason: 'safe-storage-unavailable' }),
     wrapNewDekWithPassphrase: () => ({ ok: false, reason: 'path-already-keyed' }),
@@ -116,12 +125,46 @@ export async function openConfiguredDatabase(
 async function openDefaultSqliteDatabase(
   manager: DatabaseManager,
   userDataPath: string,
-  keyStore: DbKeyStoreLike,
+  keyStore: StartupKeyStore,
   fileExists: (path: string) => boolean
 ): Promise<void> {
   const defaultDbPath = join(userDataPath, 'varlens.db')
 
   if (fileExists(defaultDbPath)) {
+    const pendingKeyId =
+      keyStore.getKeyStateForPath?.(defaultDbPath) === 'pending'
+        ? (keyStore.getKeyIdForPath?.(defaultDbPath) ?? null)
+        : null
+    if (pendingKeyId !== null) {
+      const { needsPassword } = manager.openDetectEncryption(defaultDbPath)
+      if (!needsPassword) {
+        await manager.open(defaultDbPath)
+        keyStore.removeKey(pendingKeyId)
+        try {
+          removeRecoverySidecar(defaultDbPath)
+        } catch (error) {
+          mainLogger.warn(
+            `Failed to remove abandoned migration recovery sidecar: ${error instanceof Error ? error.message : String(error)}`,
+            'database-startup'
+          )
+        }
+        return
+      }
+
+      const pendingResolved = keyStore.resolveKeyForPath(defaultDbPath)
+      if (pendingResolved.ok) {
+        await manager.open(defaultDbPath, pendingResolved.dek)
+        keyStore.activateKey?.(pendingKeyId)
+      } else {
+        mainLogger.warn(
+          'An encrypted migration is pending and requires its recovery passphrase. Starting ' +
+            'without an active database so the user can reopen it interactively.',
+          'database-startup'
+        )
+      }
+      return
+    }
+
     const resolved = keyStore.resolveKeyForPath(defaultDbPath)
     if (resolved.ok) {
       await manager.open(defaultDbPath, resolved.dek)
@@ -131,10 +174,27 @@ async function openDefaultSqliteDatabase(
     return
   }
 
-  const managed = keyStore.createManagedKey(defaultDbPath)
+  if (keyStore.getKeyStateForPath?.(defaultDbPath) === 'pending') {
+    const abandonedKeyId = keyStore.getKeyIdForPath?.(defaultDbPath)
+    if (abandonedKeyId !== undefined && abandonedKeyId !== null) {
+      keyStore.removeKey(abandonedKeyId)
+      try {
+        removeRecoverySidecar(defaultDbPath)
+      } catch (error) {
+        mainLogger.warn(
+          `Failed to remove abandoned database-creation sidecar: ${error instanceof Error ? error.message : String(error)}`,
+          'database-startup'
+        )
+      }
+    }
+  }
+
+  const managed =
+    keyStore.createPendingManagedKey?.(defaultDbPath) ?? keyStore.createManagedKey(defaultDbPath)
   if (managed.ok) {
     try {
       await manager.createDatabase(defaultDbPath, managed.dek)
+      keyStore.activateKey?.(managed.keyId)
     } catch (error) {
       // The registry entry was written before the DB file exists. If
       // creation fails, roll it back so the path isn't permanently burned --

--- a/src/main/database/startup.ts
+++ b/src/main/database/startup.ts
@@ -146,13 +146,24 @@ async function openDefaultSqliteDatabase(
     return
   }
 
+  // A managed (safeStorage-wrapped) key could not be minted for the default
+  // database -- most commonly because no OS keyring is available before the
+  // application window opens. Encryption-by-default means the app must
+  // NEVER silently fall back to creating a PLAINTEXT default database here:
+  // leave the manager with no active database open (it already tolerates
+  // this state -- see `initDatabaseManagerSafe`) so the renderer's
+  // passphrase-required create flow (`needsPassphraseSetup`, handled in
+  // `createDatabase` in `database-lifecycle-logic.ts`) is what actually
+  // creates the (still encrypted, passphrase-wrapped) database once the user
+  // supplies a passphrase.
   mainLogger.warn(
-    `Default database created without encryption (reason: ${managed.reason}). Secure key ` +
-      'storage is unavailable before the application window opens, so the default database ' +
-      'could not be encrypted automatically at startup. It can be encrypted later.',
+    `Default database was NOT created (reason: ${managed.reason}). Secure key storage is ` +
+      'unavailable before the application window opens, so an encrypted-by-default database ' +
+      'could not be created automatically at startup, and creating it unencrypted would break ' +
+      'the encryption-by-default guarantee. Starting with no active database -- create one from ' +
+      'the UI to set a passphrase.',
     'database-startup'
   )
-  await manager.createDatabase(defaultDbPath)
 }
 
 async function closePostgresStartupResources({

--- a/src/main/database/startup.ts
+++ b/src/main/database/startup.ts
@@ -1,7 +1,10 @@
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { Pool } from 'pg'
 
+import type { DbKeyStoreLike } from './db-key-store'
 import type { DatabaseManager } from '../services/DatabaseManager'
+import { mainLogger } from '../services/MainLogger'
 import {
   buildPostgresPoolConfig,
   getPostgresStorageConfig,
@@ -17,6 +20,28 @@ interface OpenConfiguredDatabaseOptions {
   getPostgresConfig?: (env: NodeJS.ProcessEnv) => PostgresStorageConfig | null
   createPostgresPool?: (config: PostgresStorageConfig) => Pool
   createPostgresSession?: (config: PostgresStorageConfig, pool: Pool) => StorageSession
+  /**
+   * DB key-store used to encrypt a freshly-created default database by
+   * default, and to transparently resolve an existing encrypted default
+   * database on subsequent launches. Optional so callers that only exercise
+   * the postgres branch (or want today's always-unencrypted default DB in a
+   * test) don't need to supply one; defaults to a store that always reports
+   * "unavailable" -- this module stays Electron-free (no `safeStorage`
+   * import) so it can be unit-tested without mocking `electron`. The real
+   * app wires the actual singleton in from `database/index.ts`.
+   */
+  keyStore?: DbKeyStoreLike
+  /** Injectable for tests; defaults to `fs.existsSync`. */
+  fileExists?: (path: string) => boolean
+}
+
+function createUnavailableKeyStore(): DbKeyStoreLike {
+  return {
+    createManagedKey: () => ({ ok: false, reason: 'safe-storage-unavailable' }),
+    wrapNewDekWithPassphrase: () => ({ ok: false, reason: 'path-already-keyed' }),
+    resolveKeyForPath: () => ({ ok: false, reason: 'not-found' }),
+    resolveKeyWithPassphrase: () => ({ ok: false, reason: 'not-found' })
+  }
 }
 
 function getExperimentalBackend(env: NodeJS.ProcessEnv): string | null {
@@ -64,7 +89,60 @@ export async function openConfiguredDatabase(
     }
   }
 
-  await manager.open(join(options.userDataPath, 'varlens.db'))
+  await openDefaultSqliteDatabase(
+    manager,
+    options.userDataPath,
+    options.keyStore ?? createUnavailableKeyStore(),
+    options.fileExists ?? existsSync
+  )
+}
+
+/**
+ * Open (or create) the default SQLite database at `<userDataPath>/varlens.db`.
+ *
+ * - File doesn't exist yet (fresh install): create it encrypted by default
+ *   via a managed key. If the key-store can't mint one (safeStorage
+ *   unavailable pre-window, or a stale registry entry for this exact path),
+ *   fall back to creating it unencrypted -- startup must never block on
+ *   encryption -- and log clearly so the gap is visible. A later flow (I2b)
+ *   can offer to encrypt it once the window is up and a passphrase can be
+ *   collected.
+ * - File exists: open as today, but first try to resolve a managed key
+ *   transparently so a default DB that a PRIOR launch auto-encrypted keeps
+ *   opening without a prompt. A DB with no key-store entry (plaintext, or
+ *   encrypted some other way) opens exactly as before.
+ */
+async function openDefaultSqliteDatabase(
+  manager: DatabaseManager,
+  userDataPath: string,
+  keyStore: DbKeyStoreLike,
+  fileExists: (path: string) => boolean
+): Promise<void> {
+  const defaultDbPath = join(userDataPath, 'varlens.db')
+
+  if (fileExists(defaultDbPath)) {
+    const resolved = keyStore.resolveKeyForPath(defaultDbPath)
+    if (resolved.ok) {
+      await manager.open(defaultDbPath, resolved.dek)
+    } else {
+      await manager.open(defaultDbPath)
+    }
+    return
+  }
+
+  const managed = keyStore.createManagedKey(defaultDbPath)
+  if (managed.ok) {
+    await manager.createDatabase(defaultDbPath, managed.dek)
+    return
+  }
+
+  mainLogger.warn(
+    `Default database created without encryption (reason: ${managed.reason}). Secure key ` +
+      'storage is unavailable before the application window opens, so the default database ' +
+      'could not be encrypted automatically at startup. It can be encrypted later.',
+    'database-startup'
+  )
+  await manager.createDatabase(defaultDbPath)
 }
 
 async function closePostgresStartupResources({

--- a/src/main/database/startup.ts
+++ b/src/main/database/startup.ts
@@ -40,7 +40,8 @@ function createUnavailableKeyStore(): DbKeyStoreLike {
     createManagedKey: () => ({ ok: false, reason: 'safe-storage-unavailable' }),
     wrapNewDekWithPassphrase: () => ({ ok: false, reason: 'path-already-keyed' }),
     resolveKeyForPath: () => ({ ok: false, reason: 'not-found' }),
-    resolveKeyWithPassphrase: () => ({ ok: false, reason: 'not-found' })
+    resolveKeyWithPassphrase: () => ({ ok: false, reason: 'not-found' }),
+    removeKey: () => undefined
   }
 }
 
@@ -132,7 +133,16 @@ async function openDefaultSqliteDatabase(
 
   const managed = keyStore.createManagedKey(defaultDbPath)
   if (managed.ok) {
-    await manager.createDatabase(defaultDbPath, managed.dek)
+    try {
+      await manager.createDatabase(defaultDbPath, managed.dek)
+    } catch (error) {
+      // The registry entry was written before the DB file exists. If
+      // creation fails, roll it back so the path isn't permanently burned --
+      // otherwise the NEXT launch would find a stale `path-already-keyed`
+      // entry here and silently fall through to an unencrypted default DB.
+      keyStore.removeKey(managed.keyId)
+      throw error
+    }
     return
   }
 

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -135,28 +135,32 @@ function enrollOrRepointSidecarRecovery(
  * SQLite accepts the DEK), then the legacy fallback of treating the supplied
  * value as a raw SQLCipher key.
  *
- * A sidecar unwrap failure (wrong passphrase against a genuine sidecar, OR a
- * STALE sidecar left behind by a legacy `rekeyDatabase` call that changed
- * the real SQLCipher key without updating the sidecar/registry) is NEVER
- * terminal here: it falls through to the legacy raw-key fallback below, so
- * the database's actual current password can still open it. If that raw-key
- * attempt is also wrong, `manager.switchDatabase` in `openDatabase` throws
- * `WrongPasswordError`, which is what ultimately surfaces `WRONG_PASSWORD`
- * to the caller -- this function itself never fails closed.
+ * Unwrapped values are candidates, not trusted answers. SQLite verifies each
+ * candidate in order because a stale registry wrap can authenticate the same
+ * reused passphrase while belonging to a different database that previously
+ * occupied this path. Registry repointing/enrollment remains deferred until
+ * one candidate actually opens the target database.
  */
-interface ResolvedPasswordAttempt {
-  effectiveKey: string
+interface ResolvedPasswordCandidate {
+  effectiveKey?: string
   pendingSidecarRecovery?: { dek: string; passWrap: PassphraseWrap }
 }
 
-function resolvePasswordAttempt(
+function resolvePasswordCandidates(
   vPath: string,
   vPassword: string,
   keyStore: DbKeyStoreWithRecoveryLike
-): ResolvedPasswordAttempt {
+): ResolvedPasswordCandidate[] {
+  const candidates: ResolvedPasswordCandidate[] = []
+  const addCandidate = (candidate: ResolvedPasswordCandidate): void => {
+    if (!candidates.some((existing) => existing.effectiveKey === candidate.effectiveKey)) {
+      candidates.push(candidate)
+    }
+  }
+
   const viaRegistry = keyStore.resolveKeyWithPassphrase(vPath, vPassword)
   if (viaRegistry.ok) {
-    return { effectiveKey: viaRegistry.dek }
+    addCandidate({ effectiveKey: viaRegistry.dek })
   }
 
   if (recoverySidecarExists(vPath)) {
@@ -164,21 +168,36 @@ function resolvePasswordAttempt(
     if (sidecar !== null) {
       const viaSidecar = keyStore.resolveKeyWithPassphraseFromSidecar(sidecar.passWrap, vPassword)
       if (viaSidecar.ok) {
-        return {
+        addCandidate({
           effectiveKey: viaSidecar.dek,
           pendingSidecarRecovery: { dek: viaSidecar.dek, passWrap: sidecar.passWrap }
-        }
+        })
       }
-      // Sidecar unwrap failed -- fall through to the raw-key fallback below
-      // rather than failing closed. See the doc comment above.
     }
   }
 
-  // No registry entry and no successful sidecar resolution at this path:
-  // legacy fallback -- treat the supplied value as a raw SQLCipher key,
-  // unchanged. A wrong value here surfaces as WRONG_PASSWORD from the actual
-  // `switchDatabase` attempt, not from this function.
-  return { effectiveKey: vPassword }
+  // Always retain the legacy raw-key attempt as the final candidate. A stale
+  // registry or sidecar wrap may authenticate the same user passphrase while
+  // describing a different database that previously occupied this path; only
+  // SQLite can authoritatively choose among the successfully unwrapped keys.
+  addCandidate({ effectiveKey: vPassword })
+  return candidates
+}
+
+async function switchDatabaseWithVerifiedCandidate(
+  manager: DatabaseManager,
+  vPath: string,
+  candidates: ResolvedPasswordCandidate[]
+): Promise<ResolvedPasswordCandidate> {
+  for (const candidate of candidates) {
+    try {
+      await manager.switchDatabase(vPath, candidate.effectiveKey)
+      return candidate
+    } catch (error) {
+      if (!(error instanceof WrongPasswordError)) throw error
+    }
+  }
+  throw new WrongPasswordError()
 }
 
 /**
@@ -192,9 +211,9 @@ function resolvePasswordAttempt(
  * this branch doesn't need to know it exists.
  *
  * When the caller supplies a password/passphrase attempt, see
- * `resolvePasswordAttempt` for the full resolution order (registry
- * passphrase wrap -> recovery sidecar with same-machine self-heal -> legacy
- * raw-key fallback).
+ * `resolvePasswordCandidates` for the full verified order (registry
+ * passphrase wrap -> recovery sidecar with deferred same-machine self-heal ->
+ * legacy raw-key fallback).
  */
 export async function openDatabase(
   params: { path: string; password?: string },
@@ -211,8 +230,7 @@ export async function openDatabase(
   const pendingKeyId =
     keyStore.getKeyStateForPath(vPath) === 'pending' ? keyStore.getKeyIdForPath(vPath) : null
 
-  let effectiveKey = vPassword
-  let pendingSidecarRecovery: ResolvedPasswordAttempt['pendingSidecarRecovery']
+  let candidates: ResolvedPasswordCandidate[]
 
   if (needsPassword) {
     if (vPassword === undefined || vPassword === '') {
@@ -220,17 +238,18 @@ export async function openDatabase(
       if (!resolved.ok) {
         return { success: false, needsPassword: true }
       }
-      effectiveKey = resolved.dek
+      candidates = [{ effectiveKey: resolved.dek }]
     } else {
-      const resolved = resolvePasswordAttempt(vPath, vPassword, keyStore)
-      effectiveKey = resolved.effectiveKey
-      pendingSidecarRecovery = resolved.pendingSidecarRecovery
+      candidates = resolvePasswordCandidates(vPath, vPassword, keyStore)
     }
+  } else {
+    candidates = [{ effectiveKey: vPassword }]
   }
 
   // Switch to new database with rollback on failure
   try {
-    await manager.switchDatabase(vPath, effectiveKey)
+    const verifiedCandidate = await switchDatabaseWithVerifiedCandidate(manager, vPath, candidates)
+    const pendingSidecarRecovery = verifiedCandidate.pendingSidecarRecovery
     mainLogger.info(`Switched to database: ${vPath}`, 'database')
 
     if (pendingKeyId !== null) {

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -136,14 +136,30 @@ export async function createDatabase(
     if (!wrapped.ok) {
       return { success: false, error: PATH_ALREADY_KEYED_ERROR }
     }
-    await manager.createDatabase(params.path, wrapped.dek)
+    try {
+      await manager.createDatabase(params.path, wrapped.dek)
+    } catch (error) {
+      // The registry entry was written before the DB file exists. If creation
+      // fails (disk full, permission error, path collision), roll it back so
+      // the path isn't permanently burned -- a retry must be able to mint a
+      // fresh key for the same path instead of hitting `path-already-keyed`.
+      keyStore.removeKey(wrapped.keyId)
+      throw error
+    }
     const info = manager.getCurrentInfo()
     return { success: true, info: info! }
   }
 
   const managed = keyStore.createManagedKey(params.path)
   if (managed.ok) {
-    await manager.createDatabase(params.path, managed.dek)
+    try {
+      await manager.createDatabase(params.path, managed.dek)
+    } catch (error) {
+      // Same rollback as the passphrase path above: don't leave a stale
+      // key-store entry when the DB file was never actually created.
+      keyStore.removeKey(managed.keyId)
+      throw error
+    }
     const info = manager.getCurrentInfo()
     return { success: true, info: info! }
   }

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -19,7 +19,11 @@ import type {
   DbKeyStoreWithRecoveryLike,
   PassphraseWrap
 } from '../../database/db-key-store'
-import { readRecoverySidecar, recoverySidecarExists } from '../../database/recovery-sidecar'
+import {
+  readRecoverySidecar,
+  recoverySidecarExists,
+  removeRecoverySidecar
+} from '../../database/recovery-sidecar'
 import type {
   DatabaseInfo,
   DatabaseOpenResult,
@@ -113,9 +117,9 @@ function enrollOrRepointSidecarRecovery(
  * Resolve a supplied password/passphrase attempt against, in order: the
  * key-store's own passphrase wrap for this exact path (unchanged today's
  * behavior), then a portable recovery sidecar next to the database file
- * (self-healing the registry on success -- see
- * `enrollOrRepointSidecarRecovery`), then the legacy fallback of treating the
- * supplied value as a raw SQLCipher key.
+ * (returning a pending self-heal that `openDatabase` applies only after
+ * SQLite accepts the DEK), then the legacy fallback of treating the supplied
+ * value as a raw SQLCipher key.
  *
  * A sidecar unwrap failure (wrong passphrase against a genuine sidecar, OR a
  * STALE sidecar left behind by a legacy `rekeyDatabase` call that changed
@@ -126,14 +130,19 @@ function enrollOrRepointSidecarRecovery(
  * `WrongPasswordError`, which is what ultimately surfaces `WRONG_PASSWORD`
  * to the caller -- this function itself never fails closed.
  */
+interface ResolvedPasswordAttempt {
+  effectiveKey: string
+  pendingSidecarRecovery?: { dek: string; passWrap: PassphraseWrap }
+}
+
 function resolvePasswordAttempt(
   vPath: string,
   vPassword: string,
   keyStore: DbKeyStoreWithRecoveryLike
-): string {
+): ResolvedPasswordAttempt {
   const viaRegistry = keyStore.resolveKeyWithPassphrase(vPath, vPassword)
   if (viaRegistry.ok) {
-    return viaRegistry.dek
+    return { effectiveKey: viaRegistry.dek }
   }
 
   if (recoverySidecarExists(vPath)) {
@@ -141,8 +150,10 @@ function resolvePasswordAttempt(
     if (sidecar !== null) {
       const viaSidecar = keyStore.resolveKeyWithPassphraseFromSidecar(sidecar.passWrap, vPassword)
       if (viaSidecar.ok) {
-        enrollOrRepointSidecarRecovery(vPath, viaSidecar.dek, sidecar.passWrap, keyStore)
-        return viaSidecar.dek
+        return {
+          effectiveKey: viaSidecar.dek,
+          pendingSidecarRecovery: { dek: viaSidecar.dek, passWrap: sidecar.passWrap }
+        }
       }
       // Sidecar unwrap failed -- fall through to the raw-key fallback below
       // rather than failing closed. See the doc comment above.
@@ -153,7 +164,7 @@ function resolvePasswordAttempt(
   // legacy fallback -- treat the supplied value as a raw SQLCipher key,
   // unchanged. A wrong value here surfaces as WRONG_PASSWORD from the actual
   // `switchDatabase` attempt, not from this function.
-  return vPassword
+  return { effectiveKey: vPassword }
 }
 
 /**
@@ -185,6 +196,7 @@ export async function openDatabase(
   const { needsPassword } = manager.openDetectEncryption(vPath)
 
   let effectiveKey = vPassword
+  let pendingSidecarRecovery: ResolvedPasswordAttempt['pendingSidecarRecovery']
 
   if (needsPassword) {
     if (vPassword === undefined || vPassword === '') {
@@ -194,7 +206,9 @@ export async function openDatabase(
       }
       effectiveKey = resolved.dek
     } else {
-      effectiveKey = resolvePasswordAttempt(vPath, vPassword, keyStore)
+      const resolved = resolvePasswordAttempt(vPath, vPassword, keyStore)
+      effectiveKey = resolved.effectiveKey
+      pendingSidecarRecovery = resolved.pendingSidecarRecovery
     }
   }
 
@@ -202,6 +216,15 @@ export async function openDatabase(
   try {
     await manager.switchDatabase(vPath, effectiveKey)
     mainLogger.info(`Switched to database: ${vPath}`, 'database')
+
+    if (pendingSidecarRecovery !== undefined) {
+      enrollOrRepointSidecarRecovery(
+        vPath,
+        pendingSidecarRecovery.dek,
+        pendingSidecarRecovery.passWrap,
+        keyStore
+      )
+    }
 
     // Trigger async cohort summary rebuild if needed (non-blocking)
     try {
@@ -227,6 +250,19 @@ export async function openDatabase(
 /** Generic "don't silently create an unencrypted DB" failure for a key-store conflict. */
 const PATH_ALREADY_KEYED_ERROR =
   'This database path already has a registered encryption key. Choose a different location.'
+const RECOVERY_SIDECAR_REQUIRED_ERROR =
+  'The portable recovery file could not be written. No database was created; check the destination permissions and try again.'
+
+function removeRecoverySidecarBestEffort(dbPath: string): void {
+  try {
+    removeRecoverySidecar(dbPath)
+  } catch (error) {
+    mainLogger.warn(
+      `Failed to remove a recovery sidecar while rolling back database creation: ${error instanceof Error ? error.message : String(error)}`,
+      'database'
+    )
+  }
+}
 
 /**
  * Create a new database at the specified path.
@@ -259,6 +295,10 @@ export async function createDatabase(
     if (!wrapped.ok) {
       return { success: false, error: PATH_ALREADY_KEYED_ERROR }
     }
+    if (!wrapped.sidecarWritten) {
+      keyStore.removeKey(wrapped.keyId)
+      return { success: false, error: RECOVERY_SIDECAR_REQUIRED_ERROR }
+    }
     try {
       await manager.createDatabase(params.path, wrapped.dek)
     } catch (error) {
@@ -267,6 +307,7 @@ export async function createDatabase(
       // the path isn't permanently burned -- a retry must be able to mint a
       // fresh key for the same path instead of hitting `path-already-keyed`.
       keyStore.removeKey(wrapped.keyId)
+      removeRecoverySidecarBestEffort(params.path)
       throw error
     }
     const info = withKeyManaged(manager.getCurrentInfo(), true)
@@ -335,7 +376,7 @@ export function rekeyDatabase(
 /**
  * Set (or replace) a recovery passphrase on the CURRENTLY OPEN database's
  * managed key. Non-destructive: envelope-wraps the SAME DEK via
- * `keyStore.setPassphrase` -- unlike `rekeyDatabase` (a `PRAGMA rekey` that
+ * `keyStore.setPassphraseForVerifiedDek` -- unlike `rekeyDatabase` (a `PRAGMA rekey` that
  * changes the live SQLCipher key), this never touches the database file or
  * its actual encryption key. Also writes the escrow recovery sidecar next to
  * the database (see `db-key-store.ts`'s `setPassphrase`).
@@ -350,7 +391,7 @@ export function rekeyDatabase(
 export function setRecoveryPassphrase(
   passphrase: string,
   getDbManager: () => DatabaseManager,
-  keyStore: Pick<DbKeyStoreWithPassphraseLike, 'setPassphrase' | 'getKeyIdForPath'>
+  keyStore: Pick<DbKeyStoreWithPassphraseLike, 'setPassphraseForVerifiedDek' | 'getKeyIdForPath'>
 ): SetRecoveryPassphraseResult {
   const manager = getDbManager()
   const currentPath = manager.getCurrentPath()
@@ -366,13 +407,19 @@ export function setRecoveryPassphrase(
     )
   }
 
-  const result = keyStore.setPassphrase(keyId, passphrase)
+  const verifiedDek = manager.getCurrent().getEncryptionKey()
+  if (verifiedDek === undefined || verifiedDek === '') {
+    throw new DatabaseError(
+      'The current database session does not have a verified managed encryption key.'
+    )
+  }
+
+  const result = keyStore.setPassphraseForVerifiedDek(keyId, verifiedDek, passphrase)
   if (!result.ok) {
     if (result.reason === 'cannot-resolve-dek') {
       throw new DatabaseError(
-        'Could not unlock the managed encryption key on this machine right now, so a recovery ' +
-          "passphrase could not be set. Check that this system's secure key storage " +
-          '(keyring) is available and try again.'
+        'The verified encryption key from the current database session was not valid, so a ' +
+          'recovery passphrase could not be set.'
       )
     }
     throw new DatabaseError('The managed encryption key for this database could not be found.')

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -96,10 +96,10 @@ export interface DatabaseCreateParams {
  * the SAME DEK (the "same-machine move" case -- the `.db` file, plus its
  * sidecar, moved to a new path on a machine that already has a keyring entry
  * for that exact DEK under the old, now-stale path) rather than minting a
- * redundant, orphaned key. Otherwise enroll a brand-new entry from the
- * sidecar's wrap so a genuinely new/wiped machine also becomes transparent
- * next time. Never fails the open itself -- a failure to enroll here is
- * logged and the caller proceeds with the already-recovered `dek`.
+ * redundant key. Otherwise enroll a brand-new entry from the sidecar's wrap
+ * so a genuinely new/wiped machine also becomes transparent next time. A
+ * stale mapping already occupying the restored path is displaced only after
+ * SQLite verification; its wrapped key remains preserved as an orphan.
  */
 function enrollOrRepointSidecarRecovery(
   vPath: string,
@@ -113,18 +113,7 @@ function enrollOrRepointSidecarRecovery(
     return
   }
 
-  const enrolled = keyStore.enrollRecoveredKey(vPath, dek, passWrap)
-  if (!enrolled.ok) {
-    // Defensive only: step 1 (resolveKeyWithPassphrase) already failed to
-    // resolve this exact path, so `path-already-keyed` here would mean
-    // someone else enrolled it concurrently. Not fatal to this open.
-    mainLogger.warn(
-      `Recovered a database via its portable recovery sidecar, but enrolling a local key ` +
-        `entry failed (${enrolled.reason}); this open proceeds, but future opens on this ` +
-        `machine may prompt for the passphrase again.`,
-      'database'
-    )
-  }
+  keyStore.enrollRecoveredKey(vPath, dek, passWrap)
 }
 
 /**

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure business logic for the SQLite database lifecycle: open, create,
+ * rekey, and read current-session info/capabilities/diagnostics.
+ *
+ * Split out of `database-logic.ts` (which now covers PostgreSQL profile
+ * management, recent-database bookkeeping, and file deletion) to keep both
+ * files under the repo's LLM-sustainable size guideline. Re-exported from
+ * `database-logic.ts` so it stays the single stable import surface for
+ * handlers and tests -- see the `createPostgresStorageSession` re-export
+ * there for the same pattern.
+ */
+import { mainLogger } from '../../services/MainLogger'
+import { WrongPasswordError } from '../../database/errors'
+import type { DatabaseService } from '../../database/DatabaseService'
+import type { DatabaseManager } from '../../services/DatabaseManager'
+import type { DbKeyStoreLike } from '../../database/db-key-store'
+import type { DatabaseOpenResult } from '../../../shared/ipc/domains/database'
+import type { StorageCapabilities } from '../../../shared/types/storage-capabilities'
+import type { PostgresHealthDiagnosticResult } from '../../../shared/types/postgres-profile'
+
+/** Callbacks for pool init and cohort rebuild during database open/create. */
+export interface DatabaseLifecycleCallbacks {
+  triggerStartupRebuild: (db: DatabaseService) => void
+}
+
+/** Params accepted by `createDatabase`. See task-I2a-brief.md for the 3-path design. */
+export interface DatabaseCreateParams {
+  path: string
+  /** Legacy/advanced explicit password: used directly as the SQLCipher key, unchanged. */
+  password?: string
+  /**
+   * First-run passphrase-setup completion (only used when a prior create call
+   * returned `needsPassphraseSetup`). Wraps a freshly generated random DEK --
+   * the passphrase itself never becomes the SQLCipher key.
+   */
+  setupPassphrase?: string
+}
+
+/**
+ * Open a database: detect encryption, resolve/validate a key, switch connection.
+ *
+ * Resolution order when the target is encrypted and no explicit password is
+ * supplied: try the key-store's managed (safeStorage-wrapped) key first --
+ * transparent, no prompt. If that can't resolve (moved machine, no keyring
+ * entry), fall back to the existing `needsPassword` prompt flow. When the
+ * caller later supplies a password, it is tried as a key-store passphrase
+ * first (for a managed DB whose safeStorage wrap can't resolve here), then
+ * as a direct SQLCipher key (today's explicit-password behavior, unchanged).
+ */
+export async function openDatabase(
+  params: { path: string; password?: string },
+  getDb: () => DatabaseService,
+  getDbManager: () => DatabaseManager,
+  callbacks: DatabaseLifecycleCallbacks,
+  keyStore: DbKeyStoreLike
+): Promise<DatabaseOpenResult> {
+  const manager = getDbManager()
+  const { path: vPath, password: vPassword } = params
+
+  // First detect if database is encrypted
+  const { needsPassword } = manager.openDetectEncryption(vPath)
+
+  let effectiveKey = vPassword
+
+  if (needsPassword) {
+    if (vPassword === undefined || vPassword === '') {
+      const resolved = keyStore.resolveKeyForPath(vPath)
+      if (!resolved.ok) {
+        return { success: false, needsPassword: true }
+      }
+      effectiveKey = resolved.dek
+    } else {
+      const resolved = keyStore.resolveKeyWithPassphrase(vPath, vPassword)
+      effectiveKey = resolved.ok ? resolved.dek : vPassword
+    }
+  }
+
+  // Switch to new database with rollback on failure
+  try {
+    await manager.switchDatabase(vPath, effectiveKey)
+    mainLogger.info(`Switched to database: ${vPath}`, 'database')
+
+    // Trigger async cohort summary rebuild if needed (non-blocking)
+    try {
+      callbacks.triggerStartupRebuild(getDb())
+    } catch (e) {
+      mainLogger.warn(
+        'triggerStartupRebuildIfNeeded failed (best effort -- database open continues): ' +
+          (e instanceof Error ? e.message : String(e)),
+        'database'
+      )
+    }
+
+    const info = manager.getCurrentInfo()
+    return { success: true, info: info! }
+  } catch (error) {
+    if (error instanceof WrongPasswordError) {
+      return { success: false, error: 'WRONG_PASSWORD' }
+    }
+    throw error
+  }
+}
+
+/** Generic "don't silently create an unencrypted DB" failure for a key-store conflict. */
+const PATH_ALREADY_KEYED_ERROR =
+  'This database path already has a registered encryption key. Choose a different location.'
+
+/**
+ * Create a new database at the specified path.
+ *
+ * Three paths (see task-I2a-brief.md):
+ * - Explicit `password` -- unchanged legacy behavior: the password IS the
+ *   SQLCipher key directly. The key-store is never consulted.
+ * - `setupPassphrase` -- completes the safeStorage-unavailable fallback:
+ *   wraps a freshly generated random DEK with the passphrase and uses the
+ *   DEK (not the passphrase) as the key.
+ * - Neither supplied -- encrypt-by-default: mint a managed (safeStorage-
+ *   wrapped) key transparently. If safeStorage is unavailable, return
+ *   `needsPassphraseSetup` instead of silently creating an unencrypted DB.
+ */
+export async function createDatabase(
+  params: DatabaseCreateParams,
+  getDbManager: () => DatabaseManager,
+  keyStore: DbKeyStoreLike
+): Promise<DatabaseOpenResult> {
+  const manager = getDbManager()
+
+  if (params.password !== undefined && params.password !== '') {
+    await manager.createDatabase(params.path, params.password)
+    const info = manager.getCurrentInfo()
+    return { success: true, info: info! }
+  }
+
+  if (params.setupPassphrase !== undefined && params.setupPassphrase !== '') {
+    const wrapped = keyStore.wrapNewDekWithPassphrase(params.path, params.setupPassphrase)
+    if (!wrapped.ok) {
+      return { success: false, error: PATH_ALREADY_KEYED_ERROR }
+    }
+    await manager.createDatabase(params.path, wrapped.dek)
+    const info = manager.getCurrentInfo()
+    return { success: true, info: info! }
+  }
+
+  const managed = keyStore.createManagedKey(params.path)
+  if (managed.ok) {
+    await manager.createDatabase(params.path, managed.dek)
+    const info = manager.getCurrentInfo()
+    return { success: true, info: info! }
+  }
+
+  if (managed.reason === 'safe-storage-unavailable') {
+    return { success: false, needsPassphraseSetup: true }
+  }
+
+  // path-already-keyed: never silently fall back to an unencrypted DB.
+  return { success: false, error: PATH_ALREADY_KEYED_ERROR }
+}
+
+/**
+ * Change the encryption key for the current database.
+ */
+export function rekeyDatabase(
+  newPassword: string,
+  getDbManager: () => DatabaseManager
+): { success: boolean } {
+  const manager = getDbManager()
+  manager.rekey(newPassword)
+  return { success: true }
+}
+
+export function getDatabaseInfo(
+  getDbManager: () => DatabaseManager
+): { path: string; name: string; encrypted: boolean } | null {
+  const manager = getDbManager()
+  return manager.getCurrentInfo()
+}
+
+export function getDatabaseCapabilities(getDbManager: () => DatabaseManager): StorageCapabilities {
+  return getDbManager().getCurrentSession().capabilities
+}
+
+export async function getPostgresDiagnostics(
+  getDbManager: () => DatabaseManager
+): Promise<PostgresHealthDiagnosticResult> {
+  const session = getDbManager().getCurrentSession()
+  if (session.capabilities.backend !== 'postgres' || session.workspace.kind !== 'postgres') {
+    return {
+      ok: false,
+      schema: '',
+      message: 'PostgreSQL diagnostics are only available for PostgreSQL sessions'
+    }
+  }
+
+  const collectDiagnostics = (
+    session as {
+      collectDiagnostics?: () => Promise<PostgresHealthDiagnosticResult>
+    }
+  ).collectDiagnostics
+  if (collectDiagnostics !== undefined) {
+    return await collectDiagnostics.call(session)
+  }
+
+  return {
+    ok: false,
+    schema: session.workspace.schema,
+    message: 'Current PostgreSQL session does not expose diagnostics'
+  }
+}

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -14,7 +14,7 @@ import { WrongPasswordError } from '../../database/errors'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DatabaseManager } from '../../services/DatabaseManager'
 import type { DbKeyStoreLike } from '../../database/db-key-store'
-import type { DatabaseOpenResult } from '../../../shared/ipc/domains/database'
+import type { DatabaseInfo, DatabaseOpenResult } from '../../../shared/ipc/domains/database'
 import type { StorageCapabilities } from '../../../shared/types/storage-capabilities'
 import type { PostgresHealthDiagnosticResult } from '../../../shared/types/postgres-profile'
 
@@ -184,9 +184,7 @@ export function rekeyDatabase(
   return { success: true }
 }
 
-export function getDatabaseInfo(
-  getDbManager: () => DatabaseManager
-): { path: string; name: string; encrypted: boolean } | null {
+export function getDatabaseInfo(getDbManager: () => DatabaseManager): DatabaseInfo | null {
   const manager = getDbManager()
   return manager.getCurrentInfo()
 }

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -13,7 +13,12 @@ import { mainLogger } from '../../services/MainLogger'
 import { WrongPasswordError } from '../../database/errors'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DatabaseManager } from '../../services/DatabaseManager'
-import type { DbKeyStoreLike } from '../../database/db-key-store'
+import type {
+  DbKeyStoreLike,
+  DbKeyStoreWithRecoveryLike,
+  PassphraseWrap
+} from '../../database/db-key-store'
+import { readRecoverySidecar, recoverySidecarExists } from '../../database/recovery-sidecar'
 import type { DatabaseInfo, DatabaseOpenResult } from '../../../shared/ipc/domains/database'
 import type { StorageCapabilities } from '../../../shared/types/storage-capabilities'
 import type { PostgresHealthDiagnosticResult } from '../../../shared/types/postgres-profile'
@@ -36,23 +41,104 @@ export interface DatabaseCreateParams {
   setupPassphrase?: string
 }
 
+/** Outcome of resolving a user-supplied password/passphrase attempt. */
+type PasswordResolution = { kind: 'resolved'; dek: string } | { kind: 'wrong-passphrase' }
+
+/**
+ * After a successful sidecar-based passphrase recovery, make future opens at
+ * `vPath` transparent on THIS machine: repoint an existing LOCAL entry for
+ * the SAME DEK (the "same-machine move" case -- the `.db` file, plus its
+ * sidecar, moved to a new path on a machine that already has a keyring entry
+ * for that exact DEK under the old, now-stale path) rather than minting a
+ * redundant, orphaned key. Otherwise enroll a brand-new entry from the
+ * sidecar's wrap so a genuinely new/wiped machine also becomes transparent
+ * next time. Never fails the open itself -- a failure to enroll here is
+ * logged and the caller proceeds with the already-recovered `dek`.
+ */
+function enrollOrRepointSidecarRecovery(
+  vPath: string,
+  dek: string,
+  passWrap: PassphraseWrap,
+  keyStore: DbKeyStoreWithRecoveryLike
+): void {
+  const existingKeyId = keyStore.findManagedKeyIdForDek(dek)
+  if (existingKeyId !== null) {
+    keyStore.updatePath(existingKeyId, vPath)
+    return
+  }
+
+  const enrolled = keyStore.enrollRecoveredKey(vPath, dek, passWrap)
+  if (!enrolled.ok) {
+    // Defensive only: step 1 (resolveKeyWithPassphrase) already failed to
+    // resolve this exact path, so `path-already-keyed` here would mean
+    // someone else enrolled it concurrently. Not fatal to this open.
+    mainLogger.warn(
+      `Recovered a database via its portable recovery sidecar, but enrolling a local key ` +
+        `entry failed (${enrolled.reason}); this open proceeds, but future opens on this ` +
+        `machine may prompt for the passphrase again.`,
+      'database'
+    )
+  }
+}
+
+/**
+ * Resolve a supplied password/passphrase attempt against, in order: the
+ * key-store's own passphrase wrap for this exact path (unchanged today's
+ * behavior), then a portable recovery sidecar next to the database file
+ * (self-healing the registry on success -- see
+ * `enrollOrRepointSidecarRecovery`), then the legacy fallback of treating the
+ * supplied value as a raw SQLCipher key. A wrong passphrase against a
+ * genuine sidecar is a typed failure -- it never falls through to being
+ * treated as a raw key.
+ */
+function resolvePasswordAttempt(
+  vPath: string,
+  vPassword: string,
+  keyStore: DbKeyStoreWithRecoveryLike
+): PasswordResolution {
+  const viaRegistry = keyStore.resolveKeyWithPassphrase(vPath, vPassword)
+  if (viaRegistry.ok) {
+    return { kind: 'resolved', dek: viaRegistry.dek }
+  }
+
+  if (recoverySidecarExists(vPath)) {
+    const sidecar = readRecoverySidecar(vPath)
+    if (sidecar !== null) {
+      const viaSidecar = keyStore.resolveKeyWithPassphraseFromSidecar(sidecar.passWrap, vPassword)
+      if (!viaSidecar.ok) {
+        return { kind: 'wrong-passphrase' }
+      }
+      enrollOrRepointSidecarRecovery(vPath, viaSidecar.dek, sidecar.passWrap, keyStore)
+      return { kind: 'resolved', dek: viaSidecar.dek }
+    }
+  }
+
+  // No registry entry and no (parseable) sidecar at this path: legacy
+  // fallback -- treat the supplied value as a raw SQLCipher key, unchanged.
+  return { kind: 'resolved', dek: vPassword }
+}
+
 /**
  * Open a database: detect encryption, resolve/validate a key, switch connection.
  *
  * Resolution order when the target is encrypted and no explicit password is
  * supplied: try the key-store's managed (safeStorage-wrapped) key first --
  * transparent, no prompt. If that can't resolve (moved machine, no keyring
- * entry), fall back to the existing `needsPassword` prompt flow. When the
- * caller later supplies a password, it is tried as a key-store passphrase
- * first (for a managed DB whose safeStorage wrap can't resolve here), then
- * as a direct SQLCipher key (today's explicit-password behavior, unchanged).
+ * entry), fall back to the existing `needsPassword` prompt flow -- a
+ * portable recovery sidecar alone is never enough without a passphrase, so
+ * this branch doesn't need to know it exists.
+ *
+ * When the caller supplies a password/passphrase attempt, see
+ * `resolvePasswordAttempt` for the full resolution order (registry
+ * passphrase wrap -> recovery sidecar with same-machine self-heal -> legacy
+ * raw-key fallback).
  */
 export async function openDatabase(
   params: { path: string; password?: string },
   getDb: () => DatabaseService,
   getDbManager: () => DatabaseManager,
   callbacks: DatabaseLifecycleCallbacks,
-  keyStore: DbKeyStoreLike
+  keyStore: DbKeyStoreWithRecoveryLike
 ): Promise<DatabaseOpenResult> {
   const manager = getDbManager()
   const { path: vPath, password: vPassword } = params
@@ -70,8 +156,11 @@ export async function openDatabase(
       }
       effectiveKey = resolved.dek
     } else {
-      const resolved = keyStore.resolveKeyWithPassphrase(vPath, vPassword)
-      effectiveKey = resolved.ok ? resolved.dek : vPassword
+      const resolution = resolvePasswordAttempt(vPath, vPassword, keyStore)
+      if (resolution.kind === 'wrong-passphrase') {
+        return { success: false, error: 'WRONG_PASSWORD' }
+      }
+      effectiveKey = resolution.dek
     }
   }
 

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -10,16 +10,21 @@
  * there for the same pattern.
  */
 import { mainLogger } from '../../services/MainLogger'
-import { WrongPasswordError } from '../../database/errors'
+import { DatabaseError, WrongPasswordError } from '../../database/errors'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DatabaseManager } from '../../services/DatabaseManager'
 import type {
   DbKeyStoreLike,
+  DbKeyStoreWithPassphraseLike,
   DbKeyStoreWithRecoveryLike,
   PassphraseWrap
 } from '../../database/db-key-store'
 import { readRecoverySidecar, recoverySidecarExists } from '../../database/recovery-sidecar'
-import type { DatabaseInfo, DatabaseOpenResult } from '../../../shared/ipc/domains/database'
+import type {
+  DatabaseInfo,
+  DatabaseOpenResult,
+  SetRecoveryPassphraseResult
+} from '../../../shared/ipc/domains/database'
 import type { StorageCapabilities } from '../../../shared/types/storage-capabilities'
 import type { PostgresHealthDiagnosticResult } from '../../../shared/types/postgres-profile'
 
@@ -271,6 +276,64 @@ export function rekeyDatabase(
   const manager = getDbManager()
   manager.rekey(newPassword)
   return { success: true }
+}
+
+/**
+ * Set (or replace) a recovery passphrase on the CURRENTLY OPEN database's
+ * managed key. Non-destructive: envelope-wraps the SAME DEK via
+ * `keyStore.setPassphrase` -- unlike `rekeyDatabase` (a `PRAGMA rekey` that
+ * changes the live SQLCipher key), this never touches the database file or
+ * its actual encryption key. Also writes the escrow recovery sidecar next to
+ * the database (see `db-key-store.ts`'s `setPassphrase`).
+ *
+ * Gated to the currently open database's path via `getDbManager().getCurrentPath()`
+ * -- there is no caller-supplied path parameter to spoof. A database that was
+ * never registered in the key-store (an explicit-password database, or an
+ * unencrypted one) has no `keyId` for its path, so it is rejected with a
+ * typed error rather than silently doing nothing -- this doubles as the
+ * "managed-key databases only" gate without a separate check.
+ */
+export function setRecoveryPassphrase(
+  passphrase: string,
+  getDbManager: () => DatabaseManager,
+  keyStore: Pick<DbKeyStoreWithPassphraseLike, 'setPassphrase' | 'getKeyIdForPath'>
+): SetRecoveryPassphraseResult {
+  const manager = getDbManager()
+  const currentPath = manager.getCurrentPath()
+  if (currentPath === null) {
+    throw new DatabaseError('No database is currently open.')
+  }
+
+  const keyId = keyStore.getKeyIdForPath(currentPath)
+  if (keyId === null) {
+    throw new DatabaseError(
+      'The current database has no managed encryption key to set a recovery passphrase on. ' +
+        'This action is only available for databases created with encryption-by-default.'
+    )
+  }
+
+  const result = keyStore.setPassphrase(keyId, passphrase)
+  if (!result.ok) {
+    if (result.reason === 'cannot-resolve-dek') {
+      throw new DatabaseError(
+        'Could not unlock the managed encryption key on this machine right now, so a recovery ' +
+          "passphrase could not be set. Check that this system's secure key storage " +
+          '(keyring) is available and try again.'
+      )
+    }
+    throw new DatabaseError('The managed encryption key for this database could not be found.')
+  }
+
+  if (!result.sidecarWritten) {
+    mainLogger.warn(
+      'Recovery passphrase was set on the managed key, but writing the portable recovery ' +
+        'sidecar file failed -- the passphrase works on this machine but the database is not ' +
+        'yet portable to another machine or a fresh key registry.',
+      'database'
+    )
+  }
+
+  return { success: true, recoveryPassphraseSet: true, sidecarWritten: result.sidecarWritten }
 }
 
 export function getDatabaseInfo(getDbManager: () => DatabaseManager): DatabaseInfo | null {

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -287,6 +287,13 @@ export async function openDatabase(
     return { success: true, info: info! }
   } catch (error) {
     if (error instanceof WrongPasswordError) {
+      if (needsPassword && (vPassword === undefined || vPassword === '')) {
+        // A transparent registry key can be stale when a different encrypted
+        // database was restored over the same path. Surface the normal
+        // passphrase prompt so the verified sidecar/raw candidate flow above
+        // remains reachable instead of stranding a valid recovery sidecar.
+        return { success: false, needsPassword: true }
+      }
       return { success: false, error: 'WRONG_PASSWORD' }
     }
     throw error

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -14,11 +14,13 @@ import { DatabaseError, WrongPasswordError } from '../../database/errors'
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DatabaseManager } from '../../services/DatabaseManager'
 import type {
+  DbKeyStore,
   DbKeyStoreLike,
   DbKeyStoreWithPassphraseLike,
   DbKeyStoreWithRecoveryLike,
   PassphraseWrap
 } from '../../database/db-key-store'
+import { existsSync } from 'fs'
 import {
   readRecoverySidecar,
   recoverySidecarExists,
@@ -31,6 +33,18 @@ import type {
 } from '../../../shared/ipc/domains/database'
 import type { StorageCapabilities } from '../../../shared/types/storage-capabilities'
 import type { PostgresHealthDiagnosticResult } from '../../../shared/types/postgres-profile'
+
+type DbKeyStoreProvisioningLike = DbKeyStoreLike &
+  Partial<
+    Pick<
+      DbKeyStore,
+      | 'createPendingManagedKey'
+      | 'wrapNewPendingDekWithPassphrase'
+      | 'getKeyStateForPath'
+      | 'getKeyIdForPath'
+      | 'activateKey'
+    >
+  >
 
 /** Callbacks for pool init and cohort rebuild during database open/create. */
 export interface DatabaseLifecycleCallbacks {
@@ -194,6 +208,8 @@ export async function openDatabase(
 
   // First detect if database is encrypted
   const { needsPassword } = manager.openDetectEncryption(vPath)
+  const pendingKeyId =
+    keyStore.getKeyStateForPath(vPath) === 'pending' ? keyStore.getKeyIdForPath(vPath) : null
 
   let effectiveKey = vPassword
   let pendingSidecarRecovery: ResolvedPasswordAttempt['pendingSidecarRecovery']
@@ -216,6 +232,17 @@ export async function openDatabase(
   try {
     await manager.switchDatabase(vPath, effectiveKey)
     mainLogger.info(`Switched to database: ${vPath}`, 'database')
+
+    if (pendingKeyId !== null) {
+      if (needsPassword) {
+        keyStore.activateKey(pendingKeyId)
+      } else {
+        // Plaintext detection plus a successful open proves the pending
+        // migration never swapped. Remove only now, after verification.
+        keyStore.removeKey(pendingKeyId)
+        removeRecoverySidecarBestEffort(vPath)
+      }
+    }
 
     if (pendingSidecarRecovery !== undefined) {
       enrollOrRepointSidecarRecovery(
@@ -280,7 +307,7 @@ function removeRecoverySidecarBestEffort(dbPath: string): void {
 export async function createDatabase(
   params: DatabaseCreateParams,
   getDbManager: () => DatabaseManager,
-  keyStore: DbKeyStoreLike
+  keyStore: DbKeyStoreProvisioningLike
 ): Promise<DatabaseOpenResult> {
   const manager = getDbManager()
 
@@ -291,7 +318,10 @@ export async function createDatabase(
   }
 
   if (params.setupPassphrase !== undefined && params.setupPassphrase !== '') {
-    const wrapped = keyStore.wrapNewDekWithPassphrase(params.path, params.setupPassphrase)
+    reconcileMissingPendingProvision(params.path, keyStore)
+    const wrapped =
+      keyStore.wrapNewPendingDekWithPassphrase?.(params.path, params.setupPassphrase) ??
+      keyStore.wrapNewDekWithPassphrase(params.path, params.setupPassphrase)
     if (!wrapped.ok) {
       return { success: false, error: PATH_ALREADY_KEYED_ERROR }
     }
@@ -301,6 +331,7 @@ export async function createDatabase(
     }
     try {
       await manager.createDatabase(params.path, wrapped.dek)
+      keyStore.activateKey?.(wrapped.keyId)
     } catch (error) {
       // The registry entry was written before the DB file exists. If creation
       // fails (disk full, permission error, path collision), roll it back so
@@ -314,10 +345,13 @@ export async function createDatabase(
     return { success: true, info: info! }
   }
 
-  const managed = keyStore.createManagedKey(params.path)
+  reconcileMissingPendingProvision(params.path, keyStore)
+  const managed =
+    keyStore.createPendingManagedKey?.(params.path) ?? keyStore.createManagedKey(params.path)
   if (managed.ok) {
     try {
       await manager.createDatabase(params.path, managed.dek)
+      keyStore.activateKey?.(managed.keyId)
     } catch (error) {
       // Same rollback as the passphrase path above: don't leave a stale
       // key-store entry when the DB file was never actually created.
@@ -334,6 +368,17 @@ export async function createDatabase(
 
   // path-already-keyed: never silently fall back to an unencrypted DB.
   return { success: false, error: PATH_ALREADY_KEYED_ERROR }
+}
+
+function reconcileMissingPendingProvision(
+  dbPath: string,
+  keyStore: DbKeyStoreProvisioningLike
+): void {
+  if (existsSync(dbPath) || keyStore.getKeyStateForPath?.(dbPath) !== 'pending') return
+  const keyId = keyStore.getKeyIdForPath?.(dbPath)
+  if (keyId === undefined || keyId === null) return
+  keyStore.removeKey(keyId)
+  removeRecoverySidecarBestEffort(dbPath)
 }
 
 /**

--- a/src/main/ipc/handlers/database-lifecycle-logic.ts
+++ b/src/main/ipc/handlers/database-lifecycle-logic.ts
@@ -33,6 +33,32 @@ export interface DatabaseLifecycleCallbacks {
   triggerStartupRebuild: (db: DatabaseService) => void
 }
 
+/**
+ * Attach `keyManaged` to a `DatabaseInfo` snapshot by checking whether its
+ * `path` has a key-store registry entry. `null` passes through unchanged. A
+ * non-SQLite (PostgreSQL) session's `path` is never registered in the
+ * SQLite key-store, so this naturally resolves to `keyManaged: false` for it
+ * without needing a separate backend check.
+ */
+function attachKeyManaged(
+  info: DatabaseInfo | null,
+  keyStore: Pick<DbKeyStoreWithRecoveryLike, 'getKeyIdForPath'>
+): DatabaseInfo | null {
+  if (info === null) return null
+  return { ...info, keyManaged: keyStore.getKeyIdForPath(info.path) !== null }
+}
+
+/**
+ * Attach a statically-known `keyManaged` value to a `DatabaseInfo` snapshot.
+ * Used by `createDatabase`, whose three branches already know for certain
+ * whether a key-store entry was (or wasn't) minted for the path just
+ * created, so no registry lookup is needed.
+ */
+function withKeyManaged(info: DatabaseInfo | null, keyManaged: boolean): DatabaseInfo | null {
+  if (info === null) return null
+  return { ...info, keyManaged }
+}
+
 /** Params accepted by `createDatabase`. See task-I2a-brief.md for the 3-path design. */
 export interface DatabaseCreateParams {
   path: string
@@ -45,9 +71,6 @@ export interface DatabaseCreateParams {
    */
   setupPassphrase?: string
 }
-
-/** Outcome of resolving a user-supplied password/passphrase attempt. */
-type PasswordResolution = { kind: 'resolved'; dek: string } | { kind: 'wrong-passphrase' }
 
 /**
  * After a successful sidecar-based passphrase recovery, make future opens at
@@ -92,35 +115,45 @@ function enrollOrRepointSidecarRecovery(
  * behavior), then a portable recovery sidecar next to the database file
  * (self-healing the registry on success -- see
  * `enrollOrRepointSidecarRecovery`), then the legacy fallback of treating the
- * supplied value as a raw SQLCipher key. A wrong passphrase against a
- * genuine sidecar is a typed failure -- it never falls through to being
- * treated as a raw key.
+ * supplied value as a raw SQLCipher key.
+ *
+ * A sidecar unwrap failure (wrong passphrase against a genuine sidecar, OR a
+ * STALE sidecar left behind by a legacy `rekeyDatabase` call that changed
+ * the real SQLCipher key without updating the sidecar/registry) is NEVER
+ * terminal here: it falls through to the legacy raw-key fallback below, so
+ * the database's actual current password can still open it. If that raw-key
+ * attempt is also wrong, `manager.switchDatabase` in `openDatabase` throws
+ * `WrongPasswordError`, which is what ultimately surfaces `WRONG_PASSWORD`
+ * to the caller -- this function itself never fails closed.
  */
 function resolvePasswordAttempt(
   vPath: string,
   vPassword: string,
   keyStore: DbKeyStoreWithRecoveryLike
-): PasswordResolution {
+): string {
   const viaRegistry = keyStore.resolveKeyWithPassphrase(vPath, vPassword)
   if (viaRegistry.ok) {
-    return { kind: 'resolved', dek: viaRegistry.dek }
+    return viaRegistry.dek
   }
 
   if (recoverySidecarExists(vPath)) {
     const sidecar = readRecoverySidecar(vPath)
     if (sidecar !== null) {
       const viaSidecar = keyStore.resolveKeyWithPassphraseFromSidecar(sidecar.passWrap, vPassword)
-      if (!viaSidecar.ok) {
-        return { kind: 'wrong-passphrase' }
+      if (viaSidecar.ok) {
+        enrollOrRepointSidecarRecovery(vPath, viaSidecar.dek, sidecar.passWrap, keyStore)
+        return viaSidecar.dek
       }
-      enrollOrRepointSidecarRecovery(vPath, viaSidecar.dek, sidecar.passWrap, keyStore)
-      return { kind: 'resolved', dek: viaSidecar.dek }
+      // Sidecar unwrap failed -- fall through to the raw-key fallback below
+      // rather than failing closed. See the doc comment above.
     }
   }
 
-  // No registry entry and no (parseable) sidecar at this path: legacy
-  // fallback -- treat the supplied value as a raw SQLCipher key, unchanged.
-  return { kind: 'resolved', dek: vPassword }
+  // No registry entry and no successful sidecar resolution at this path:
+  // legacy fallback -- treat the supplied value as a raw SQLCipher key,
+  // unchanged. A wrong value here surfaces as WRONG_PASSWORD from the actual
+  // `switchDatabase` attempt, not from this function.
+  return vPassword
 }
 
 /**
@@ -161,11 +194,7 @@ export async function openDatabase(
       }
       effectiveKey = resolved.dek
     } else {
-      const resolution = resolvePasswordAttempt(vPath, vPassword, keyStore)
-      if (resolution.kind === 'wrong-passphrase') {
-        return { success: false, error: 'WRONG_PASSWORD' }
-      }
-      effectiveKey = resolution.dek
+      effectiveKey = resolvePasswordAttempt(vPath, vPassword, keyStore)
     }
   }
 
@@ -185,7 +214,7 @@ export async function openDatabase(
       )
     }
 
-    const info = manager.getCurrentInfo()
+    const info = attachKeyManaged(manager.getCurrentInfo(), keyStore)
     return { success: true, info: info! }
   } catch (error) {
     if (error instanceof WrongPasswordError) {
@@ -221,7 +250,7 @@ export async function createDatabase(
 
   if (params.password !== undefined && params.password !== '') {
     await manager.createDatabase(params.path, params.password)
-    const info = manager.getCurrentInfo()
+    const info = withKeyManaged(manager.getCurrentInfo(), false)
     return { success: true, info: info! }
   }
 
@@ -240,7 +269,7 @@ export async function createDatabase(
       keyStore.removeKey(wrapped.keyId)
       throw error
     }
-    const info = manager.getCurrentInfo()
+    const info = withKeyManaged(manager.getCurrentInfo(), true)
     return { success: true, info: info! }
   }
 
@@ -254,7 +283,7 @@ export async function createDatabase(
       keyStore.removeKey(managed.keyId)
       throw error
     }
-    const info = manager.getCurrentInfo()
+    const info = withKeyManaged(manager.getCurrentInfo(), true)
     return { success: true, info: info! }
   }
 
@@ -267,13 +296,38 @@ export async function createDatabase(
 }
 
 /**
- * Change the encryption key for the current database.
+ * Change the encryption key for the current database via `PRAGMA rekey`.
+ *
+ * REFUSED for a key-store-managed database (one with a registry entry for
+ * its current path -- i.e. created encrypted-by-default, or migrated to
+ * encrypted). A `PRAGMA rekey` changes the LIVE SQLCipher key directly,
+ * without touching the key-store's wrapped DEK/registry entry/recovery
+ * sidecar/live session key -- the next open would then resolve the STALE
+ * DEK and fail with `WRONG_PASSWORD`, and a mismatched recovery sidecar left
+ * behind by the stale DEK could otherwise make even the correct raw
+ * password unusable. Managed databases must use `setRecoveryPassphrase`
+ * instead, which re-wraps the SAME DEK and never touches the live key.
+ *
+ * Legacy `rekey` stays valid ONLY for explicit-user-password databases that
+ * have no key-store entry for their current path.
  */
 export function rekeyDatabase(
   newPassword: string,
-  getDbManager: () => DatabaseManager
+  getDbManager: () => DatabaseManager,
+  keyStore: Pick<DbKeyStoreWithPassphraseLike, 'getKeyIdForPath'>
 ): { success: boolean } {
   const manager = getDbManager()
+  const currentPath = manager.getCurrentPath()
+
+  if (currentPath !== null && keyStore.getKeyIdForPath(currentPath) !== null) {
+    throw new DatabaseError(
+      'This database uses a managed encryption key and cannot have its password changed this ' +
+        'way -- doing so would desynchronize it from the encryption key registry and could make ' +
+        'the database unopenable. Use "Set Recovery Passphrase..." instead to add or replace a ' +
+        'portable recovery passphrase without changing the underlying encryption key.'
+    )
+  }
+
   manager.rekey(newPassword)
   return { success: true }
 }
@@ -336,9 +390,12 @@ export function setRecoveryPassphrase(
   return { success: true, recoveryPassphraseSet: true, sidecarWritten: result.sidecarWritten }
 }
 
-export function getDatabaseInfo(getDbManager: () => DatabaseManager): DatabaseInfo | null {
+export function getDatabaseInfo(
+  getDbManager: () => DatabaseManager,
+  keyStore: Pick<DbKeyStoreWithRecoveryLike, 'getKeyIdForPath'>
+): DatabaseInfo | null {
   const manager = getDbManager()
-  return manager.getCurrentInfo()
+  return attachKeyManaged(manager.getCurrentInfo(), keyStore)
 }
 
 export function getDatabaseCapabilities(getDbManager: () => DatabaseManager): StorageCapabilities {

--- a/src/main/ipc/handlers/database-logic.ts
+++ b/src/main/ipc/handlers/database-logic.ts
@@ -27,6 +27,8 @@ import { PostgresConnectionProfileInputSchema } from '../../storage/postgres/pos
 import type { DatabaseService } from '../../database/DatabaseService'
 import type { DatabaseManager } from '../../services/DatabaseManager'
 import type { DbPool } from '../../database/DbPool'
+import type { DbKeyStore } from '../../database/db-key-store'
+import { removeRecoverySidecar } from '../../database/recovery-sidecar'
 import type { StorageSession } from '../../storage/session'
 import type { DatabaseOpenResult } from '../../../shared/ipc/domains/database'
 import type {
@@ -385,7 +387,8 @@ export function removeRecentDatabase(
  */
 export async function deleteDbFile(
   path: string,
-  getDbManager: () => DatabaseManager
+  getDbManager: () => DatabaseManager,
+  keyStore: Pick<DbKeyStore, 'getKeyIdForPath' | 'removeKey'>
 ): Promise<{ success: boolean }> {
   // Canonicalize to resolve any ../ segments (defense-in-depth)
   const canonicalPath = resolve(path)
@@ -407,6 +410,7 @@ export async function deleteDbFile(
   }
 
   const currentPath = manager.getCurrentPath()
+  const keyId = keyStore.getKeyIdForPath(canonicalPath)
 
   // Refuse to delete the currently active database
   if (currentPath === canonicalPath) {
@@ -416,7 +420,7 @@ export async function deleteDbFile(
   }
 
   if (!existsSync(canonicalPath)) {
-    // File already gone -- just remove from recent list
+    removeManagedDatabaseArtifacts(canonicalPath, keyId, keyStore)
     manager.removeRecentDatabase(canonicalPath)
     return { success: true }
   }
@@ -447,7 +451,18 @@ export async function deleteDbFile(
     }
   }
 
+  removeManagedDatabaseArtifacts(canonicalPath, keyId, keyStore)
+
   manager.removeRecentDatabase(canonicalPath)
   mainLogger.info(`Deleted database file: ${canonicalPath}`, 'database')
   return { success: true }
+}
+
+function removeManagedDatabaseArtifacts(
+  dbPath: string,
+  keyId: string | null,
+  keyStore: Pick<DbKeyStore, 'removeKey'>
+): void {
+  if (keyId !== null) keyStore.removeKey(keyId)
+  removeRecoverySidecar(dbPath)
 }

--- a/src/main/ipc/handlers/database-logic.ts
+++ b/src/main/ipc/handlers/database-logic.ts
@@ -169,6 +169,7 @@ export {
   openDatabase,
   createDatabase,
   rekeyDatabase,
+  setRecoveryPassphrase,
   getDatabaseInfo,
   getDatabaseCapabilities,
   getPostgresDiagnostics

--- a/src/main/ipc/handlers/database-logic.ts
+++ b/src/main/ipc/handlers/database-logic.ts
@@ -11,7 +11,6 @@ import { extname, resolve } from 'path'
 import { Pool } from 'pg'
 import { z } from 'zod'
 import { mainLogger } from '../../services/MainLogger'
-import { WrongPasswordError } from '../../database/errors'
 import { convertBigInts } from '../../utils/convertBigInts'
 import {
   buildPostgresPoolConfig,
@@ -30,7 +29,6 @@ import type { DatabaseManager } from '../../services/DatabaseManager'
 import type { DbPool } from '../../database/DbPool'
 import type { StorageSession } from '../../storage/session'
 import type { DatabaseOpenResult } from '../../../shared/ipc/domains/database'
-import type { StorageCapabilities } from '../../../shared/types/storage-capabilities'
 import type {
   PostgresConnectionProfileInput,
   PostgresConnectionProfilePublic,
@@ -66,11 +64,6 @@ export interface PostgresProfileOpenDependencies {
   profileStore: Pick<PostgresProfileStoreLike, 'listProfiles' | 'getProfileSecrets'>
   getDbManager: () => Pick<DatabaseManager, 'openPostgresSession' | 'getCurrentInfo'>
   createSession?: (config: PostgresStorageConfig) => Promise<StorageSession> | StorageSession
-}
-
-/** Callbacks for pool init and cohort rebuild during database open/create. */
-export interface DatabaseLifecycleCallbacks {
-  triggerStartupRebuild: (db: DatabaseService) => void
 }
 
 export function createDefaultPostgresPool(config: PostgresStorageConfig): PostgresPoolLike {
@@ -165,131 +158,22 @@ function errorWithCause(message: string, cause: unknown): Error {
 }
 
 // ============================================================
-// Database Lifecycle
+// Database Lifecycle + Info
 // ============================================================
+// Split into database-lifecycle-logic.ts to keep this file under the repo's
+// LLM-sustainable size guideline; re-exported here so this stays the single
+// stable import surface for handlers and tests (same pattern as the
+// `createPostgresStorageSession` re-export above).
 
-/**
- * Open a database: detect encryption, validate password, switch connection.
- */
-export async function openDatabase(
-  params: { path: string; password?: string },
-  getDb: () => DatabaseService,
-  getDbManager: () => DatabaseManager,
-  callbacks: DatabaseLifecycleCallbacks
-): Promise<{
-  success: boolean
-  needsPassword?: boolean
-  error?: string
-  info?: { path: string; name: string; encrypted: boolean }
-}> {
-  const manager = getDbManager()
-  const { path: vPath, password: vPassword } = params
-
-  // First detect if database is encrypted
-  const { needsPassword } = manager.openDetectEncryption(vPath)
-
-  // If encrypted and no password provided, return early
-  if (needsPassword && (vPassword === undefined || vPassword === '')) {
-    return {
-      success: false,
-      needsPassword: true
-    }
-  }
-
-  // Switch to new database with rollback on failure
-  try {
-    await manager.switchDatabase(vPath, vPassword)
-    mainLogger.info(`Switched to database: ${vPath}`, 'database')
-
-    // Trigger async cohort summary rebuild if needed (non-blocking)
-    try {
-      callbacks.triggerStartupRebuild(getDb())
-    } catch (e) {
-      mainLogger.warn(
-        'triggerStartupRebuildIfNeeded failed (best effort -- database open continues): ' +
-          (e instanceof Error ? e.message : String(e)),
-        'database'
-      )
-    }
-
-    const info = manager.getCurrentInfo()
-    return { success: true, info: info! }
-  } catch (error) {
-    if (error instanceof WrongPasswordError) {
-      return { success: false, error: 'WRONG_PASSWORD' }
-    }
-    throw error
-  }
-}
-
-/**
- * Create a new database at the specified path.
- */
-export async function createDatabase(
-  params: { path: string; password?: string },
-  getDbManager: () => DatabaseManager
-): Promise<{ success: boolean; info: { path: string; name: string; encrypted: boolean } }> {
-  const manager = getDbManager()
-  await manager.createDatabase(params.path, params.password)
-
-  const info = manager.getCurrentInfo()
-  return { success: true, info: info! }
-}
-
-/**
- * Change the encryption key for the current database.
- */
-export function rekeyDatabase(
-  newPassword: string,
-  getDbManager: () => DatabaseManager
-): { success: boolean } {
-  const manager = getDbManager()
-  manager.rekey(newPassword)
-  return { success: true }
-}
-
-// ============================================================
-// Database Info
-// ============================================================
-
-export function getDatabaseInfo(
-  getDbManager: () => DatabaseManager
-): { path: string; name: string; encrypted: boolean } | null {
-  const manager = getDbManager()
-  return manager.getCurrentInfo()
-}
-
-export function getDatabaseCapabilities(getDbManager: () => DatabaseManager): StorageCapabilities {
-  return getDbManager().getCurrentSession().capabilities
-}
-
-export async function getPostgresDiagnostics(
-  getDbManager: () => DatabaseManager
-): Promise<PostgresHealthDiagnosticResult> {
-  const session = getDbManager().getCurrentSession()
-  if (session.capabilities.backend !== 'postgres' || session.workspace.kind !== 'postgres') {
-    return {
-      ok: false,
-      schema: '',
-      message: 'PostgreSQL diagnostics are only available for PostgreSQL sessions'
-    }
-  }
-
-  const collectDiagnostics = (
-    session as {
-      collectDiagnostics?: () => Promise<PostgresHealthDiagnosticResult>
-    }
-  ).collectDiagnostics
-  if (collectDiagnostics !== undefined) {
-    return await collectDiagnostics.call(session)
-  }
-
-  return {
-    ok: false,
-    schema: session.workspace.schema,
-    message: 'Current PostgreSQL session does not expose diagnostics'
-  }
-}
+export {
+  openDatabase,
+  createDatabase,
+  rekeyDatabase,
+  getDatabaseInfo,
+  getDatabaseCapabilities,
+  getPostgresDiagnostics
+} from './database-lifecycle-logic'
+export type { DatabaseLifecycleCallbacks, DatabaseCreateParams } from './database-lifecycle-logic'
 
 // ============================================================
 // PostgreSQL Profile Management

--- a/src/main/ipc/handlers/database-migration-logic.ts
+++ b/src/main/ipc/handlers/database-migration-logic.ts
@@ -29,6 +29,7 @@ import type {
   MigrateToEncryptedResult
 } from '../../../shared/ipc/domains/database'
 import type { DatabaseLifecycleCallbacks } from './database-lifecycle-logic'
+import { removeRecoverySidecar } from '../../database/recovery-sidecar'
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -92,6 +93,7 @@ export async function migrateCurrentToEncrypted(
   let dek: string
   let keyId: string
   let recoveryPassphraseSet = false
+  let passphraseOnly = false
 
   if (managed.ok) {
     dek = managed.dek
@@ -113,7 +115,15 @@ export async function migrateCurrentToEncrypted(
     }
     dek = wrapped.dek
     keyId = wrapped.keyId
+    if (!wrapped.sidecarWritten) {
+      keyStore.removeKey(keyId)
+      throw new DatabaseError(
+        'The required recovery sidecar could not be written. The database was not migrated; ' +
+          'check the database directory permissions and try again.'
+      )
+    }
     recoveryPassphraseSet = true
+    passphraseOnly = true
   } else {
     // No keyring AND no passphrase: refuse outright. Never half-migrate.
     throw new DatabaseError(
@@ -128,11 +138,14 @@ export async function migrateCurrentToEncrypted(
     // We minted a key-store entry above but never touched the database file
     // -- roll the entry back so a retry at the same path isn't burned.
     keyStore.removeKey(keyId)
+    if (passphraseOnly) removeRecoverySidecarBestEffort(currentPath)
     throw error
   }
 
+  let migrationCompleted = false
   try {
     const migration = migratePlaintextToEncrypted({ path: currentPath, dek, keyId, keyStore })
+    migrationCompleted = true
 
     if (managed.ok && recoveryPassphrase !== undefined) {
       const setResult = keyStore.setPassphrase(keyId, recoveryPassphrase)
@@ -165,7 +178,7 @@ export async function migrateCurrentToEncrypted(
       success: true,
       backupPath: migration.backupPath,
       recoveryPassphraseSet,
-      info
+      info: { ...info, keyManaged: true }
     }
   } catch (error) {
     // `migratePlaintextToEncrypted` already restored/left `currentPath` as a
@@ -181,12 +194,27 @@ export async function migrateCurrentToEncrypted(
       )
     }
 
+    if (passphraseOnly && !migrationCompleted) {
+      removeRecoverySidecarBestEffort(currentPath)
+    }
+
     if (error instanceof PlaintextMigrationError || error instanceof DatabaseError) {
       throw error
     }
     throw new DatabaseError(
       `Failed to migrate database to encrypted-at-rest: ${errorMessage(error)}`,
       error instanceof Error ? error : undefined
+    )
+  }
+}
+
+function removeRecoverySidecarBestEffort(dbPath: string): void {
+  try {
+    removeRecoverySidecar(dbPath)
+  } catch (error) {
+    mainLogger.warn(
+      `Failed to remove a recovery sidecar while rolling back migration: ${errorMessage(error)}`,
+      'plaintext-migration'
     )
   }
 }

--- a/src/main/ipc/handlers/database-migration-logic.ts
+++ b/src/main/ipc/handlers/database-migration-logic.ts
@@ -73,6 +73,21 @@ export async function migrateCurrentToEncrypted(
       ? options.recoveryPassphrase
       : undefined
 
+  // `createManagedKey`/`wrapNewDekWithPassphrase` mint AND PERSIST the
+  // key-store entry immediately, before the database file has been touched
+  // at all -- so every branch below that can fail without ever reaching
+  // `migratePlaintextToEncrypted` (the `manager.close()` catch just below)
+  // rolls the entry back via `keyStore.removeKey`, mirroring the same
+  // pattern `migratePlaintextToEncrypted` itself now applies to EVERY one of
+  // its own failure paths -- including its earliest ones (source missing /
+  // already encrypted / WAL checkpoint failure) -- so no stale entry can
+  // survive a failed/aborted migration this process can catch. A genuine
+  // hard crash (SIGKILL, power loss) between this mint and a completed swap
+  // is the one scenario no in-process rollback can observe; a retry at the
+  // same path would then see `path-already-keyed` even though the database
+  // is still plaintext on disk -- a known, low-probability residual risk
+  // (see the I2b hardening review, finding 4) that would need a
+  // registry-side reconciliation step to close entirely.
   const managed = keyStore.createManagedKey(currentPath)
   let dek: string
   let keyId: string

--- a/src/main/ipc/handlers/database-migration-logic.ts
+++ b/src/main/ipc/handlers/database-migration-logic.ts
@@ -30,6 +30,7 @@ import type {
 } from '../../../shared/ipc/domains/database'
 import type { DatabaseLifecycleCallbacks } from './database-lifecycle-logic'
 import { removeRecoverySidecar } from '../../database/recovery-sidecar'
+import { fsyncContainingDirectory } from '../../database/fs-durability'
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -74,26 +75,15 @@ export async function migrateCurrentToEncrypted(
       ? options.recoveryPassphrase
       : undefined
 
-  // `createManagedKey`/`wrapNewDekWithPassphrase` mint AND PERSIST the
-  // key-store entry immediately, before the database file has been touched
-  // at all -- so every branch below that can fail without ever reaching
-  // `migratePlaintextToEncrypted` (the `manager.close()` catch just below)
-  // rolls the entry back via `keyStore.removeKey`, mirroring the same
-  // pattern `migratePlaintextToEncrypted` itself now applies to EVERY one of
-  // its own failure paths -- including its earliest ones (source missing /
-  // already encrypted / WAL checkpoint failure) -- so no stale entry can
-  // survive a failed/aborted migration this process can catch. A genuine
-  // hard crash (SIGKILL, power loss) between this mint and a completed swap
-  // is the one scenario no in-process rollback can observe; a retry at the
-  // same path would then see `path-already-keyed` even though the database
-  // is still plaintext on disk -- a known, low-probability residual risk
-  // (see the I2b hardening review, finding 4) that would need a
-  // registry-side reconciliation step to close entirely.
-  const managed = keyStore.createManagedKey(currentPath)
+  // Migration keys are persisted as pending. In-process failures remove
+  // them; a hard crash is reconciled on the next verified open: plaintext
+  // removes the abandoned entry, encrypted activates it.
+  const managed = keyStore.createPendingManagedKey(currentPath)
   let dek: string
   let keyId: string
   let recoveryPassphraseSet = false
   let passphraseOnly = false
+  let sidecarWritten: boolean | undefined
 
   if (managed.ok) {
     dek = managed.dek
@@ -106,7 +96,7 @@ export async function migrateCurrentToEncrypted(
   } else if (recoveryPassphrase !== undefined) {
     // safeStorage unavailable: fall back to a passphrase-only wrap. This is
     // the ONLY case where a passphrase is required rather than optional.
-    const wrapped = keyStore.wrapNewDekWithPassphrase(currentPath, recoveryPassphrase)
+    const wrapped = keyStore.wrapNewPendingDekWithPassphrase(currentPath, recoveryPassphrase)
     if (!wrapped.ok) {
       throw new DatabaseError(
         'This database path already has a registered encryption key -- it may already be ' +
@@ -123,6 +113,7 @@ export async function migrateCurrentToEncrypted(
       )
     }
     recoveryPassphraseSet = true
+    sidecarWritten = true
     passphraseOnly = true
   } else {
     // No keyring AND no passphrase: refuse outright. Never half-migrate.
@@ -150,6 +141,7 @@ export async function migrateCurrentToEncrypted(
     if (managed.ok && recoveryPassphrase !== undefined) {
       const setResult = keyStore.setPassphrase(keyId, recoveryPassphrase)
       recoveryPassphraseSet = setResult.ok
+      sidecarWritten = setResult.ok ? setResult.sidecarWritten : false
       if (!setResult.ok) {
         mainLogger.warn(
           'Migration succeeded but setting the recovery passphrase failed; the managed key ' +
@@ -160,6 +152,7 @@ export async function migrateCurrentToEncrypted(
     }
 
     await manager.open(currentPath, dek)
+    keyStore.activateKey(keyId)
     try {
       callbacks.triggerStartupRebuild(manager.getCurrent())
     } catch (e) {
@@ -178,6 +171,7 @@ export async function migrateCurrentToEncrypted(
       success: true,
       backupPath: migration.backupPath,
       recoveryPassphraseSet,
+      sidecarWritten,
       info: { ...info, keyManaged: true }
     }
   } catch (error) {
@@ -185,6 +179,15 @@ export async function migrateCurrentToEncrypted(
     // working plaintext database on every one of its own failure paths (see
     // its module docs). Reopen it here so the app is NEVER left without a
     // working database, regardless of which step failed.
+    if (migrationCompleted) {
+      throw new DatabaseError(
+        'The encrypted migration completed and was verified, but VarLens could not reopen the ' +
+          'new session. The encryption key remains recoverable; restart VarLens and reopen the ' +
+          'database. Keep the plaintext backup until the encrypted database opens successfully.',
+        error instanceof Error ? error : undefined
+      )
+    }
+
     try {
       await manager.open(currentPath)
     } catch (reopenError) {
@@ -263,21 +266,16 @@ export async function deletePlaintextBackup(
     return { success: true }
   }
 
-  await unlink(resolvedBackup)
-
+  // Remove plaintext-bearing sidecars first. If one fails, keep the main
+  // backup and fail the action rather than claiming all plaintext is gone.
   for (const suffix of ['-wal', '-shm']) {
     const sidecarPath = `${resolvedBackup}${suffix}`
     if (existsSync(sidecarPath)) {
-      try {
-        await unlink(sidecarPath)
-      } catch (e) {
-        mainLogger.warn(
-          `Failed to delete backup sidecar ${sidecarPath}: ${errorMessage(e)}`,
-          'database'
-        )
-      }
+      await unlink(sidecarPath)
     }
   }
+  await unlink(resolvedBackup)
+  fsyncContainingDirectory(resolvedBackup)
 
   mainLogger.info(`Deleted plaintext backup: ${resolvedBackup}`, 'database')
   return { success: true }

--- a/src/main/ipc/handlers/database-migration-logic.ts
+++ b/src/main/ipc/handlers/database-migration-logic.ts
@@ -1,0 +1,241 @@
+/**
+ * Orchestration for the consented, backed-up, REVERSIBLE plaintext -> encrypted
+ * migration IPC actions (`database:migrateToEncrypted`,
+ * `database:deletePlaintextBackup`). See `.superpowers/sdd/task-I2b-brief.md`
+ * for the full design; the actual byte-level migration algorithm lives in
+ * `src/main/database/plaintext-migration.ts` -- this module only wires it to
+ * the app's live `DatabaseManager` session and the key-store.
+ *
+ * Split out of `database-lifecycle-logic.ts` (rather than added to it) to
+ * keep both files well under the repo's LLM-sustainable size guideline; kept
+ * as a peer module rather than re-exported through `database-logic.ts`'s
+ * barrel to avoid growing that file further -- the IPC handler imports both
+ * directly.
+ */
+import { resolve } from 'path'
+import { existsSync } from 'fs'
+import { unlink } from 'fs/promises'
+import { mainLogger } from '../../services/MainLogger'
+import { DatabaseError } from '../../database/errors'
+import {
+  migratePlaintextToEncrypted,
+  PlaintextMigrationError
+} from '../../database/plaintext-migration'
+import type { DatabaseManager } from '../../services/DatabaseManager'
+import type { DbKeyStoreWithPassphraseLike } from '../../database/db-key-store'
+import type {
+  DatabaseActionResult,
+  MigrateToEncryptedOptions,
+  MigrateToEncryptedResult
+} from '../../../shared/ipc/domains/database'
+import type { DatabaseLifecycleCallbacks } from './database-lifecycle-logic'
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Orchestrate the full migration flow:
+ *  (a) require the DB be currently open + plaintext SQLite
+ *  (b) obtain a DEK -- a managed (safeStorage) key if available, else REQUIRE
+ *      a recovery passphrase (never silently skip encryption)
+ *  (c) close the live connection
+ *  (d) run `migratePlaintextToEncrypted`
+ *  (e) reopen the now-encrypted DB
+ *  (f) return the backup path + whether a recovery passphrase is set
+ *
+ * Never migrates without `options.consent === true`. On any failure, the app
+ * is left with a working (re-opened) database -- see the two `catch` blocks
+ * below and `plaintext-migration.ts`'s own rollback guarantees.
+ */
+export async function migrateCurrentToEncrypted(
+  options: MigrateToEncryptedOptions,
+  getDbManager: () => DatabaseManager,
+  keyStore: DbKeyStoreWithPassphraseLike,
+  callbacks: DatabaseLifecycleCallbacks
+): Promise<MigrateToEncryptedResult> {
+  if (options.consent !== true) {
+    throw new DatabaseError('Migrating to an encrypted database requires explicit consent.')
+  }
+
+  const manager = getDbManager()
+  const currentInfo = manager.getCurrentInfo()
+  const currentPath = manager.getCurrentPath()
+
+  if (currentInfo === null || currentPath === null || currentInfo.encrypted) {
+    throw new DatabaseError(
+      'Migration requires a currently open, plaintext SQLite database. Open one first.'
+    )
+  }
+
+  const recoveryPassphrase =
+    options.recoveryPassphrase !== undefined && options.recoveryPassphrase !== ''
+      ? options.recoveryPassphrase
+      : undefined
+
+  const managed = keyStore.createManagedKey(currentPath)
+  let dek: string
+  let keyId: string
+  let recoveryPassphraseSet = false
+
+  if (managed.ok) {
+    dek = managed.dek
+    keyId = managed.keyId
+  } else if (managed.reason === 'path-already-keyed') {
+    throw new DatabaseError(
+      'This database path already has a registered encryption key -- it may already be ' +
+        'migrated. Reopen the database to check.'
+    )
+  } else if (recoveryPassphrase !== undefined) {
+    // safeStorage unavailable: fall back to a passphrase-only wrap. This is
+    // the ONLY case where a passphrase is required rather than optional.
+    const wrapped = keyStore.wrapNewDekWithPassphrase(currentPath, recoveryPassphrase)
+    if (!wrapped.ok) {
+      throw new DatabaseError(
+        'This database path already has a registered encryption key -- it may already be ' +
+          'migrated. Reopen the database to check.'
+      )
+    }
+    dek = wrapped.dek
+    keyId = wrapped.keyId
+    recoveryPassphraseSet = true
+  } else {
+    // No keyring AND no passphrase: refuse outright. Never half-migrate.
+    throw new DatabaseError(
+      'No secure key storage is available on this system, and no recovery passphrase was ' +
+        'supplied. Provide a recovery passphrase to encrypt this database.'
+    )
+  }
+
+  try {
+    await manager.close()
+  } catch (error) {
+    // We minted a key-store entry above but never touched the database file
+    // -- roll the entry back so a retry at the same path isn't burned.
+    keyStore.removeKey(keyId)
+    throw error
+  }
+
+  try {
+    const migration = migratePlaintextToEncrypted({ path: currentPath, dek, keyId, keyStore })
+
+    if (managed.ok && recoveryPassphrase !== undefined) {
+      const setResult = keyStore.setPassphrase(keyId, recoveryPassphrase)
+      recoveryPassphraseSet = setResult.ok
+      if (!setResult.ok) {
+        mainLogger.warn(
+          'Migration succeeded but setting the recovery passphrase failed; the managed key ' +
+            'remains keyring-only.',
+          'plaintext-migration'
+        )
+      }
+    }
+
+    await manager.open(currentPath, dek)
+    try {
+      callbacks.triggerStartupRebuild(manager.getCurrent())
+    } catch (e) {
+      mainLogger.warn(
+        `triggerStartupRebuildIfNeeded failed after migration (best effort): ${errorMessage(e)}`,
+        'plaintext-migration'
+      )
+    }
+
+    const info = manager.getCurrentInfo()
+    if (info === null) {
+      throw new DatabaseError('Migration succeeded but the database session could not be reopened.')
+    }
+
+    return {
+      success: true,
+      backupPath: migration.backupPath,
+      recoveryPassphraseSet,
+      info
+    }
+  } catch (error) {
+    // `migratePlaintextToEncrypted` already restored/left `currentPath` as a
+    // working plaintext database on every one of its own failure paths (see
+    // its module docs). Reopen it here so the app is NEVER left without a
+    // working database, regardless of which step failed.
+    try {
+      await manager.open(currentPath)
+    } catch (reopenError) {
+      mainLogger.error(
+        `Failed to reopen the original database after a failed migration: ${errorMessage(reopenError)}`,
+        'plaintext-migration'
+      )
+    }
+
+    if (error instanceof PlaintextMigrationError || error instanceof DatabaseError) {
+      throw error
+    }
+    throw new DatabaseError(
+      `Failed to migrate database to encrypted-at-rest: ${errorMessage(error)}`,
+      error instanceof Error ? error : undefined
+    )
+  }
+}
+
+/**
+ * Authority check tying a backup-delete request to the CURRENTLY open
+ * database path: only `<currentPath>.plaintext-backup-<digits>` (the exact
+ * naming pattern `migratePlaintextToEncrypted` produces) is deletable --
+ * never an arbitrary caller-supplied path.
+ */
+function isPlaintextBackupOfPath(backupPath: string, currentPath: string): boolean {
+  const resolvedBackup = resolve(backupPath)
+  const resolvedCurrent = resolve(currentPath)
+  const prefix = `${resolvedCurrent}.plaintext-backup-`
+  if (!resolvedBackup.startsWith(prefix)) {
+    return false
+  }
+  const suffix = resolvedBackup.slice(prefix.length)
+  return /^\d+$/.test(suffix)
+}
+
+/**
+ * Delete a plaintext backup produced by a prior migration, plus any
+ * `-wal`/`-shm` sidecars. Refuses any path that isn't exactly the backup of
+ * the currently-open database.
+ */
+export async function deletePlaintextBackup(
+  backupPath: string,
+  getDbManager: () => DatabaseManager
+): Promise<DatabaseActionResult> {
+  const manager = getDbManager()
+  const currentPath = manager.getCurrentPath()
+
+  if (currentPath === null) {
+    throw new DatabaseError('No database is currently open.')
+  }
+
+  if (!isPlaintextBackupOfPath(backupPath, currentPath)) {
+    throw new DatabaseError(
+      'Refusing to delete a file that is not a plaintext backup of the currently open database.'
+    )
+  }
+
+  const resolvedBackup = resolve(backupPath)
+  if (!existsSync(resolvedBackup)) {
+    return { success: true }
+  }
+
+  await unlink(resolvedBackup)
+
+  for (const suffix of ['-wal', '-shm']) {
+    const sidecarPath = `${resolvedBackup}${suffix}`
+    if (existsSync(sidecarPath)) {
+      try {
+        await unlink(sidecarPath)
+      } catch (e) {
+        mainLogger.warn(
+          `Failed to delete backup sidecar ${sidecarPath}: ${errorMessage(e)}`,
+          'database'
+        )
+      }
+    }
+  }
+
+  mainLogger.info(`Deleted plaintext backup: ${resolvedBackup}`, 'database')
+  return { success: true }
+}

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -18,6 +18,7 @@ import {
   DatabaseRekeySchema,
   FilePathSchema
 } from '../../../shared/types/ipc-schemas'
+import { getDbKeyStore as getDefaultDbKeyStore } from '../../database/db-key-store-instance'
 import { triggerStartupRebuildIfNeeded } from './cohort'
 import {
   openDatabase,
@@ -205,6 +206,7 @@ export function registerDatabaseHandlers({
   getDbManager,
   getDbPool,
   getPostgresProfileStore = getDefaultPostgresProfileStore,
+  getDbKeyStore = getDefaultDbKeyStore,
   createPostgresPool = createDefaultPostgresPool,
   createPostgresSession = createPostgresStorageSession,
   collectPostgresDiagnostics
@@ -268,23 +270,26 @@ export function registerDatabaseHandlers({
         mainLogger.error(`Invalid database:open params: ${validated.error.message}`, 'database')
         throw new Error('Invalid database open parameters')
       }
-      return openDatabase(validated.data, getDb, getDbManager, lifecycleCallbacks)
+      return openDatabase(validated.data, getDb, getDbManager, lifecycleCallbacks, getDbKeyStore())
     })
   })
 
   /**
    * Create a new database at the specified path
    */
-  ipcMain.handle('database:create', async (_event, path: unknown, password?: unknown) => {
-    return wrapHandler(async () => {
-      const validated = DatabaseCreateSchema.safeParse({ path, password })
-      if (!validated.success) {
-        mainLogger.error(`Invalid database:create params: ${validated.error.message}`, 'database')
-        throw new Error('Invalid database create parameters')
-      }
-      return createDatabase(validated.data, getDbManager)
-    })
-  })
+  ipcMain.handle(
+    'database:create',
+    async (_event, path: unknown, password?: unknown, setupPassphrase?: unknown) => {
+      return wrapHandler(async () => {
+        const validated = DatabaseCreateSchema.safeParse({ path, password, setupPassphrase })
+        if (!validated.success) {
+          mainLogger.error(`Invalid database:create params: ${validated.error.message}`, 'database')
+          throw new Error('Invalid database create parameters')
+        }
+        return createDatabase(validated.data, getDbManager, getDbKeyStore())
+      })
+    }
+  )
 
   /**
    * Change the encryption key for the current database

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -18,6 +18,7 @@ import {
   DatabaseRekeySchema,
   DatabaseMigrateToEncryptedSchema,
   DatabaseDeletePlaintextBackupSchema,
+  DatabaseSetRecoveryPassphraseSchema,
   FilePathSchema
 } from '../../../shared/types/ipc-schemas'
 import { getDbKeyStore as getDefaultDbKeyStore } from '../../database/db-key-store-instance'
@@ -26,6 +27,7 @@ import {
   openDatabase,
   createDatabase,
   rekeyDatabase,
+  setRecoveryPassphrase,
   getDatabaseInfo,
   getDatabaseCapabilities,
   getPostgresDiagnostics,
@@ -305,6 +307,25 @@ export function registerDatabaseHandlers({
         throw new Error('Invalid encryption key')
       }
       return rekeyDatabase(validated.data.newPassword, getDbManager)
+    })
+  })
+
+  /**
+   * Set (or replace) a recovery passphrase on the currently open database's
+   * managed key. Non-destructive -- see `setRecoveryPassphrase` in
+   * `database-lifecycle-logic.ts` for the full contract.
+   */
+  ipcMain.handle('database:setRecoveryPassphrase', async (_event, passphrase: unknown) => {
+    return wrapHandler(async () => {
+      const validated = DatabaseSetRecoveryPassphraseSchema.safeParse({ passphrase })
+      if (!validated.success) {
+        mainLogger.error(
+          `Invalid database:setRecoveryPassphrase params: ${validated.error.message}`,
+          'database'
+        )
+        throw new Error('Invalid recovery passphrase')
+      }
+      return setRecoveryPassphrase(validated.data.passphrase, getDbManager, getDbKeyStore())
     })
   })
 

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -306,7 +306,7 @@ export function registerDatabaseHandlers({
         mainLogger.error(`Invalid database:rekey params: ${validated.error.message}`, 'database')
         throw new Error('Invalid encryption key')
       }
-      return rekeyDatabase(validated.data.newPassword, getDbManager)
+      return rekeyDatabase(validated.data.newPassword, getDbManager, getDbKeyStore())
     })
   })
 
@@ -374,7 +374,7 @@ export function registerDatabaseHandlers({
    */
   ipcMain.handle('database:info', async () => {
     return wrapHandler(async () => {
-      return getDatabaseInfo(getDbManager)
+      return getDatabaseInfo(getDbManager, getDbKeyStore())
     })
   })
 

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -16,6 +16,8 @@ import {
   DatabaseOpenSchema,
   DatabaseCreateSchema,
   DatabaseRekeySchema,
+  DatabaseMigrateToEncryptedSchema,
+  DatabaseDeletePlaintextBackupSchema,
   FilePathSchema
 } from '../../../shared/types/ipc-schemas'
 import { getDbKeyStore as getDefaultDbKeyStore } from '../../database/db-key-store-instance'
@@ -41,6 +43,7 @@ import {
   PostgresProfileIdSchema
 } from './database-logic'
 import type { DatabaseLifecycleCallbacks } from './database-logic'
+import { migrateCurrentToEncrypted, deletePlaintextBackup } from './database-migration-logic'
 import { PostgresProfileStore, type SecretStore } from '../../storage/postgres/PostgresProfileStore'
 import {
   PostgresConnectionProfileInputSchema,
@@ -302,6 +305,46 @@ export function registerDatabaseHandlers({
         throw new Error('Invalid encryption key')
       }
       return rekeyDatabase(validated.data.newPassword, getDbManager)
+    })
+  })
+
+  /**
+   * Migrate the currently-open, plaintext SQLite database to encrypted-at-rest.
+   * Requires explicit consent; see `database-migration-logic.ts`.
+   */
+  ipcMain.handle('database:migrateToEncrypted', async (_event, options: unknown) => {
+    return wrapHandler(async () => {
+      const validated = DatabaseMigrateToEncryptedSchema.safeParse(options)
+      if (!validated.success) {
+        mainLogger.error(
+          `Invalid database:migrateToEncrypted params: ${validated.error.message}`,
+          'database'
+        )
+        throw new Error('Invalid migration parameters')
+      }
+      return migrateCurrentToEncrypted(
+        validated.data,
+        getDbManager,
+        getDbKeyStore(),
+        lifecycleCallbacks
+      )
+    })
+  })
+
+  /**
+   * Delete a plaintext backup produced by a prior migration.
+   */
+  ipcMain.handle('database:deletePlaintextBackup', async (_event, backupPath: unknown) => {
+    return wrapHandler(async () => {
+      const validated = DatabaseDeletePlaintextBackupSchema.safeParse({ backupPath })
+      if (!validated.success) {
+        mainLogger.error(
+          `Invalid database:deletePlaintextBackup params: ${validated.error.message}`,
+          'database'
+        )
+        throw new Error('Invalid backup path')
+      }
+      return deletePlaintextBackup(validated.data.backupPath, getDbManager)
     })
   })
 

--- a/src/main/ipc/handlers/database.ts
+++ b/src/main/ipc/handlers/database.ts
@@ -524,7 +524,7 @@ export function registerDatabaseHandlers({
         mainLogger.error(`Invalid database:deleteFile path: ${validated.error.message}`, 'database')
         throw new Error('Invalid file path')
       }
-      return deleteDbFile(validated.data, getDbManager)
+      return deleteDbFile(validated.data, getDbManager, getDbKeyStore())
     })
   })
 

--- a/src/main/ipc/types.ts
+++ b/src/main/ipc/types.ts
@@ -1,6 +1,7 @@
 import type { IpcMain } from 'electron'
 import type { DatabaseService } from '../database/DatabaseService'
 import type { DatabaseManager } from '../services/DatabaseManager'
+import type { DbKeyStoreLike } from '../database/db-key-store'
 import type { DbPool } from '../database/DbPool'
 import type { PostgresPoolLike, PostgresProfileStoreLike } from './handlers/database-logic'
 import type { PostgresStorageConfig } from '../storage/config'
@@ -21,6 +22,8 @@ export interface HandlerDependencies {
   getDbPool?: () => DbPool | null
   /** Optional PostgreSQL profile store factory for hosted workspace profile IPC. */
   getPostgresProfileStore?: () => PostgresProfileStoreLike
+  /** Optional DB key-store factory so tests can inject a fake registry/safeStorage. */
+  getDbKeyStore?: () => DbKeyStoreLike
   /** Optional PostgreSQL pool factory so tests can avoid a real server. */
   createPostgresPool?: (config: PostgresStorageConfig) => PostgresPoolLike
   /** Optional PostgreSQL session factory so tests can avoid building repository graph. */

--- a/src/main/ipc/types.ts
+++ b/src/main/ipc/types.ts
@@ -1,7 +1,10 @@
 import type { IpcMain } from 'electron'
 import type { DatabaseService } from '../database/DatabaseService'
 import type { DatabaseManager } from '../services/DatabaseManager'
-import type { DbKeyStoreWithPassphraseLike } from '../database/db-key-store'
+import type {
+  DbKeyStoreWithPassphraseLike,
+  DbKeyStoreWithRecoveryLike
+} from '../database/db-key-store'
 import type { DbPool } from '../database/DbPool'
 import type { PostgresPoolLike, PostgresProfileStoreLike } from './handlers/database-logic'
 import type { PostgresStorageConfig } from '../storage/config'
@@ -25,9 +28,14 @@ export interface HandlerDependencies {
   /**
    * Optional DB key-store factory so tests can inject a fake registry/safeStorage.
    * Widened to include `setPassphrase` (task I2b's plaintext-migration orchestration
-   * needs it); the real singleton (`DbKeyStore`) always implements it.
+   * needs it) and the recovery-sidecar surface `openDatabase` needs
+   * (`resolveKeyWithPassphraseFromSidecar`, `findManagedKeyIdForDek`,
+   * `enrollRecoveredKey`, …) -- the same accessor feeds `openDatabase`,
+   * `createDatabase`, and `migrateCurrentToEncrypted`, so it must satisfy all
+   * three narrower `DbKeyStore*Like` types at once. The real singleton
+   * (`DbKeyStore`) always implements the full surface.
    */
-  getDbKeyStore?: () => DbKeyStoreWithPassphraseLike
+  getDbKeyStore?: () => DbKeyStoreWithPassphraseLike & DbKeyStoreWithRecoveryLike
   /** Optional PostgreSQL pool factory so tests can avoid a real server. */
   createPostgresPool?: (config: PostgresStorageConfig) => PostgresPoolLike
   /** Optional PostgreSQL session factory so tests can avoid building repository graph. */

--- a/src/main/ipc/types.ts
+++ b/src/main/ipc/types.ts
@@ -1,7 +1,7 @@
 import type { IpcMain } from 'electron'
 import type { DatabaseService } from '../database/DatabaseService'
 import type { DatabaseManager } from '../services/DatabaseManager'
-import type { DbKeyStoreLike } from '../database/db-key-store'
+import type { DbKeyStoreWithPassphraseLike } from '../database/db-key-store'
 import type { DbPool } from '../database/DbPool'
 import type { PostgresPoolLike, PostgresProfileStoreLike } from './handlers/database-logic'
 import type { PostgresStorageConfig } from '../storage/config'
@@ -22,8 +22,12 @@ export interface HandlerDependencies {
   getDbPool?: () => DbPool | null
   /** Optional PostgreSQL profile store factory for hosted workspace profile IPC. */
   getPostgresProfileStore?: () => PostgresProfileStoreLike
-  /** Optional DB key-store factory so tests can inject a fake registry/safeStorage. */
-  getDbKeyStore?: () => DbKeyStoreLike
+  /**
+   * Optional DB key-store factory so tests can inject a fake registry/safeStorage.
+   * Widened to include `setPassphrase` (task I2b's plaintext-migration orchestration
+   * needs it); the real singleton (`DbKeyStore`) always implements it.
+   */
+  getDbKeyStore?: () => DbKeyStoreWithPassphraseLike
   /** Optional PostgreSQL pool factory so tests can avoid a real server. */
   createPostgresPool?: (config: PostgresStorageConfig) => PostgresPoolLike
   /** Optional PostgreSQL session factory so tests can avoid building repository graph. */

--- a/src/main/services/DatabaseManager.ts
+++ b/src/main/services/DatabaseManager.ts
@@ -7,6 +7,7 @@
 
 import { DatabaseService } from '../database/DatabaseService'
 import { DatabaseError, WrongPasswordError } from '../database/errors'
+import { isNotADatabaseError } from '../database/sqlite-error'
 import { RecentDatabasesService, type RecentDatabase } from './RecentDatabasesService'
 import { mainLogger } from './MainLogger'
 import { createSqliteStorageSession } from '../storage/sqlite/createSqliteStorageSession'
@@ -92,10 +93,7 @@ export class DatabaseManager {
         }
       }
 
-      if (
-        error instanceof Error &&
-        error.message.includes('file is encrypted or is not a database')
-      ) {
+      if (isNotADatabaseError(error)) {
         return { needsPassword: true }
       }
 

--- a/src/main/services/DatabaseManager.ts
+++ b/src/main/services/DatabaseManager.ts
@@ -272,7 +272,12 @@ export class DatabaseManager {
    *
    * @returns Database info object, or null if no database is open
    */
-  getCurrentInfo(): { path: string; name: string; encrypted: boolean } | null {
+  getCurrentInfo(): {
+    path: string
+    name: string
+    encrypted: boolean
+    unencryptedMigratable: boolean
+  } | null {
     if (this.currentSession === null) {
       return null
     }
@@ -281,14 +286,16 @@ export class DatabaseManager {
       return {
         path: this.currentSession.workspace.connectionUrlRedacted,
         name: `PostgreSQL: ${this.currentSession.workspace.connectionLabel}`,
-        encrypted: false
+        encrypted: false,
+        unencryptedMigratable: false
       }
     }
 
     return {
       path: this.currentSession.workspace.path,
       name: this.currentSession.workspace.name,
-      encrypted: this.currentSession.workspace.encrypted
+      encrypted: this.currentSession.workspace.encrypted,
+      unencryptedMigratable: !this.currentSession.workspace.encrypted
     }
   }
 

--- a/src/main/storage/sqlite/createSqliteStorageSession.ts
+++ b/src/main/storage/sqlite/createSqliteStorageSession.ts
@@ -2,22 +2,34 @@ import { DatabaseService } from '../../database/DatabaseService'
 import { DbPool } from '../../database/DbPool'
 import { WrongPasswordError } from '../../database/errors'
 import { resolveGeneRefDbPath } from '../../database/geneReferenceLoader'
+import { isNotADatabaseError } from '../../database/sqlite-error'
 import { getWorkerThreads } from '../../ipc/dbPoolManager'
 import { SqliteStorageSession } from './SqliteStorageSession'
 
-export function createSqliteStorageSession(dbPath: string, key?: string): SqliteStorageSession {
-  const databaseService = new DatabaseService(dbPath, key)
+const hasKey = (key?: string): key is string => key !== undefined && key.length > 0
 
-  if (key !== undefined && key.length > 0) {
+export function createSqliteStorageSession(dbPath: string, key?: string): SqliteStorageSession {
+  // A wrong/missing key against an actually-encrypted file fails INSIDE the
+  // DatabaseService constructor (the `journal_mode` pragma is what triggers
+  // SQLite's read validation) -- so this must wrap the constructor call
+  // itself, not just a query issued after it succeeds.
+  let databaseService: DatabaseService
+  try {
+    databaseService = new DatabaseService(dbPath, key)
+  } catch (error) {
+    if (hasKey(key) && isNotADatabaseError(error)) {
+      throw new WrongPasswordError()
+    }
+    throw error
+  }
+
+  if (hasKey(key)) {
     try {
       databaseService.database.prepare('SELECT count(*) FROM sqlite_master').get()
     } catch (error) {
       databaseService.close()
 
-      if (
-        error instanceof Error &&
-        error.message.includes('file is encrypted or is not a database')
-      ) {
+      if (isNotADatabaseError(error)) {
         throw new WrongPasswordError()
       }
 

--- a/src/preload/domains/database.ts
+++ b/src/preload/domains/database.ts
@@ -10,6 +10,9 @@ export function createDatabaseApi(): DatabaseDomainContract {
     create: (path, password, setupPassphrase) =>
       ipcRenderer.invoke('database:create', path, password, setupPassphrase),
     rekey: (newPassword) => ipcRenderer.invoke('database:rekey', newPassword),
+    migrateToEncrypted: (options) => ipcRenderer.invoke('database:migrateToEncrypted', options),
+    deletePlaintextBackup: (backupPath) =>
+      ipcRenderer.invoke('database:deletePlaintextBackup', backupPath),
     info: () => ipcRenderer.invoke('database:info'),
     capabilities: () => ipcRenderer.invoke('database:capabilities'),
     postgresDiagnostics: () => ipcRenderer.invoke('database:postgresDiagnostics'),

--- a/src/preload/domains/database.ts
+++ b/src/preload/domains/database.ts
@@ -7,7 +7,8 @@ export function createDatabaseApi(): DatabaseDomainContract {
     selectSaveLocation: (defaultName) =>
       ipcRenderer.invoke('database:selectSaveLocation', defaultName),
     open: (path, password) => ipcRenderer.invoke('database:open', path, password),
-    create: (path, password) => ipcRenderer.invoke('database:create', path, password),
+    create: (path, password, setupPassphrase) =>
+      ipcRenderer.invoke('database:create', path, password, setupPassphrase),
     rekey: (newPassword) => ipcRenderer.invoke('database:rekey', newPassword),
     info: () => ipcRenderer.invoke('database:info'),
     capabilities: () => ipcRenderer.invoke('database:capabilities'),

--- a/src/preload/domains/database.ts
+++ b/src/preload/domains/database.ts
@@ -13,6 +13,8 @@ export function createDatabaseApi(): DatabaseDomainContract {
     migrateToEncrypted: (options) => ipcRenderer.invoke('database:migrateToEncrypted', options),
     deletePlaintextBackup: (backupPath) =>
       ipcRenderer.invoke('database:deletePlaintextBackup', backupPath),
+    setRecoveryPassphrase: (passphrase) =>
+      ipcRenderer.invoke('database:setRecoveryPassphrase', passphrase),
     info: () => ipcRenderer.invoke('database:info'),
     capabilities: () => ipcRenderer.invoke('database:capabilities'),
     postgresDiagnostics: () => ipcRenderer.invoke('database:postgresDiagnostics'),

--- a/src/renderer/src/components/CreateDatabaseDialog.vue
+++ b/src/renderer/src/components/CreateDatabaseDialog.vue
@@ -1,20 +1,36 @@
 <template>
   <v-dialog v-model="dialogOpen" max-width="500">
     <v-card>
-      <v-card-title>Create New Database</v-card-title>
+      <v-card-title>{{
+        needsPassphraseSetup ? 'Set a Database Password' : 'Create New Database'
+      }}</v-card-title>
       <v-card-text>
-        <v-text-field
-          v-model="databaseName"
-          label="Database Name"
-          hint="File will be saved as name.sqlite"
-          :error-messages="nameError"
-          @keyup.enter="selectLocation"
-        />
+        <v-alert v-if="needsPassphraseSetup" type="info" variant="tonal" class="mb-4">
+          Secure key storage isn't available on this system, so VarLens can't encrypt this database
+          automatically. Choose a password to protect it instead.
+        </v-alert>
 
-        <v-checkbox v-model="encrypt" label="Encrypt with password" color="primary" class="mt-2" />
+        <template v-if="!needsPassphraseSetup">
+          <v-text-field
+            v-model="databaseName"
+            label="Database Name"
+            hint="File will be saved as name.sqlite"
+            :error-messages="nameError"
+            @keyup.enter="selectLocation"
+          />
+
+          <v-checkbox
+            v-model="encrypt"
+            label="Encrypt with a custom password"
+            hint="Leave unchecked to encrypt automatically with a managed key"
+            persistent-hint
+            color="primary"
+            class="mt-2"
+          />
+        </template>
 
         <v-expand-transition>
-          <div v-if="encrypt">
+          <div v-if="encrypt || needsPassphraseSetup">
             <v-text-field
               v-model="password"
               label="Password"
@@ -38,7 +54,9 @@
       <v-card-actions>
         <v-spacer />
         <v-btn @click="cancel">Cancel</v-btn>
-        <v-btn color="primary" :loading="creating" @click="selectLocation">Create</v-btn>
+        <v-btn color="primary" :loading="creating" @click="submit">
+          {{ needsPassphraseSetup ? 'Set Password' : 'Create' }}
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -63,6 +81,12 @@ const creating = ref(false)
 const nameError = ref('')
 const passwordError = ref('')
 
+// First-run passphrase-setup fallback (safeStorage unavailable on this
+// system): the location was already picked on the first attempt, so this
+// mode re-uses the SAME password fields and re-submits against `pendingPath`.
+const needsPassphraseSetup = ref(false)
+const pendingPath = ref<string | null>(null)
+
 // Emits
 const emit = defineEmits<{
   'database-created': []
@@ -79,11 +103,28 @@ function show(): void {
   creating.value = false
   nameError.value = ''
   passwordError.value = ''
+  needsPassphraseSetup.value = false
+  pendingPath.value = null
   dialogOpen.value = true
 }
 
 function hide(): void {
   dialogOpen.value = false
+}
+
+function validatePasswordFields(): boolean {
+  passwordError.value = ''
+
+  if (password.value.length === 0) {
+    passwordError.value = 'Password is required'
+    return false
+  }
+  if (password.value !== confirmPassword.value) {
+    passwordError.value = 'Passwords do not match'
+    return false
+  }
+
+  return true
 }
 
 function validate(): boolean {
@@ -95,18 +136,19 @@ function validate(): boolean {
     return false
   }
 
-  if (encrypt.value) {
-    if (password.value.length === 0) {
-      passwordError.value = 'Password is required'
-      return false
-    }
-    if (password.value !== confirmPassword.value) {
-      passwordError.value = 'Passwords do not match'
-      return false
-    }
+  if (encrypt.value && !validatePasswordFields()) {
+    return false
   }
 
   return true
+}
+
+async function submit(): Promise<void> {
+  if (needsPassphraseSetup.value) {
+    await submitPassphraseSetup()
+  } else {
+    await selectLocation()
+  }
 }
 
 async function selectLocation(): Promise<void> {
@@ -132,6 +174,30 @@ async function selectLocation(): Promise<void> {
       path,
       encrypt.value ? password.value : undefined
     )
+
+    if (result.success) {
+      hide()
+      emit('database-created')
+    } else if (result.needsPassphraseSetup === true) {
+      pendingPath.value = path
+      needsPassphraseSetup.value = true
+      password.value = ''
+      confirmPassword.value = ''
+    } else {
+      passwordError.value = result.error ?? 'Failed to create database'
+    }
+  } finally {
+    creating.value = false
+  }
+}
+
+async function submitPassphraseSetup(): Promise<void> {
+  if (pendingPath.value === null || !validatePasswordFields()) return
+
+  creating.value = true
+
+  try {
+    const result = await databaseStore.createDatabase(pendingPath.value, undefined, password.value)
 
     if (result.success) {
       hide()

--- a/src/renderer/src/components/DatabasePicker.vue
+++ b/src/renderer/src/components/DatabasePicker.vue
@@ -184,9 +184,15 @@
         </template>
       </v-list-item>
 
-      <!-- Change password (only for encrypted databases) -->
+      <!-- Change password / set recovery passphrase (only for encrypted databases) -->
       <template v-if="databaseStore.isEncrypted">
         <v-divider />
+        <v-list-item @click="handleSetRecoveryPassphrase">
+          <template #prepend>
+            <v-icon :icon="mdiKeyPlus" />
+          </template>
+          <v-list-item-title>Set Recovery Passphrase...</v-list-item-title>
+        </v-list-item>
         <v-list-item @click="handleChangePassword">
           <template #prepend>
             <v-icon :icon="mdiLockReset" />
@@ -212,9 +218,14 @@
   <PasswordDialog ref="passwordDialogRef" />
   <CreateDatabaseDialog ref="createDialogRef" @database-created="handleDatabaseCreated" />
   <ChangePasswordDialog ref="changePasswordDialogRef" @password-changed="handlePasswordChanged" />
+  <SetRecoveryPassphraseDialog
+    ref="setRecoveryPassphraseDialogRef"
+    @recovery-passphrase-set="handleRecoveryPassphraseSet"
+  />
   <EncryptDatabaseDialog
     ref="encryptDialogRef"
     @database-migrated="handleDatabaseMigrated"
+    @request-recovery-passphrase="handleRequestRecoveryPassphrase"
     @error="handleEncryptDatabaseError"
   />
   <PostgresConnectionDialog
@@ -249,6 +260,7 @@ import { isWebRuntime } from '../utils/runtime-mode'
 import PasswordDialog from './PasswordDialog.vue'
 import CreateDatabaseDialog from './CreateDatabaseDialog.vue'
 import ChangePasswordDialog from './ChangePasswordDialog.vue'
+import SetRecoveryPassphraseDialog from './SetRecoveryPassphraseDialog.vue'
 import EncryptDatabaseDialog from './EncryptDatabaseDialog.vue'
 import PostgresConnectionDialog from './PostgresConnectionDialog.vue'
 import type { RecentDatabase } from '../../../shared/types/api'
@@ -263,6 +275,7 @@ import {
   mdiDeleteOutline,
   mdiFolderEye,
   mdiFolderOpen,
+  mdiKeyPlus,
   mdiLock,
   mdiLockReset,
   mdiPencil,
@@ -277,6 +290,9 @@ const isWebMode = isWebRuntime()
 const passwordDialogRef = ref<InstanceType<typeof PasswordDialog> | null>(null)
 const createDialogRef = ref<InstanceType<typeof CreateDatabaseDialog> | null>(null)
 const changePasswordDialogRef = ref<InstanceType<typeof ChangePasswordDialog> | null>(null)
+const setRecoveryPassphraseDialogRef = ref<InstanceType<typeof SetRecoveryPassphraseDialog> | null>(
+  null
+)
 const encryptDialogRef = ref<InstanceType<typeof EncryptDatabaseDialog> | null>(null)
 const postgresDialogRef = ref<InstanceType<typeof PostgresConnectionDialog> | null>(null)
 
@@ -347,12 +363,37 @@ function handleChangePassword(): void {
   changePasswordDialogRef.value?.show()
 }
 
+function handleSetRecoveryPassphrase(): void {
+  setRecoveryPassphraseDialogRef.value?.show()
+}
+
 function handleEncryptDatabase(): void {
   encryptDialogRef.value?.show()
 }
 
 function handleDatabaseMigrated(): void {
   emit('database-switched')
+}
+
+/**
+ * The "Set Recovery Passphrase Now" affordance inside `EncryptDatabaseDialog`'s
+ * success phase opens this dialog on top of it -- both dialogs are owned
+ * here so `EncryptDatabaseDialog` stays open underneath, preserving its
+ * still-pending plaintext-backup decision.
+ */
+function handleRequestRecoveryPassphrase(): void {
+  setRecoveryPassphraseDialogRef.value?.show()
+}
+
+/**
+ * Setting a recovery passphrase only re-wraps the existing key -- it never
+ * changes the live database connection or its data, so (unlike
+ * `handleDatabaseMigrated`/`handlePasswordChanged`) there is nothing here
+ * that needs a `database-switched` refresh. The dialog itself already
+ * confirms success by closing.
+ */
+function handleRecoveryPassphraseSet(): void {
+  // Intentional no-op -- see doc comment above.
 }
 
 function handleEncryptDatabaseError(message: string): void {

--- a/src/renderer/src/components/DatabasePicker.vue
+++ b/src/renderer/src/components/DatabasePicker.vue
@@ -193,7 +193,18 @@
           </template>
           <v-list-item-title>Set Recovery Passphrase...</v-list-item-title>
         </v-list-item>
-        <v-list-item @click="handleChangePassword">
+        <!--
+          "Change Password..." performs a raw `PRAGMA rekey`, which changes
+          the LIVE SQLCipher key directly. For a key-store-managed database
+          (created encrypted-by-default, or migrated to encrypted) that would
+          desynchronize the live key from the key-store's wrapped DEK and can
+          make the database unopenable -- see `rekeyDatabase` in
+          `database-lifecycle-logic.ts`. Managed databases use
+          "Set Recovery Passphrase..." above instead, which safely re-wraps
+          the SAME key. Only offer "Change Password..." for legacy
+          explicit-password databases that have no managed key.
+        -->
+        <v-list-item v-if="!databaseStore.keyManaged" @click="handleChangePassword">
           <template #prepend>
             <v-icon :icon="mdiLockReset" />
           </template>

--- a/src/renderer/src/components/DatabasePicker.vue
+++ b/src/renderer/src/components/DatabasePicker.vue
@@ -187,7 +187,7 @@
       <!-- Change password / set recovery passphrase (only for encrypted databases) -->
       <template v-if="databaseStore.isEncrypted">
         <v-divider />
-        <v-list-item @click="handleSetRecoveryPassphrase">
+        <v-list-item v-if="databaseStore.keyManaged" @click="handleSetRecoveryPassphrase">
           <template #prepend>
             <v-icon :icon="mdiKeyPlus" />
           </template>

--- a/src/renderer/src/components/DatabasePicker.vue
+++ b/src/renderer/src/components/DatabasePicker.vue
@@ -194,6 +194,17 @@
           <v-list-item-title>Change Password...</v-list-item-title>
         </v-list-item>
       </template>
+
+      <!-- Encrypt database (only for a currently open, plaintext SQLite database) -->
+      <template v-if="databaseStore.unencryptedMigratable">
+        <v-divider />
+        <v-list-item @click="handleEncryptDatabase">
+          <template #prepend>
+            <v-icon :icon="mdiLock" />
+          </template>
+          <v-list-item-title>Encrypt Database...</v-list-item-title>
+        </v-list-item>
+      </template>
     </v-list>
   </v-menu>
 
@@ -201,6 +212,11 @@
   <PasswordDialog ref="passwordDialogRef" />
   <CreateDatabaseDialog ref="createDialogRef" @database-created="handleDatabaseCreated" />
   <ChangePasswordDialog ref="changePasswordDialogRef" @password-changed="handlePasswordChanged" />
+  <EncryptDatabaseDialog
+    ref="encryptDialogRef"
+    @database-migrated="handleDatabaseMigrated"
+    @error="handleEncryptDatabaseError"
+  />
   <PostgresConnectionDialog
     ref="postgresDialogRef"
     @saved="handlePostgresProfileSaved"
@@ -233,6 +249,7 @@ import { isWebRuntime } from '../utils/runtime-mode'
 import PasswordDialog from './PasswordDialog.vue'
 import CreateDatabaseDialog from './CreateDatabaseDialog.vue'
 import ChangePasswordDialog from './ChangePasswordDialog.vue'
+import EncryptDatabaseDialog from './EncryptDatabaseDialog.vue'
 import PostgresConnectionDialog from './PostgresConnectionDialog.vue'
 import type { RecentDatabase } from '../../../shared/types/api'
 import type { PostgresConnectionProfilePublic } from '../../../shared/types/postgres-profile'
@@ -260,6 +277,7 @@ const isWebMode = isWebRuntime()
 const passwordDialogRef = ref<InstanceType<typeof PasswordDialog> | null>(null)
 const createDialogRef = ref<InstanceType<typeof CreateDatabaseDialog> | null>(null)
 const changePasswordDialogRef = ref<InstanceType<typeof ChangePasswordDialog> | null>(null)
+const encryptDialogRef = ref<InstanceType<typeof EncryptDatabaseDialog> | null>(null)
 const postgresDialogRef = ref<InstanceType<typeof PostgresConnectionDialog> | null>(null)
 
 // Track pending password authentication
@@ -327,6 +345,18 @@ function handleEditPostgresProfile(profile: PostgresConnectionProfilePublic): vo
 
 function handleChangePassword(): void {
   changePasswordDialogRef.value?.show()
+}
+
+function handleEncryptDatabase(): void {
+  encryptDialogRef.value?.show()
+}
+
+function handleDatabaseMigrated(): void {
+  emit('database-switched')
+}
+
+function handleEncryptDatabaseError(message: string): void {
+  emit('error', message)
 }
 
 async function handlePasswordSubmit(

--- a/src/renderer/src/components/EncryptDatabaseDialog.vue
+++ b/src/renderer/src/components/EncryptDatabaseDialog.vue
@@ -93,6 +93,22 @@
             </v-btn>
           </v-alert>
 
+          <v-alert
+            v-else-if="recoverySidecarWritten === false"
+            type="warning"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            <p class="mb-2">
+              The recovery passphrase was saved locally, but the portable recovery file could not be
+              written. Do not move this database or remove this system's key storage yet.
+            </p>
+            <v-btn variant="tonal" color="warning" size="small" @click="requestRecoveryPassphrase">
+              Retry Portable Recovery Setup
+            </v-btn>
+          </v-alert>
+
           <p class="mb-2">A plaintext backup of the original, unencrypted database was kept at:</p>
           <p class="text-body-small mb-4" style="word-break: break-all">{{ backupPath }}</p>
           <p>
@@ -137,6 +153,7 @@ const submitting = ref(false)
 const deletingBackup = ref(false)
 const backupPath = ref('')
 const recoveryPassphraseSet = ref(false)
+const recoverySidecarWritten = ref<boolean | undefined>()
 
 // Emits
 const emit = defineEmits<{
@@ -167,6 +184,7 @@ function show(options: { keyringAvailable?: boolean } = {}): void {
   deletingBackup.value = false
   backupPath.value = ''
   recoveryPassphraseSet.value = false
+  recoverySidecarWritten.value = undefined
   dialogOpen.value = true
 }
 
@@ -211,6 +229,7 @@ async function submit(): Promise<void> {
     if (result.success) {
       backupPath.value = result.backupPath ?? ''
       recoveryPassphraseSet.value = result.recoveryPassphraseSet ?? false
+      recoverySidecarWritten.value = result.sidecarWritten
       phase.value = 'success'
     } else {
       submitError.value = result.error ?? 'Failed to encrypt database'

--- a/src/renderer/src/components/EncryptDatabaseDialog.vue
+++ b/src/renderer/src/components/EncryptDatabaseDialog.vue
@@ -1,0 +1,249 @@
+<template>
+  <v-dialog v-model="dialogOpen" max-width="480" :persistent="submitting">
+    <v-card>
+      <template v-if="phase === 'consent'">
+        <v-card-title>Encrypt This Database?</v-card-title>
+        <v-card-text>
+          <p class="mb-4">
+            VarLens will convert <strong>{{ databaseStore.currentName }}</strong> to an
+            encrypted-at-rest database. A plaintext backup is kept on disk until you confirm the
+            encrypted database opens correctly, so this is fully reversible.
+          </p>
+
+          <v-checkbox
+            v-model="consent"
+            label="I understand and want to encrypt this database"
+            color="primary"
+            hide-details
+          />
+
+          <v-alert
+            v-if="!keyringAvailable"
+            type="warning"
+            variant="tonal"
+            density="compact"
+            class="mt-4"
+          >
+            Secure key storage isn't available on this system. A recovery passphrase is required to
+            encrypt this database -- without it, VarLens cannot proceed.
+          </v-alert>
+
+          <v-checkbox
+            v-if="keyringAvailable"
+            v-model="setRecoveryPassphrase"
+            label="Also set a recovery passphrase (recommended)"
+            hint="If you ever lose access to this system's secure key storage, only a recovery passphrase can unlock this database again."
+            persistent-hint
+            color="primary"
+            class="mt-2"
+          />
+
+          <v-expand-transition>
+            <div v-if="!keyringAvailable || setRecoveryPassphrase">
+              <v-text-field
+                v-model="recoveryPassphrase"
+                label="Recovery Passphrase"
+                :type="showPassphrase ? 'text' : 'password'"
+                :append-inner-icon="showPassphrase ? mdiEyeOff : mdiEye"
+                :error-messages="passphraseError"
+                class="mt-2"
+                @click:append-inner="showPassphrase = !showPassphrase"
+              />
+              <v-text-field
+                v-model="confirmPassphrase"
+                label="Confirm Recovery Passphrase"
+                :type="showPassphrase ? 'text' : 'password'"
+              />
+            </div>
+          </v-expand-transition>
+
+          <v-alert v-if="submitError" type="error" variant="tonal" density="compact" class="mt-4">
+            {{ submitError }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn :disabled="submitting" @click="cancel">Cancel</v-btn>
+          <v-btn color="primary" :loading="submitting" :disabled="!consent" @click="submit">
+            Encrypt Database
+          </v-btn>
+        </v-card-actions>
+      </template>
+
+      <template v-else>
+        <v-card-title>Database Encrypted</v-card-title>
+        <v-card-text>
+          <v-alert type="success" variant="tonal" density="compact" class="mb-4">
+            The database is now encrypted at rest.
+          </v-alert>
+
+          <v-alert
+            v-if="!recoveryPassphraseSet"
+            type="warning"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            No recovery passphrase is set on this key. If this system's secure key storage is ever
+            lost, this database cannot be recovered. Use "Change Password..." to add one later.
+          </v-alert>
+
+          <p class="mb-2">A plaintext backup of the original, unencrypted database was kept at:</p>
+          <p class="text-body-small mb-4" style="word-break: break-all">{{ backupPath }}</p>
+          <p>
+            This backup contains your data <strong>unencrypted</strong>. Once you've confirmed
+            everything looks right, delete it.
+          </p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn :disabled="deletingBackup" @click="keepBackup">Keep Backup</v-btn>
+          <v-btn color="error" :loading="deletingBackup" @click="removeBackup">
+            Delete Plaintext Backup
+          </v-btn>
+        </v-card-actions>
+      </template>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useDatabaseStore } from '../stores/databaseStore'
+import { isIpcError } from '../../../shared/types/errors'
+import { mdiEye, mdiEyeOff } from '@mdi/js'
+
+const databaseStore = useDatabaseStore()
+
+type Phase = 'consent' | 'success'
+
+// Component state
+const dialogOpen = ref(false)
+const phase = ref<Phase>('consent')
+const keyringAvailable = ref(true)
+const consent = ref(false)
+const setRecoveryPassphrase = ref(false)
+const recoveryPassphrase = ref('')
+const confirmPassphrase = ref('')
+const showPassphrase = ref(false)
+const passphraseError = ref('')
+const submitError = ref('')
+const submitting = ref(false)
+const deletingBackup = ref(false)
+const backupPath = ref('')
+const recoveryPassphraseSet = ref(false)
+
+// Emits
+const emit = defineEmits<{
+  'database-migrated': []
+  error: [message: string]
+}>()
+
+/**
+ * `keyringAvailable` is a best-effort UI hint, not an authority check -- the
+ * main process makes the actual keyring-vs-passphrase decision and returns a
+ * typed error if a passphrase is required but missing. Callers should pass
+ * `databaseStore.capabilities?.workspace.encryptionAtRest` or similar if a
+ * cheap client-side signal exists; otherwise this defaults to true (the
+ * common case) and lets the submit-time error surface the real requirement.
+ */
+function show(options: { keyringAvailable?: boolean } = {}): void {
+  phase.value = 'consent'
+  keyringAvailable.value = options.keyringAvailable ?? true
+  consent.value = false
+  setRecoveryPassphrase.value = false
+  recoveryPassphrase.value = ''
+  confirmPassphrase.value = ''
+  showPassphrase.value = false
+  passphraseError.value = ''
+  submitError.value = ''
+  submitting.value = false
+  deletingBackup.value = false
+  backupPath.value = ''
+  recoveryPassphraseSet.value = false
+  dialogOpen.value = true
+}
+
+function hide(): void {
+  dialogOpen.value = false
+}
+
+function errorText(e: unknown): string {
+  return e instanceof Error ? e.message : isIpcError(e) ? (e.userMessage ?? e.message) : String(e)
+}
+
+function validatePassphrase(): boolean {
+  passphraseError.value = ''
+  const needsPassphrase = !keyringAvailable.value || setRecoveryPassphrase.value
+  if (!needsPassphrase) {
+    return true
+  }
+  if (recoveryPassphrase.value.length === 0) {
+    passphraseError.value = 'A recovery passphrase is required'
+    return false
+  }
+  if (recoveryPassphrase.value !== confirmPassphrase.value) {
+    passphraseError.value = 'Passphrases do not match'
+    return false
+  }
+  return true
+}
+
+async function submit(): Promise<void> {
+  submitError.value = ''
+  if (!consent.value || !validatePassphrase()) {
+    return
+  }
+
+  submitting.value = true
+  try {
+    const result = await databaseStore.migrateToEncrypted({
+      consent: true,
+      recoveryPassphrase: recoveryPassphrase.value.length > 0 ? recoveryPassphrase.value : undefined
+    })
+
+    if (result.success) {
+      backupPath.value = result.backupPath ?? ''
+      recoveryPassphraseSet.value = result.recoveryPassphraseSet ?? false
+      phase.value = 'success'
+    } else {
+      submitError.value = result.error ?? 'Failed to encrypt database'
+    }
+  } catch (e) {
+    submitError.value = errorText(e)
+  } finally {
+    submitting.value = false
+  }
+}
+
+function cancel(): void {
+  hide()
+}
+
+function keepBackup(): void {
+  hide()
+  emit('database-migrated')
+}
+
+async function removeBackup(): Promise<void> {
+  if (backupPath.value === '') {
+    keepBackup()
+    return
+  }
+  deletingBackup.value = true
+  try {
+    await databaseStore.deletePlaintextBackup(backupPath.value)
+    hide()
+    emit('database-migrated')
+  } catch (e) {
+    emit('error', errorText(e))
+  } finally {
+    deletingBackup.value = false
+  }
+}
+
+defineExpose({
+  show,
+  hide
+})
+</script>

--- a/src/renderer/src/components/EncryptDatabaseDialog.vue
+++ b/src/renderer/src/components/EncryptDatabaseDialog.vue
@@ -84,8 +84,13 @@
             density="compact"
             class="mb-4"
           >
-            No recovery passphrase is set on this key. If this system's secure key storage is ever
-            lost, this database cannot be recovered. Use "Change Password..." to add one later.
+            <p class="mb-2">
+              No recovery passphrase is set on this key. If this system's secure key storage is ever
+              lost, this database cannot be recovered.
+            </p>
+            <v-btn variant="tonal" color="warning" size="small" @click="requestRecoveryPassphrase">
+              Set Recovery Passphrase Now
+            </v-btn>
           </v-alert>
 
           <p class="mb-2">A plaintext backup of the original, unencrypted database was kept at:</p>
@@ -136,6 +141,7 @@ const recoveryPassphraseSet = ref(false)
 // Emits
 const emit = defineEmits<{
   'database-migrated': []
+  'request-recovery-passphrase': []
   error: [message: string]
 }>()
 
@@ -218,6 +224,16 @@ async function submit(): Promise<void> {
 
 function cancel(): void {
   hide()
+}
+
+/**
+ * Opens `SetRecoveryPassphraseDialog` on top of this one (owned by
+ * `DatabasePicker.vue`, which handles the emit) rather than closing this
+ * dialog first -- the plaintext-backup decision below is still pending and
+ * should not be lost just because the user set a passphrase first.
+ */
+function requestRecoveryPassphrase(): void {
+  emit('request-recovery-passphrase')
 }
 
 function keepBackup(): void {

--- a/src/renderer/src/components/SetRecoveryPassphraseDialog.vue
+++ b/src/renderer/src/components/SetRecoveryPassphraseDialog.vue
@@ -1,0 +1,129 @@
+<template>
+  <v-dialog v-model="dialogOpen" max-width="440">
+    <v-card>
+      <v-card-title>Set Recovery Passphrase</v-card-title>
+      <v-card-text>
+        <p class="mb-4">
+          This does <strong>not</strong> change your database password and does
+          <strong>not</strong> re-encrypt anything. It adds a portable way to recover this database
+          if you ever lose access to this system's secure key storage, or want to open it on another
+          machine. VarLens writes a small <code>.varlens-recovery.json</code> file next to the
+          database file.
+        </p>
+
+        <v-text-field
+          v-model="passphrase"
+          label="Recovery Passphrase"
+          :type="showPassphrase ? 'text' : 'password'"
+          :append-inner-icon="showPassphrase ? mdiEyeOff : mdiEye"
+          @click:append-inner="showPassphrase = !showPassphrase"
+        />
+
+        <v-text-field
+          v-model="confirmPassphrase"
+          label="Confirm Recovery Passphrase"
+          :type="showPassphrase ? 'text' : 'password'"
+          :error-messages="passphraseError"
+        />
+
+        <v-alert v-if="submitError" type="error" variant="tonal" density="compact" class="mt-4">
+          {{ submitError }}
+        </v-alert>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn :disabled="submitting" @click="cancel">Cancel</v-btn>
+        <v-btn color="primary" :loading="submitting" @click="submit">
+          Set Recovery Passphrase
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useDatabaseStore } from '../stores/databaseStore'
+import { isIpcError } from '../../../shared/types/errors'
+import { mdiEye, mdiEyeOff } from '@mdi/js'
+
+const databaseStore = useDatabaseStore()
+
+// Component state
+const dialogOpen = ref(false)
+const passphrase = ref('')
+const confirmPassphrase = ref('')
+const showPassphrase = ref(false)
+const submitting = ref(false)
+const passphraseError = ref('')
+const submitError = ref('')
+
+// Emits
+const emit = defineEmits<{
+  'recovery-passphrase-set': []
+}>()
+
+// Exposed methods
+function show(): void {
+  passphrase.value = ''
+  confirmPassphrase.value = ''
+  showPassphrase.value = false
+  submitting.value = false
+  passphraseError.value = ''
+  submitError.value = ''
+  dialogOpen.value = true
+}
+
+function hide(): void {
+  dialogOpen.value = false
+}
+
+function errorText(e: unknown): string {
+  return e instanceof Error ? e.message : isIpcError(e) ? (e.userMessage ?? e.message) : String(e)
+}
+
+function validate(): boolean {
+  passphraseError.value = ''
+
+  if (passphrase.value.length === 0) {
+    passphraseError.value = 'A recovery passphrase is required'
+    return false
+  }
+
+  if (passphrase.value !== confirmPassphrase.value) {
+    passphraseError.value = 'Passphrases do not match'
+    return false
+  }
+
+  return true
+}
+
+async function submit(): Promise<void> {
+  submitError.value = ''
+  if (!validate()) return
+
+  submitting.value = true
+  try {
+    const result = await databaseStore.setRecoveryPassphrase(passphrase.value)
+    if (result.success) {
+      hide()
+      emit('recovery-passphrase-set')
+    } else {
+      submitError.value = result.error ?? 'Failed to set recovery passphrase'
+    }
+  } catch (e) {
+    submitError.value = errorText(e)
+  } finally {
+    submitting.value = false
+  }
+}
+
+function cancel(): void {
+  hide()
+}
+
+defineExpose({
+  show,
+  hide
+})
+</script>

--- a/src/renderer/src/components/SetRecoveryPassphraseDialog.vue
+++ b/src/renderer/src/components/SetRecoveryPassphraseDialog.vue
@@ -105,9 +105,13 @@ async function submit(): Promise<void> {
   submitting.value = true
   try {
     const result = await databaseStore.setRecoveryPassphrase(passphrase.value)
-    if (result.success) {
+    if (result.success && result.sidecarWritten !== false) {
       hide()
       emit('recovery-passphrase-set')
+    } else if (result.success) {
+      submitError.value =
+        'The passphrase was updated locally, but writing the portable recovery file failed. ' +
+        'Check the database directory permissions and try again.'
     } else {
       submitError.value = result.error ?? 'Failed to set recovery passphrase'
     }

--- a/src/renderer/src/mocks/mockApi.ts
+++ b/src/renderer/src/mocks/mockApi.ts
@@ -274,7 +274,6 @@ export const mockApi: WindowAPI = {
     onProgress: () => () => {},
     cancel: async () => {}
   },
-
   system: {
     getVersion: async () => ({ app: '0.6.0-mock', electron: 'browser-mode' }),
     getUserDataPath: async () => '/mock/user/data',
@@ -283,12 +282,10 @@ export const mockApi: WindowAPI = {
     getWorkerThreads: async () => 0,
     getLogFilePath: async () => '/mock/logs/main.log'
   },
-
   export: {
     variants: async () => ({ success: true, filePath: '/mock/export.xlsx' }),
     cohort: async () => ({ success: true, filePath: '/mock/cohort_export.xlsx' })
   },
-
   shell: {
     openExternal: async (url) => {
       window.open(url, '_blank')
@@ -310,6 +307,9 @@ export const mockApi: WindowAPI = {
       info: { path: '/mock/new-database.db', name: 'New Mock Database', encrypted: false }
     }),
     rekey: async () => ({ success: true }),
+    migrateToEncrypted: async () => ({ success: true }),
+    deletePlaintextBackup: async () => ({ success: true }),
+    setRecoveryPassphrase: async () => ({ success: true, recoveryPassphraseSet: true }),
     info: async () => ({ path: '/mock/database.db', name: 'Mock Database', encrypted: false }),
     capabilities: async () => MOCK_SQLITE_CAPABILITIES,
     postgresDiagnostics: async () => ({ ok: false, schema: '' }),

--- a/src/renderer/src/stores/databaseStore.ts
+++ b/src/renderer/src/stores/databaseStore.ts
@@ -108,10 +108,16 @@ export const useDatabaseStore = defineStore('database', () => {
     }
   }
 
-  async function createDatabase(path: string, password?: string): Promise<DatabaseOpenResult> {
+  async function createDatabase(
+    path: string,
+    password?: string,
+    setupPassphrase?: string
+  ): Promise<DatabaseOpenResult> {
     isLoading.value = true
     try {
-      const result = unwrapIpcResult(await getApi().database.create(path, password))
+      const result = unwrapIpcResult(
+        await getApi().database.create(path, password, setupPassphrase)
+      )
       if (result.success && result.info) {
         currentPath.value = result.info.path
         currentName.value = result.info.name

--- a/src/renderer/src/stores/databaseStore.ts
+++ b/src/renderer/src/stores/databaseStore.ts
@@ -38,6 +38,16 @@ export const useDatabaseStore = defineStore('database', () => {
   const currentName = ref<string>('')
   const isEncrypted = ref<boolean>(false)
   const unencryptedMigratable = ref<boolean>(false)
+  /**
+   * True when the current database has a key-store registry entry --
+   * created encrypted-by-default, or migrated to encrypted. Gates the
+   * "Change Password..." action in `DatabasePicker.vue`: a managed
+   * database's `PRAGMA rekey` would desynchronize the live SQLCipher key
+   * from the key-store's wrapped DEK, so managed databases must use
+   * "Set Recovery Passphrase..." instead. See `rekeyDatabase` in
+   * `database-lifecycle-logic.ts`.
+   */
+  const keyManaged = ref<boolean>(false)
   const isLoading = ref<boolean>(false)
   const recentDatabases = ref<RecentDatabase[]>([])
   const capabilities = ref<StorageCapabilities | null>(null)
@@ -52,6 +62,7 @@ export const useDatabaseStore = defineStore('database', () => {
     currentName.value = info.name
     isEncrypted.value = info.encrypted
     unencryptedMigratable.value = info.unencryptedMigratable ?? false
+    keyManaged.value = info.keyManaged ?? false
   }
 
   async function fetchInfo(): Promise<void> {
@@ -64,6 +75,7 @@ export const useDatabaseStore = defineStore('database', () => {
       currentName.value = ''
       isEncrypted.value = false
       unencryptedMigratable.value = false
+      keyManaged.value = false
       capabilities.value = null
     }
     await fetchRecent()
@@ -220,6 +232,7 @@ export const useDatabaseStore = defineStore('database', () => {
     currentName,
     isEncrypted,
     unencryptedMigratable,
+    keyManaged,
     isLoading,
     recentDatabases,
     capabilities,

--- a/src/renderer/src/stores/databaseStore.ts
+++ b/src/renderer/src/stores/databaseStore.ts
@@ -8,6 +8,11 @@ import { defineStore } from 'pinia'
 import type { DatabaseOpenResult, RecentDatabase, WindowAPI } from '../../../shared/types/api'
 import { unwrapIpcResult } from '../../../shared/types/errors'
 import type {
+  DatabaseInfo,
+  MigrateToEncryptedOptions,
+  MigrateToEncryptedResult
+} from '../../../shared/ipc/domains/database'
+import type {
   PostgresConnectionProfileInput,
   PostgresConnectionProfilePublic,
   PostgresConnectionProfileSaveInput,
@@ -31,6 +36,7 @@ export const useDatabaseStore = defineStore('database', () => {
   const currentPath = ref<string | null>(null)
   const currentName = ref<string>('')
   const isEncrypted = ref<boolean>(false)
+  const unencryptedMigratable = ref<boolean>(false)
   const isLoading = ref<boolean>(false)
   const recentDatabases = ref<RecentDatabase[]>([])
   const capabilities = ref<StorageCapabilities | null>(null)
@@ -38,17 +44,25 @@ export const useDatabaseStore = defineStore('database', () => {
   const isTestingPostgres = ref<boolean>(false)
 
   // Actions
+
+  /** Applies a `DatabaseInfo` snapshot to the current-database state refs. */
+  function applyInfo(info: DatabaseInfo): void {
+    currentPath.value = info.path
+    currentName.value = info.name
+    isEncrypted.value = info.encrypted
+    unencryptedMigratable.value = info.unencryptedMigratable ?? false
+  }
+
   async function fetchInfo(): Promise<void> {
     const info = unwrapIpcResult(await getApi().database.info())
     if (info) {
-      currentPath.value = info.path
-      currentName.value = info.name
-      isEncrypted.value = info.encrypted
+      applyInfo(info)
       await loadCapabilities()
     } else {
       currentPath.value = null
       currentName.value = ''
       isEncrypted.value = false
+      unencryptedMigratable.value = false
       capabilities.value = null
     }
     await fetchRecent()
@@ -96,9 +110,7 @@ export const useDatabaseStore = defineStore('database', () => {
     try {
       const result = unwrapIpcResult(await getApi().database.open(path, password))
       if (result.success && result.info) {
-        currentPath.value = result.info.path
-        currentName.value = result.info.name
-        isEncrypted.value = result.info.encrypted
+        applyInfo(result.info)
         await loadCapabilities()
         await fetchRecent()
       }
@@ -119,9 +131,7 @@ export const useDatabaseStore = defineStore('database', () => {
         await getApi().database.create(path, password, setupPassphrase)
       )
       if (result.success && result.info) {
-        currentPath.value = result.info.path
-        currentName.value = result.info.name
-        isEncrypted.value = result.info.encrypted
+        applyInfo(result.info)
         await loadCapabilities()
         await fetchRecent()
       }
@@ -136,9 +146,7 @@ export const useDatabaseStore = defineStore('database', () => {
     try {
       const result = unwrapIpcResult(await getApi().database.postgresProfileOpen(profileId))
       if (result.success && result.info) {
-        currentPath.value = result.info.path
-        currentName.value = result.info.name
-        isEncrypted.value = result.info.encrypted
+        applyInfo(result.info)
         await loadCapabilities()
         await fetchRecent()
         await fetchPostgresProfiles()
@@ -167,10 +175,39 @@ export const useDatabaseStore = defineStore('database', () => {
     return unwrapIpcResult(await getApi().database.rekey(newPassword))
   }
 
+  /**
+   * Migrate the currently-open plaintext database to encrypted-at-rest.
+   * Requires explicit consent (`options.consent === true`). On success,
+   * refreshes the current-database state (now encrypted) and the recent
+   * list, matching `openDatabase`/`createDatabase`.
+   */
+  async function migrateToEncrypted(
+    options: MigrateToEncryptedOptions
+  ): Promise<MigrateToEncryptedResult> {
+    isLoading.value = true
+    try {
+      const result = unwrapIpcResult(await getApi().database.migrateToEncrypted(options))
+      if (result.success && result.info) {
+        applyInfo(result.info)
+        await loadCapabilities()
+        await fetchRecent()
+      }
+      return result
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Delete a plaintext backup produced by a prior `migrateToEncrypted` call. */
+  async function deletePlaintextBackup(backupPath: string): Promise<{ success: boolean }> {
+    return unwrapIpcResult(await getApi().database.deletePlaintextBackup(backupPath))
+  }
+
   return {
     currentPath,
     currentName,
     isEncrypted,
+    unencryptedMigratable,
     isLoading,
     recentDatabases,
     capabilities,
@@ -188,6 +225,8 @@ export const useDatabaseStore = defineStore('database', () => {
     openPostgresProfile,
     selectAndOpenFile,
     selectSaveLocation,
-    changePassword
+    changePassword,
+    migrateToEncrypted,
+    deletePlaintextBackup
   }
 })

--- a/src/renderer/src/stores/databaseStore.ts
+++ b/src/renderer/src/stores/databaseStore.ts
@@ -10,7 +10,8 @@ import { unwrapIpcResult } from '../../../shared/types/errors'
 import type {
   DatabaseInfo,
   MigrateToEncryptedOptions,
-  MigrateToEncryptedResult
+  MigrateToEncryptedResult,
+  SetRecoveryPassphraseResult
 } from '../../../shared/ipc/domains/database'
 import type {
   PostgresConnectionProfileInput,
@@ -203,6 +204,17 @@ export const useDatabaseStore = defineStore('database', () => {
     return unwrapIpcResult(await getApi().database.deletePlaintextBackup(backupPath))
   }
 
+  /**
+   * Set (or replace) a recovery passphrase on the current database's managed
+   * key. Non-destructive -- unlike `changePassword`, this never re-keys the
+   * live database; it only envelope-wraps the existing DEK and writes the
+   * portable recovery sidecar. Throws (via `unwrapIpcResult`) a typed error
+   * for databases with no managed key (explicit-password or unencrypted).
+   */
+  async function setRecoveryPassphrase(passphrase: string): Promise<SetRecoveryPassphraseResult> {
+    return unwrapIpcResult(await getApi().database.setRecoveryPassphrase(passphrase))
+  }
+
   return {
     currentPath,
     currentName,
@@ -227,6 +239,7 @@ export const useDatabaseStore = defineStore('database', () => {
     selectSaveLocation,
     changePassword,
     migrateToEncrypted,
-    deletePlaintextBackup
+    deletePlaintextBackup,
+    setRecoveryPassphrase
   }
 })

--- a/src/shared/ipc/domains/database.ts
+++ b/src/shared/ipc/domains/database.ts
@@ -18,6 +18,12 @@ export interface DatabaseInfo {
 export interface DatabaseOpenResult {
   success: boolean
   needsPassword?: boolean
+  /**
+   * Set on a `create` call when no password/DEK could be minted transparently
+   * (safeStorage unavailable). The caller must collect a passphrase from the
+   * user and re-call `create(path, undefined, setupPassphrase)`.
+   */
+  needsPassphraseSetup?: boolean
   error?: string
   info?: DatabaseInfo
 }
@@ -36,7 +42,16 @@ export interface DatabaseDomainContract {
   selectFile: () => Promise<string | null>
   selectSaveLocation: (defaultName: string) => Promise<string | null>
   open: (path: string, password?: string) => Promise<IpcResult<DatabaseOpenResult>>
-  create: (path: string, password?: string) => Promise<IpcResult<DatabaseOpenResult>>
+  /**
+   * `setupPassphrase` is only used to complete the safeStorage-unavailable
+   * fallback signalled by a prior `create` call's `needsPassphraseSetup`.
+   * It wraps a freshly generated DEK -- it is never itself the SQLCipher key.
+   */
+  create: (
+    path: string,
+    password?: string,
+    setupPassphrase?: string
+  ) => Promise<IpcResult<DatabaseOpenResult>>
   rekey: (newPassword: string) => Promise<IpcResult<DatabaseActionResult>>
   info: () => Promise<IpcResult<DatabaseInfo | null>>
   capabilities: () => Promise<IpcResult<StorageCapabilities>>

--- a/src/shared/ipc/domains/database.ts
+++ b/src/shared/ipc/domains/database.ts
@@ -13,6 +13,12 @@ export interface DatabaseInfo {
   path: string
   name: string
   encrypted: boolean
+  /**
+   * True when this is a currently-open, plaintext, local SQLite database --
+   * i.e. it is eligible for the `migrateToEncrypted` action. Absent/false for
+   * encrypted databases and for non-SQLite (e.g. PostgreSQL) sessions.
+   */
+  unencryptedMigratable?: boolean
 }
 
 export interface DatabaseOpenResult {
@@ -38,6 +44,34 @@ export interface DatabaseActionResult {
   success: boolean
 }
 
+export interface MigrateToEncryptedOptions {
+  /**
+   * Must be `true` -- migration is only ever performed with explicit user
+   * consent. Never inferred or defaulted; a request without consent is
+   * refused before anything is touched.
+   */
+  consent: boolean
+  /**
+   * Recovery passphrase for the migrated database's key.
+   *  - REQUIRED when no OS keyring (safeStorage) is available -- the DEK is
+   *    then wrapped ONLY by this passphrase.
+   *  - OPTIONAL (but strongly encouraged) when a keyring is available -- it
+   *    is set as an additional recovery wrap on the managed key, so keyring
+   *    loss (e.g. OS reinstall) does not make the data unrecoverable.
+   */
+  recoveryPassphrase?: string
+}
+
+export interface MigrateToEncryptedResult {
+  success: boolean
+  error?: string
+  /** Path to the plaintext backup kept alongside the database after a successful migration. */
+  backupPath?: string
+  /** Whether a recovery passphrase is now set on the migrated key. */
+  recoveryPassphraseSet?: boolean
+  info?: DatabaseInfo
+}
+
 export interface DatabaseDomainContract {
   selectFile: () => Promise<string | null>
   selectSaveLocation: (defaultName: string) => Promise<string | null>
@@ -53,6 +87,21 @@ export interface DatabaseDomainContract {
     setupPassphrase?: string
   ) => Promise<IpcResult<DatabaseOpenResult>>
   rekey: (newPassword: string) => Promise<IpcResult<DatabaseActionResult>>
+  /**
+   * Migrate the currently-open, plaintext SQLite database to encrypted-at-rest.
+   * Requires explicit consent; see `MigrateToEncryptedOptions`. Reversible:
+   * a plaintext backup is kept until the caller explicitly deletes it via
+   * `deletePlaintextBackup`.
+   */
+  migrateToEncrypted: (
+    options: MigrateToEncryptedOptions
+  ) => Promise<IpcResult<MigrateToEncryptedResult>>
+  /**
+   * Delete a plaintext backup produced by a prior `migrateToEncrypted` call.
+   * Only accepts a path that matches the currently-open database's backup
+   * naming pattern -- cannot target an arbitrary file.
+   */
+  deletePlaintextBackup: (backupPath: string) => Promise<IpcResult<DatabaseActionResult>>
   info: () => Promise<IpcResult<DatabaseInfo | null>>
   capabilities: () => Promise<IpcResult<StorageCapabilities>>
   postgresDiagnostics: () => Promise<IpcResult<PostgresHealthDiagnosticResult>>

--- a/src/shared/ipc/domains/database.ts
+++ b/src/shared/ipc/domains/database.ts
@@ -81,6 +81,8 @@ export interface MigrateToEncryptedResult {
   backupPath?: string
   /** Whether a recovery passphrase is now set on the migrated key. */
   recoveryPassphraseSet?: boolean
+  /** Whether the optional portable recovery sidecar was durably written. */
+  sidecarWritten?: boolean
   info?: DatabaseInfo
 }
 

--- a/src/shared/ipc/domains/database.ts
+++ b/src/shared/ipc/domains/database.ts
@@ -72,6 +72,21 @@ export interface MigrateToEncryptedResult {
   info?: DatabaseInfo
 }
 
+export interface SetRecoveryPassphraseResult {
+  success: boolean
+  error?: string
+  /** Whether a recovery passphrase is now set on the current database's key. */
+  recoveryPassphraseSet?: boolean
+  /**
+   * Whether the portable recovery sidecar (`<db>.varlens-recovery.json`) was
+   * written alongside the database. A `false` here (with `success: true`)
+   * means the passphrase wrap itself succeeded but its on-disk escrow copy
+   * did not -- the recovery passphrase still works on this machine, but the
+   * database is not yet portable to another machine/registry.
+   */
+  sidecarWritten?: boolean
+}
+
 export interface DatabaseDomainContract {
   selectFile: () => Promise<string | null>
   selectSaveLocation: (defaultName: string) => Promise<string | null>
@@ -102,6 +117,15 @@ export interface DatabaseDomainContract {
    * naming pattern -- cannot target an arbitrary file.
    */
   deletePlaintextBackup: (backupPath: string) => Promise<IpcResult<DatabaseActionResult>>
+  /**
+   * Set (or replace) a recovery passphrase on the CURRENTLY OPEN database's
+   * managed key. Non-destructive: envelope-wraps the SAME DEK -- unlike
+   * `rekey`, it never changes the live SQLCipher key. Also writes the escrow
+   * recovery sidecar next to the database file. Requires a currently open,
+   * key-store-managed database; gated to the current session's path (no path
+   * parameter -- there is nothing for a caller to spoof).
+   */
+  setRecoveryPassphrase: (passphrase: string) => Promise<IpcResult<SetRecoveryPassphraseResult>>
   info: () => Promise<IpcResult<DatabaseInfo | null>>
   capabilities: () => Promise<IpcResult<StorageCapabilities>>
   postgresDiagnostics: () => Promise<IpcResult<PostgresHealthDiagnosticResult>>

--- a/src/shared/ipc/domains/database.ts
+++ b/src/shared/ipc/domains/database.ts
@@ -19,6 +19,18 @@ export interface DatabaseInfo {
    * encrypted databases and for non-SQLite (e.g. PostgreSQL) sessions.
    */
   unencryptedMigratable?: boolean
+  /**
+   * True when the currently-open database has a key-store registry entry
+   * for its path -- i.e. it was created encrypted-by-default, or migrated
+   * to encrypted, so its SQLCipher key is a key-store-managed DEK. Managed
+   * databases must use `setRecoveryPassphrase` instead of the legacy
+   * `rekey` action: `rekey` (`PRAGMA rekey`) changes the live SQLCipher key
+   * directly without updating the key-store's wrapped DEK, which would
+   * desynchronize the two and make the database unopenable. Absent/false
+   * for explicit-user-password databases, unencrypted databases, and
+   * non-SQLite sessions.
+   */
+  keyManaged?: boolean
 }
 
 export interface DatabaseOpenResult {

--- a/src/shared/types/ipc-schemas.ts
+++ b/src/shared/types/ipc-schemas.ts
@@ -491,6 +491,22 @@ export const DatabaseRekeySchema = z.object({
   newPassword: z.string().max(256)
 })
 
+/**
+ * Schema for the plaintext-to-encrypted migration action. `consent` must be
+ * literally `true` -- migration is never performed silently or by default.
+ */
+export const DatabaseMigrateToEncryptedSchema = z.object({
+  consent: z.literal(true),
+  recoveryPassphrase: z.string().max(256).optional()
+})
+
+/**
+ * Schema for deleting a plaintext backup produced by a prior migration.
+ */
+export const DatabaseDeletePlaintextBackupSchema = z.object({
+  backupPath: FilePathSchema
+})
+
 // ============================================================
 // Gene List Schemas
 // ============================================================

--- a/src/shared/types/ipc-schemas.ts
+++ b/src/shared/types/ipc-schemas.ts
@@ -479,7 +479,9 @@ export const DatabaseOpenSchema = z.object({
  */
 export const DatabaseCreateSchema = z.object({
   path: FilePathSchema,
-  password: z.string().max(256).optional()
+  password: z.string().max(256).optional(),
+  /** First-run passphrase-setup completion; see DatabaseDomainContract.create. */
+  setupPassphrase: z.string().max(256).optional()
 })
 
 /**

--- a/src/shared/types/ipc-schemas.ts
+++ b/src/shared/types/ipc-schemas.ts
@@ -507,6 +507,15 @@ export const DatabaseDeletePlaintextBackupSchema = z.object({
   backupPath: FilePathSchema
 })
 
+/**
+ * Schema for setting a recovery passphrase on the current database's managed
+ * key. Non-empty -- an empty recovery passphrase would be a silent no-op
+ * footgun (unlike `DatabaseRekeySchema`, which allows an empty string today).
+ */
+export const DatabaseSetRecoveryPassphraseSchema = z.object({
+  passphrase: z.string().min(1).max(256)
+})
+
 // ============================================================
 // Gene List Schemas
 // ============================================================

--- a/tests/main/database/database-startup.test.ts
+++ b/tests/main/database/database-startup.test.ts
@@ -61,7 +61,8 @@ describe('openConfiguredDatabase', () => {
       createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' }),
       wrapNewDekWithPassphrase: vi.fn(),
       resolveKeyForPath: vi.fn(),
-      resolveKeyWithPassphrase: vi.fn()
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn()
     }
 
     const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
@@ -81,6 +82,38 @@ describe('openConfiguredDatabase', () => {
     expect(manager.open).not.toHaveBeenCalled()
   })
 
+  it('rolls back the managed key-store entry and rethrows when creating the default sqlite database fails', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      createDatabase: vi.fn().mockRejectedValue(new Error('disk full')),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const keyStore = {
+      createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' }),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn(),
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn()
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await expect(
+      openConfiguredDatabase(manager as never, {
+        env: {},
+        userDataPath: '/tmp/varlens-user-data',
+        fileExists: () => false,
+        keyStore
+      })
+    ).rejects.toThrow('disk full')
+
+    // The registry entry minted before `createDatabase` was attempted must be
+    // rolled back -- otherwise the NEXT launch would find a stale
+    // `path-already-keyed` entry and silently fall through to an unencrypted
+    // default DB.
+    expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
+  })
+
   it('falls back to an unencrypted default database (with a warning) when the key-store cannot mint a managed key pre-window', async () => {
     const manager = {
       open: vi.fn().mockResolvedValue(undefined),
@@ -91,7 +124,8 @@ describe('openConfiguredDatabase', () => {
       createManagedKey: vi.fn().mockReturnValue({ ok: false, reason: 'safe-storage-unavailable' }),
       wrapNewDekWithPassphrase: vi.fn(),
       resolveKeyForPath: vi.fn(),
-      resolveKeyWithPassphrase: vi.fn()
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn()
     }
 
     const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
@@ -127,7 +161,8 @@ describe('openConfiguredDatabase', () => {
       createManagedKey: vi.fn(),
       wrapNewDekWithPassphrase: vi.fn(),
       resolveKeyForPath: vi.fn().mockReturnValue({ ok: true, dek: 'the-dek' }),
-      resolveKeyWithPassphrase: vi.fn()
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn()
     }
 
     const { openConfiguredDatabase } = await import('../../../src/main/database/startup')

--- a/tests/main/database/database-startup.test.ts
+++ b/tests/main/database/database-startup.test.ts
@@ -21,7 +21,8 @@ describe('openConfiguredDatabase', () => {
 
       await openConfiguredDatabase(manager as never, {
         env: {},
-        userDataPath: '/tmp/varlens-user-data'
+        userDataPath: '/tmp/varlens-user-data',
+        fileExists: () => true
       })
 
       expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
@@ -32,7 +33,7 @@ describe('openConfiguredDatabase', () => {
     }
   })
 
-  it('opens the default sqlite database when no experimental backend is requested', async () => {
+  it('opens the default sqlite database when no experimental backend is requested and it already exists', async () => {
     const manager = {
       open: vi.fn().mockResolvedValue(undefined),
       openPostgresSession: vi.fn().mockResolvedValue(undefined)
@@ -42,11 +43,104 @@ describe('openConfiguredDatabase', () => {
 
     await openConfiguredDatabase(manager as never, {
       env: {},
-      userDataPath: '/tmp/varlens-user-data'
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => true
     })
 
     expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
     expect(manager.openPostgresSession).not.toHaveBeenCalled()
+  })
+
+  it('creates the default sqlite database encrypted by default via a managed key when it does not exist yet', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      createDatabase: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const keyStore = {
+      createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' }),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn(),
+      resolveKeyWithPassphrase: vi.fn()
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => false,
+      keyStore
+    })
+
+    expect(keyStore.createManagedKey).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+    expect(manager.createDatabase).toHaveBeenCalledWith(
+      '/tmp/varlens-user-data/varlens.db',
+      'the-dek'
+    )
+    expect(manager.open).not.toHaveBeenCalled()
+  })
+
+  it('falls back to an unencrypted default database (with a warning) when the key-store cannot mint a managed key pre-window', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      createDatabase: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const keyStore = {
+      createManagedKey: vi.fn().mockReturnValue({ ok: false, reason: 'safe-storage-unavailable' }),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn(),
+      resolveKeyWithPassphrase: vi.fn()
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+    // Fetched via the same dynamic import so the spy targets the exact
+    // `mainLogger` module instance `startup.ts` resolved -- a prior test's
+    // `vi.resetModules()` can otherwise leave a statically-imported binding
+    // pointing at a stale module instance.
+    const { mainLogger: startupMainLogger } = await import('../../../src/main/services/MainLogger')
+    const warnSpy = vi.spyOn(startupMainLogger, 'warn').mockImplementation(() => undefined)
+
+    try {
+      await openConfiguredDatabase(manager as never, {
+        env: {},
+        userDataPath: '/tmp/varlens-user-data',
+        fileExists: () => false,
+        keyStore
+      })
+
+      expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+      expect(warnSpy).toHaveBeenCalledOnce()
+      expect(warnSpy.mock.calls[0]?.[0]).toContain('safe-storage-unavailable')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('resolves an existing encrypted default database transparently via the key-store on a later launch', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const keyStore = {
+      createManagedKey: vi.fn(),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn().mockReturnValue({ ok: true, dek: 'the-dek' }),
+      resolveKeyWithPassphrase: vi.fn()
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => true,
+      keyStore
+    })
+
+    expect(keyStore.resolveKeyForPath).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+    expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db', 'the-dek')
   })
 
   it('opens a postgres session when the experimental backend is explicitly requested', async () => {

--- a/tests/main/database/database-startup.test.ts
+++ b/tests/main/database/database-startup.test.ts
@@ -114,7 +114,7 @@ describe('openConfiguredDatabase', () => {
     expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
   })
 
-  it('falls back to an unencrypted default database (with a warning) when the key-store cannot mint a managed key pre-window', async () => {
+  it('BLOCKER 2: does NOT fall back to a plaintext default database when the key-store cannot mint a managed key pre-window; starts with no active database instead', async () => {
     const manager = {
       open: vi.fn().mockResolvedValue(undefined),
       createDatabase: vi.fn().mockResolvedValue(undefined),
@@ -144,12 +144,73 @@ describe('openConfiguredDatabase', () => {
         keyStore
       })
 
-      expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+      // Never silently fall back to plaintext: neither create nor open is
+      // called at all, so the manager stays in its natural "no active
+      // database" state -- exactly what `initDatabaseManagerSafe` produces.
+      expect(manager.createDatabase).not.toHaveBeenCalled()
+      expect(manager.open).not.toHaveBeenCalled()
       expect(warnSpy).toHaveBeenCalledOnce()
       expect(warnSpy.mock.calls[0]?.[0]).toContain('safe-storage-unavailable')
+      expect(warnSpy.mock.calls[0]?.[0]).not.toContain('created without encryption')
     } finally {
       warnSpy.mockRestore()
     }
+  })
+
+  it('BLOCKER 2: does NOT fall back to plaintext when the key-store reports path-already-keyed pre-window either', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      createDatabase: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const keyStore = {
+      createManagedKey: vi.fn().mockReturnValue({ ok: false, reason: 'path-already-keyed' }),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn(),
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn()
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => false,
+      keyStore
+    })
+
+    expect(manager.createDatabase).not.toHaveBeenCalled()
+    expect(manager.open).not.toHaveBeenCalled()
+  })
+
+  it('BLOCKER 2: an EXISTING plaintext default database still opens as before (no key-store entry, safeStorage unavailable)', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      createDatabase: vi.fn().mockResolvedValue(undefined),
+      openPostgresSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const keyStore = {
+      createManagedKey: vi.fn().mockReturnValue({ ok: false, reason: 'safe-storage-unavailable' }),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' }),
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn()
+    }
+
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => true,
+      keyStore
+    })
+
+    // File already exists (a pre-existing plaintext DB): the create path is
+    // never reached, so a missing keyring can't block opening it.
+    expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+    expect(manager.createDatabase).not.toHaveBeenCalled()
   })
 
   it('resolves an existing encrypted default database transparently via the key-store on a later launch', async () => {

--- a/tests/main/database/database-startup.test.ts
+++ b/tests/main/database/database-startup.test.ts
@@ -5,6 +5,64 @@ import type { PostgresStorageConfig } from '../../../src/main/storage/config'
 import { POSTGRES_CAPABILITIES } from '../../../src/main/storage/postgres/PostgresStorageSession'
 
 describe('openConfiguredDatabase', () => {
+  it('reconciles an abandoned pending migration after verified plaintext detection', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: false }),
+      openPostgresSession: vi.fn()
+    }
+    const keyStore = {
+      createManagedKey: vi.fn(),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn(),
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn(),
+      getKeyStateForPath: vi.fn().mockReturnValue('pending'),
+      getKeyIdForPath: vi.fn().mockReturnValue('pending-key'),
+      activateKey: vi.fn()
+    }
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => true,
+      keyStore
+    })
+
+    expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+    expect(keyStore.removeKey).toHaveBeenCalledWith('pending-key')
+    expect(keyStore.activateKey).not.toHaveBeenCalled()
+  })
+
+  it('activates a pending migration after the encrypted default accepts its managed DEK', async () => {
+    const manager = {
+      open: vi.fn().mockResolvedValue(undefined),
+      openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+      openPostgresSession: vi.fn()
+    }
+    const keyStore = {
+      createManagedKey: vi.fn(),
+      wrapNewDekWithPassphrase: vi.fn(),
+      resolveKeyForPath: vi.fn().mockReturnValue({ ok: true, dek: 'pending-dek' }),
+      resolveKeyWithPassphrase: vi.fn(),
+      removeKey: vi.fn(),
+      getKeyStateForPath: vi.fn().mockReturnValue('pending'),
+      getKeyIdForPath: vi.fn().mockReturnValue('pending-key'),
+      activateKey: vi.fn()
+    }
+    const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
+
+    await openConfiguredDatabase(manager as never, {
+      env: {},
+      userDataPath: '/tmp/varlens-user-data',
+      fileExists: () => true,
+      keyStore
+    })
+
+    expect(manager.open).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db', 'pending-dek')
+    expect(keyStore.activateKey).toHaveBeenCalledWith('pending-key')
+  })
   it('does not load postgres migration definitions for the default sqlite database', async () => {
     vi.resetModules()
     vi.doMock('../../../src/main/storage/postgres/migrations/definitions', () => {
@@ -59,10 +117,14 @@ describe('openConfiguredDatabase', () => {
     }
     const keyStore = {
       createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' }),
+      createPendingManagedKey: vi
+        .fn()
+        .mockReturnValue({ ok: true, keyId: 'pending-k1', dek: 'the-dek' }),
       wrapNewDekWithPassphrase: vi.fn(),
       resolveKeyForPath: vi.fn(),
       resolveKeyWithPassphrase: vi.fn(),
-      removeKey: vi.fn()
+      removeKey: vi.fn(),
+      activateKey: vi.fn()
     }
 
     const { openConfiguredDatabase } = await import('../../../src/main/database/startup')
@@ -74,11 +136,15 @@ describe('openConfiguredDatabase', () => {
       keyStore
     })
 
-    expect(keyStore.createManagedKey).toHaveBeenCalledWith('/tmp/varlens-user-data/varlens.db')
+    expect(keyStore.createPendingManagedKey).toHaveBeenCalledWith(
+      '/tmp/varlens-user-data/varlens.db'
+    )
+    expect(keyStore.createManagedKey).not.toHaveBeenCalled()
     expect(manager.createDatabase).toHaveBeenCalledWith(
       '/tmp/varlens-user-data/varlens.db',
       'the-dek'
     )
+    expect(keyStore.activateKey).toHaveBeenCalledWith('pending-k1')
     expect(manager.open).not.toHaveBeenCalled()
   })
 

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -13,11 +13,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { assertNotHexLiteralKey } from '../../../src/main/database/sqlcipher-key-guard'
 import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
+import { recoverySidecarPathFor } from '../../../src/main/database/recovery-sidecar'
 
 /** Reversible fake "encryption" so round-trips work in tests. */
 function fakeSafeStorage(available = true): SafeStorageLike {
@@ -281,5 +282,171 @@ describe('DbKeyStore', () => {
     // The store must still be usable after encountering a corrupt file.
     const created = store.createManagedKey(join(tmpDir, 'case.db'))
     expect(created.ok).toBe(true)
+  })
+
+  describe('recovery sidecar portability', () => {
+    it('wrapNewDekWithPassphrase writes a sidecar at <dbPath>.varlens-recovery.json matching the registry passWrap', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+      const dbPath = join(tmpDir, 'case.db')
+
+      const result = store.wrapNewDekWithPassphrase(dbPath, 'hunter2')
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error('expected ok result')
+      expect(result.sidecarWritten).toBe(true)
+
+      const sidecarPath = recoverySidecarPathFor(dbPath)
+      expect(existsSync(sidecarPath)).toBe(true)
+
+      const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
+      expect(sidecar.version).toBe(1)
+
+      const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+      const registryPassWrap = raw.keys[result.keyId].passWrap
+      expect(sidecar.passWrap).toEqual(registryPassWrap)
+    })
+
+    it('setPassphrase on an existing managed-key entry also writes/overwrites the sidecar at the entry stored path', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const dbPath = join(tmpDir, 'case.db')
+
+      const created = store.createManagedKey(dbPath)
+      expect(created.ok).toBe(true)
+      if (!created.ok) throw new Error('expected ok result')
+
+      const sidecarPath = recoverySidecarPathFor(dbPath)
+      expect(existsSync(sidecarPath)).toBe(false)
+
+      const setResult = store.setPassphrase(created.keyId, 'hunter2')
+      expect(setResult.ok).toBe(true)
+      if (!setResult.ok) throw new Error('expected ok result')
+      expect(setResult.sidecarWritten).toBe(true)
+      expect(existsSync(sidecarPath)).toBe(true)
+
+      const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
+      const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+      expect(sidecar.passWrap).toEqual(raw.keys[created.keyId].passWrap)
+
+      // A second setPassphrase call overwrites the sidecar with the new wrap.
+      const secondSet = store.setPassphrase(created.keyId, 'different-passphrase')
+      expect(secondSet.ok).toBe(true)
+      const sidecarAfter = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
+      const rawAfter = JSON.parse(readFileSync(registryPath, 'utf-8'))
+      expect(sidecarAfter.passWrap).toEqual(rawAfter.keys[created.keyId].passWrap)
+      expect(sidecarAfter.passWrap).not.toEqual(sidecar.passWrap)
+    })
+
+    it('resolveKeyWithPassphraseFromSidecar: correct passphrase resolves the DEK; wrong passphrase returns a typed wrong-passphrase result, never a wrong key', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+      const dbPath = join(tmpDir, 'case.db')
+
+      const created = store.wrapNewDekWithPassphrase(dbPath, 'correct horse battery staple')
+      expect(created.ok).toBe(true)
+      if (!created.ok) throw new Error('expected ok result')
+
+      const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+      const passWrap = raw.keys[created.keyId].passWrap
+
+      const correct = store.resolveKeyWithPassphraseFromSidecar(
+        passWrap,
+        'correct horse battery staple'
+      )
+      expect(correct.ok).toBe(true)
+      if (!correct.ok) throw new Error('expected ok result')
+      expect(correct.dek).toBe(created.dek)
+
+      const wrong = store.resolveKeyWithPassphraseFromSidecar(passWrap, 'wrong-passphrase')
+      expect(wrong.ok).toBe(false)
+      if (wrong.ok) throw new Error('expected failure result')
+      expect(wrong.reason).toBe('wrong-passphrase')
+    })
+
+    it('enrollRecoveredKey: succeeds on an un-keyed path, mapping a fresh keyId to it with the given passWrap (and a safeWrap too, when safeStorage is available)', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const dbPath = join(tmpDir, 'recovered.db')
+      const passWrap = {
+        saltB64: 'salt',
+        ivB64: 'iv',
+        ctB64: 'ct',
+        tagB64: 'tag'
+      }
+
+      const result = store.enrollRecoveredKey(dbPath, 'a'.repeat(64), passWrap)
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error('expected ok result')
+
+      const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+      expect(raw.pathIndex[dbPath]).toBe(result.keyId)
+      expect(raw.keys[result.keyId].path).toBe(dbPath)
+      expect(raw.keys[result.keyId].passWrap).toEqual(passWrap)
+      expect(typeof raw.keys[result.keyId].safeWrap).toBe('string')
+
+      // No sidecar is (re-)written by enrollment -- the passWrap came FROM
+      // the sidecar and is already correct and current on disk.
+      expect(existsSync(recoverySidecarPathFor(dbPath))).toBe(false)
+    })
+
+    it('enrollRecoveredKey: refuses a path that is already keyed, without mutating the registry', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const dbPath = join(tmpDir, 'case.db')
+      const original = store.createManagedKey(dbPath)
+      expect(original.ok).toBe(true)
+      if (!original.ok) throw new Error('expected ok result')
+
+      const before = readFileSync(registryPath, 'utf-8')
+
+      const result = store.enrollRecoveredKey(dbPath, 'a'.repeat(64), {
+        saltB64: 'salt',
+        ivB64: 'iv',
+        ctB64: 'ct',
+        tagB64: 'tag'
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('expected failure result')
+      expect(result.reason).toBe('path-already-keyed')
+
+      const after = readFileSync(registryPath, 'utf-8')
+      expect(after).toBe(before)
+    })
+
+    it('findManagedKeyIdForDek: returns the matching keyId when a local safeWrap-bearing entry decrypts to that DEK', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const dbPath = join(tmpDir, 'case.db')
+      const created = store.createManagedKey(dbPath)
+      expect(created.ok).toBe(true)
+      if (!created.ok) throw new Error('expected ok result')
+
+      const found = store.findManagedKeyIdForDek(created.dek)
+      expect(found).toBe(created.keyId)
+    })
+
+    it('findManagedKeyIdForDek: returns null when no entry matches', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      store.createManagedKey(join(tmpDir, 'case.db'))
+
+      expect(store.findManagedKeyIdForDek('nonexistent-dek')).toBeNull()
+    })
+
+    it('findManagedKeyIdForDek: returns null when safeStorage is unavailable, even with matching local entries', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+      const dbPath = join(tmpDir, 'case.db')
+      const created = store.wrapNewDekWithPassphrase(dbPath, 'hunter2')
+      expect(created.ok).toBe(true)
+      if (!created.ok) throw new Error('expected ok result')
+
+      // No safeWrap exists at all on a passphrase-only entry, and safeStorage
+      // is unavailable regardless -- nothing can match.
+      expect(store.findManagedKeyIdForDek(created.dek)).toBeNull()
+    })
+
+    it('getKeyIdForPath: returns the mapped keyId, or null for an unknown path', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const dbPath = join(tmpDir, 'case.db')
+      const created = store.createManagedKey(dbPath)
+      expect(created.ok).toBe(true)
+      if (!created.ok) throw new Error('expected ok result')
+
+      expect(store.getKeyIdForPath(dbPath)).toBe(created.keyId)
+      expect(store.getKeyIdForPath(join(tmpDir, 'never-created.db'))).toBeNull()
+    })
   })
 })

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -322,19 +322,37 @@ describe('DbKeyStore', () => {
     expect(resolved.ok).toBe(false)
   })
 
-  it('tolerates a corrupt registry file: logs, treats as empty, and preserves a .bak backup', () => {
+  it('fails closed on a corrupt registry and never overwrites the only key material', () => {
     writeFileSync(registryPath, '{ this is not valid json', 'utf-8')
     const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
 
-    const resolved = store.resolveKeyForPath(join(tmpDir, 'anything.db'))
-    expect(resolved.ok).toBe(false)
+    expect(() => store.resolveKeyForPath(join(tmpDir, 'anything.db'))).toThrow(
+      'key registry is corrupt or invalid'
+    )
 
     const backup = readFileSync(`${registryPath}.bak`, 'utf-8')
     expect(backup).toBe('{ this is not valid json')
 
-    // The store must still be usable after encountering a corrupt file.
-    const created = store.createManagedKey(join(tmpDir, 'case.db'))
-    expect(created.ok).toBe(true)
+    expect(() => store.createManagedKey(join(tmpDir, 'case.db'))).toThrow(
+      'key registry is corrupt or invalid'
+    )
+    expect(readFileSync(registryPath, 'utf-8')).toBe('{ this is not valid json')
+  })
+
+  it('fails closed when registry indexes and key entries are structurally inconsistent', () => {
+    const dbPath = join(tmpDir, 'case.db')
+    const malformed = JSON.stringify({
+      keys: { keyA: { path: dbPath, safeWrap: 'wrapped-key' } },
+      pathIndex: { [dbPath]: 'missing-key' }
+    })
+    writeFileSync(registryPath, malformed, 'utf-8')
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+
+    expect(() => store.createManagedKey(join(tmpDir, 'other.db'))).toThrow(
+      'key registry is corrupt or invalid'
+    )
+    expect(readFileSync(registryPath, 'utf-8')).toBe(malformed)
+    expect(readFileSync(`${registryPath}.bak`, 'utf-8')).toBe(malformed)
   })
 
   describe('recovery sidecar portability', () => {

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -158,6 +158,8 @@ describe('DbKeyStore', () => {
     // "Machine A": no keyring available, so the no-keyring create path is used.
     const storeA = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
     const created = storeA.wrapNewDekWithPassphrase(dbPath, 'correct horse battery staple')
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
 
     // "Machine B": a fresh store instance over the SAME registry file, safeStorage also unavailable.
     const storeB = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
@@ -173,10 +175,58 @@ describe('DbKeyStore', () => {
     const dbPath = join(tmpDir, 'case.db')
 
     const created = store.wrapNewDekWithPassphrase(dbPath, 'hunter2')
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
 
     const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
     expect(raw.keys[created.keyId].safeWrap).toBeUndefined()
     expect(raw.keys[created.keyId].passWrap).toBeDefined()
+  })
+
+  it('createManagedKey on an already-keyed path returns path-already-keyed and does not change the resolved DEK', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const original = store.createManagedKey(dbPath)
+    expect(original.ok).toBe(true)
+    if (!original.ok) throw new Error('expected ok result')
+
+    const second = store.createManagedKey(dbPath)
+    expect(second.ok).toBe(false)
+    if (second.ok) throw new Error('expected failure result')
+    expect(second.reason).toBe('path-already-keyed')
+
+    const resolved = store.resolveKeyForPath(dbPath)
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+    expect(resolved.dek).toBe(original.dek)
+
+    const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+    expect(raw.pathIndex[dbPath]).toBe(original.keyId)
+    expect(Object.keys(raw.keys)).toHaveLength(1)
+  })
+
+  it('wrapNewDekWithPassphrase on an already-keyed path returns path-already-keyed and does not orphan the existing key', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const original = store.wrapNewDekWithPassphrase(dbPath, 'hunter2')
+    expect(original.ok).toBe(true)
+    if (!original.ok) throw new Error('expected ok result')
+
+    const second = store.wrapNewDekWithPassphrase(dbPath, 'different-passphrase')
+    expect(second.ok).toBe(false)
+    if (second.ok) throw new Error('expected failure result')
+    expect(second.reason).toBe('path-already-keyed')
+
+    const resolved = store.resolveKeyWithPassphrase(dbPath, 'hunter2')
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+    expect(resolved.dek).toBe(original.dek)
+
+    const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+    expect(raw.pathIndex[dbPath]).toBe(original.keyId)
+    expect(Object.keys(raw.keys)).toHaveLength(1)
   })
 
   it('7. removeKey deletes both the keyId entry and the path mapping', () => {

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -90,6 +90,25 @@ describe('DbKeyStore', () => {
     expect(result.reason).toBe('safe-storage-unavailable')
   })
 
+  it('treats Electron basic_text as unavailable and never stores a managed safeWrap', () => {
+    const encryptString = vi.fn((s: string) => Buffer.from(`SS:${s}`))
+    const store = new DbKeyStore({
+      registryPath,
+      safeStorage: {
+        isEncryptionAvailable: () => true,
+        getSelectedStorageBackend: () => 'basic_text',
+        encryptString,
+        decryptString: (b: Buffer) => b.toString().replace(/^SS:/, '')
+      }
+    })
+
+    const result = store.createManagedKey(join(tmpDir, 'basic-text.db'))
+
+    expect(result).toEqual({ ok: false, reason: 'safe-storage-unavailable' })
+    expect(encryptString).not.toHaveBeenCalled()
+    expect(existsSync(registryPath)).toBe(false)
+  })
+
   it('4a. setPassphrase + resolveKeyWithPassphrase returns the SAME DEK', () => {
     const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
     const dbPath = join(tmpDir, 'case.db')

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -198,6 +198,23 @@ describe('DbKeyStore', () => {
     expect(['not-found', 'needs-passphrase']).toContain(resolvedOld.reason)
   })
 
+  it('keeps the registry readable when repointing displaces a stale path entry', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const sourcePath = join(tmpDir, 'source.db')
+    const destinationPath = join(tmpDir, 'destination.db')
+    const moved = store.createManagedKey(sourcePath)
+    const stale = store.createManagedKey(destinationPath)
+    expect(moved.ok).toBe(true)
+    expect(stale.ok).toBe(true)
+    if (!moved.ok || !stale.ok) throw new Error('expected managed keys')
+
+    store.updatePath(moved.keyId, destinationPath)
+
+    const freshStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    expect(freshStore.resolveKeyForPath(destinationPath)).toEqual({ ok: true, dek: moved.dek })
+    expect(freshStore.findManagedKeyIdForDek(stale.dek)).toBe(stale.keyId)
+  })
+
   it('resolveKeyForPath on a totally unknown path returns not-found', () => {
     const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
     const resolved = store.resolveKeyForPath(join(tmpDir, 'never-created.db'))

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -473,14 +473,12 @@ describe('DbKeyStore', () => {
       expect(existsSync(recoverySidecarPathFor(dbPath))).toBe(false)
     })
 
-    it('enrollRecoveredKey: refuses a path that is already keyed, without mutating the registry', () => {
+    it('enrollRecoveredKey: displaces a stale path mapping while preserving its wrapped key', () => {
       const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
       const dbPath = join(tmpDir, 'case.db')
       const original = store.createManagedKey(dbPath)
       expect(original.ok).toBe(true)
       if (!original.ok) throw new Error('expected ok result')
-
-      const before = readFileSync(registryPath, 'utf-8')
 
       const result = store.enrollRecoveredKey(dbPath, 'a'.repeat(64), {
         saltB64: 'salt',
@@ -488,12 +486,12 @@ describe('DbKeyStore', () => {
         ctB64: 'ct',
         tagB64: 'tag'
       })
-      expect(result.ok).toBe(false)
-      if (result.ok) throw new Error('expected failure result')
-      expect(result.reason).toBe('path-already-keyed')
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error('expected success result')
 
-      const after = readFileSync(registryPath, 'utf-8')
-      expect(after).toBe(before)
+      expect(store.getKeyIdForPath(dbPath)).toBe(result.keyId)
+      expect(store.resolveKeyForPath(dbPath)).toEqual({ ok: true, dek: 'a'.repeat(64) })
+      expect(store.findManagedKeyIdForDek(original.dek)).toBe(original.keyId)
     })
 
     it('findManagedKeyIdForDek: returns the matching keyId when a local safeWrap-bearing entry decrypts to that DEK', () => {

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -12,7 +12,7 @@
  * 8. Registry persistence across store instances reading the same file
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -447,6 +447,65 @@ describe('DbKeyStore', () => {
 
       expect(store.getKeyIdForPath(dbPath)).toBe(created.keyId)
       expect(store.getKeyIdForPath(join(tmpDir, 'never-created.db'))).toBeNull()
+    })
+  })
+
+  describe('registry write durability (power-loss safety)', () => {
+    afterEach(() => {
+      vi.doUnmock('fs')
+      vi.resetModules()
+    })
+
+    it('fsyncs the temp file before the rename, and best-effort fsyncs the directory after it', async () => {
+      const calls: string[] = []
+      vi.resetModules()
+      vi.doMock('fs', async (importOriginal) => {
+        const actual = await importOriginal<typeof import('fs')>()
+        return {
+          ...actual,
+          fsyncSync: vi.fn((...args: Parameters<typeof actual.fsyncSync>) => {
+            calls.push('fsync')
+            return actual.fsyncSync(...args)
+          }),
+          renameSync: vi.fn((...args: Parameters<typeof actual.renameSync>) => {
+            calls.push('rename')
+            return actual.renameSync(...args)
+          })
+        }
+      })
+
+      const { DbKeyStore: FreshDbKeyStore } =
+        await import('../../../src/main/database/db-key-store')
+      const store = new FreshDbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const created = store.createManagedKey(join(tmpDir, 'case.db'))
+      expect(created.ok).toBe(true)
+
+      // At least two fsyncs: the temp file (blocking) and the containing
+      // directory (best-effort) -- and the file fsync must precede the
+      // rename that makes the write visible.
+      expect(calls.filter((c) => c === 'fsync').length).toBeGreaterThanOrEqual(2)
+      expect(calls[0]).toBe('fsync')
+      expect(calls).toContain('rename')
+      expect(calls.indexOf('fsync')).toBeLessThan(calls.indexOf('rename'))
+    })
+
+    it('a managed key is durably persisted on disk before the caller can proceed to create the database', () => {
+      const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+      const dbPath = join(tmpDir, 'case.db')
+
+      const created = store.createManagedKey(dbPath)
+      expect(created.ok).toBe(true)
+
+      // Synchronous by construction: by the time `createManagedKey` returns,
+      // the registry write (including its fsyncs) has already completed, so
+      // a fresh read from disk must already see the new key -- a caller that
+      // creates the database file next never races ahead of durable key
+      // material.
+      expect(existsSync(registryPath)).toBe(true)
+      const onDisk = JSON.parse(readFileSync(registryPath, 'utf-8')) as {
+        pathIndex: Record<string, string>
+      }
+      expect(onDisk.pathIndex[dbPath]).toBeDefined()
     })
   })
 })

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -1,0 +1,235 @@
+/**
+ * DbKeyStore — envelope-encryption key-lifecycle store tests
+ *
+ * Covers the 8 required scenarios from the task brief:
+ * 1. DEK format (64 hex chars, never starts with x/X, passes assertNotHexLiteralKey)
+ * 2. Transparent round-trip via safeStorage
+ * 3. safeStorage unavailable → typed failure result
+ * 4. Passphrase wrap round-trip + wrong-passphrase typed failure
+ * 5. Move/rename path mapping
+ * 6. Portability: passphrase-only DEK resolves with safeStorage unavailable
+ * 7. removeKey deletes both keyId entry and path mapping
+ * 8. Registry persistence across store instances reading the same file
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { assertNotHexLiteralKey } from '../../../src/main/database/sqlcipher-key-guard'
+import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
+
+/** Reversible fake "encryption" so round-trips work in tests. */
+function fakeSafeStorage(available = true): SafeStorageLike {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (s: string) => {
+      if (!available) throw new Error('unavailable')
+      return Buffer.from('SS:' + s)
+    },
+    decryptString: (b: Buffer) => b.toString().replace(/^SS:/, '')
+  }
+}
+
+describe('DbKeyStore', () => {
+  let tmpDir: string
+  let registryPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-keystore-'))
+    registryPath = join(tmpDir, 'varlens-db-keys.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('1. createManagedKey returns a 64-hex-char DEK that never starts with x/X and passes assertNotHexLiteralKey; registry gains a keyId with a safeWrap mapped to the path', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const result = store.createManagedKey(dbPath)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok result')
+    expect(result.dek).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.dek.startsWith('x')).toBe(false)
+    expect(result.dek.startsWith('X')).toBe(false)
+    expect(() => assertNotHexLiteralKey(result.dek)).not.toThrow()
+
+    const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+    expect(raw.keys[result.keyId]).toBeDefined()
+    expect(raw.keys[result.keyId].path).toBe(dbPath)
+    expect(typeof raw.keys[result.keyId].safeWrap).toBe('string')
+    expect(raw.pathIndex[dbPath]).toBe(result.keyId)
+  })
+
+  it('2. resolveKeyForPath returns the SAME DEK after createManagedKey (transparent round-trip)', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = store.createManagedKey(dbPath)
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
+
+    const resolved = store.resolveKeyForPath(dbPath)
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+    expect(resolved.dek).toBe(created.dek)
+  })
+
+  it('3. createManagedKey reports safe-storage-unavailable (typed result, not a throw) when safeStorage is unavailable', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const result = store.createManagedKey(dbPath)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure result')
+    expect(result.reason).toBe('safe-storage-unavailable')
+  })
+
+  it('4a. setPassphrase + resolveKeyWithPassphrase returns the SAME DEK', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = store.createManagedKey(dbPath)
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
+
+    const setResult = store.setPassphrase(created.keyId, 'hunter2')
+    expect(setResult.ok).toBe(true)
+
+    const resolved = store.resolveKeyWithPassphrase(dbPath, 'hunter2')
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+    expect(resolved.dek).toBe(created.dek)
+  })
+
+  it('4b. resolveKeyWithPassphrase with a wrong passphrase returns a typed wrong-passphrase result, NOT the wrong key', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = store.createManagedKey(dbPath)
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
+    store.setPassphrase(created.keyId, 'hunter2')
+
+    const resolved = store.resolveKeyWithPassphrase(dbPath, 'wrong-passphrase')
+
+    expect(resolved.ok).toBe(false)
+    if (resolved.ok) throw new Error('expected failure result')
+    expect(resolved.reason).toBe('wrong-passphrase')
+  })
+
+  it('5. updatePath makes resolveKeyForPath(newPath) work; the old path miss returns a typed miss, never a wrong key', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const oldPath = join(tmpDir, 'case-old.db')
+    const newPath = join(tmpDir, 'case-new.db')
+
+    const created = store.createManagedKey(oldPath)
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
+
+    store.updatePath(created.keyId, newPath)
+
+    const resolvedNew = store.resolveKeyForPath(newPath)
+    expect(resolvedNew.ok).toBe(true)
+    if (!resolvedNew.ok) throw new Error('expected ok result')
+    expect(resolvedNew.dek).toBe(created.dek)
+
+    const resolvedOld = store.resolveKeyForPath(oldPath)
+    expect(resolvedOld.ok).toBe(false)
+    if (resolvedOld.ok) throw new Error('expected failure result')
+    expect(['not-found', 'needs-passphrase']).toContain(resolvedOld.reason)
+  })
+
+  it('resolveKeyForPath on a totally unknown path returns not-found', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const resolved = store.resolveKeyForPath(join(tmpDir, 'never-created.db'))
+    expect(resolved.ok).toBe(false)
+    if (resolved.ok) throw new Error('expected failure result')
+    expect(resolved.reason).toBe('not-found')
+  })
+
+  it('6. Portability: a passphrase-wrapped DEK resolves with the passphrase even when safeStorage is unavailable on another "machine"', () => {
+    const dbPath = join(tmpDir, 'case.db')
+
+    // "Machine A": no keyring available, so the no-keyring create path is used.
+    const storeA = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const created = storeA.wrapNewDekWithPassphrase(dbPath, 'correct horse battery staple')
+
+    // "Machine B": a fresh store instance over the SAME registry file, safeStorage also unavailable.
+    const storeB = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const resolved = storeB.resolveKeyWithPassphrase(dbPath, 'correct horse battery staple')
+
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+    expect(resolved.dek).toBe(created.dek)
+  })
+
+  it('wrapNewDekWithPassphrase stores ONLY a passphrase wrap (no safeWrap)', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = store.wrapNewDekWithPassphrase(dbPath, 'hunter2')
+
+    const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+    expect(raw.keys[created.keyId].safeWrap).toBeUndefined()
+    expect(raw.keys[created.keyId].passWrap).toBeDefined()
+  })
+
+  it('7. removeKey deletes both the keyId entry and the path mapping', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = store.createManagedKey(dbPath)
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
+
+    store.removeKey(created.keyId)
+
+    const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+    expect(raw.keys[created.keyId]).toBeUndefined()
+    expect(raw.pathIndex[dbPath]).toBeUndefined()
+
+    const resolved = store.resolveKeyForPath(dbPath)
+    expect(resolved.ok).toBe(false)
+  })
+
+  it('8. Registry persistence: a second store instance reading the same file sees prior entries', () => {
+    const dbPath = join(tmpDir, 'case.db')
+    const store1 = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const created = store1.createManagedKey(dbPath)
+    expect(created.ok).toBe(true)
+    if (!created.ok) throw new Error('expected ok result')
+
+    const store2 = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const resolved = store2.resolveKeyForPath(dbPath)
+
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+    expect(resolved.dek).toBe(created.dek)
+  })
+
+  it('tolerates a missing registry file (treats as empty)', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const resolved = store.resolveKeyForPath(join(tmpDir, 'anything.db'))
+    expect(resolved.ok).toBe(false)
+  })
+
+  it('tolerates a corrupt registry file: logs, treats as empty, and preserves a .bak backup', () => {
+    writeFileSync(registryPath, '{ this is not valid json', 'utf-8')
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+
+    const resolved = store.resolveKeyForPath(join(tmpDir, 'anything.db'))
+    expect(resolved.ok).toBe(false)
+
+    const backup = readFileSync(`${registryPath}.bak`, 'utf-8')
+    expect(backup).toBe('{ this is not valid json')
+
+    // The store must still be usable after encountering a corrupt file.
+    const created = store.createManagedKey(join(tmpDir, 'case.db'))
+    expect(created.ok).toBe(true)
+  })
+})

--- a/tests/main/database/db-key-store.test.ts
+++ b/tests/main/database/db-key-store.test.ts
@@ -79,6 +79,40 @@ describe('DbKeyStore', () => {
     expect(resolved.dek).toBe(created.dek)
   })
 
+  it('keeps migration keys pending until explicitly activated, with legacy/new normal keys active', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'migrating.db')
+
+    const pending = store.createPendingManagedKey(dbPath)
+    expect(pending.ok).toBe(true)
+    if (!pending.ok) throw new Error('expected ok result')
+
+    expect(store.getKeyStateForPath(dbPath)).toBe('pending')
+    expect(store.resolveKeyForPath(dbPath)).toMatchObject({ ok: true, dek: pending.dek })
+
+    store.activateKey(pending.keyId)
+    expect(store.getKeyStateForPath(dbPath)).toBe('active')
+
+    const raw = JSON.parse(readFileSync(registryPath, 'utf-8'))
+    expect(raw.keys[pending.keyId].state).toBe('active')
+  })
+
+  it('creates passphrase-only migration keys as pending without changing their recovery semantics', () => {
+    const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const dbPath = join(tmpDir, 'migrating-passphrase.db')
+
+    const pending = store.wrapNewPendingDekWithPassphrase(dbPath, 'portable secret')
+    expect(pending.ok).toBe(true)
+    if (!pending.ok) throw new Error('expected ok result')
+
+    expect(pending.sidecarWritten).toBe(true)
+    expect(store.getKeyStateForPath(dbPath)).toBe('pending')
+    expect(store.resolveKeyWithPassphrase(dbPath, 'portable secret')).toMatchObject({
+      ok: true,
+      dek: pending.dek
+    })
+  })
+
   it('3. createManagedKey reports safe-storage-unavailable (typed result, not a throw) when safeStorage is unavailable', () => {
     const store = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
     const dbPath = join(tmpDir, 'case.db')

--- a/tests/main/database/encryption-default.test.ts
+++ b/tests/main/database/encryption-default.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Encrypt-by-default for NEW databases (managed key + first-run passphrase).
+ *
+ * See .superpowers/sdd/task-I2a-brief.md for the full design. These tests
+ * exercise `createDatabase`/`openDatabase` from
+ * `src/main/ipc/handlers/database-logic.ts` against a REAL `DbKeyStore` and a
+ * REAL `DatabaseManager` (better-sqlite3-multiple-ciphers underneath), with
+ * only `safeStorage` faked -- so the "encrypted at rest" assertions are
+ * proven against the actual SQLCipher file format, not a mock.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import Database from 'better-sqlite3-multiple-ciphers'
+import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
+import { DatabaseManager } from '../../../src/main/services/DatabaseManager'
+import { RecentDatabasesService } from '../../../src/main/services/RecentDatabasesService'
+import {
+  createDatabase,
+  openDatabase,
+  type DatabaseLifecycleCallbacks
+} from '../../../src/main/ipc/handlers/database-logic'
+
+/** Reversible fake "encryption" so round-trips work in tests (same fake as db-key-store.test.ts). */
+function fakeSafeStorage(available = true): SafeStorageLike {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (s: string) => {
+      if (!available) throw new Error('unavailable')
+      return Buffer.from('SS:' + s)
+    },
+    decryptString: (b: Buffer) => b.toString().replace(/^SS:/, '')
+  }
+}
+
+const noopCallbacks: DatabaseLifecycleCallbacks = {
+  triggerStartupRebuild: () => undefined
+}
+
+describe('encrypt-by-default for NEW databases', () => {
+  let tmpDir: string
+  let registryPath: string
+  let manager: DatabaseManager
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-enc-default-'))
+    registryPath = join(tmpDir, 'varlens-db-keys.json')
+    manager = new DatabaseManager(new RecentDatabasesService(join(tmpDir, 'varlens-settings.json')))
+  })
+
+  afterEach(async () => {
+    await manager.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('a newly created DB (no password) is encrypted at rest: opening with NO key throws the SQLCipher "not a database" error, and opening with the stored DEK succeeds and reads back written data', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const result = await createDatabase({ path: dbPath }, () => manager, keyStore)
+    expect(result.success).toBe(true)
+
+    manager.getCurrent().database.exec('CREATE TABLE marker (id INTEGER)')
+    manager.getCurrent().database.prepare('INSERT INTO marker (id) VALUES (1)').run()
+    await manager.close()
+
+    // Opening the raw file with NO key must fail with SQLCipher's error.
+    const rawNoKey = new Database(dbPath)
+    expect(() => rawNoKey.prepare('SELECT count(*) FROM sqlite_master').get()).toThrow(
+      /file is not a database/i
+    )
+    rawNoKey.close()
+
+    // Opening with the stored DEK must succeed and read back the data.
+    const resolved = keyStore.resolveKeyForPath(dbPath)
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+
+    const rawWithKey = new Database(dbPath)
+    rawWithKey.pragma(`key='${resolved.dek}'`)
+    const row = rawWithKey.prepare('SELECT id FROM marker').get() as { id: number }
+    expect(row.id).toBe(1)
+    rawWithKey.close()
+  })
+
+  it('managed round-trip: create, close, and reopen transparently via the key-store -- data intact', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = await createDatabase({ path: dbPath }, () => manager, keyStore)
+    expect(created.success).toBe(true)
+
+    manager.getCurrent().database.exec('CREATE TABLE marker (id INTEGER)')
+    manager.getCurrent().database.prepare('INSERT INTO marker (id) VALUES (42)').run()
+    await manager.close()
+
+    // Fresh manager + fresh key-store instance over the SAME registry file --
+    // simulates a second app launch. No password supplied.
+    const manager2 = new DatabaseManager(
+      new RecentDatabasesService(join(tmpDir, 'varlens-settings-2.json'))
+    )
+    const keyStore2 = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+
+    try {
+      const opened = await openDatabase(
+        { path: dbPath },
+        () => manager2.getCurrent(),
+        () => manager2,
+        noopCallbacks,
+        keyStore2
+      )
+
+      expect(opened.success).toBe(true)
+      expect(opened.needsPassword).toBeUndefined()
+
+      const row = manager2.getCurrent().database.prepare('SELECT id FROM marker').get() as {
+        id: number
+      }
+      expect(row.id).toBe(42)
+    } finally {
+      await manager2.close()
+    }
+  })
+
+  it('safeStorage-unavailable create returns needsPassphraseSetup and does NOT create an unencrypted DB; a follow-up passphrase create succeeds and is encrypted', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const attempt = await createDatabase({ path: dbPath }, () => manager, keyStore)
+    expect(attempt).toEqual({ success: false, needsPassphraseSetup: true })
+    expect(existsSync(dbPath)).toBe(false)
+    expect(manager.getCurrentPath()).toBeNull()
+
+    const withPassphrase = await createDatabase(
+      { path: dbPath, setupPassphrase: 'correct horse battery staple' },
+      () => manager,
+      keyStore
+    )
+    expect(withPassphrase.success).toBe(true)
+    await manager.close()
+
+    // Still encrypted at rest.
+    const rawNoKey = new Database(dbPath)
+    expect(() => rawNoKey.prepare('SELECT count(*) FROM sqlite_master').get()).toThrow(
+      /file is not a database/i
+    )
+    rawNoKey.close()
+
+    const resolved = keyStore.resolveKeyWithPassphrase(dbPath, 'correct horse battery staple')
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected ok result')
+
+    const rawWithKey = new Database(dbPath)
+    rawWithKey.pragma(`key='${resolved.dek}'`)
+    expect(() => rawWithKey.prepare('SELECT count(*) FROM sqlite_master').get()).not.toThrow()
+    rawWithKey.close()
+  })
+
+  it('explicit password create/open is unchanged: the password itself is the SQLCipher key and the key-store is never consulted', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    const created = await createDatabase(
+      { path: dbPath, password: 'hunter2literal' },
+      () => manager,
+      keyStore
+    )
+    expect(created.success).toBe(true)
+    await manager.close()
+
+    // The key-store must have no entry for an explicit-password DB.
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+
+    const openedWithNoPassword = await openDatabase(
+      { path: dbPath },
+      () => manager.getCurrent(),
+      () => manager,
+      noopCallbacks,
+      keyStore
+    )
+    expect(openedWithNoPassword).toEqual({ success: false, needsPassword: true })
+
+    const openedWithPassword = await openDatabase(
+      { path: dbPath, password: 'hunter2literal' },
+      () => manager.getCurrent(),
+      () => manager,
+      noopCallbacks,
+      keyStore
+    )
+    expect(openedWithPassword.success).toBe(true)
+  })
+
+  it('open with a wrong password against an explicit-password DB still reports WRONG_PASSWORD', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    await createDatabase({ path: dbPath, password: 'hunter2literal' }, () => manager, keyStore)
+    await manager.close()
+
+    const opened = await openDatabase(
+      { path: dbPath, password: 'totally-wrong' },
+      () => manager.getCurrent(),
+      () => manager,
+      noopCallbacks,
+      keyStore
+    )
+    expect(opened).toEqual({ success: false, error: 'WRONG_PASSWORD' })
+  })
+
+  it('createManagedKey on an already-keyed path never falls back to an unencrypted DB', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+
+    // Pre-register the path against a key (simulating a stale/duplicate registry entry).
+    const preexisting = keyStore.createManagedKey(dbPath)
+    expect(preexisting.ok).toBe(true)
+
+    const result = await createDatabase({ path: dbPath }, () => manager, keyStore)
+    expect(result.success).toBe(false)
+    expect(result.needsPassphraseSetup).toBeUndefined()
+    expect(existsSync(dbPath)).toBe(false)
+  })
+})

--- a/tests/main/database/encryption-default.test.ts
+++ b/tests/main/database/encryption-default.test.ts
@@ -61,6 +61,7 @@ describe('encrypt-by-default for NEW databases', () => {
 
     const result = await createDatabase({ path: dbPath }, () => manager, keyStore)
     expect(result.success).toBe(true)
+    expect(keyStore.getKeyStateForPath(dbPath)).toBe('active')
 
     manager.getCurrent().database.exec('CREATE TABLE marker (id INTEGER)')
     manager.getCurrent().database.prepare('INSERT INTO marker (id) VALUES (1)').run()
@@ -83,6 +84,21 @@ describe('encrypt-by-default for NEW databases', () => {
     const row = rawWithKey.prepare('SELECT id FROM marker').get() as { id: number }
     expect(row.id).toBe(1)
     rawWithKey.close()
+  })
+
+  it('reconciles a crash-abandoned pending create when no database file exists', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'crash-retry.db')
+    const abandoned = keyStore.createPendingManagedKey(dbPath)
+    expect(abandoned.ok).toBe(true)
+    if (!abandoned.ok) throw new Error('expected pending key')
+
+    const result = await createDatabase({ path: dbPath }, () => manager, keyStore)
+
+    expect(result.success).toBe(true)
+    expect(keyStore.getKeyStateForPath(dbPath)).toBe('active')
+    expect(keyStore.getKeyIdForPath(dbPath)).not.toBe(abandoned.keyId)
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(true)
   })
 
   it('managed round-trip: create, close, and reopen transparently via the key-store -- data intact', async () => {
@@ -139,6 +155,7 @@ describe('encrypt-by-default for NEW databases', () => {
       keyStore
     )
     expect(withPassphrase.success).toBe(true)
+    expect(keyStore.getKeyStateForPath(dbPath)).toBe('active')
     await manager.close()
 
     // Still encrypted at rest.

--- a/tests/main/database/encryption-default.test.ts
+++ b/tests/main/database/encryption-default.test.ts
@@ -222,4 +222,48 @@ describe('encrypt-by-default for NEW databases', () => {
     expect(result.needsPassphraseSetup).toBeUndefined()
     expect(existsSync(dbPath)).toBe(false)
   })
+
+  it('a failed managed create rolls back the key-store entry so a retry at the same path is not burned', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const dbPath = join(tmpDir, 'case.db')
+    const failingManager = {
+      createDatabase: async () => {
+        throw new Error('disk full')
+      },
+      getCurrentInfo: () => null
+    }
+
+    await expect(
+      createDatabase({ path: dbPath }, () => failingManager as never, keyStore)
+    ).rejects.toThrow('disk full')
+
+    // The registry must have NO entry for this path -- a fresh managed-key
+    // create at the same path must succeed instead of hitting
+    // `path-already-keyed`.
+    const retry = keyStore.createManagedKey(dbPath)
+    expect(retry.ok).toBe(true)
+  })
+
+  it('a failed passphrase-setup create rolls back the key-store entry so a retry at the same path is not burned', async () => {
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(false) })
+    const dbPath = join(tmpDir, 'case.db')
+    const failingManager = {
+      createDatabase: async () => {
+        throw new Error('disk full')
+      },
+      getCurrentInfo: () => null
+    }
+
+    await expect(
+      createDatabase(
+        { path: dbPath, setupPassphrase: 'correct horse battery staple' },
+        () => failingManager as never,
+        keyStore
+      )
+    ).rejects.toThrow('disk full')
+
+    // Same rollback guarantee for the passphrase-wrap path.
+    const retry = keyStore.wrapNewDekWithPassphrase(dbPath, 'correct horse battery staple')
+    expect(retry.ok).toBe(true)
+  })
 })

--- a/tests/main/database/fs-durability.test.ts
+++ b/tests/main/database/fs-durability.test.ts
@@ -1,0 +1,52 @@
+/**
+ * fs-durability.ts -- fsync helper tests.
+ *
+ * Covers the direct contract of `fsyncFile`/`fsyncContainingDirectory`:
+ * fsyncing a real file/directory succeeds without throwing, a missing file
+ * is a real (propagating) failure for `fsyncFile`, and a missing directory
+ * is swallowed by `fsyncContainingDirectory`'s best-effort contract.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { fsyncContainingDirectory, fsyncFile } from '../../../src/main/database/fs-durability'
+
+describe('fs-durability', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-fs-durability-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('fsyncFile succeeds for an existing file', () => {
+    const filePath = join(tmpDir, 'durable.txt')
+    writeFileSync(filePath, 'hello', 'utf-8')
+
+    expect(() => fsyncFile(filePath)).not.toThrow()
+  })
+
+  it('fsyncFile propagates a real failure for a missing file', () => {
+    const filePath = join(tmpDir, 'does-not-exist.txt')
+
+    expect(() => fsyncFile(filePath)).toThrow()
+  })
+
+  it('fsyncContainingDirectory succeeds (best-effort) for an existing directory', () => {
+    const filePath = join(tmpDir, 'durable.txt')
+    writeFileSync(filePath, 'hello', 'utf-8')
+
+    expect(() => fsyncContainingDirectory(filePath)).not.toThrow()
+  })
+
+  it('fsyncContainingDirectory swallows a missing-directory failure rather than throwing', () => {
+    const filePath = join(tmpDir, 'nested-missing-dir', 'durable.txt')
+
+    expect(() => fsyncContainingDirectory(filePath)).not.toThrow()
+  })
+})

--- a/tests/main/database/plaintext-migration-signal.test.ts
+++ b/tests/main/database/plaintext-migration-signal.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { computeContentSignal } from '../../../src/main/database/plaintext-migration-signal'
+
+describe('plaintext migration content signal', () => {
+  it('streams user-table rows and never materializes the table with all()', () => {
+    const rowStatement = {
+      all: vi.fn(() => {
+        throw new Error('table rows must not be materialized')
+      }),
+      iterate: vi.fn(function* () {
+        yield { id: 1, label: 'alpha' }
+        yield { id: 2, label: 'beta' }
+      })
+    }
+    const prepare = vi.fn((sql: string) => {
+      if (sql.includes('sqlite_master')) {
+        return { all: () => [{ name: 'marker', sql: 'CREATE TABLE marker (id, label)' }] }
+      }
+      if (sql.includes('COUNT(*)')) return { get: () => ({ c: 2 }) }
+      if (sql.includes('PRAGMA table_info'))
+        return { all: () => [{ name: 'id' }, { name: 'label' }] }
+      if (sql.startsWith('SELECT "id", "label"')) return rowStatement
+      throw new Error(`Unexpected SQL: ${sql}`)
+    })
+    const db = {
+      prepare,
+      pragma: vi.fn().mockReturnValue(7)
+    }
+
+    const signal = computeContentSignal(db as never)
+
+    expect(signal.userVersion).toBe(7)
+    expect(signal.tableRowCounts).toEqual({ marker: 2 })
+    expect(signal.tableContentHashes.marker).toMatch(/^[0-9a-f]{64}$/)
+    expect(rowStatement.iterate).toHaveBeenCalledOnce()
+    expect(rowStatement.all).not.toHaveBeenCalled()
+  })
+})

--- a/tests/main/database/plaintext-migration.test.ts
+++ b/tests/main/database/plaintext-migration.test.ts
@@ -14,7 +14,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, existsSync, readdirSync, writeFileSync, truncateSync } from 'fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  writeFileSync,
+  truncateSync
+} from 'fs'
 import { tmpdir } from 'os'
 import { join, basename, dirname } from 'path'
 import Database from 'better-sqlite3-multiple-ciphers'
@@ -32,6 +40,7 @@ import {
 } from '../../../src/main/ipc/handlers/database-migration-logic'
 import type { DatabaseLifecycleCallbacks } from '../../../src/main/ipc/handlers/database-lifecycle-logic'
 import { DatabaseError } from '../../../src/main/database/errors'
+import { recoverySidecarPathFor } from '../../../src/main/database/recovery-sidecar'
 
 /** Reversible fake "encryption" so round-trips work in tests (same fake used across the I1/I2a suites). */
 function fakeSafeStorage(available = true): SafeStorageLike {
@@ -480,6 +489,29 @@ describe('migrateCurrentToEncrypted (consent + orchestration)', () => {
     expect(rows).toEqual([{ label: 'needs-migration' }])
   })
 
+  it('no-keyring migration fails closed when the required recovery sidecar cannot be written', async () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    mkdirSync(recoverySidecarPathFor(dbPath))
+
+    await expect(
+      migrateCurrentToEncrypted(
+        { consent: true, recoveryPassphrase: 'required portable recovery' },
+        () => manager,
+        keyStore,
+        noopCallbacks
+      )
+    ).rejects.toThrow(/recovery sidecar/i)
+
+    expect(manager.getCurrentInfo()?.encrypted).toBe(false)
+    expect(keyStore.getKeyIdForPath(dbPath)).toBeNull()
+    expect(manager.getCurrent().database.prepare('SELECT label FROM marker').pluck().all()).toEqual(
+      ['needs-migration']
+    )
+  })
+
   it('managed-key migration with a recovery passphrase sets durable recovery, and the app session stays usable', async () => {
     const keyStore = new DbKeyStore({
       registryPath: join(tmpDir, 'keys.json'),
@@ -496,6 +528,7 @@ describe('migrateCurrentToEncrypted (consent + orchestration)', () => {
     expect(result.success).toBe(true)
     expect(result.recoveryPassphraseSet).toBe(true)
     expect(result.info?.encrypted).toBe(true)
+    expect(result.info?.keyManaged).toBe(true)
     expect(existsSync(result.backupPath!)).toBe(true)
 
     // The app's live session is now the encrypted DB, with the original data intact.

--- a/tests/main/database/plaintext-migration.test.ts
+++ b/tests/main/database/plaintext-migration.test.ts
@@ -13,7 +13,7 @@
  *     no data loss.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   mkdirSync,
   mkdtempSync,
@@ -527,6 +527,7 @@ describe('migrateCurrentToEncrypted (consent + orchestration)', () => {
 
     expect(result.success).toBe(true)
     expect(result.recoveryPassphraseSet).toBe(true)
+    expect(result.sidecarWritten).toBe(true)
     expect(result.info?.encrypted).toBe(true)
     expect(result.info?.keyManaged).toBe(true)
     expect(existsSync(result.backupPath!)).toBe(true)
@@ -550,9 +551,56 @@ describe('migrateCurrentToEncrypted (consent + orchestration)', () => {
 
     // Post-migration cleanup: the plaintext backup can be deleted through the
     // gated IPC-facing action, but only because it matches the CURRENT db path.
+    writeFileSync(`${result.backupPath!}-wal`, 'plaintext wal bytes')
+    writeFileSync(`${result.backupPath!}-shm`, 'plaintext shm bytes')
     const deleteResult = await deletePlaintextBackup(result.backupPath!, () => manager)
     expect(deleteResult.success).toBe(true)
     expect(existsSync(result.backupPath!)).toBe(false)
+    expect(existsSync(`${result.backupPath!}-wal`)).toBe(false)
+    expect(existsSync(`${result.backupPath!}-shm`)).toBe(false)
+  })
+
+  it('reports optional recovery sidecar failure without claiming portable recovery', async () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    mkdirSync(recoverySidecarPathFor(dbPath))
+
+    const result = await migrateCurrentToEncrypted(
+      { consent: true, recoveryPassphrase: 'local recovery only' },
+      () => manager,
+      keyStore,
+      noopCallbacks
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.recoveryPassphraseSet).toBe(true)
+    expect(result.sidecarWritten).toBe(false)
+    expect(result.info?.encrypted).toBe(true)
+  })
+
+  it('keeps a verified encrypted migration recoverable when the app session reopen fails', async () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const openSpy = manager.open.bind(manager)
+    manager.open = vi.fn(async (path: string, password?: string) => {
+      if (password !== undefined) throw new Error('session initialization failed')
+      return await openSpy(path, password)
+    }) as never
+
+    await expect(
+      migrateCurrentToEncrypted({ consent: true }, () => manager, keyStore, noopCallbacks)
+    ).rejects.toThrow(/encrypted migration completed/i)
+
+    expect(keyStore.getKeyStateForPath(dbPath)).toBe('pending')
+    const resolved = keyStore.resolveKeyForPath(dbPath)
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) throw new Error('expected recoverable key')
+    expect(readMarkerLabels(dbPath, resolved.dek)).toEqual(['needs-migration'])
+    expect(manager.open).toHaveBeenCalledTimes(1)
   })
 
   it('deletePlaintextBackup refuses to delete a file that is not a plaintext backup of the currently open database', async () => {

--- a/tests/main/database/plaintext-migration.test.ts
+++ b/tests/main/database/plaintext-migration.test.ts
@@ -14,12 +14,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, existsSync, readdirSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, existsSync, readdirSync, writeFileSync, truncateSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, basename, dirname } from 'path'
 import Database from 'better-sqlite3-multiple-ciphers'
 import {
   migratePlaintextToEncrypted,
+  realVerifyEncrypted,
   PlaintextMigrationError
 } from '../../../src/main/database/plaintext-migration'
 import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
@@ -218,12 +219,10 @@ describe('migratePlaintextToEncrypted (core algorithm)', () => {
           verifyEncrypted: (filePath, dek) => {
             calls += 1
             if (calls === 1) {
-              // Pre-swap verification (step 4) must succeed for the swap to happen at all.
-              const db = new Database(filePath)
-              db.pragma(`key='${dek}'`)
-              db.pragma('integrity_check', { simple: true })
-              db.close()
-              return { userVersion: 7, tableRowCounts: { marker: 3, other: 1 } }
+              // Pre-swap verification (step 4) must succeed for real for the
+              // swap to happen at all -- delegate to the real implementation
+              // rather than hand-crafting a fake signal.
+              return realVerifyEncrypted(filePath, dek)
             }
             // Post-swap verification (step 7): simulate a failure here specifically.
             throw new Error('simulated failure re-opening the swapped-in encrypted file')
@@ -246,6 +245,123 @@ describe('migratePlaintextToEncrypted (core algorithm)', () => {
 
     // The key-store entry was rolled back.
     expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+  })
+
+  it('rollback — corrupt/truncated backup is rejected BEFORE the swap: original untouched, no swap happened', () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(dbPath)
+    if (!managed.ok) throw new Error('expected ok')
+
+    const originalLabels = readMarkerLabels(dbPath)
+
+    expect(() =>
+      migratePlaintextToEncrypted(
+        { path: dbPath, dek: managed.dek, keyId: managed.keyId, keyStore },
+        {
+          // Truncate the REAL backup file right after it's written, then let
+          // the REAL backup-verification logic (open with no key,
+          // integrity_check, content signal) run against the truncated
+          // bytes -- proving the shipped code detects this, not a stub.
+          afterBackupCopy: (backupPath) => {
+            truncateSync(backupPath, 4)
+          }
+        }
+      )
+    ).toThrow(PlaintextMigrationError)
+
+    // Original untouched: still plaintext, still has the real seeded rows.
+    expect(readMarkerLabels(dbPath)).toEqual(originalLabels)
+    const rawNoKey = new Database(dbPath)
+    expect(() => rawNoKey.prepare('SELECT count(*) FROM sqlite_master').get()).not.toThrow()
+    rawNoKey.close()
+
+    // No swap happened and no leftover `.encrypting-*.tmp` or
+    // `.plaintext-backup-*` files -- the corrupt backup was cleaned up.
+    expect(siblingFiles(dbPath)).toEqual([])
+
+    // The key-store entry created before the attempt was rolled back.
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+  })
+
+  it('rollback — a same-cardinality content divergence (row COUNT matches, content differs) is rejected', () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(dbPath)
+    if (!managed.ok) throw new Error('expected ok')
+
+    const originalLabels = readMarkerLabels(dbPath)
+
+    expect(() =>
+      migratePlaintextToEncrypted(
+        { path: dbPath, dek: managed.dek, keyId: managed.keyId, keyStore },
+        {
+          // Mutate ONE row's content in the REAL encrypting candidate right
+          // after it's rekeyed -- same row count (3 marker rows), same
+          // `user_version`, different bytes. A plain COUNT(*)+user_version
+          // signal cannot see this; the strengthened per-table content hash
+          // must.
+          afterCandidateRekey: (candidatePath, dek) => {
+            const db = new Database(candidatePath)
+            db.pragma(`key='${dek}'`)
+            db.prepare("UPDATE marker SET label = 'tampered' WHERE label = 'beta'").run()
+            db.close()
+          }
+        }
+      )
+    ).toThrow(PlaintextMigrationError)
+
+    // Original untouched: the divergence was caught before the swap.
+    expect(readMarkerLabels(dbPath)).toEqual(originalLabels)
+    const rawNoKey = new Database(dbPath)
+    expect(() => rawNoKey.prepare('SELECT count(*) FROM sqlite_master').get()).not.toThrow()
+    rawNoKey.close()
+
+    // No leftover `.encrypting-*.tmp` candidate file.
+    const leftovers = siblingFiles(dbPath).filter((f) => f.includes('.encrypting-'))
+    expect(leftovers).toEqual([])
+
+    // The key-store entry created before the attempt was rolled back.
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+  })
+
+  it('rollback — a failure in the earliest step (already-encrypted) also rolls back the key-store entry', () => {
+    // Regression test for the I2b hardening review's MINOR-4 finding: every
+    // failure path of `migratePlaintextToEncrypted`, INCLUDING the earliest
+    // one (before the `rollbackBeforeSwap` closure even exists), must roll
+    // back a real, previously-minted key-store entry -- not just the later
+    // steps.
+    const encryptedPath = join(tmpDir, 'already-encrypted-2.db')
+    const seedDb = new Database(encryptedPath)
+    seedDb.pragma("key='some-existing-key'")
+    seedDb.exec('CREATE TABLE t (id INTEGER)')
+    seedDb.close()
+
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(encryptedPath)
+    if (!managed.ok) throw new Error('expected ok')
+    expect(keyStore.resolveKeyForPath(encryptedPath).ok).toBe(true)
+
+    expect(() =>
+      migratePlaintextToEncrypted({
+        path: encryptedPath,
+        dek: managed.dek,
+        keyId: managed.keyId,
+        keyStore
+      })
+    ).toThrow(PlaintextMigrationError)
+
+    // The key-store entry minted before the attempt was rolled back, even
+    // though the failure happened before any tmp/backup file was created.
+    expect(keyStore.resolveKeyForPath(encryptedPath).ok).toBe(false)
+    expect(siblingFiles(encryptedPath)).toEqual([])
   })
 
   it('idempotence: migrating an already-encrypted database is a typed no-op error', () => {

--- a/tests/main/database/plaintext-migration.test.ts
+++ b/tests/main/database/plaintext-migration.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Consented, backed-up, REVERSIBLE plaintext -> encrypted migration.
+ *
+ * See `.superpowers/sdd/task-I2b-brief.md` for the full design. These tests
+ * ARE the safety proof for the highest-risk task in this milestone: they run
+ * against a REAL `better-sqlite3-multiple-ciphers` database on real temp
+ * files (no mocking of SQLite itself), and prove -- with seeded rows read
+ * back byte-for-byte -- that:
+ *   - a successful migration produces a genuinely encrypted file plus an
+ *     intact plaintext backup, and
+ *   - EVERY failure mode (verification failure, swap failure, no consent,
+ *     no keyring+no passphrase) leaves the user with a working database and
+ *     no data loss.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, basename, dirname } from 'path'
+import Database from 'better-sqlite3-multiple-ciphers'
+import {
+  migratePlaintextToEncrypted,
+  PlaintextMigrationError
+} from '../../../src/main/database/plaintext-migration'
+import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
+import { DatabaseManager } from '../../../src/main/services/DatabaseManager'
+import { RecentDatabasesService } from '../../../src/main/services/RecentDatabasesService'
+import {
+  migrateCurrentToEncrypted,
+  deletePlaintextBackup
+} from '../../../src/main/ipc/handlers/database-migration-logic'
+import type { DatabaseLifecycleCallbacks } from '../../../src/main/ipc/handlers/database-lifecycle-logic'
+import { DatabaseError } from '../../../src/main/database/errors'
+
+/** Reversible fake "encryption" so round-trips work in tests (same fake used across the I1/I2a suites). */
+function fakeSafeStorage(available = true): SafeStorageLike {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (s: string) => {
+      if (!available) throw new Error('unavailable')
+      return Buffer.from('SS:' + s)
+    },
+    decryptString: (b: Buffer) => b.toString().replace(/^SS:/, '')
+  }
+}
+
+const noopCallbacks: DatabaseLifecycleCallbacks = {
+  triggerStartupRebuild: () => undefined
+}
+
+/** Seeds a fresh PLAINTEXT database with a couple of tables and some rows. */
+function seedPlaintextDb(path: string): { rows: number } {
+  const db = new Database(path)
+  db.pragma('user_version = 7')
+  db.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, label TEXT)')
+  db.exec('CREATE TABLE other (id INTEGER PRIMARY KEY, value INTEGER)')
+  const insertMarker = db.prepare('INSERT INTO marker (label) VALUES (?)')
+  insertMarker.run('alpha')
+  insertMarker.run('beta')
+  insertMarker.run('gamma')
+  db.prepare('INSERT INTO other (value) VALUES (?)').run(42)
+  db.close()
+  return { rows: 3 }
+}
+
+function readMarkerLabels(path: string, dek?: string): string[] {
+  const db = new Database(path)
+  if (dek !== undefined) {
+    db.pragma(`key='${dek}'`)
+  }
+  const rows = db.prepare('SELECT label FROM marker ORDER BY id').all() as Array<{
+    label: string
+  }>
+  db.close()
+  return rows.map((r) => r.label)
+}
+
+function siblingFiles(path: string): string[] {
+  const dir = dirname(path)
+  const base = basename(path)
+  return readdirSync(dir).filter((f) => f !== base && f.startsWith(base))
+}
+
+describe('migratePlaintextToEncrypted (core algorithm)', () => {
+  let tmpDir: string
+  let dbPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-plaintext-migration-'))
+    dbPath = join(tmpDir, 'case.db')
+    seedPlaintextDb(dbPath)
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('happy path: encrypts at rest, keeps an intact plaintext backup, preserves all rows', () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(dbPath)
+    expect(managed.ok).toBe(true)
+    if (!managed.ok) throw new Error('expected ok')
+
+    const result = migratePlaintextToEncrypted({
+      path: dbPath,
+      dek: managed.dek,
+      keyId: managed.keyId,
+      keyStore
+    })
+
+    // The file at the ORIGINAL path is now encrypted: no-key open fails.
+    const rawNoKey = new Database(dbPath)
+    expect(() => rawNoKey.prepare('SELECT count(*) FROM sqlite_master').get()).toThrow(
+      /file is not a database/i
+    )
+    rawNoKey.close()
+
+    // With the DEK, the same rows are readable and integrity_check is ok.
+    const rawWithKey = new Database(dbPath)
+    rawWithKey.pragma(`key='${managed.dek}'`)
+    expect(rawWithKey.pragma('integrity_check', { simple: true })).toBe('ok')
+    const rows = rawWithKey.prepare('SELECT label FROM marker ORDER BY id').all() as Array<{
+      label: string
+    }>
+    expect(rows.map((r) => r.label)).toEqual(['alpha', 'beta', 'gamma'])
+    rawWithKey.close()
+
+    // The plaintext backup exists, is non-empty, and contains the ORIGINAL rows unencrypted.
+    expect(result.backupPath).toContain('.plaintext-backup-')
+    expect(existsSync(result.backupPath)).toBe(true)
+    expect(readMarkerLabels(result.backupPath)).toEqual(['alpha', 'beta', 'gamma'])
+
+    // No leftover `.encrypting-*.tmp` candidate files.
+    const leftovers = siblingFiles(dbPath).filter((f) => f.includes('.encrypting-'))
+    expect(leftovers).toEqual([])
+  })
+
+  it('backup exists and is complete before the swap replaces the original', () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(dbPath)
+    if (!managed.ok) throw new Error('expected ok')
+
+    const result = migratePlaintextToEncrypted({
+      path: dbPath,
+      dek: managed.dek,
+      keyId: managed.keyId,
+      keyStore
+    })
+
+    const stat = existsSync(result.backupPath)
+    expect(stat).toBe(true)
+    expect(readMarkerLabels(result.backupPath)).toHaveLength(3)
+  })
+
+  it('rollback — verification failure: original is byte-for-byte unchanged, no tmp file, no key-store entry', () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(dbPath)
+    if (!managed.ok) throw new Error('expected ok')
+
+    const originalBytes = readMarkerLabels(dbPath)
+
+    expect(() =>
+      migratePlaintextToEncrypted(
+        {
+          path: dbPath,
+          dek: managed.dek,
+          keyId: managed.keyId,
+          keyStore
+        },
+        {
+          verifyEncrypted: () => {
+            throw new Error('simulated corruption detected during verification')
+          }
+        }
+      )
+    ).toThrow(PlaintextMigrationError)
+
+    // Original untouched: still plaintext, still has the same rows.
+    expect(readMarkerLabels(dbPath)).toEqual(originalBytes)
+
+    // No `.encrypting-*.tmp` or `.plaintext-backup-*` files left behind.
+    const leftovers = siblingFiles(dbPath)
+    expect(leftovers).toEqual([])
+
+    // The key-store entry created before the attempt was rolled back.
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+  })
+
+  it('rollback — swap/post-swap failure: original is restored from backup, still openable, no data loss', () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const managed = keyStore.createManagedKey(dbPath)
+    if (!managed.ok) throw new Error('expected ok')
+
+    const originalLabels = readMarkerLabels(dbPath)
+    let calls = 0
+
+    expect(() =>
+      migratePlaintextToEncrypted(
+        {
+          path: dbPath,
+          dek: managed.dek,
+          keyId: managed.keyId,
+          keyStore
+        },
+        {
+          verifyEncrypted: (filePath, dek) => {
+            calls += 1
+            if (calls === 1) {
+              // Pre-swap verification (step 4) must succeed for the swap to happen at all.
+              const db = new Database(filePath)
+              db.pragma(`key='${dek}'`)
+              db.pragma('integrity_check', { simple: true })
+              db.close()
+              return { userVersion: 7, tableRowCounts: { marker: 3, other: 1 } }
+            }
+            // Post-swap verification (step 7): simulate a failure here specifically.
+            throw new Error('simulated failure re-opening the swapped-in encrypted file')
+          }
+        }
+      )
+    ).toThrow(PlaintextMigrationError)
+
+    expect(calls).toBe(2)
+
+    // The original database is restored at `path` -- plaintext, same rows, still openable.
+    expect(readMarkerLabels(dbPath)).toEqual(originalLabels)
+    const rawNoKey = new Database(dbPath)
+    expect(() => rawNoKey.prepare('SELECT count(*) FROM sqlite_master').get()).not.toThrow()
+    rawNoKey.close()
+
+    // No leftover `.encrypting-*.tmp` candidate file.
+    const leftovers = siblingFiles(dbPath).filter((f) => f.includes('.encrypting-'))
+    expect(leftovers).toEqual([])
+
+    // The key-store entry was rolled back.
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+  })
+
+  it('idempotence: migrating an already-encrypted database is a typed no-op error', () => {
+    const encryptedPath = join(tmpDir, 'already-encrypted.db')
+    const db = new Database(encryptedPath)
+    db.pragma("key='some-existing-key'")
+    db.exec('CREATE TABLE t (id INTEGER)')
+    db.close()
+
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+
+    let thrown: unknown
+    try {
+      migratePlaintextToEncrypted({
+        path: encryptedPath,
+        dek: 'a'.repeat(64),
+        keyId: 'unused-key-id',
+        keyStore
+      })
+    } catch (e) {
+      thrown = e
+    }
+
+    expect(thrown).toBeInstanceOf(PlaintextMigrationError)
+    expect((thrown as PlaintextMigrationError).reason).toBe('already-encrypted')
+
+    // Untouched: still opens with the ORIGINAL key, no tmp/backup files created.
+    const raw = new Database(encryptedPath)
+    raw.pragma("key='some-existing-key'")
+    expect(() => raw.prepare('SELECT count(*) FROM sqlite_master').get()).not.toThrow()
+    raw.close()
+    expect(siblingFiles(encryptedPath)).toEqual([])
+  })
+})
+
+describe('migrateCurrentToEncrypted (consent + orchestration)', () => {
+  let tmpDir: string
+  let dbPath: string
+  let manager: DatabaseManager
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-migration-orchestration-'))
+    dbPath = join(tmpDir, 'case.db')
+    manager = new DatabaseManager(new RecentDatabasesService(join(tmpDir, 'settings.json')))
+    // A plaintext database, currently open -- as if the app just launched
+    // and opened an existing pre-encryption-by-default database.
+    await manager.createDatabase(dbPath)
+    manager.getCurrent().database.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, label TEXT)')
+    manager
+      .getCurrent()
+      .database.prepare('INSERT INTO marker (label) VALUES (?)')
+      .run('needs-migration')
+  })
+
+  afterEach(async () => {
+    await manager.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('refuses without explicit consent, leaving the database open and untouched', async () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+
+    await expect(
+      migrateCurrentToEncrypted(
+        { consent: false, recoveryPassphrase: undefined },
+        () => manager,
+        keyStore,
+        noopCallbacks
+      )
+    ).rejects.toThrow(/consent/i)
+
+    // The database is still open, still plaintext, data intact.
+    expect(manager.getCurrentInfo()?.encrypted).toBe(false)
+    const rows = manager.getCurrent().database.prepare('SELECT label FROM marker').all() as Array<{
+      label: string
+    }>
+    expect(rows).toEqual([{ label: 'needs-migration' }])
+    // No migration-artifact files -- a `-wal`/`-shm` sidecar from the still-open
+    // WAL-mode session is expected and is not a migration artifact.
+    expect(siblingFiles(dbPath).filter((f) => !f.endsWith('-wal') && !f.endsWith('-shm'))).toEqual(
+      []
+    )
+  })
+
+  it('no-keyring path: safeStorage unavailable and no passphrase supplied -> typed error, never half-migrates', async () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+
+    await expect(
+      migrateCurrentToEncrypted({ consent: true }, () => manager, keyStore, noopCallbacks)
+    ).rejects.toThrow(DatabaseError)
+
+    // No key-store entry was minted for this path.
+    expect(keyStore.resolveKeyForPath(dbPath).ok).toBe(false)
+
+    // No `.encrypting-*.tmp` or `.plaintext-backup-*` files -- migration never started.
+    // (A `-wal`/`-shm` sidecar from the still-open WAL-mode session is expected.)
+    expect(siblingFiles(dbPath).filter((f) => !f.endsWith('-wal') && !f.endsWith('-shm'))).toEqual(
+      []
+    )
+
+    // The database is still usable (reopened plaintext by the orchestration layer).
+    expect(manager.getCurrentInfo()).not.toBeNull()
+    expect(manager.getCurrentInfo()?.encrypted).toBe(false)
+    const rows = manager.getCurrent().database.prepare('SELECT label FROM marker').all() as Array<{
+      label: string
+    }>
+    expect(rows).toEqual([{ label: 'needs-migration' }])
+  })
+
+  it('managed-key migration with a recovery passphrase sets durable recovery, and the app session stays usable', async () => {
+    const keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+
+    const result = await migrateCurrentToEncrypted(
+      { consent: true, recoveryPassphrase: 'correct horse battery staple' },
+      () => manager,
+      keyStore,
+      noopCallbacks
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.recoveryPassphraseSet).toBe(true)
+    expect(result.info?.encrypted).toBe(true)
+    expect(existsSync(result.backupPath!)).toBe(true)
+
+    // The app's live session is now the encrypted DB, with the original data intact.
+    expect(manager.getCurrentInfo()?.encrypted).toBe(true)
+    const rows = manager.getCurrent().database.prepare('SELECT label FROM marker').all() as Array<{
+      label: string
+    }>
+    expect(rows).toEqual([{ label: 'needs-migration' }])
+
+    // Durability: the recovery passphrase alone (no keyring) resolves the SAME DEK
+    // that the managed (safeStorage) wrap resolves -- keyring loss would not be fatal.
+    const viaKeyring = keyStore.resolveKeyForPath(dbPath)
+    const viaPassphrase = keyStore.resolveKeyWithPassphrase(dbPath, 'correct horse battery staple')
+    expect(viaKeyring.ok).toBe(true)
+    expect(viaPassphrase.ok).toBe(true)
+    if (viaKeyring.ok && viaPassphrase.ok) {
+      expect(viaPassphrase.dek).toBe(viaKeyring.dek)
+    }
+
+    // Post-migration cleanup: the plaintext backup can be deleted through the
+    // gated IPC-facing action, but only because it matches the CURRENT db path.
+    const deleteResult = await deletePlaintextBackup(result.backupPath!, () => manager)
+    expect(deleteResult.success).toBe(true)
+    expect(existsSync(result.backupPath!)).toBe(false)
+  })
+
+  it('deletePlaintextBackup refuses to delete a file that is not a plaintext backup of the currently open database', async () => {
+    const arbitraryFile = join(tmpDir, 'not-a-backup.txt')
+    writeFileSync(arbitraryFile, 'not a database backup')
+
+    await expect(deletePlaintextBackup(arbitraryFile, () => manager)).rejects.toThrow()
+    expect(existsSync(arbitraryFile)).toBe(true)
+  })
+})

--- a/tests/main/database/recovery-portability.test.ts
+++ b/tests/main/database/recovery-portability.test.ts
@@ -229,28 +229,37 @@ describe('recovery sidecar portability (openDatabase end-to-end)', () => {
   })
 
   it('tries a verified sidecar candidate when a stale path registry wrap accepts the same passphrase', async () => {
-    const dir = makeTmpDir('varlens-recovery-stale-registry-')
-    const registryPath = join(dir, 'keys.json')
-    const stalePath = join(dir, 'restored.db')
-    const replacementPath = join(dir, 'replacement.db')
-    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
-    const staleManager = makeManager(dir, 'stale-settings')
-    const replacementManager = makeManager(dir, 'replacement-settings')
+    const destinationDir = makeTmpDir('varlens-recovery-stale-registry-')
+    const sourceDir = makeTmpDir('varlens-recovery-source-machine-')
+    const stalePath = join(destinationDir, 'restored.db')
+    const replacementPath = join(sourceDir, 'replacement.db')
+    const destinationKeyStore = new DbKeyStore({
+      registryPath: join(destinationDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const sourceKeyStore = new DbKeyStore({
+      registryPath: join(sourceDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+    const staleManager = makeManager(destinationDir, 'stale-settings')
+    const replacementManager = makeManager(sourceDir, 'replacement-settings')
 
-    await createDatabase({ path: stalePath }, () => staleManager, keyStore)
-    const staleKeyId = keyStore.getKeyIdForPath(stalePath)
+    await createDatabase({ path: stalePath }, () => staleManager, destinationKeyStore)
+    const staleKeyId = destinationKeyStore.getKeyIdForPath(stalePath)
     expect(staleKeyId).not.toBeNull()
     if (staleKeyId === null) throw new Error('expected stale managed key')
-    expect(keyStore.setPassphrase(staleKeyId, PASSPHRASE)).toMatchObject({ ok: true })
+    const staleResolved = destinationKeyStore.resolveKeyForPath(stalePath)
+    expect(staleResolved.ok).toBe(true)
+    expect(destinationKeyStore.setPassphrase(staleKeyId, PASSPHRASE)).toMatchObject({ ok: true })
     await staleManager.close()
 
-    await createDatabase({ path: replacementPath }, () => replacementManager, keyStore)
-    const replacementKeyId = keyStore.getKeyIdForPath(replacementPath)
+    await createDatabase({ path: replacementPath }, () => replacementManager, sourceKeyStore)
+    const replacementKeyId = sourceKeyStore.getKeyIdForPath(replacementPath)
     expect(replacementKeyId).not.toBeNull()
     if (replacementKeyId === null) throw new Error('expected replacement managed key')
-    const replacementResolved = keyStore.resolveKeyForPath(replacementPath)
+    const replacementResolved = sourceKeyStore.resolveKeyForPath(replacementPath)
     expect(replacementResolved.ok).toBe(true)
-    expect(keyStore.setPassphrase(replacementKeyId, PASSPHRASE)).toMatchObject({ ok: true })
+    expect(sourceKeyStore.setPassphrase(replacementKeyId, PASSPHRASE)).toMatchObject({ ok: true })
     replacementManager
       .getCurrent()
       .database.exec('CREATE TABLE restored_marker (label TEXT NOT NULL)')
@@ -272,25 +281,27 @@ describe('recovery sidecar portability (openDatabase end-to-end)', () => {
       () => staleManager.getCurrent(),
       () => staleManager,
       noopCallbacks,
-      keyStore
+      destinationKeyStore
     )
     expect(detected).toEqual({ success: false, needsPassword: true })
-    expect(keyStore.getKeyIdForPath(stalePath)).toBe(staleKeyId)
+    expect(destinationKeyStore.getKeyIdForPath(stalePath)).toBe(staleKeyId)
 
     const opened = await openDatabase(
       { path: stalePath, password: PASSPHRASE },
       () => staleManager.getCurrent(),
       () => staleManager,
       noopCallbacks,
-      keyStore
+      destinationKeyStore
     )
 
     expect(opened.success).toBe(true)
     expect(
       staleManager.getCurrent().database.prepare('SELECT label FROM restored_marker').pluck().all()
     ).toEqual(['replacement-data'])
-    expect(keyStore.getKeyIdForPath(stalePath)).toBe(replacementKeyId)
-    expect(keyStore.resolveKeyForPath(stalePath)).toEqual(replacementResolved)
-    expect(keyStore.resolveKeyForPath(replacementPath)).toEqual({ ok: false, reason: 'not-found' })
+    expect(destinationKeyStore.getKeyIdForPath(stalePath)).not.toBe(staleKeyId)
+    expect(destinationKeyStore.resolveKeyForPath(stalePath)).toEqual(replacementResolved)
+    if (staleResolved.ok) {
+      expect(destinationKeyStore.findManagedKeyIdForDek(staleResolved.dek)).toBe(staleKeyId)
+    }
   })
 })

--- a/tests/main/database/recovery-portability.test.ts
+++ b/tests/main/database/recovery-portability.test.ts
@@ -186,4 +186,45 @@ describe('recovery sidecar portability (openDatabase end-to-end)', () => {
     expect(managerB.getCurrentInfo()).toBeNull()
     expect(keyStoreB.getKeyIdForPath(newPath)).toBeNull()
   })
+
+  it('a valid but mismatched copied sidecar cannot mutate the registry before SQLite rejects its DEK', async () => {
+    const dir = makeTmpDir('varlens-recovery-mismatch-')
+    const sourcePath = join(dir, 'source.db')
+    const targetPath = join(dir, 'target.db')
+    const registryPath = join(dir, 'keys.json')
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const sourceManager = makeManager(dir, 'source-settings')
+    const targetManager = makeManager(dir, 'target-settings')
+
+    await createDatabase({ path: sourcePath }, () => sourceManager, keyStore)
+    const sourceKeyId = keyStore.getKeyIdForPath(sourcePath)
+    expect(sourceKeyId).not.toBeNull()
+    if (sourceKeyId === null) throw new Error('expected source key')
+    expect(keyStore.setPassphrase(sourceKeyId, PASSPHRASE)).toMatchObject({ ok: true })
+    await sourceManager.close()
+
+    await createDatabase(
+      { path: targetPath, password: 'target-raw-sqlcipher-key' },
+      () => targetManager,
+      keyStore
+    )
+    targetManager.getCurrent().database.exec('CREATE TABLE target_marker (id INTEGER PRIMARY KEY)')
+    await targetManager.close()
+
+    copyFileSync(recoverySidecarPathFor(sourcePath), recoverySidecarPathFor(targetPath))
+    const registryBefore = readFileSync(registryPath)
+
+    const opened = await openDatabase(
+      { path: targetPath, password: PASSPHRASE },
+      () => targetManager.getCurrent(),
+      () => targetManager,
+      noopCallbacks,
+      keyStore
+    )
+
+    expect(opened).toEqual({ success: false, error: 'WRONG_PASSWORD' })
+    expect(readFileSync(registryPath)).toEqual(registryBefore)
+    expect(keyStore.getKeyIdForPath(sourcePath)).toBe(sourceKeyId)
+    expect(keyStore.getKeyIdForPath(targetPath)).toBeNull()
+  })
 })

--- a/tests/main/database/recovery-portability.test.ts
+++ b/tests/main/database/recovery-portability.test.ts
@@ -267,6 +267,16 @@ describe('recovery sidecar portability (openDatabase end-to-end)', () => {
     copyFileSync(replacementPath, stalePath)
     copyFileSync(recoverySidecarPathFor(replacementPath), recoverySidecarPathFor(stalePath))
 
+    const detected = await openDatabase(
+      { path: stalePath },
+      () => staleManager.getCurrent(),
+      () => staleManager,
+      noopCallbacks,
+      keyStore
+    )
+    expect(detected).toEqual({ success: false, needsPassword: true })
+    expect(keyStore.getKeyIdForPath(stalePath)).toBe(staleKeyId)
+
     const opened = await openDatabase(
       { path: stalePath, password: PASSPHRASE },
       () => staleManager.getCurrent(),

--- a/tests/main/database/recovery-portability.test.ts
+++ b/tests/main/database/recovery-portability.test.ts
@@ -227,4 +227,60 @@ describe('recovery sidecar portability (openDatabase end-to-end)', () => {
     expect(keyStore.getKeyIdForPath(sourcePath)).toBe(sourceKeyId)
     expect(keyStore.getKeyIdForPath(targetPath)).toBeNull()
   })
+
+  it('tries a verified sidecar candidate when a stale path registry wrap accepts the same passphrase', async () => {
+    const dir = makeTmpDir('varlens-recovery-stale-registry-')
+    const registryPath = join(dir, 'keys.json')
+    const stalePath = join(dir, 'restored.db')
+    const replacementPath = join(dir, 'replacement.db')
+    const keyStore = new DbKeyStore({ registryPath, safeStorage: fakeSafeStorage(true) })
+    const staleManager = makeManager(dir, 'stale-settings')
+    const replacementManager = makeManager(dir, 'replacement-settings')
+
+    await createDatabase({ path: stalePath }, () => staleManager, keyStore)
+    const staleKeyId = keyStore.getKeyIdForPath(stalePath)
+    expect(staleKeyId).not.toBeNull()
+    if (staleKeyId === null) throw new Error('expected stale managed key')
+    expect(keyStore.setPassphrase(staleKeyId, PASSPHRASE)).toMatchObject({ ok: true })
+    await staleManager.close()
+
+    await createDatabase({ path: replacementPath }, () => replacementManager, keyStore)
+    const replacementKeyId = keyStore.getKeyIdForPath(replacementPath)
+    expect(replacementKeyId).not.toBeNull()
+    if (replacementKeyId === null) throw new Error('expected replacement managed key')
+    const replacementResolved = keyStore.resolveKeyForPath(replacementPath)
+    expect(replacementResolved.ok).toBe(true)
+    expect(keyStore.setPassphrase(replacementKeyId, PASSPHRASE)).toMatchObject({ ok: true })
+    replacementManager
+      .getCurrent()
+      .database.exec('CREATE TABLE restored_marker (label TEXT NOT NULL)')
+    replacementManager
+      .getCurrent()
+      .database.prepare('INSERT INTO restored_marker (label) VALUES (?)')
+      .run('replacement-data')
+    await replacementManager.close()
+
+    // Simulate restoring/copying a different managed database and its valid
+    // recovery sidecar over a path whose old registry entry still exists.
+    // Reusing the same passphrase is deliberately realistic: the stale
+    // registry wrap authenticates successfully, but yields the wrong DEK.
+    copyFileSync(replacementPath, stalePath)
+    copyFileSync(recoverySidecarPathFor(replacementPath), recoverySidecarPathFor(stalePath))
+
+    const opened = await openDatabase(
+      { path: stalePath, password: PASSPHRASE },
+      () => staleManager.getCurrent(),
+      () => staleManager,
+      noopCallbacks,
+      keyStore
+    )
+
+    expect(opened.success).toBe(true)
+    expect(
+      staleManager.getCurrent().database.prepare('SELECT label FROM restored_marker').pluck().all()
+    ).toEqual(['replacement-data'])
+    expect(keyStore.getKeyIdForPath(stalePath)).toBe(replacementKeyId)
+    expect(keyStore.resolveKeyForPath(stalePath)).toEqual(replacementResolved)
+    expect(keyStore.resolveKeyForPath(replacementPath)).toEqual({ ok: false, reason: 'not-found' })
+  })
 })

--- a/tests/main/database/recovery-portability.test.ts
+++ b/tests/main/database/recovery-portability.test.ts
@@ -1,0 +1,189 @@
+/**
+ * End-to-end proof of the recovery-sidecar fix: a passphrase-wrapped DEK must
+ * be portable when the `.db` file is copied to a brand-new machine/path
+ * ALONGSIDE its `<dbPath>.varlens-recovery.json` sidecar -- even though the
+ * `DbKeyStore` registry (which lives in `userData`, outside the database
+ * file) never travels with the copy.
+ *
+ * These tests run against REAL `better-sqlite3-multiple-ciphers` files on
+ * disk, a REAL `DbKeyStore`, and the REAL `openDatabase`/`createDatabase`
+ * orchestration from `database-lifecycle-logic.ts` -- no mocking of SQLite
+ * or the key-store crypto itself.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, copyFileSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
+import { recoverySidecarPathFor } from '../../../src/main/database/recovery-sidecar'
+import { DatabaseManager } from '../../../src/main/services/DatabaseManager'
+import { RecentDatabasesService } from '../../../src/main/services/RecentDatabasesService'
+import {
+  createDatabase,
+  openDatabase,
+  type DatabaseLifecycleCallbacks
+} from '../../../src/main/ipc/handlers/database-lifecycle-logic'
+
+/** Reversible fake "encryption" so managed-key round-trips work (same fake as the other DbKeyStore suites). */
+function fakeSafeStorage(available: boolean): SafeStorageLike {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (s: string) => {
+      if (!available) throw new Error('unavailable')
+      return Buffer.from('SS:' + s)
+    },
+    decryptString: (b: Buffer) => b.toString().replace(/^SS:/, '')
+  }
+}
+
+const noopCallbacks: DatabaseLifecycleCallbacks = {
+  triggerStartupRebuild: () => undefined
+}
+
+const PASSPHRASE = 'correct horse battery staple'
+
+describe('recovery sidecar portability (openDatabase end-to-end)', () => {
+  const tmpDirs: string[] = []
+  const managers: DatabaseManager[] = []
+
+  function makeTmpDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix))
+    tmpDirs.push(dir)
+    return dir
+  }
+
+  function makeManager(dir: string, label: string): DatabaseManager {
+    const manager = new DatabaseManager(new RecentDatabasesService(join(dir, `${label}.json`)))
+    managers.push(manager)
+    return manager
+  }
+
+  afterEach(async () => {
+    await Promise.all(managers.map((m) => m.close()))
+    managers.length = 0
+    for (const dir of tmpDirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    tmpDirs.length = 0
+  })
+
+  it('a database copied to a brand-new path/machine, WITH its recovery sidecar, opens with the correct passphrase and reads back the original rows unchanged', async () => {
+    // "Machine A": no keyring -- the create flow falls back to needsPassphraseSetup,
+    // and the follow-up setupPassphrase call wraps a fresh DEK with the passphrase.
+    const dirA = makeTmpDir('varlens-recovery-origin-')
+    const originalPath = join(dirA, 'case.db')
+    const keyStoreA = new DbKeyStore({
+      registryPath: join(dirA, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    const managerA = makeManager(dirA, 'settings')
+
+    const attempt = await createDatabase({ path: originalPath }, () => managerA, keyStoreA)
+    expect(attempt).toEqual({ success: false, needsPassphraseSetup: true })
+
+    const created = await createDatabase(
+      { path: originalPath, setupPassphrase: PASSPHRASE },
+      () => managerA,
+      keyStoreA
+    )
+    expect(created.success).toBe(true)
+
+    managerA.getCurrent().database.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, label TEXT)')
+    managerA
+      .getCurrent()
+      .database.prepare('INSERT INTO marker (label) VALUES (?)')
+      .run('portable-row')
+    await managerA.close()
+
+    // Copy BOTH the .db file AND its sidecar to a brand-new path in a
+    // brand-new directory -- the registry (keys.json) deliberately does NOT
+    // travel, simulating a new machine (or a wiped userData directory).
+    const dirB = makeTmpDir('varlens-recovery-destination-')
+    const newPath = join(dirB, 'moved-case.db')
+    copyFileSync(originalPath, newPath)
+    copyFileSync(recoverySidecarPathFor(originalPath), recoverySidecarPathFor(newPath))
+
+    const keyStoreB = new DbKeyStore({
+      registryPath: join(dirB, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    const managerB = makeManager(dirB, 'settings')
+
+    // The initial no-password detection call must still prompt for a
+    // password -- a sidecar alone (without a passphrase) is never enough.
+    const detected = await openDatabase(
+      { path: newPath },
+      () => managerB.getCurrent(),
+      () => managerB,
+      noopCallbacks,
+      keyStoreB
+    )
+    expect(detected).toEqual({ success: false, needsPassword: true })
+
+    const opened = await openDatabase(
+      { path: newPath, password: PASSPHRASE },
+      () => managerB.getCurrent(),
+      () => managerB,
+      noopCallbacks,
+      keyStoreB
+    )
+    expect(opened.success).toBe(true)
+
+    const rows = managerB.getCurrent().database.prepare('SELECT label FROM marker').all() as Array<{
+      label: string
+    }>
+    expect(rows).toEqual([{ label: 'portable-row' }])
+
+    // Enrollment happened: the fresh registry now has an entry for the new
+    // path, so future opens on THIS machine are transparent.
+    const registryRaw = JSON.parse(readFileSync(join(dirB, 'keys.json'), 'utf-8'))
+    expect(registryRaw.pathIndex[newPath]).toBeDefined()
+    const enrolledKeyId = registryRaw.pathIndex[newPath]
+    expect(registryRaw.keys[enrolledKeyId].path).toBe(newPath)
+    expect(registryRaw.keys[enrolledKeyId].passWrap).toBeDefined()
+  })
+
+  it('a wrong passphrase against the sidecar-only copy is reported as WRONG_PASSWORD -- never a corrupted or wrong-key open', async () => {
+    const dirA = makeTmpDir('varlens-recovery-origin-')
+    const originalPath = join(dirA, 'case.db')
+    const keyStoreA = new DbKeyStore({
+      registryPath: join(dirA, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    const managerA = makeManager(dirA, 'settings')
+
+    await createDatabase(
+      { path: originalPath, setupPassphrase: PASSPHRASE },
+      () => managerA,
+      keyStoreA
+    )
+    managerA.getCurrent().database.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY)')
+    await managerA.close()
+
+    const dirB = makeTmpDir('varlens-recovery-destination-')
+    const newPath = join(dirB, 'moved-case.db')
+    copyFileSync(originalPath, newPath)
+    copyFileSync(recoverySidecarPathFor(originalPath), recoverySidecarPathFor(newPath))
+
+    const keyStoreB = new DbKeyStore({
+      registryPath: join(dirB, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    const managerB = makeManager(dirB, 'settings')
+
+    const opened = await openDatabase(
+      { path: newPath, password: 'totally-the-wrong-passphrase' },
+      () => managerB.getCurrent(),
+      () => managerB,
+      noopCallbacks,
+      keyStoreB
+    )
+    expect(opened).toEqual({ success: false, error: 'WRONG_PASSWORD' })
+
+    // No database session was opened, and no registry entry was minted for
+    // a recovery that never actually succeeded.
+    expect(managerB.getCurrentInfo()).toBeNull()
+    expect(keyStoreB.getKeyIdForPath(newPath)).toBeNull()
+  })
+})

--- a/tests/main/database/recovery-sidecar.test.ts
+++ b/tests/main/database/recovery-sidecar.test.ts
@@ -1,0 +1,110 @@
+/**
+ * recovery-sidecar.ts -- direct unit coverage.
+ *
+ * `db-key-store.test.ts`'s "recovery sidecar portability" block already
+ * exercises `writeRecoverySidecar` indirectly through `DbKeyStore`. This
+ * file covers the module directly, plus the power-loss durability
+ * requirement: the sidecar write must fsync its temp file before the rename
+ * that makes it live, and best-effort fsync the containing directory after.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { PassphraseWrap } from '../../../src/main/database/db-key-store'
+import {
+  readRecoverySidecar,
+  recoverySidecarExists,
+  recoverySidecarPathFor,
+  writeRecoverySidecar
+} from '../../../src/main/database/recovery-sidecar'
+
+const passWrap: PassphraseWrap = {
+  saltB64: 'c2FsdA==',
+  ivB64: 'aXY=',
+  ctB64: 'Y3Q=',
+  tagB64: 'dGFn'
+}
+
+describe('recovery-sidecar', () => {
+  let tmpDir: string
+  let dbPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-recovery-sidecar-'))
+    dbPath = join(tmpDir, 'case.db')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes a sidecar that readRecoverySidecar reads back with the same passWrap', () => {
+    writeRecoverySidecar(dbPath, passWrap)
+
+    expect(recoverySidecarExists(dbPath)).toBe(true)
+    const sidecar = readRecoverySidecar(dbPath)
+    expect(sidecar).not.toBeNull()
+    expect(sidecar?.passWrap).toEqual(passWrap)
+  })
+
+  it('readRecoverySidecar returns null for a missing sidecar', () => {
+    expect(readRecoverySidecar(dbPath)).toBeNull()
+  })
+
+  it('readRecoverySidecar tolerates a corrupt sidecar file (returns null, never throws)', () => {
+    const sidecarPath = recoverySidecarPathFor(dbPath)
+    writeFileSync(sidecarPath, 'not json', 'utf-8')
+
+    expect(() => readRecoverySidecar(dbPath)).not.toThrow()
+    expect(readRecoverySidecar(dbPath)).toBeNull()
+  })
+
+  describe('write durability (power-loss safety)', () => {
+    afterEach(() => {
+      vi.doUnmock('fs')
+      vi.resetModules()
+    })
+
+    it('fsyncs the temp file before the rename, and best-effort fsyncs the directory after it', async () => {
+      const calls: string[] = []
+      vi.resetModules()
+      vi.doMock('fs', async (importOriginal) => {
+        const actual = await importOriginal<typeof import('fs')>()
+        return {
+          ...actual,
+          fsyncSync: vi.fn((...args: Parameters<typeof actual.fsyncSync>) => {
+            calls.push('fsync')
+            return actual.fsyncSync(...args)
+          }),
+          renameSync: vi.fn((...args: Parameters<typeof actual.renameSync>) => {
+            calls.push('rename')
+            return actual.renameSync(...args)
+          })
+        }
+      })
+
+      const { writeRecoverySidecar: freshWriteRecoverySidecar } =
+        await import('../../../src/main/database/recovery-sidecar')
+      freshWriteRecoverySidecar(dbPath, passWrap)
+
+      // At least two fsyncs: the temp file (blocking) and the containing
+      // directory (best-effort) -- and the file fsync must precede the
+      // rename that makes the write visible.
+      expect(calls.filter((c) => c === 'fsync').length).toBeGreaterThanOrEqual(2)
+      expect(calls[0]).toBe('fsync')
+      expect(calls).toContain('rename')
+      expect(calls.indexOf('fsync')).toBeLessThan(calls.indexOf('rename'))
+    })
+
+    it('the sidecar is durably on disk immediately after writeRecoverySidecar returns', () => {
+      writeRecoverySidecar(dbPath, passWrap)
+
+      const sidecarPath = recoverySidecarPathFor(dbPath)
+      expect(existsSync(sidecarPath)).toBe(true)
+      const onDisk = JSON.parse(readFileSync(sidecarPath, 'utf-8')) as { passWrap: PassphraseWrap }
+      expect(onDisk.passWrap).toEqual(passWrap)
+    })
+  })
+})

--- a/tests/main/database/recovery-sidecar.test.ts
+++ b/tests/main/database/recovery-sidecar.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import type { PassphraseWrap } from '../../../src/main/database/db-key-store'
 import {
+  MAX_RECOVERY_SIDECAR_BYTES,
   readRecoverySidecar,
   recoverySidecarExists,
   recoverySidecarPathFor,
@@ -21,10 +22,10 @@ import {
 } from '../../../src/main/database/recovery-sidecar'
 
 const passWrap: PassphraseWrap = {
-  saltB64: 'c2FsdA==',
-  ivB64: 'aXY=',
-  ctB64: 'Y3Q=',
-  tagB64: 'dGFn'
+  saltB64: Buffer.alloc(16, 1).toString('base64'),
+  ivB64: Buffer.alloc(12, 2).toString('base64'),
+  ctB64: Buffer.from('a'.repeat(64), 'utf8').toString('base64'),
+  tagB64: Buffer.alloc(16, 3).toString('base64')
 }
 
 describe('recovery-sidecar', () => {
@@ -58,6 +59,35 @@ describe('recovery-sidecar', () => {
     writeFileSync(sidecarPath, 'not json', 'utf-8')
 
     expect(() => readRecoverySidecar(dbPath)).not.toThrow()
+    expect(readRecoverySidecar(dbPath)).toBeNull()
+  })
+
+  it('rejects a sidecar larger than the bounded recovery format', () => {
+    writeFileSync(recoverySidecarPathFor(dbPath), 'x'.repeat(MAX_RECOVERY_SIDECAR_BYTES + 1))
+
+    expect(readRecoverySidecar(dbPath)).toBeNull()
+  })
+
+  it.each([
+    ['saltB64', Buffer.alloc(15).toString('base64')],
+    ['ivB64', Buffer.alloc(13).toString('base64')],
+    ['ctB64', Buffer.alloc(63).toString('base64')],
+    ['tagB64', Buffer.alloc(15).toString('base64')],
+    ['saltB64', 'not canonical base64']
+  ] as const)('rejects an invalid decoded %s field', (field, value) => {
+    const invalid = { ...passWrap, [field]: value }
+    writeFileSync(
+      recoverySidecarPathFor(dbPath),
+      JSON.stringify({ version: 1, passWrap: invalid }),
+      'utf-8'
+    )
+
+    expect(readRecoverySidecar(dbPath)).toBeNull()
+  })
+
+  it('rejects unsupported sidecar versions', () => {
+    writeFileSync(recoverySidecarPathFor(dbPath), JSON.stringify({ version: 2, passWrap }), 'utf-8')
+
     expect(readRecoverySidecar(dbPath)).toBeNull()
   })
 

--- a/tests/main/database/set-recovery-passphrase.test.ts
+++ b/tests/main/database/set-recovery-passphrase.test.ts
@@ -204,4 +204,57 @@ describe('setRecoveryPassphrase (real DB, non-destructive DEK proof)', () => {
       /no managed encryption key/i
     )
   })
+
+  it('rotates a passphrase-only key using the verified DEK from the current open session', async () => {
+    await manager.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-set-recovery-passphrase-only-'))
+    dbPath = join(tmpDir, 'case.db')
+    manager = new DatabaseManager(new RecentDatabasesService(join(tmpDir, 'settings.json')))
+    keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+
+    const created = await createDatabase(
+      { path: dbPath, setupPassphrase: 'old recovery passphrase' },
+      () => manager,
+      keyStore
+    )
+    expect(created.success).toBe(true)
+
+    const result = setRecoveryPassphrase('new recovery passphrase', () => manager, keyStore)
+    expect(result).toEqual({ success: true, recoveryPassphraseSet: true, sidecarWritten: true })
+
+    await manager.close()
+    const freshStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'fresh-keys.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    const reopened = makeManager('settings-reopened')
+    await expect(
+      openDatabase(
+        { path: dbPath, password: 'new recovery passphrase' },
+        () => reopened.getCurrent(),
+        () => reopened,
+        noopCallbacks,
+        freshStore
+      )
+    ).resolves.toMatchObject({ success: true })
+
+    const oldPassphraseManager = makeManager('settings-old')
+    await expect(
+      openDatabase(
+        { path: dbPath, password: 'old recovery passphrase' },
+        () => oldPassphraseManager.getCurrent(),
+        () => oldPassphraseManager,
+        noopCallbacks,
+        new DbKeyStore({
+          registryPath: join(tmpDir, 'old-keys.json'),
+          safeStorage: fakeSafeStorage(false)
+        })
+      )
+    ).resolves.toEqual({ success: false, error: 'WRONG_PASSWORD' })
+  })
 })

--- a/tests/main/database/set-recovery-passphrase.test.ts
+++ b/tests/main/database/set-recovery-passphrase.test.ts
@@ -1,0 +1,207 @@
+/**
+ * The critical non-destructiveness proof for `setRecoveryPassphrase`
+ * (`database-lifecycle-logic.ts`): setting a recovery passphrase on a
+ * managed-key database's key must NEVER change the live SQLCipher key (the
+ * DEK). Unlike `rekeyDatabase` (a `PRAGMA rekey` that writes a NEW key
+ * literally to the database file), this only envelope-wraps the SAME DEK
+ * with a passphrase and writes a portable recovery sidecar next to the file.
+ *
+ * These tests run against a REAL `better-sqlite3-multiple-ciphers` database
+ * on real temp files, a REAL `DbKeyStore`, and the REAL `createDatabase` /
+ * `openDatabase` / `setRecoveryPassphrase` orchestration from
+ * `database-lifecycle-logic.ts` -- no mocking of SQLite or the key-store
+ * crypto itself. See `tests/main/database/recovery-portability.test.ts` and
+ * `tests/main/database/plaintext-migration.test.ts` for the sibling
+ * real-database proofs this mirrors.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { DbKeyStore, type SafeStorageLike } from '../../../src/main/database/db-key-store'
+import { recoverySidecarPathFor } from '../../../src/main/database/recovery-sidecar'
+import { DatabaseManager } from '../../../src/main/services/DatabaseManager'
+import { RecentDatabasesService } from '../../../src/main/services/RecentDatabasesService'
+import {
+  createDatabase,
+  openDatabase,
+  setRecoveryPassphrase,
+  type DatabaseLifecycleCallbacks
+} from '../../../src/main/ipc/handlers/database-lifecycle-logic'
+
+/** Reversible fake "encryption" so managed-key round-trips work (same fake as the other DbKeyStore suites). */
+function fakeSafeStorage(available: boolean): SafeStorageLike {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (s: string) => {
+      if (!available) throw new Error('unavailable')
+      return Buffer.from('SS:' + s)
+    },
+    decryptString: (b: Buffer) => b.toString().replace(/^SS:/, '')
+  }
+}
+
+const noopCallbacks: DatabaseLifecycleCallbacks = {
+  triggerStartupRebuild: () => undefined
+}
+
+const PASSPHRASE = 'correct horse battery staple'
+
+interface MarkerRow {
+  label: string
+}
+
+describe('setRecoveryPassphrase (real DB, non-destructive DEK proof)', () => {
+  let tmpDir: string
+  let dbPath: string
+  let manager: DatabaseManager
+  let keyStore: DbKeyStore
+  const extraManagers: DatabaseManager[] = []
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'varlens-set-recovery-passphrase-'))
+    dbPath = join(tmpDir, 'case.db')
+    manager = new DatabaseManager(new RecentDatabasesService(join(tmpDir, 'settings.json')))
+    keyStore = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys.json'),
+      safeStorage: fakeSafeStorage(true)
+    })
+
+    // Managed-key create path (no explicit password, no setupPassphrase): mints
+    // a safeStorage-wrapped DEK transparently -- the same path a brand-new
+    // database takes under encryption-by-default.
+    const created = await createDatabase({ path: dbPath }, () => manager, keyStore)
+    expect(created.success).toBe(true)
+
+    manager.getCurrent().database.exec('CREATE TABLE marker (id INTEGER PRIMARY KEY, label TEXT)')
+    manager
+      .getCurrent()
+      .database.prepare('INSERT INTO marker (label) VALUES (?)')
+      .run('unchanged-row')
+  })
+
+  afterEach(async () => {
+    await manager.close()
+    await Promise.all(extraManagers.map((m) => m.close()))
+    extraManagers.length = 0
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function makeManager(label: string): DatabaseManager {
+    const m = new DatabaseManager(new RecentDatabasesService(join(tmpDir, `${label}.json`)))
+    extraManagers.push(m)
+    return m
+  }
+
+  it('wraps the SAME DEK, leaves the live session untouched, and makes the DB openable both via keyring and passphrase', async () => {
+    const dekBefore = keyStore.resolveKeyForPath(dbPath)
+    expect(dekBefore.ok).toBe(true)
+
+    const result = setRecoveryPassphrase(PASSPHRASE, () => manager, keyStore)
+    expect(result).toEqual({ success: true, recoveryPassphraseSet: true, sidecarWritten: true })
+
+    // (a) DEK unchanged: the managed (safeStorage) wrap resolves to the exact
+    // same DEK before and after -- proof the live SQLCipher key was never
+    // touched, unlike `rekeyDatabase`.
+    const dekAfter = keyStore.resolveKeyForPath(dbPath)
+    expect(dekAfter.ok).toBe(true)
+    if (dekBefore.ok && dekAfter.ok) {
+      expect(dekAfter.dek).toBe(dekBefore.dek)
+    }
+
+    // (b) The live, already-open session was never closed/reopened/rekeyed --
+    // same in-memory connection, same rows, still there.
+    const liveRows = manager
+      .getCurrent()
+      .database.prepare('SELECT label FROM marker')
+      .all() as MarkerRow[]
+    expect(liveRows).toEqual([{ label: 'unchanged-row' }])
+
+    // (c) The database file still opens TRANSPARENTLY via the managed
+    // (safeStorage) key -- a fresh DatabaseManager/session against the file
+    // on disk, not the live in-memory one, proves the file itself is intact.
+    const managerB = makeManager('settings-b')
+    const openedTransparently = await openDatabase(
+      { path: dbPath },
+      () => managerB.getCurrent(),
+      () => managerB,
+      noopCallbacks,
+      keyStore
+    )
+    expect(openedTransparently.success).toBe(true)
+    const rowsViaKeyring = managerB
+      .getCurrent()
+      .database.prepare('SELECT label FROM marker')
+      .all() as MarkerRow[]
+    expect(rowsViaKeyring).toEqual([{ label: 'unchanged-row' }])
+
+    // (d) The database ALSO now opens via the recovery passphrase, through a
+    // BRAND-NEW key-store with an empty registry for this path -- this
+    // exercises the portable recovery-sidecar resolution path specifically
+    // (not the registry-only shortcut), proving the sidecar this call wrote
+    // is genuinely sufficient on its own.
+    const managerC = makeManager('settings-c')
+    const keyStoreC = new DbKeyStore({
+      registryPath: join(tmpDir, 'keys-c.json'),
+      safeStorage: fakeSafeStorage(false)
+    })
+    const openedViaPassphrase = await openDatabase(
+      { path: dbPath, password: PASSPHRASE },
+      () => managerC.getCurrent(),
+      () => managerC,
+      noopCallbacks,
+      keyStoreC
+    )
+    expect(openedViaPassphrase.success).toBe(true)
+    const rowsViaPassphrase = managerC
+      .getCurrent()
+      .database.prepare('SELECT label FROM marker')
+      .all() as MarkerRow[]
+    expect(rowsViaPassphrase).toEqual([{ label: 'unchanged-row' }])
+
+    // (e) A `<dbPath>.varlens-recovery.json` sidecar now exists on disk with
+    // the expected shape.
+    const sidecarPath = recoverySidecarPathFor(dbPath)
+    expect(existsSync(sidecarPath)).toBe(true)
+    const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8')) as {
+      version: number
+      passWrap: { saltB64: string; ivB64: string; ctB64: string; tagB64: string }
+    }
+    expect(sidecar.version).toBe(1)
+    expect(typeof sidecar.passWrap.saltB64).toBe('string')
+    expect(typeof sidecar.passWrap.ivB64).toBe('string')
+    expect(typeof sidecar.passWrap.ctB64).toBe('string')
+    expect(typeof sidecar.passWrap.tagB64).toBe('string')
+  })
+
+  it('a wrong passphrase against the newly-set recovery wrap is reported as WRONG_PASSWORD, not a corrupted/wrong-key open', async () => {
+    const result = setRecoveryPassphrase(PASSPHRASE, () => manager, keyStore)
+    expect(result.success).toBe(true)
+
+    const managerB = makeManager('settings-wrong')
+    const opened = await openDatabase(
+      { path: dbPath, password: 'totally-the-wrong-passphrase' },
+      () => managerB.getCurrent(),
+      () => managerB,
+      noopCallbacks,
+      keyStore
+    )
+    expect(opened).toEqual({ success: false, error: 'WRONG_PASSWORD' })
+  })
+
+  it('rejects setting a recovery passphrase on a database with no managed key (explicit password)', async () => {
+    const explicitPath = join(tmpDir, 'explicit-password.db')
+    const explicitManager = makeManager('settings-explicit')
+    const created = await createDatabase(
+      { path: explicitPath, password: 'literal-sqlcipher-key' },
+      () => explicitManager,
+      keyStore
+    )
+    expect(created.success).toBe(true)
+
+    expect(() => setRecoveryPassphrase('some passphrase', () => explicitManager, keyStore)).toThrow(
+      /no managed encryption key/i
+    )
+  })
+})

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'os'
 import { resolve, join } from 'path'
 import * as logic from '../../../src/main/ipc/handlers/database-logic'
 import { writeRecoverySidecar } from '../../../src/main/database/recovery-sidecar'
-import { DatabaseError } from '../../../src/main/database/errors'
+import { DatabaseError, WrongPasswordError } from '../../../src/main/database/errors'
 import type { PassphraseWrap } from '../../../src/main/database/db-key-store'
 import type {
   PostgresConnectionProfileInput,
@@ -280,7 +280,8 @@ const unusedKeyStore = {
   findManagedKeyIdForDek: vi.fn(),
   enrollRecoveredKey: vi.fn(),
   updatePath: vi.fn(),
-  removeKey: vi.fn()
+  removeKey: vi.fn(),
+  getKeyIdForPath: vi.fn().mockReturnValue(null)
 }
 
 describe('database lifecycle logic', () => {
@@ -387,11 +388,11 @@ describe('database lifecycle logic', () => {
       rmSync(tmpDir, { recursive: true, force: true })
     })
 
-    it('a wrong passphrase against a genuine sidecar is reported as WRONG_PASSWORD, never falls through to a raw-key attempt', async () => {
+    it('BLOCKER 1: a sidecar unwrap failure is NOT terminal -- it falls through to a raw-key attempt, and a wrong raw key still surfaces as WRONG_PASSWORD', async () => {
       writeRecoverySidecar(dbPath, dummyPassWrap)
       const manager = {
         openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
-        switchDatabase: vi.fn()
+        switchDatabase: vi.fn().mockRejectedValue(new WrongPasswordError())
       }
       const keyStore = {
         ...unusedKeyStore,
@@ -411,9 +412,44 @@ describe('database lifecycle logic', () => {
         )
       ).resolves.toEqual({ success: false, error: 'WRONG_PASSWORD' })
 
-      expect(manager.switchDatabase).not.toHaveBeenCalled()
+      // Falls through to the raw-key fallback -- switchDatabase IS attempted
+      // with the supplied value, unlike the old terminal-on-sidecar-failure
+      // behavior. It's the actual DB-open failure that reports WRONG_PASSWORD.
+      expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'wrong-guess')
       expect(keyStore.enrollRecoveredKey).not.toHaveBeenCalled()
       expect(keyStore.updatePath).not.toHaveBeenCalled()
+    })
+
+    it('BLOCKER 1: a stale/wrong recovery sidecar is not terminal -- the actual (raw) SQLCipher password still opens the database', async () => {
+      // Regression scenario: a legacy `rekeyDatabase` call changed the live
+      // SQLCipher key directly without updating the sidecar, so the sidecar
+      // on disk no longer decrypts with ANY passphrase that matches the
+      // real key. The user supplies the actual current raw password.
+      writeRecoverySidecar(dbPath, dummyPassWrap)
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+        switchDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi.fn().mockReturnValue({ path: dbPath, name: 'moved.db', encrypted: true })
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        resolveKeyWithPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' }),
+        resolveKeyWithPassphraseFromSidecar: vi
+          .fn()
+          .mockReturnValue({ ok: false, reason: 'wrong-passphrase' })
+      }
+
+      await expect(
+        logic.openDatabase(
+          { path: dbPath, password: 'the-real-post-rekey-password' },
+          () => ({}) as never,
+          () => manager as never,
+          { triggerStartupRebuild: vi.fn() },
+          keyStore
+        )
+      ).resolves.toMatchObject({ success: true })
+
+      expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'the-real-post-rekey-password')
     })
 
     it('same-machine move self-heal: a sidecar-recovered DEK that matches an existing LOCAL managed entry repoints that entry via updatePath instead of enrolling a new one', async () => {
@@ -512,6 +548,129 @@ describe('database lifecycle logic', () => {
 
       expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'literal-sqlcipher-key')
       expect(keyStore.resolveKeyWithPassphraseFromSidecar).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('keyManaged attachment (BLOCKER 1: renderer UI gating for Change Password vs Set Recovery Passphrase)', () => {
+    it('openDatabase reports keyManaged: true when the opened path has a key-store registry entry', async () => {
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: false }),
+        switchDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi
+          .fn()
+          .mockReturnValue({ path: '/tmp/managed.db', name: 'managed.db', encrypted: true })
+      }
+      const keyStore = { ...unusedKeyStore, getKeyIdForPath: vi.fn().mockReturnValue('key-1') }
+
+      const result = await logic.openDatabase(
+        { path: '/tmp/managed.db' },
+        () => ({}) as never,
+        () => manager as never,
+        { triggerStartupRebuild: vi.fn() },
+        keyStore
+      )
+
+      expect(result).toMatchObject({ success: true, info: { keyManaged: true } })
+      expect(keyStore.getKeyIdForPath).toHaveBeenCalledWith('/tmp/managed.db')
+    })
+
+    it('openDatabase reports keyManaged: false for a legacy explicit-password database with no registry entry', async () => {
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: false }),
+        switchDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi
+          .fn()
+          .mockReturnValue({ path: '/tmp/legacy.db', name: 'legacy.db', encrypted: true })
+      }
+      const keyStore = { ...unusedKeyStore, getKeyIdForPath: vi.fn().mockReturnValue(null) }
+
+      const result = await logic.openDatabase(
+        { path: '/tmp/legacy.db' },
+        () => ({}) as never,
+        () => manager as never,
+        { triggerStartupRebuild: vi.fn() },
+        keyStore
+      )
+
+      expect(result).toMatchObject({ success: true, info: { keyManaged: false } })
+    })
+
+    it('createDatabase reports keyManaged: false for an explicit-password create', async () => {
+      const manager = {
+        createDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi
+          .fn()
+          .mockReturnValue({ path: '/tmp/explicit.db', name: 'explicit.db', encrypted: true })
+      }
+
+      const result = await logic.createDatabase(
+        { path: '/tmp/explicit.db', password: 'literal-pw' },
+        () => manager as never,
+        unusedKeyStore
+      )
+
+      expect(result).toMatchObject({ success: true, info: { keyManaged: false } })
+    })
+
+    it('createDatabase reports keyManaged: true for a setupPassphrase create', async () => {
+      const manager = {
+        createDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi
+          .fn()
+          .mockReturnValue({ path: '/tmp/passphrase.db', name: 'passphrase.db', encrypted: true })
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        wrapNewDekWithPassphrase: vi
+          .fn()
+          .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek', sidecarWritten: true })
+      }
+
+      const result = await logic.createDatabase(
+        { path: '/tmp/passphrase.db', setupPassphrase: 'hunter2' },
+        () => manager as never,
+        keyStore
+      )
+
+      expect(result).toMatchObject({ success: true, info: { keyManaged: true } })
+    })
+
+    it('createDatabase reports keyManaged: true for a default encrypted-by-default create', async () => {
+      const manager = {
+        createDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi
+          .fn()
+          .mockReturnValue({ path: '/tmp/default.db', name: 'default.db', encrypted: true })
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' })
+      }
+
+      const result = await logic.createDatabase(
+        { path: '/tmp/default.db' },
+        () => manager as never,
+        keyStore
+      )
+
+      expect(result).toMatchObject({ success: true, info: { keyManaged: true } })
+    })
+
+    it('getDatabaseInfo attaches keyManaged based on the registry, and passes null through unchanged', () => {
+      const managerManaged = {
+        getCurrentInfo: vi
+          .fn()
+          .mockReturnValue({ path: '/tmp/managed.db', name: 'managed.db', encrypted: true })
+      }
+      const managedKeyStore = { getKeyIdForPath: vi.fn().mockReturnValue('key-1') }
+      expect(logic.getDatabaseInfo(() => managerManaged as never, managedKeyStore)).toMatchObject({
+        keyManaged: true
+      })
+
+      const managerNoDb = { getCurrentInfo: vi.fn().mockReturnValue(null) }
+      const unusedLookup = { getKeyIdForPath: vi.fn() }
+      expect(logic.getDatabaseInfo(() => managerNoDb as never, unusedLookup)).toBeNull()
+      expect(unusedLookup.getKeyIdForPath).not.toHaveBeenCalled()
     })
   })
 
@@ -645,6 +804,55 @@ describe('database lifecycle logic', () => {
     ).rejects.toThrow('disk full')
 
     expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
+  })
+
+  describe('rekeyDatabase', () => {
+    it('BLOCKER 1: refuses to rekey a key-store-managed database -- no PRAGMA rekey is executed', () => {
+      const manager = {
+        getCurrentPath: vi.fn().mockReturnValue('/tmp/managed.db'),
+        rekey: vi.fn()
+      }
+      const keyStore = { getKeyIdForPath: vi.fn().mockReturnValue('key-id-1') }
+
+      expect(() => logic.rekeyDatabase('new-password', () => manager as never, keyStore)).toThrow(
+        DatabaseError
+      )
+      expect(() => logic.rekeyDatabase('new-password', () => manager as never, keyStore)).toThrow(
+        /managed encryption key/i
+      )
+
+      expect(manager.rekey).not.toHaveBeenCalled()
+      expect(keyStore.getKeyIdForPath).toHaveBeenCalledWith('/tmp/managed.db')
+    })
+
+    it('still rekeys a legacy explicit-password database with no key-store entry', () => {
+      const manager = {
+        getCurrentPath: vi.fn().mockReturnValue('/tmp/legacy.db'),
+        rekey: vi.fn()
+      }
+      const keyStore = { getKeyIdForPath: vi.fn().mockReturnValue(null) }
+
+      expect(logic.rekeyDatabase('new-password', () => manager as never, keyStore)).toEqual({
+        success: true
+      })
+
+      expect(manager.rekey).toHaveBeenCalledWith('new-password')
+    })
+
+    it('rekeys when no database is currently open (unchanged edge-case behavior)', () => {
+      const manager = {
+        getCurrentPath: vi.fn().mockReturnValue(null),
+        rekey: vi.fn()
+      }
+      const keyStore = { getKeyIdForPath: vi.fn() }
+
+      expect(logic.rekeyDatabase('new-password', () => manager as never, keyStore)).toEqual({
+        success: true
+      })
+
+      expect(manager.rekey).toHaveBeenCalledWith('new-password')
+      expect(keyStore.getKeyIdForPath).not.toHaveBeenCalled()
+    })
   })
 
   describe('setRecoveryPassphrase', () => {

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -288,11 +288,72 @@ const unusedKeyStore = {
   enrollRecoveredKey: vi.fn(),
   updatePath: vi.fn(),
   removeKey: vi.fn(),
+  activateKey: vi.fn(),
+  getKeyStateForPath: vi.fn().mockReturnValue(null),
   setPassphraseForVerifiedDek: vi.fn(),
   getKeyIdForPath: vi.fn().mockReturnValue(null)
 }
 
 describe('database lifecycle logic', () => {
+  it('removes an abandoned pending migration key only after plaintext detection succeeds', async () => {
+    const manager = {
+      openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: false }),
+      switchDatabase: vi.fn().mockResolvedValue(undefined),
+      getCurrentInfo: vi.fn().mockReturnValue({
+        path: '/tmp/pending.db',
+        name: 'pending.db',
+        encrypted: false
+      })
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      getKeyStateForPath: vi.fn().mockReturnValue('pending'),
+      getKeyIdForPath: vi.fn().mockReturnValue('pending-key'),
+      removeKey: vi.fn()
+    }
+
+    await logic.openDatabase(
+      { path: '/tmp/pending.db' },
+      () => ({}) as never,
+      () => manager as never,
+      { triggerStartupRebuild: vi.fn() },
+      keyStore
+    )
+
+    expect(manager.switchDatabase).toHaveBeenCalledWith('/tmp/pending.db', undefined)
+    expect(keyStore.removeKey).toHaveBeenCalledWith('pending-key')
+    expect(keyStore.activateKey).not.toHaveBeenCalled()
+  })
+
+  it('activates a pending migration key only after the encrypted database accepts it', async () => {
+    const manager = {
+      openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+      switchDatabase: vi.fn().mockResolvedValue(undefined),
+      getCurrentInfo: vi.fn().mockReturnValue({
+        path: '/tmp/pending.db',
+        name: 'pending.db',
+        encrypted: true
+      })
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      resolveKeyForPath: vi.fn().mockReturnValue({ ok: true, dek: 'verified-dek' }),
+      getKeyStateForPath: vi.fn().mockReturnValue('pending'),
+      getKeyIdForPath: vi.fn().mockReturnValue('pending-key'),
+      activateKey: vi.fn()
+    }
+
+    await logic.openDatabase(
+      { path: '/tmp/pending.db' },
+      () => ({}) as never,
+      () => manager as never,
+      { triggerStartupRebuild: vi.fn() },
+      keyStore
+    )
+
+    expect(manager.switchDatabase).toHaveBeenCalledWith('/tmp/pending.db', 'verified-dek')
+    expect(keyStore.activateKey).toHaveBeenCalledWith('pending-key')
+  })
   it('does not require handler-level pool initialization after opening a database', async () => {
     const initDbPool = vi.fn()
     const triggerStartupRebuild = vi.fn()

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -3,13 +3,20 @@
  */
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { resolve, join } from 'path'
 import * as logic from '../../../src/main/ipc/handlers/database-logic'
-import { writeRecoverySidecar } from '../../../src/main/database/recovery-sidecar'
+import {
+  recoverySidecarPathFor,
+  writeRecoverySidecar
+} from '../../../src/main/database/recovery-sidecar'
 import { DatabaseError, WrongPasswordError } from '../../../src/main/database/errors'
-import type { PassphraseWrap } from '../../../src/main/database/db-key-store'
+import {
+  DbKeyStore,
+  type PassphraseWrap,
+  type SafeStorageLike
+} from '../../../src/main/database/db-key-store'
 import type {
   PostgresConnectionProfileInput,
   PostgresConnectionProfilePublic
@@ -281,6 +288,7 @@ const unusedKeyStore = {
   enrollRecoveredKey: vi.fn(),
   updatePath: vi.fn(),
   removeKey: vi.fn(),
+  setPassphraseForVerifiedDek: vi.fn(),
   getKeyIdForPath: vi.fn().mockReturnValue(null)
 }
 
@@ -373,10 +381,10 @@ describe('database lifecycle logic', () => {
     let tmpDir: string
     let dbPath: string
     const dummyPassWrap: PassphraseWrap = {
-      saltB64: 'salt',
-      ivB64: 'iv',
-      ctB64: 'ct',
-      tagB64: 'tag'
+      saltB64: Buffer.alloc(16, 1).toString('base64'),
+      ivB64: Buffer.alloc(12, 2).toString('base64'),
+      ctB64: Buffer.from('a'.repeat(64)).toString('base64'),
+      tagB64: Buffer.alloc(16, 3).toString('base64')
     }
 
     beforeEach(() => {
@@ -484,6 +492,38 @@ describe('database lifecycle logic', () => {
       expect(keyStore.updatePath).toHaveBeenCalledWith('existing-key-id', dbPath)
       expect(keyStore.enrollRecoveredKey).not.toHaveBeenCalled()
       expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'recovered-dek')
+    })
+
+    it('does not repoint or enroll a sidecar-recovered key until the database accepts the DEK', async () => {
+      writeRecoverySidecar(dbPath, dummyPassWrap)
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+        switchDatabase: vi.fn().mockRejectedValue(new WrongPasswordError())
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        resolveKeyWithPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' }),
+        resolveKeyWithPassphraseFromSidecar: vi
+          .fn()
+          .mockReturnValue({ ok: true, dek: 'unverified-dek' }),
+        findManagedKeyIdForDek: vi.fn().mockReturnValue('existing-key-id'),
+        updatePath: vi.fn(),
+        enrollRecoveredKey: vi.fn()
+      }
+
+      await expect(
+        logic.openDatabase(
+          { path: dbPath, password: 'passphrase-for-a-mismatched-sidecar' },
+          () => ({}) as never,
+          () => manager as never,
+          { triggerStartupRebuild: vi.fn() },
+          keyStore
+        )
+      ).resolves.toEqual({ success: false, error: 'WRONG_PASSWORD' })
+
+      expect(keyStore.findManagedKeyIdForDek).not.toHaveBeenCalled()
+      expect(keyStore.updatePath).not.toHaveBeenCalled()
+      expect(keyStore.enrollRecoveredKey).not.toHaveBeenCalled()
     })
 
     it('genuinely new machine: a sidecar-recovered DEK with no matching local entry is enrolled fresh via enrollRecoveredKey', async () => {
@@ -746,7 +786,7 @@ describe('database lifecycle logic', () => {
       ...unusedKeyStore,
       wrapNewDekWithPassphrase: vi
         .fn()
-        .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek' })
+        .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek', sidecarWritten: true })
     }
 
     await expect(
@@ -762,6 +802,30 @@ describe('database lifecycle logic', () => {
       'my passphrase'
     )
     expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens.db', 'wrapped-dek')
+  })
+
+  it('fails passphrase-only creation closed when the portable recovery sidecar was not written', async () => {
+    const manager = { createDatabase: vi.fn(), getCurrentInfo: vi.fn() }
+    const keyStore = {
+      ...unusedKeyStore,
+      wrapNewDekWithPassphrase: vi.fn().mockReturnValue({
+        ok: true,
+        keyId: 'k1',
+        dek: 'wrapped-dek',
+        sidecarWritten: false
+      }),
+      removeKey: vi.fn()
+    }
+
+    const result = await logic.createDatabase(
+      { path: '/tmp/varlens.db', setupPassphrase: 'my passphrase' },
+      () => manager as never,
+      keyStore
+    )
+
+    expect(result).toMatchObject({ success: false, error: expect.stringMatching(/recovery/i) })
+    expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
+    expect(manager.createDatabase).not.toHaveBeenCalled()
   })
 
   it('rolls back the managed key-store entry when createDatabase throws after minting it', async () => {
@@ -791,7 +855,7 @@ describe('database lifecycle logic', () => {
       ...unusedKeyStore,
       wrapNewDekWithPassphrase: vi
         .fn()
-        .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek' }),
+        .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek', sidecarWritten: true }),
       removeKey: vi.fn()
     }
 
@@ -858,7 +922,7 @@ describe('database lifecycle logic', () => {
   describe('setRecoveryPassphrase', () => {
     it('throws a typed DatabaseError when no database is currently open', () => {
       const manager = { getCurrentPath: vi.fn().mockReturnValue(null) }
-      const keyStore = { setPassphrase: vi.fn(), getKeyIdForPath: vi.fn() }
+      const keyStore = { setPassphraseForVerifiedDek: vi.fn(), getKeyIdForPath: vi.fn() }
 
       expect(() =>
         logic.setRecoveryPassphrase('my recovery passphrase', () => manager as never, keyStore)
@@ -868,13 +932,13 @@ describe('database lifecycle logic', () => {
       ).toThrow('No database is currently open.')
 
       expect(keyStore.getKeyIdForPath).not.toHaveBeenCalled()
-      expect(keyStore.setPassphrase).not.toHaveBeenCalled()
+      expect(keyStore.setPassphraseForVerifiedDek).not.toHaveBeenCalled()
     })
 
     it('throws a distinct typed DatabaseError when the open database has no managed key', () => {
       const manager = { getCurrentPath: vi.fn().mockReturnValue('/tmp/explicit-password.db') }
       const keyStore = {
-        setPassphrase: vi.fn(),
+        setPassphraseForVerifiedDek: vi.fn(),
         getKeyIdForPath: vi.fn().mockReturnValue(null)
       }
 
@@ -888,32 +952,42 @@ describe('database lifecycle logic', () => {
       expect(thrown).toBeInstanceOf(DatabaseError)
       expect((thrown as Error).message).not.toBe('No database is currently open.')
       expect((thrown as Error).message).toMatch(/no managed encryption key/i)
-      expect(keyStore.setPassphrase).not.toHaveBeenCalled()
+      expect(keyStore.setPassphraseForVerifiedDek).not.toHaveBeenCalled()
     })
 
     it('throws a typed DatabaseError when the key-store cannot resolve the DEK to wrap', () => {
-      const manager = { getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db') }
+      const manager = {
+        getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db'),
+        getCurrent: vi.fn().mockReturnValue({ getEncryptionKey: () => 'a'.repeat(64) })
+      }
       const keyStore = {
         getKeyIdForPath: vi.fn().mockReturnValue('key-1'),
-        setPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'cannot-resolve-dek' })
+        setPassphraseForVerifiedDek: vi
+          .fn()
+          .mockReturnValue({ ok: false, reason: 'cannot-resolve-dek' })
       }
 
       expect(() =>
         logic.setRecoveryPassphrase('my recovery passphrase', () => manager as never, keyStore)
       ).toThrow(DatabaseError)
-      expect(keyStore.setPassphrase).toHaveBeenCalledWith('key-1', 'my recovery passphrase')
+      expect(keyStore.setPassphraseForVerifiedDek).toHaveBeenCalledWith(
+        'key-1',
+        'a'.repeat(64),
+        'my recovery passphrase'
+      )
     })
 
     it('succeeds non-destructively: calls only keyStore.setPassphrase, never a rekey/database-write path', () => {
       const manager = {
         getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db'),
+        getCurrent: vi.fn().mockReturnValue({ getEncryptionKey: () => 'a'.repeat(64) }),
         rekey: vi.fn(),
         createDatabase: vi.fn(),
         switchDatabase: vi.fn()
       }
       const keyStore = {
         getKeyIdForPath: vi.fn().mockReturnValue('key-1'),
-        setPassphrase: vi.fn().mockReturnValue({ ok: true, sidecarWritten: true })
+        setPassphraseForVerifiedDek: vi.fn().mockReturnValue({ ok: true, sidecarWritten: true })
       }
 
       const result = logic.setRecoveryPassphrase(
@@ -928,17 +1002,24 @@ describe('database lifecycle logic', () => {
         sidecarWritten: true
       })
       expect(keyStore.getKeyIdForPath).toHaveBeenCalledWith('/tmp/varlens.db')
-      expect(keyStore.setPassphrase).toHaveBeenCalledWith('key-1', 'my recovery passphrase')
+      expect(keyStore.setPassphraseForVerifiedDek).toHaveBeenCalledWith(
+        'key-1',
+        'a'.repeat(64),
+        'my recovery passphrase'
+      )
       expect(manager.rekey).not.toHaveBeenCalled()
       expect(manager.createDatabase).not.toHaveBeenCalled()
       expect(manager.switchDatabase).not.toHaveBeenCalled()
     })
 
     it('still reports success when the passphrase wrap succeeds but the sidecar write fails', () => {
-      const manager = { getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db') }
+      const manager = {
+        getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db'),
+        getCurrent: vi.fn().mockReturnValue({ getEncryptionKey: () => 'a'.repeat(64) })
+      }
       const keyStore = {
         getKeyIdForPath: vi.fn().mockReturnValue('key-1'),
-        setPassphrase: vi.fn().mockReturnValue({ ok: true, sidecarWritten: false })
+        setPassphraseForVerifiedDek: vi.fn().mockReturnValue({ ok: true, sidecarWritten: false })
       }
 
       const result = logic.setRecoveryPassphrase(
@@ -953,6 +1034,41 @@ describe('database lifecycle logic', () => {
         sidecarWritten: false
       })
     })
+  })
+})
+
+describe('managed database deletion', () => {
+  it('removes the registry entry and recovery sidecar, permitting the path to be recreated', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'varlens-delete-managed-'))
+    const dbPath = join(tmpDir, 'case.db')
+    const safeStorage: SafeStorageLike = {
+      isEncryptionAvailable: () => true,
+      encryptString: (value) => Buffer.from(`SS:${value}`),
+      decryptString: (value) => value.toString().replace(/^SS:/, '')
+    }
+    const keyStore = new DbKeyStore({ registryPath: join(tmpDir, 'keys.json'), safeStorage })
+
+    try {
+      writeFileSync(dbPath, 'database bytes')
+      const created = keyStore.createManagedKey(dbPath)
+      expect(created.ok).toBe(true)
+      if (!created.ok) throw new Error('expected managed key')
+      expect(keyStore.setPassphrase(created.keyId, 'recovery').ok).toBe(true)
+
+      const manager = {
+        getRecentDatabases: () => [{ path: dbPath }],
+        getCurrentPath: () => null,
+        removeRecentDatabase: vi.fn()
+      }
+      await logic.deleteDbFile(dbPath, () => manager as never, keyStore)
+
+      expect(existsSync(dbPath)).toBe(false)
+      expect(existsSync(recoverySidecarPathFor(dbPath))).toBe(false)
+      expect(keyStore.getKeyIdForPath(dbPath)).toBeNull()
+      expect(keyStore.createManagedKey(dbPath).ok).toBe(true)
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -270,7 +270,8 @@ const unusedKeyStore = {
   createManagedKey: vi.fn(),
   wrapNewDekWithPassphrase: vi.fn(),
   resolveKeyForPath: vi.fn(),
-  resolveKeyWithPassphrase: vi.fn()
+  resolveKeyWithPassphrase: vi.fn(),
+  removeKey: vi.fn()
 }
 
 describe('database lifecycle logic', () => {
@@ -446,6 +447,48 @@ describe('database lifecycle logic', () => {
       'my passphrase'
     )
     expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens.db', 'wrapped-dek')
+  })
+
+  it('rolls back the managed key-store entry when createDatabase throws after minting it', async () => {
+    const manager = {
+      createDatabase: vi.fn().mockRejectedValue(new Error('disk full')),
+      getCurrentInfo: vi.fn()
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' }),
+      removeKey: vi.fn()
+    }
+
+    await expect(
+      logic.createDatabase({ path: '/tmp/varlens.db' }, () => manager as never, keyStore)
+    ).rejects.toThrow('disk full')
+
+    expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
+  })
+
+  it('rolls back the passphrase-wrapped key-store entry when createDatabase throws after minting it', async () => {
+    const manager = {
+      createDatabase: vi.fn().mockRejectedValue(new Error('disk full')),
+      getCurrentInfo: vi.fn()
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      wrapNewDekWithPassphrase: vi
+        .fn()
+        .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek' }),
+      removeKey: vi.fn()
+    }
+
+    await expect(
+      logic.createDatabase(
+        { path: '/tmp/varlens.db', setupPassphrase: 'my passphrase' },
+        () => manager as never,
+        keyStore
+      )
+    ).rejects.toThrow('disk full')
+
+    expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
   })
 })
 

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'os'
 import { resolve, join } from 'path'
 import * as logic from '../../../src/main/ipc/handlers/database-logic'
 import { writeRecoverySidecar } from '../../../src/main/database/recovery-sidecar'
+import { DatabaseError } from '../../../src/main/database/errors'
 import type { PassphraseWrap } from '../../../src/main/database/db-key-store'
 import type {
   PostgresConnectionProfileInput,
@@ -68,6 +69,7 @@ describe('database-logic exports', () => {
     expect(typeof logic.openDatabase).toBe('function')
     expect(typeof logic.createDatabase).toBe('function')
     expect(typeof logic.rekeyDatabase).toBe('function')
+    expect(typeof logic.setRecoveryPassphrase).toBe('function')
     expect(typeof logic.getDatabaseInfo).toBe('function')
     expect(typeof logic.getRecentDatabases).toBe('function')
     expect(typeof logic.getDatabaseOverview).toBe('function')
@@ -643,6 +645,106 @@ describe('database lifecycle logic', () => {
     ).rejects.toThrow('disk full')
 
     expect(keyStore.removeKey).toHaveBeenCalledWith('k1')
+  })
+
+  describe('setRecoveryPassphrase', () => {
+    it('throws a typed DatabaseError when no database is currently open', () => {
+      const manager = { getCurrentPath: vi.fn().mockReturnValue(null) }
+      const keyStore = { setPassphrase: vi.fn(), getKeyIdForPath: vi.fn() }
+
+      expect(() =>
+        logic.setRecoveryPassphrase('my recovery passphrase', () => manager as never, keyStore)
+      ).toThrow(DatabaseError)
+      expect(() =>
+        logic.setRecoveryPassphrase('my recovery passphrase', () => manager as never, keyStore)
+      ).toThrow('No database is currently open.')
+
+      expect(keyStore.getKeyIdForPath).not.toHaveBeenCalled()
+      expect(keyStore.setPassphrase).not.toHaveBeenCalled()
+    })
+
+    it('throws a distinct typed DatabaseError when the open database has no managed key', () => {
+      const manager = { getCurrentPath: vi.fn().mockReturnValue('/tmp/explicit-password.db') }
+      const keyStore = {
+        setPassphrase: vi.fn(),
+        getKeyIdForPath: vi.fn().mockReturnValue(null)
+      }
+
+      let thrown: unknown
+      try {
+        logic.setRecoveryPassphrase('my recovery passphrase', () => manager as never, keyStore)
+      } catch (e) {
+        thrown = e
+      }
+
+      expect(thrown).toBeInstanceOf(DatabaseError)
+      expect((thrown as Error).message).not.toBe('No database is currently open.')
+      expect((thrown as Error).message).toMatch(/no managed encryption key/i)
+      expect(keyStore.setPassphrase).not.toHaveBeenCalled()
+    })
+
+    it('throws a typed DatabaseError when the key-store cannot resolve the DEK to wrap', () => {
+      const manager = { getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db') }
+      const keyStore = {
+        getKeyIdForPath: vi.fn().mockReturnValue('key-1'),
+        setPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'cannot-resolve-dek' })
+      }
+
+      expect(() =>
+        logic.setRecoveryPassphrase('my recovery passphrase', () => manager as never, keyStore)
+      ).toThrow(DatabaseError)
+      expect(keyStore.setPassphrase).toHaveBeenCalledWith('key-1', 'my recovery passphrase')
+    })
+
+    it('succeeds non-destructively: calls only keyStore.setPassphrase, never a rekey/database-write path', () => {
+      const manager = {
+        getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db'),
+        rekey: vi.fn(),
+        createDatabase: vi.fn(),
+        switchDatabase: vi.fn()
+      }
+      const keyStore = {
+        getKeyIdForPath: vi.fn().mockReturnValue('key-1'),
+        setPassphrase: vi.fn().mockReturnValue({ ok: true, sidecarWritten: true })
+      }
+
+      const result = logic.setRecoveryPassphrase(
+        'my recovery passphrase',
+        () => manager as never,
+        keyStore
+      )
+
+      expect(result).toEqual({
+        success: true,
+        recoveryPassphraseSet: true,
+        sidecarWritten: true
+      })
+      expect(keyStore.getKeyIdForPath).toHaveBeenCalledWith('/tmp/varlens.db')
+      expect(keyStore.setPassphrase).toHaveBeenCalledWith('key-1', 'my recovery passphrase')
+      expect(manager.rekey).not.toHaveBeenCalled()
+      expect(manager.createDatabase).not.toHaveBeenCalled()
+      expect(manager.switchDatabase).not.toHaveBeenCalled()
+    })
+
+    it('still reports success when the passphrase wrap succeeds but the sidecar write fails', () => {
+      const manager = { getCurrentPath: vi.fn().mockReturnValue('/tmp/varlens.db') }
+      const keyStore = {
+        getKeyIdForPath: vi.fn().mockReturnValue('key-1'),
+        setPassphrase: vi.fn().mockReturnValue({ ok: true, sidecarWritten: false })
+      }
+
+      const result = logic.setRecoveryPassphrase(
+        'my recovery passphrase',
+        () => manager as never,
+        keyStore
+      )
+
+      expect(result).toEqual({
+        success: true,
+        recoveryPassphraseSet: true,
+        sidecarWritten: false
+      })
+    })
   })
 })
 

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -265,6 +265,14 @@ describe('postgres profile logic', () => {
   })
 })
 
+/** A key-store stub that never resolves/mints anything -- for tests that don't exercise it. */
+const unusedKeyStore = {
+  createManagedKey: vi.fn(),
+  wrapNewDekWithPassphrase: vi.fn(),
+  resolveKeyForPath: vi.fn(),
+  resolveKeyWithPassphrase: vi.fn()
+}
+
 describe('database lifecycle logic', () => {
   it('does not require handler-level pool initialization after opening a database', async () => {
     const initDbPool = vi.fn()
@@ -287,12 +295,67 @@ describe('database lifecycle logic', () => {
         { path: '/tmp/varlens.db' },
         () => db as never,
         () => manager as never,
-        callbacks
+        callbacks,
+        unusedKeyStore
       )
     ).resolves.toMatchObject({ success: true })
 
     expect(initDbPool).not.toHaveBeenCalled()
     expect(triggerStartupRebuild).toHaveBeenCalledWith(db)
+    expect(unusedKeyStore.resolveKeyForPath).not.toHaveBeenCalled()
+  })
+
+  it('opening an encrypted database with no password resolves the key transparently via the key-store', async () => {
+    const triggerStartupRebuild = vi.fn()
+    const manager = {
+      openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+      switchDatabase: vi.fn().mockResolvedValue(undefined),
+      getCurrentInfo: vi.fn().mockReturnValue({
+        path: '/tmp/varlens.db',
+        name: 'varlens.db',
+        encrypted: true
+      })
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      resolveKeyForPath: vi.fn().mockReturnValue({ ok: true, dek: 'the-dek' })
+    }
+
+    await expect(
+      logic.openDatabase(
+        { path: '/tmp/varlens.db' },
+        () => ({}) as never,
+        () => manager as never,
+        { triggerStartupRebuild },
+        keyStore
+      )
+    ).resolves.toMatchObject({ success: true })
+
+    expect(keyStore.resolveKeyForPath).toHaveBeenCalledWith('/tmp/varlens.db')
+    expect(manager.switchDatabase).toHaveBeenCalledWith('/tmp/varlens.db', 'the-dek')
+  })
+
+  it('opening an encrypted database the key-store cannot resolve falls back to needsPassword', async () => {
+    const manager = {
+      openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+      switchDatabase: vi.fn()
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      resolveKeyForPath: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' })
+    }
+
+    await expect(
+      logic.openDatabase(
+        { path: '/tmp/varlens.db' },
+        () => ({}) as never,
+        () => manager as never,
+        { triggerStartupRebuild: vi.fn() },
+        keyStore
+      )
+    ).resolves.toEqual({ success: false, needsPassword: true })
+
+    expect(manager.switchDatabase).not.toHaveBeenCalled()
   })
 
   it('does not require handler-level pool initialization after creating a database', async () => {
@@ -305,12 +368,84 @@ describe('database lifecycle logic', () => {
         encrypted: false
       })
     }
+    const keyStore = {
+      ...unusedKeyStore,
+      createManagedKey: vi.fn().mockReturnValue({ ok: true, keyId: 'k1', dek: 'the-dek' })
+    }
 
     await expect(
-      logic.createDatabase({ path: '/tmp/varlens.db' }, () => manager as never)
+      logic.createDatabase({ path: '/tmp/varlens.db' }, () => manager as never, keyStore)
     ).resolves.toMatchObject({ success: true })
 
     expect(initDbPool).not.toHaveBeenCalled()
+    expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens.db', 'the-dek')
+  })
+
+  it('creating a database with an explicit password never consults the key-store', async () => {
+    const manager = {
+      createDatabase: vi.fn().mockResolvedValue(undefined),
+      getCurrentInfo: vi.fn().mockReturnValue({
+        path: '/tmp/varlens.db',
+        name: 'varlens.db',
+        encrypted: true
+      })
+    }
+
+    await expect(
+      logic.createDatabase(
+        { path: '/tmp/varlens.db', password: 'literal-pw' },
+        () => manager as never,
+        unusedKeyStore
+      )
+    ).resolves.toMatchObject({ success: true })
+
+    expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens.db', 'literal-pw')
+    expect(unusedKeyStore.createManagedKey).not.toHaveBeenCalled()
+  })
+
+  it('creating a database when safeStorage is unavailable returns needsPassphraseSetup without creating anything', async () => {
+    const manager = { createDatabase: vi.fn(), getCurrentInfo: vi.fn() }
+    const keyStore = {
+      ...unusedKeyStore,
+      createManagedKey: vi.fn().mockReturnValue({ ok: false, reason: 'safe-storage-unavailable' })
+    }
+
+    await expect(
+      logic.createDatabase({ path: '/tmp/varlens.db' }, () => manager as never, keyStore)
+    ).resolves.toEqual({ success: false, needsPassphraseSetup: true })
+
+    expect(manager.createDatabase).not.toHaveBeenCalled()
+  })
+
+  it('completing passphrase setup wraps a fresh DEK and creates the database with it', async () => {
+    const manager = {
+      createDatabase: vi.fn().mockResolvedValue(undefined),
+      getCurrentInfo: vi.fn().mockReturnValue({
+        path: '/tmp/varlens.db',
+        name: 'varlens.db',
+        encrypted: true
+      })
+    }
+    const keyStore = {
+      ...unusedKeyStore,
+      wrapNewDekWithPassphrase: vi
+        .fn()
+        .mockReturnValue({ ok: true, keyId: 'k1', dek: 'wrapped-dek' })
+    }
+
+    await expect(
+      logic.createDatabase(
+        { path: '/tmp/varlens.db', setupPassphrase: 'my passphrase' },
+        () => manager as never,
+        keyStore
+      )
+    ).resolves.toMatchObject({ success: true })
+
+    expect(keyStore.wrapNewDekWithPassphrase).toHaveBeenCalledWith(
+      '/tmp/varlens.db',
+      'my passphrase'
+    )
+    expect(manager.createDatabase).toHaveBeenCalledWith('/tmp/varlens.db', 'wrapped-dek')
   })
 })
 

--- a/tests/main/handlers/database-logic.test.ts
+++ b/tests/main/handlers/database-logic.test.ts
@@ -2,10 +2,13 @@
  * Database logic smoke tests plus domain registration coverage.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve, join } from 'path'
 import * as logic from '../../../src/main/ipc/handlers/database-logic'
+import { writeRecoverySidecar } from '../../../src/main/database/recovery-sidecar'
+import type { PassphraseWrap } from '../../../src/main/database/db-key-store'
 import type {
   PostgresConnectionProfileInput,
   PostgresConnectionProfilePublic
@@ -271,6 +274,10 @@ const unusedKeyStore = {
   wrapNewDekWithPassphrase: vi.fn(),
   resolveKeyForPath: vi.fn(),
   resolveKeyWithPassphrase: vi.fn(),
+  resolveKeyWithPassphraseFromSidecar: vi.fn(),
+  findManagedKeyIdForDek: vi.fn(),
+  enrollRecoveredKey: vi.fn(),
+  updatePath: vi.fn(),
   removeKey: vi.fn()
 }
 
@@ -357,6 +364,153 @@ describe('database lifecycle logic', () => {
     ).resolves.toEqual({ success: false, needsPassword: true })
 
     expect(manager.switchDatabase).not.toHaveBeenCalled()
+  })
+
+  describe('opening with a supplied password — recovery sidecar resolution', () => {
+    let tmpDir: string
+    let dbPath: string
+    const dummyPassWrap: PassphraseWrap = {
+      saltB64: 'salt',
+      ivB64: 'iv',
+      ctB64: 'ct',
+      tagB64: 'tag'
+    }
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'varlens-open-sidecar-'))
+      dbPath = join(tmpDir, 'moved.db')
+    })
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('a wrong passphrase against a genuine sidecar is reported as WRONG_PASSWORD, never falls through to a raw-key attempt', async () => {
+      writeRecoverySidecar(dbPath, dummyPassWrap)
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+        switchDatabase: vi.fn()
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        resolveKeyWithPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' }),
+        resolveKeyWithPassphraseFromSidecar: vi
+          .fn()
+          .mockReturnValue({ ok: false, reason: 'wrong-passphrase' })
+      }
+
+      await expect(
+        logic.openDatabase(
+          { path: dbPath, password: 'wrong-guess' },
+          () => ({}) as never,
+          () => manager as never,
+          { triggerStartupRebuild: vi.fn() },
+          keyStore
+        )
+      ).resolves.toEqual({ success: false, error: 'WRONG_PASSWORD' })
+
+      expect(manager.switchDatabase).not.toHaveBeenCalled()
+      expect(keyStore.enrollRecoveredKey).not.toHaveBeenCalled()
+      expect(keyStore.updatePath).not.toHaveBeenCalled()
+    })
+
+    it('same-machine move self-heal: a sidecar-recovered DEK that matches an existing LOCAL managed entry repoints that entry via updatePath instead of enrolling a new one', async () => {
+      writeRecoverySidecar(dbPath, dummyPassWrap)
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+        switchDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi.fn().mockReturnValue({ path: dbPath, name: 'moved.db', encrypted: true })
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        resolveKeyWithPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' }),
+        resolveKeyWithPassphraseFromSidecar: vi
+          .fn()
+          .mockReturnValue({ ok: true, dek: 'recovered-dek' }),
+        findManagedKeyIdForDek: vi.fn().mockReturnValue('existing-key-id'),
+        updatePath: vi.fn(),
+        enrollRecoveredKey: vi.fn()
+      }
+
+      await expect(
+        logic.openDatabase(
+          { path: dbPath, password: 'correct horse battery staple' },
+          () => ({}) as never,
+          () => manager as never,
+          { triggerStartupRebuild: vi.fn() },
+          keyStore
+        )
+      ).resolves.toMatchObject({ success: true })
+
+      expect(keyStore.findManagedKeyIdForDek).toHaveBeenCalledWith('recovered-dek')
+      expect(keyStore.updatePath).toHaveBeenCalledWith('existing-key-id', dbPath)
+      expect(keyStore.enrollRecoveredKey).not.toHaveBeenCalled()
+      expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'recovered-dek')
+    })
+
+    it('genuinely new machine: a sidecar-recovered DEK with no matching local entry is enrolled fresh via enrollRecoveredKey', async () => {
+      writeRecoverySidecar(dbPath, dummyPassWrap)
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+        switchDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi.fn().mockReturnValue({ path: dbPath, name: 'moved.db', encrypted: true })
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        resolveKeyWithPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' }),
+        resolveKeyWithPassphraseFromSidecar: vi
+          .fn()
+          .mockReturnValue({ ok: true, dek: 'recovered-dek' }),
+        findManagedKeyIdForDek: vi.fn().mockReturnValue(null),
+        updatePath: vi.fn(),
+        enrollRecoveredKey: vi.fn().mockReturnValue({ ok: true, keyId: 'new-key-id' })
+      }
+
+      await expect(
+        logic.openDatabase(
+          { path: dbPath, password: 'correct horse battery staple' },
+          () => ({}) as never,
+          () => manager as never,
+          { triggerStartupRebuild: vi.fn() },
+          keyStore
+        )
+      ).resolves.toMatchObject({ success: true })
+
+      expect(keyStore.enrollRecoveredKey).toHaveBeenCalledWith(
+        dbPath,
+        'recovered-dek',
+        dummyPassWrap
+      )
+      expect(keyStore.updatePath).not.toHaveBeenCalled()
+      expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'recovered-dek')
+    })
+
+    it('no sidecar and no registry entry at this path: legacy fallback treats the supplied value as a raw SQLCipher key, unchanged', async () => {
+      // Deliberately no `writeRecoverySidecar` call -- this path has neither a
+      // registry entry nor a sidecar.
+      const manager = {
+        openDetectEncryption: vi.fn().mockReturnValue({ needsPassword: true }),
+        switchDatabase: vi.fn().mockResolvedValue(undefined),
+        getCurrentInfo: vi.fn().mockReturnValue({ path: dbPath, name: 'moved.db', encrypted: true })
+      }
+      const keyStore = {
+        ...unusedKeyStore,
+        resolveKeyWithPassphrase: vi.fn().mockReturnValue({ ok: false, reason: 'not-found' })
+      }
+
+      await expect(
+        logic.openDatabase(
+          { path: dbPath, password: 'literal-sqlcipher-key' },
+          () => ({}) as never,
+          () => manager as never,
+          { triggerStartupRebuild: vi.fn() },
+          keyStore
+        )
+      ).resolves.toMatchObject({ success: true })
+
+      expect(manager.switchDatabase).toHaveBeenCalledWith(dbPath, 'literal-sqlcipher-key')
+      expect(keyStore.resolveKeyWithPassphraseFromSidecar).not.toHaveBeenCalled()
+    })
   })
 
   it('does not require handler-level pool initialization after creating a database', async () => {

--- a/tests/main/services/DatabaseManager.test.ts
+++ b/tests/main/services/DatabaseManager.test.ts
@@ -309,15 +309,30 @@ describe('DatabaseManager', () => {
       }).toThrow(DatabaseError)
     })
 
-    it('throws DatabaseError for corrupted file', () => {
+    it('treats an unreadable/corrupted file as needing a password -- SQLite cannot distinguish it from a wrong-key encrypted file', () => {
       const badPath = tempDbPath('-bad')
       writeFileSync(badPath, 'not a database')
       try {
-        expect(() => {
-          manager.openDetectEncryption(badPath)
-        }).toThrow(DatabaseError)
+        const result = manager.openDetectEncryption(badPath)
+        expect(result.needsPassword).toBe(true)
       } finally {
         cleanupDb(badPath)
+      }
+    })
+
+    it('detects a genuinely SQLCipher-encrypted database (opened with no key) as needing a password', async () => {
+      const dbPath = tempDbPath('-enc')
+      try {
+        await manager.createDatabase(
+          dbPath,
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd'
+        )
+        await manager.close()
+
+        const result = manager.openDetectEncryption(dbPath)
+        expect(result.needsPassword).toBe(true)
+      } finally {
+        cleanupDb(dbPath)
       }
     })
   })

--- a/tests/main/services/DatabaseManager.test.ts
+++ b/tests/main/services/DatabaseManager.test.ts
@@ -67,7 +67,8 @@ describe('DatabaseManager', () => {
         expect(manager.getCurrentInfo()).toEqual({
           path: dbPath,
           name: expect.stringContaining('.db'),
-          encrypted: false
+          encrypted: false,
+          unencryptedMigratable: true
         })
       } finally {
         await manager.close()
@@ -404,7 +405,8 @@ describe('DatabaseManager', () => {
         expect(info).toEqual({
           path: dbPath,
           name: expect.any(String),
-          encrypted: false
+          encrypted: false,
+          unencryptedMigratable: true
         })
       } finally {
         await manager.close()

--- a/tests/main/storage/storage-manager-compat.test.ts
+++ b/tests/main/storage/storage-manager-compat.test.ts
@@ -103,7 +103,8 @@ describe('DatabaseManager storage-session compatibility', () => {
     expect(manager.getCurrentInfo()).toEqual({
       path: 'postgres://127.0.0.1:55432/varlens_dev',
       name: 'PostgreSQL: 127.0.0.1:55432/varlens_dev (public)',
-      encrypted: false
+      encrypted: false,
+      unencryptedMigratable: false
     })
 
     await manager.close()

--- a/tests/renderer/components/DatabasePicker.test.ts
+++ b/tests/renderer/components/DatabasePicker.test.ts
@@ -195,7 +195,7 @@ describe('DatabasePicker', () => {
       await openPickerMenu()
 
       const menuText = document.body.textContent ?? ''
-      expect(menuText).toContain('Set Recovery Passphrase...')
+      expect(menuText).not.toContain('Set Recovery Passphrase...')
       expect(menuText).toContain('Change Password...')
     })
   })

--- a/tests/renderer/components/DatabasePicker.test.ts
+++ b/tests/renderer/components/DatabasePicker.test.ts
@@ -167,4 +167,36 @@ describe('DatabasePicker', () => {
     expect(menuText).not.toContain('Add PostgreSQL...')
     expect(mockApi.database.postgresProfilesList).not.toHaveBeenCalled()
   })
+
+  describe('BLOCKER 1: Change Password vs Set Recovery Passphrase gating', () => {
+    it('hides "Change Password..." for a key-store-managed encrypted database, showing only "Set Recovery Passphrase..."', async () => {
+      const store = useDatabaseStore()
+      store.currentPath = '/tmp/managed.db'
+      store.currentName = 'managed.db'
+      store.isEncrypted = true
+      store.keyManaged = true
+
+      mountPicker()
+      await openPickerMenu()
+
+      const menuText = document.body.textContent ?? ''
+      expect(menuText).toContain('Set Recovery Passphrase...')
+      expect(menuText).not.toContain('Change Password...')
+    })
+
+    it('shows "Change Password..." for a legacy explicit-password encrypted database with no managed key', async () => {
+      const store = useDatabaseStore()
+      store.currentPath = '/tmp/legacy.db'
+      store.currentName = 'legacy.db'
+      store.isEncrypted = true
+      store.keyManaged = false
+
+      mountPicker()
+      await openPickerMenu()
+
+      const menuText = document.body.textContent ?? ''
+      expect(menuText).toContain('Set Recovery Passphrase...')
+      expect(menuText).toContain('Change Password...')
+    })
+  })
 })

--- a/tests/renderer/components/SetRecoveryPassphraseDialog.test.ts
+++ b/tests/renderer/components/SetRecoveryPassphraseDialog.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+import SetRecoveryPassphraseDialog from '../../../src/renderer/src/components/SetRecoveryPassphraseDialog.vue'
+import { useDatabaseStore } from '../../../src/renderer/src/stores/databaseStore'
+
+const vuetify = createVuetify({ components, directives })
+
+describe('SetRecoveryPassphraseDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SetRecoveryPassphraseDialog>>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces a portable-sidecar partial failure and keeps the dialog open', async () => {
+    const store = useDatabaseStore()
+    store.setRecoveryPassphrase = vi.fn().mockResolvedValue({
+      success: true,
+      recoveryPassphraseSet: true,
+      sidecarWritten: false
+    })
+    wrapper = mount(SetRecoveryPassphraseDialog, {
+      global: { plugins: [vuetify] },
+      attachTo: document.body
+    })
+
+    wrapper.vm.show()
+    await wrapper.vm.$nextTick()
+    await flushPromises()
+    const inputs = Array.from(document.body.querySelectorAll('input'))
+    expect(inputs).toHaveLength(2)
+    for (const input of inputs) {
+      input.value = 'correct horse battery staple'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    const submit = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Set Recovery Passphrase')
+    )
+    expect(submit).toBeDefined()
+    submit?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+
+    expect(document.body.textContent).toMatch(/portable recovery.*failed/i)
+    expect(document.body.textContent).toContain('Set Recovery Passphrase')
+    expect(wrapper.emitted('recovery-passphrase-set')).toBeUndefined()
+  })
+})

--- a/tests/renderer/stores/databaseStore.test.ts
+++ b/tests/renderer/stores/databaseStore.test.ts
@@ -154,12 +154,36 @@ describe('databaseStore.fetchInfo', () => {
     store.currentPath = '/tmp/old.db'
     store.currentName = 'old.db'
     store.isEncrypted = true
+    store.keyManaged = true
 
     await store.fetchInfo()
 
     expect(store.currentPath).toBeNull()
     expect(store.currentName).toBe('')
     expect(store.isEncrypted).toBe(false)
+    expect(store.keyManaged).toBe(false)
+  })
+
+  it('BLOCKER 1: applyInfo picks up keyManaged from database:info (defaulting to false when absent)', async () => {
+    const store = useDatabaseStore()
+    const infoMock = window.api.database.info as ReturnType<typeof vi.fn>
+
+    infoMock.mockResolvedValueOnce({
+      path: '/tmp/managed.db',
+      name: 'managed.db',
+      encrypted: true,
+      keyManaged: true
+    })
+    await store.fetchInfo()
+    expect(store.keyManaged).toBe(true)
+
+    infoMock.mockResolvedValueOnce({
+      path: '/tmp/legacy.db',
+      name: 'legacy.db',
+      encrypted: true
+    })
+    await store.fetchInfo()
+    expect(store.keyManaged).toBe(false)
   })
 
   it('loads postgres profiles through the database API', async () => {

--- a/tests/shared/types/preload-contract.test.ts
+++ b/tests/shared/types/preload-contract.test.ts
@@ -362,6 +362,10 @@ describe('Preload contract alignment', () => {
     expect(databaseDomainSource).toContain(
       "showInFolder: (path) => ipcRenderer.invoke('database:showInFolder', path)"
     )
+    expect(databaseDomainSource).toContain(
+      "migrateToEncrypted: (options) => ipcRenderer.invoke('database:migrateToEncrypted', options)"
+    )
+    expect(databaseDomainSource).toContain("'database:deletePlaintextBackup'")
     expect(preloadSource).not.toContain('unwrapIpcResult(await databaseDomain.open')
   })
 

--- a/tests/shared/types/preload-contract.test.ts
+++ b/tests/shared/types/preload-contract.test.ts
@@ -366,6 +366,8 @@ describe('Preload contract alignment', () => {
       "migrateToEncrypted: (options) => ipcRenderer.invoke('database:migrateToEncrypted', options)"
     )
     expect(databaseDomainSource).toContain("'database:deletePlaintextBackup'")
+    expect(databaseDomainSource).toContain('setRecoveryPassphrase:')
+    expect(databaseDomainSource).toContain("'database:setRecoveryPassphrase'")
     expect(preloadSource).not.toContain('unwrapIpcResult(await databaseDomain.open')
   })
 

--- a/tests/utils/mock-api.ts
+++ b/tests/utils/mock-api.ts
@@ -181,6 +181,8 @@ export function createMockApi(): MockApi {
       open: vi.fn().mockResolvedValue({ success: true }),
       create: vi.fn().mockResolvedValue({ success: true }),
       rekey: vi.fn().mockResolvedValue({ success: true }),
+      migrateToEncrypted: vi.fn().mockResolvedValue({ success: true }),
+      deletePlaintextBackup: vi.fn().mockResolvedValue({ success: true }),
       info: vi.fn().mockResolvedValue({ path: '/tmp/test.db', encrypted: false }),
       capabilities: vi.fn().mockResolvedValue(TEST_SQLITE_CAPABILITIES),
       postgresDiagnostics: vi.fn().mockResolvedValue({ ok: false, schema: '' }),

--- a/tests/utils/mock-api.ts
+++ b/tests/utils/mock-api.ts
@@ -183,6 +183,9 @@ export function createMockApi(): MockApi {
       rekey: vi.fn().mockResolvedValue({ success: true }),
       migrateToEncrypted: vi.fn().mockResolvedValue({ success: true }),
       deletePlaintextBackup: vi.fn().mockResolvedValue({ success: true }),
+      setRecoveryPassphrase: vi
+        .fn()
+        .mockResolvedValue({ success: true, recoveryPassphraseSet: true, sidecarWritten: true }),
       info: vi.fn().mockResolvedValue({ path: '/tmp/test.db', encrypted: false }),
       capabilities: vi.fn().mockResolvedValue(TEST_SQLITE_CAPABILITIES),
       postgresDiagnostics: vi.fn().mockResolvedValue({ ok: false, schema: '' }),


### PR DESCRIPTION
## PR-I — Encryption-by-default (finding S8-encryption; Codex F-01) · spike-led

VarLens now **encrypts new databases at rest by default**, with a portable recovery path — so a stolen `.db` file cannot be read, without locking users out of their own data.

### I0 spike: is `safeStorage` real encryption?

On **Electron 40**, `safeStorage` is genuine encryption where an OS keyring exists (macOS Keychain, Windows DPAPI, Linux GNOME/KDE) and returns `isEncryptionAvailable() === false` (and *throws* on `encryptString`) where it doesn't — **no silent hardcoded-key fallback**. So we can detect the insecure case and never ship false security. The maintainer chose the **hybrid** model: transparent managed key where safeStorage is available, first-run passphrase where it isn't, plus a passphrase escape hatch for portability.

### Design — envelope encryption

- A random **DEK** (the SQLCipher `PRAGMA key`) encrypts the DB. The DEK is *wrapped* two ways: by `safeStorage` (transparent, OS-keyring) and/or by a scrypt-derived passphrase key (AES-256-GCM, portable).
- A per-DB `keyId` registry (`userData/varlens-db-keys.json`) maps wraps ↔ path; a recovery passphrase also writes a portable **`<db>.varlens-recovery.json` escrow sidecar** so the DB can be recovered on another machine / after a keyring loss (copy the `.db` **and** the sidecar, enter the passphrase). Switching keyring↔passphrase just re-wraps the same DEK — no DB rekey.

### What changed (I1–I3)

- **I1** `db-key-store.ts` — envelope key-store (safeStorage + scrypt/AES-256-GCM), typed failures that never return a wrong DEK, guards against already-keyed paths.
- **I2a** — encrypt NEW DBs by default (managed key, or first-run passphrase when safeStorage is unavailable); transparent open-resolve. Also fixed a **pre-existing dead-code bug**: encrypted-DB detection matched an error string the native module never emits, so encrypted-DB / wrong-password detection never actually worked (`sqlite-error.ts`).
- **I2b** — consented, **backed-up, reversible** plaintext→encrypted migration: build a verified encrypted copy → write + verify a plaintext backup → fsync → atomic swap → post-swap verify → roll back in **both** directions on any failure. (`sqlcipher_export` is absent in `better-sqlite3-multiple-ciphers`, so it byte-copies then rekeys the *copy* — the original is never touched until backup+swap.) Per-table SHA-256 content signal catches same-cardinality divergence.
- **Recovery lifecycle** — portable escrow sidecar + a **non-destructive `setRecoveryPassphrase`** IPC action (the destructive legacy `rekey` is now refused for managed DBs); startup no longer creates a silent plaintext default DB when safeStorage is unavailable; registry + sidecar writes are fsync-durable.
- **I3** `docs/guide/database-encryption.md` — user-facing threat model: what it protects against (offline file theft), the per-platform key-at-rest dependency, the honest Linux caveat, and the **critical recovery-passphrase guidance**.

### Verification

- Typecheck clean; **3988 tests pass** (full main+renderer suite). `make ci-startup-smoke` green earlier in the branch. (`make ci`'s `lint-check` OOMs only because ESLint recursively scans sibling `.worktrees/` checkouts of the other open PRs — an environment artifact; scoped `eslint src tests` is clean.)
- Data-safety proven with **real** `better-sqlite3-multiple-ciphers` DBs: encrypted-at-rest (raw open with no key → `SQLITE_NOTADB`); both migration rollback directions restore real seeded rows; portability (copy `.db` + sidecar to a fresh registry with no keyring → open with the passphrase); `setRecoveryPassphrase` leaves the DEK byte-identical.
- Four opus reviews (crypto, create/open flow, migration data-safety, whole-branch recovery lifecycle) + a Codex-high adversarial round — real findings (unrecoverable recovery passphrase, destructive "Change Password" on managed DBs, silent plaintext default DB, missing fsync durability) were found and **fixed + regression-tested** each round. (The final Codex *re-confirmation* pass stalled on the local tooling; the three blockers it would re-check are fixed in `510f59b0` with tests, and the branch is green.)

### Follow-ups (non-blocking)

- Hard-crash between key-persist and swap can orphan a registry entry (retry-only, not data loss).
- Renderer passphrase/consent dialogs lack component tests (static-reviewed).
- scrypt N=16384 (per spec; future-harden option). Windows rename-replace/fsync semantics reasoned, not runner-tested.

Spec: `.planning/specs/2026-07-06-security-and-bug-remediation.md` · Plan: `.planning/plans/2026-07-06-security-and-bug-remediation-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmqdEMGjqVhTX8EKr6QxoH
