### PR TITLE
fix(docs): create screenshot database in e2e

### DIFF
--- a/tests/e2e/screenshots.e2e.ts
+++ b/tests/e2e/screenshots.e2e.ts
@@ -11,6 +11,7 @@ import { test, expect, _electron as electron, ElectronApplication, Page } from '
 import * as path from 'path'
 import * as fs from 'fs'
 import * as zlib from 'zlib'
+import * as os from 'os'
 
 const SCREENSHOT_DIR = path.resolve(__dirname, '../../docs/public/screenshots')
 const DEMO_DATA_PATH = path.resolve(__dirname, 'test-data/demo-case.json')
@@ -19,6 +20,7 @@ const VIEWPORT = { width: 1280, height: 800 }
 let app: ElectronApplication
 let window: Page
 let tempGzipPath: string
+let tempDatabaseDir: string
 
 function expectSuccessfulIpcResult<T>(result: T): T {
   expect(result).not.toEqual(
@@ -195,6 +197,7 @@ test.describe('Documentation Screenshots', () => {
     const compressed = zlib.gzipSync(demoData)
     tempGzipPath = path.resolve(__dirname, 'test-data/demo-case.json.gz')
     fs.writeFileSync(tempGzipPath, compressed)
+    tempDatabaseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlens-screenshots-db-'))
 
     // Launch the compiled Electron app
     app = await electron.launch({
@@ -231,6 +234,44 @@ test.describe('Documentation Screenshots', () => {
     await window.reload()
     await window.waitForSelector('.v-application', { timeout: 30000 })
     await dismissDisclaimer(window)
+
+    const databasePath = path.join(tempDatabaseDir, 'screenshots.varlens.db')
+    await app.evaluate(async ({ dialog }, filePath) => {
+      dialog.showSaveDialog = async () => ({
+        canceled: false,
+        filePath
+      })
+    }, databasePath)
+    const databaseCreateResult = await window.evaluate(async (expectedPath) => {
+      const api = (
+        window as unknown as {
+          api: {
+            database: {
+              selectSaveLocation: (defaultName: string) => Promise<string | null>
+              create: (
+                path: string,
+                password?: string,
+                setupPassphrase?: string
+              ) => Promise<unknown>
+            }
+          }
+        }
+      ).api
+      const selectedPath = await api.database.selectSaveLocation('screenshots.varlens.db')
+      if (selectedPath !== expectedPath) {
+        return {
+          code: 'SCREENSHOT_DATABASE_SELECTION_FAILED',
+          message: `Expected database path ${expectedPath}, got ${selectedPath ?? 'null'}`,
+          userMessage: 'Screenshot database selection failed.'
+        }
+      }
+      const result = await api.database.create(selectedPath, 'screenshot-database-passphrase')
+      return JSON.parse(JSON.stringify(result))
+    }, databasePath)
+    const databasePayload = expectSuccessfulIpcResult(
+      databaseCreateResult as { success?: boolean; needsPassphraseSetup?: boolean }
+    )
+    expect(databasePayload.success).toBe(true)
   })
 
   test.afterAll(async () => {
@@ -238,6 +279,9 @@ test.describe('Documentation Screenshots', () => {
     // Clean up temp gzip file
     if (tempGzipPath && fs.existsSync(tempGzipPath)) {
       fs.unlinkSync(tempGzipPath)
+    }
+    if (tempDatabaseDir && fs.existsSync(tempDatabaseDir)) {
+      fs.rmSync(tempDatabaseDir, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Summary
- create an isolated encrypted database for docs screenshot E2E runs before importing demo data
- preserve the strict import enrollment flow from the previous path-authority fix
- clean up temporary screenshot database files after the suite

## Verification
- isolated fresh-env focused repro: `xvfb-run --auto-servernum npx playwright test tests/e2e/screenshots.e2e.ts -g '03 - import demo case'`
- isolated fresh-env screenshot suite: `xvfb-run --auto-servernum npx playwright test tests/e2e/screenshots.e2e.ts` (23/23 passed)
- `make format-check`
- `git diff --check`
- `make docs`
- `make agent-check`