### PR TITLE
fix(docs): enroll screenshot fixture before import

### DIFF
--- a/tests/e2e/screenshots.e2e.ts
+++ b/tests/e2e/screenshots.e2e.ts
@@ -274,14 +274,35 @@ test.describe('Documentation Screenshots', () => {
   })
 
   test('03 - import demo case', async () => {
-    // Import via the preload IPC API (window.api.import.start)
+    await app.evaluate(async ({ dialog }, filePath) => {
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [filePath]
+      })
+    }, tempGzipPath)
+
     const importResult = await window.evaluate(async (filePath) => {
       const api = (
         window as unknown as {
-          api: { import: { start: (p: string, n: string) => Promise<unknown> } }
+          api: {
+            cases: { deleteAll: () => Promise<number> }
+            import: {
+              selectFile: () => Promise<string | null>
+              start: (p: string, n: string) => Promise<unknown>
+            }
+          }
         }
       ).api
-      const result = await api.import.start(filePath, 'DemoCase')
+      await api.cases.deleteAll()
+      const selectedPath = await api.import.selectFile()
+      if (selectedPath !== filePath) {
+        return {
+          code: 'SCREENSHOT_SELECTION_FAILED',
+          message: `Expected selected path ${filePath}, got ${selectedPath ?? 'null'}`,
+          userMessage: 'Screenshot fixture selection failed.'
+        }
+      }
+      const result = await api.import.start(selectedPath, 'DemoCase')
       return JSON.parse(JSON.stringify(result))
     }, tempGzipPath)
 


### PR DESCRIPTION
## Summary

Fixes the post-merge Deploy Docs screenshot workflow after PR311 strict path authority.

The docs screenshot harness was directly calling `window.api.import.start(path, ...)` for `tests/e2e/test-data/demo-case.json.gz`. That bypassed the trusted file-selection provenance required by the new strict import gate, so the workflow failed with `INVALID_PARAMETERS` and later table/detail screenshots cascaded.

The harness now mocks the native open dialog, calls `window.api.import.selectFile()` to enroll the fixture path through the normal dialog authority path, then imports the selected path.

## Validation

- Reproduced red locally: `xvfb-run --auto-servernum npx playwright test tests/e2e/screenshots.e2e.ts -g "03 - import demo case"` failed with the same unallowed import path error.
- Focused green: `xvfb-run --auto-servernum npx playwright test tests/e2e/screenshots.e2e.ts -g "03 - import demo case"` passed.
- Full green: `xvfb-run --auto-servernum npx playwright test tests/e2e/screenshots.e2e.ts` passed, 23/23.
- `make format-check` passed.
- `make docs` passed.
- `make agent-check` passed.
- `git diff --check` passed.
