### PR TITLE
feat(web): add operation outcome metrics

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -20,9 +20,10 @@
  *   - production runs `node out/web/server.cjs` via main()
  */
 
+import { randomUUID } from 'node:crypto'
 import { isAbsolute } from 'path'
 
-import Fastify, { type FastifyInstance } from 'fastify'
+import Fastify, { LogController, type FastifyInstance } from 'fastify'
 
 import { getPostgresStorageConfig } from '../main/storage/config'
 import { createPostgresStorageSession } from '../main/storage/postgres/createPostgresStorageSession'
@@ -93,11 +94,16 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   }
 
   const app = Fastify({
+    genReqId: () => randomUUID(),
+    logController: new LogController({ requestIdLogLabel: 'request_id' }),
     logger: {
       level: process.env.VARLENS_LOG_LEVEL ?? 'info'
     }
   })
   const metrics = options.metrics ?? createAppMetricsFromEnv()
+  app.addHook('onRequest', async (request, reply) => {
+    reply.header('x-request-id', request.id)
+  })
   registerRequestMetrics(app, metrics)
   await registerWebRateLimit(app)
 
@@ -132,7 +138,8 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   const dispatcherDeps = {
     session: session as StorageSession,
     authService,
-    events
+    events,
+    metrics
   }
   const { overrides } = buildDispatcher(dispatcherDeps)
   registerImportUploadRoutes(app, dispatcherDeps)

--- a/src/web/server/dispatcher.ts
+++ b/src/web/server/dispatcher.ts
@@ -62,6 +62,7 @@ import {
   DispatcherInvokeBodySchema,
   DispatcherParamsSchema
 } from '../../shared/api/schemas/dispatcher'
+import type { AppMetrics, OperationMetricName } from './metrics'
 
 /**
  * Methods reachable to a session that still has
@@ -131,6 +132,73 @@ async function applyDevApiLatency(): Promise<void> {
   const delayMs = resolveDevApiLatencyMs()
   if (delayMs <= 0) return
   await new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+function operationMetricForKey(key: string): OperationMetricName | undefined {
+  if (key.startsWith('batch-import:')) return 'batch-import'
+  if (key.startsWith('import:')) return 'import'
+  return undefined
+}
+
+function recordDispatcherOperationMetrics(params: {
+  metrics: AppMetrics | undefined
+  key: string
+  statusCode: number
+  result: unknown
+}): void {
+  const operation = operationMetricForKey(params.key)
+  if (operation === undefined) return
+  const failed = params.statusCode >= 400 || resultLooksLikeFailure(params.result)
+  params.metrics?.recordOperationEvent({
+    operation,
+    result: failed ? 'error' : 'success',
+    failureClass: failed ? failureClassForResult(params.result, params.statusCode) : undefined
+  })
+}
+
+function resultLooksLikeFailure(result: unknown): boolean {
+  if (result === null || typeof result !== 'object') return false
+  const body = result as Record<string, unknown>
+  if (typeof body.error === 'string' && body.error.trim() !== '') return true
+  if (Array.isArray(body.errors) && body.errors.length > 0) return true
+  return typeof body.code === 'string' && body.code.trim() !== ''
+}
+
+function failureClassForResult(result: unknown, statusCode: number): string {
+  if (result !== null && typeof result === 'object') {
+    const body = result as Record<string, unknown>
+    const raw =
+      typeof body.error === 'string'
+        ? body.error
+        : typeof body.code === 'string'
+          ? body.code
+          : undefined
+    const mapped = mapKnownFailureClass(raw)
+    if (mapped !== undefined) return mapped
+  }
+  if (statusCode === 400) return 'validation'
+  if (statusCode === 401) return 'unauthenticated'
+  if (statusCode === 403) return 'forbidden'
+  if (statusCode === 404) return 'not-found'
+  if (statusCode >= 500) return 'server-error'
+  return 'unknown'
+}
+
+function mapKnownFailureClass(raw: string | undefined): string | undefined {
+  switch (raw) {
+    case 'FORBIDDEN_ORIGIN':
+      return 'forbidden-origin'
+    case 'NOT_FOUND':
+      return 'not-found'
+    case 'UNAUTHENTICATED':
+      return 'unauthenticated'
+    case 'UNKNOWN':
+      return 'server-error'
+    case 'upload-not-found':
+      return 'upload-not-found'
+    default:
+      return undefined
+  }
 }
 
 export type { DispatcherDeps, InvokeBody, OverrideHandler } from './routes/types'
@@ -256,6 +324,12 @@ export function registerDispatcher(
         const result = await invokeAsIpcResult(reply, () =>
           override.handle(args, request, reply, deps)
         )
+        recordDispatcherOperationMetrics({
+          metrics: deps.metrics,
+          key,
+          statusCode: reply.statusCode,
+          result
+        })
         if (reply.statusCode < 400 && (isWriteTaskType(key) || shouldAuditOverrideWrite(key))) {
           const auditResult = await invokeAsIpcResult(reply, () =>
             recordApiWriteAudit(deps, { key, username: request.session?.user?.username })
@@ -275,6 +349,12 @@ export function registerDispatcher(
         const result = await invokeAsIpcResult(reply, () =>
           deps.session.getReadExecutor().execute(task)
         )
+        recordDispatcherOperationMetrics({
+          metrics: deps.metrics,
+          key,
+          statusCode: reply.statusCode,
+          result
+        })
         if (reply.statusCode < 400 && shouldAuditApiRead(key)) {
           const auditResult = await invokeAsIpcResult(reply, () =>
             recordApiReadAudit(deps, { key, username: request.session?.user?.username })
@@ -289,6 +369,12 @@ export function registerDispatcher(
         const result = await invokeAsIpcResult(reply, () =>
           deps.session.getWriteExecutor().execute(task)
         )
+        recordDispatcherOperationMetrics({
+          metrics: deps.metrics,
+          key,
+          statusCode: reply.statusCode,
+          result
+        })
         if (reply.statusCode < 400) {
           const auditResult = await invokeAsIpcResult(reply, () =>
             recordApiWriteAudit(deps, { key, username: request.session?.user?.username })

--- a/src/web/server/metrics.ts
+++ b/src/web/server/metrics.ts
@@ -125,6 +125,11 @@ export function resolveMetricsIpc(method: string, url: string): string | undefin
   return `${toTaskDomain(domain)}:${ipcMethod}`
 }
 
+export type OperationMetricName =
+  'auth-change-password' | 'auth-login' | 'batch-import' | 'import' | 'upload-stage'
+
+export type OperationMetricResult = 'success' | 'error'
+
 export class AppMetrics {
   private readonly baseLabels: Labels
   private readonly requests = new Map<string, { labels: Labels; value: number }>()
@@ -134,6 +139,7 @@ export class AppMetrics {
   private readonly ipcInFlight = new Map<string, { labels: Labels; value: number }>()
   private readonly ipcDurations = new Map<string, { labels: Labels; state: HistogramState }>()
   private readonly ipcLastSuccess = new Map<string, { labels: Labels; value: number }>()
+  private readonly operationEvents = new Map<string, { labels: Labels; value: number }>()
   private dbHealthy = 0
   private readonly startedAt = Date.now() / 1000
 
@@ -230,6 +236,23 @@ export class AppMetrics {
     this.dbHealthy = value ? 1 : 0
   }
 
+  recordOperationEvent(params: {
+    operation: OperationMetricName
+    result: OperationMetricResult
+    failureClass?: string
+  }): void {
+    const labels = {
+      ...this.baseLabels,
+      operation: params.operation,
+      result: params.result,
+      failure_class:
+        params.result === 'success' ? 'none' : normalizeFailureClass(params.failureClass)
+    }
+    const key = labelKey(labels)
+    const current = this.operationEvents.get(key)
+    this.operationEvents.set(key, { labels, value: (current?.value ?? 0) + 1 })
+  }
+
   contentType(): string {
     return 'text/plain; version=0.0.4; charset=utf-8'
   }
@@ -270,6 +293,12 @@ export class AppMetrics {
     lines.push('# TYPE varlens_ipc_last_success_timestamp_seconds gauge')
     pushSeries(lines, 'varlens_ipc_last_success_timestamp_seconds', this.ipcLastSuccess.values())
 
+    lines.push(
+      '# HELP varlens_operation_events_total Bounded VarLens operation outcomes for support triage.'
+    )
+    lines.push('# TYPE varlens_operation_events_total counter')
+    pushSeries(lines, 'varlens_operation_events_total', this.operationEvents.values())
+
     lines.push('# HELP process_start_time_seconds Start time of the Node.js process.')
     lines.push('# TYPE process_start_time_seconds gauge')
     lines.push(metricLine('process_start_time_seconds', this.baseLabels, this.startedAt))
@@ -288,6 +317,13 @@ export class AppMetrics {
 
     return `${lines.join('\n')}\n`
   }
+}
+
+function normalizeFailureClass(value: string | undefined): string {
+  const raw = value?.trim().toLowerCase()
+  if (raw === undefined || raw === '') return 'unknown'
+  const normalized = raw.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '')
+  return normalized === '' ? 'unknown' : normalized.slice(0, 64)
 }
 
 export function createAppMetricsFromEnv(env: NodeJS.ProcessEnv = process.env): AppMetrics {

--- a/src/web/server/routes/auth.ts
+++ b/src/web/server/routes/auth.ts
@@ -18,6 +18,11 @@ export function buildAuthOverrides(): Record<string, OverrideHandler> {
         const { authService } = deps
         const parsed = LoginArgsSchema.safeParse(args)
         if (!parsed.success) {
+          deps.metrics?.recordOperationEvent({
+            operation: 'auth-login',
+            result: 'error',
+            failureClass: 'validation'
+          })
           reply.code(400)
           return { error: 'username and password (string) required' }
         }
@@ -34,12 +39,19 @@ export function buildAuthOverrides(): Record<string, OverrideHandler> {
             success: true,
             mustChangePassword: result.mustChangePassword === true
           })
+          deps.metrics?.recordOperationEvent({ operation: 'auth-login', result: 'success' })
         } else {
+          const reason = result.locked === true ? 'locked' : 'invalid-credentials'
           await recordAuthAudit(deps, {
             action_type: 'auth_login_failure',
             username,
             success: false,
-            reason: result.locked === true ? 'locked' : 'invalid-credentials'
+            reason
+          })
+          deps.metrics?.recordOperationEvent({
+            operation: 'auth-login',
+            result: 'error',
+            failureClass: reason
           })
         }
         return result
@@ -83,6 +95,11 @@ export function buildAuthOverrides(): Record<string, OverrideHandler> {
 
         const parsed = ChangePasswordArgsSchema.safeParse(args)
         if (!parsed.success) {
+          deps.metrics?.recordOperationEvent({
+            operation: 'auth-change-password',
+            result: 'error',
+            failureClass: 'validation'
+          })
           reply.code(400)
           return { error: 'oldPassword and newPassword (string) required' }
         }
@@ -101,6 +118,11 @@ export function buildAuthOverrides(): Record<string, OverrideHandler> {
               actor: sessionUser.username,
               success: false,
               reason: 'old-password-invalid'
+            })
+            deps.metrics?.recordOperationEvent({
+              operation: 'auth-change-password',
+              result: 'error',
+              failureClass: 'old-password-invalid'
             })
             reply.code(401)
             return { success: false, error: 'old-password-invalid' }
@@ -121,6 +143,10 @@ export function buildAuthOverrides(): Record<string, OverrideHandler> {
             actor: sessionUser.username,
             success: true
           })
+          deps.metrics?.recordOperationEvent({
+            operation: 'auth-change-password',
+            result: 'success'
+          })
           return { success: true }
         } catch (err) {
           if (err instanceof PasswordPolicyError) {
@@ -130,6 +156,11 @@ export function buildAuthOverrides(): Record<string, OverrideHandler> {
               actor: sessionUser.username,
               success: false,
               reason: err.code
+            })
+            deps.metrics?.recordOperationEvent({
+              operation: 'auth-change-password',
+              result: 'error',
+              failureClass: err.code
             })
             reply.code(422)
             return { success: false, error: err.code, message: err.message }

--- a/src/web/server/routes/types.ts
+++ b/src/web/server/routes/types.ts
@@ -3,11 +3,13 @@ import type { FastifyReply, FastifyRequest } from 'fastify'
 import type { StorageSession } from '../../../main/storage/session'
 import type { PostgresWebAuthService } from '../../auth/PostgresWebAuthService'
 import type { WebEventHub } from '../events'
+import type { AppMetrics } from '../metrics'
 
 export interface DispatcherDeps {
   session: StorageSession
   authService: PostgresWebAuthService
   events: WebEventHub
+  metrics?: AppMetrics
 }
 
 export interface InvokeBodyPayload {

--- a/src/web/server/routes/upload-staging.ts
+++ b/src/web/server/routes/upload-staging.ts
@@ -71,7 +71,7 @@ export function replaceWebUploadPathWithRef<T extends { filePath: string }>(
   return ref === undefined ? item : { ...item, filePath: ref }
 }
 
-export function registerImportUploadRoutes(app: FastifyInstance, deps: DispatcherDeps): void {
+export function registerImportUploadRoutes(app: FastifyInstance, deps?: DispatcherDeps): void {
   app.addContentTypeParser('application/octet-stream', (_request, payload, done) => {
     done(null, payload)
   })
@@ -79,6 +79,11 @@ export function registerImportUploadRoutes(app: FastifyInstance, deps: Dispatche
   app.post('/api/import/upload', async (request: UploadRouteBody, reply) => {
     const userId = request.session.user?.id
     if (userId === undefined) {
+      deps?.metrics?.recordOperationEvent({
+        operation: 'upload-stage',
+        result: 'error',
+        failureClass: 'unauthenticated'
+      })
       reply.code(401)
       return {
         code: 'UNAUTHENTICATED',
@@ -89,12 +94,22 @@ export function registerImportUploadRoutes(app: FastifyInstance, deps: Dispatche
 
     const originalName = headerString(request.headers['x-varlens-file-name'])
     if (originalName === undefined || originalName.trim() === '') {
+      deps?.metrics?.recordOperationEvent({
+        operation: 'upload-stage',
+        result: 'error',
+        failureClass: 'missing-file-name'
+      })
       reply.code(400)
       return { error: 'missing-file-name', message: 'X-VarLens-File-Name is required' }
     }
 
     const safeName = sanitizeUploadName(originalName)
     if (!isAllowedUploadName(safeName)) {
+      deps?.metrics?.recordOperationEvent({
+        operation: 'upload-stage',
+        result: 'error',
+        failureClass: 'unsupported-file-type'
+      })
       reply.code(400)
       return {
         error: 'unsupported-file-type',
@@ -104,6 +119,11 @@ export function registerImportUploadRoutes(app: FastifyInstance, deps: Dispatche
 
     const source = toReadable(request.body)
     if (source === null) {
+      deps?.metrics?.recordOperationEvent({
+        operation: 'upload-stage',
+        result: 'error',
+        failureClass: 'missing-body'
+      })
       reply.code(400)
       return { error: 'missing-body', message: 'Upload body is required' }
     }
@@ -117,6 +137,11 @@ export function registerImportUploadRoutes(app: FastifyInstance, deps: Dispatche
       source
     }).catch((error: unknown) => {
       if (error instanceof UploadTooLargeError) {
+        deps?.metrics?.recordOperationEvent({
+          operation: 'upload-stage',
+          result: 'error',
+          failureClass: 'upload-too-large'
+        })
         reply.code(413)
         return {
           error: 'upload-too-large',
@@ -128,10 +153,13 @@ export function registerImportUploadRoutes(app: FastifyInstance, deps: Dispatche
 
     if (!isStagedUpload(upload)) return upload
 
-    await recordApiWriteAudit(deps, {
-      key: 'import:upload',
-      username: request.session.user?.username
-    })
+    if (deps !== undefined) {
+      await recordApiWriteAudit(deps, {
+        key: 'import:upload',
+        username: request.session.user?.username
+      })
+      deps.metrics?.recordOperationEvent({ operation: 'upload-stage', result: 'success' })
+    }
 
     return {
       id: upload.id,

--- a/tests/main/storage/postgres-migrations-idempotent.test.ts
+++ b/tests/main/storage/postgres-migrations-idempotent.test.ts
@@ -146,7 +146,7 @@ describe.skipIf(!RUN)('Postgres migrations: real-instance idempotency', () => {
     )
 
     const result = await new PostgresMigrationRunner(pool, schema, POSTGRES_MIGRATIONS).migrate()
-    expect(result.applied).toEqual(['0014'])
+    expect(result.applied).toEqual(['0014', '0015'])
 
     const migratedTranscript = await probeClient.query<{ consequence: string; func: string }>(
       `SELECT consequence, func

--- a/tests/web-gate/dispatcher-adapters-auth-import.test.ts
+++ b/tests/web-gate/dispatcher-adapters-auth-import.test.ts
@@ -8,6 +8,7 @@ import { jobRunner } from '../../src/main/services/jobs/runner'
 import { ErrorCode } from '../../src/shared/types/errors'
 import { PasswordPolicyError } from '../../src/web/auth/PostgresWebAuthService'
 import { buildDispatcher } from '../../src/web/server/dispatcher'
+import { AppMetrics } from '../../src/web/server/metrics'
 import { stageExistingFileUpload } from '../../src/web/server/routes/upload-staging'
 import { makeDeps } from './helpers/dispatcher-adapters'
 
@@ -35,6 +36,8 @@ describe('web dispatcher adapters: auth and import', () => {
 
   test('auth.login records success and failure audit events without credentials', async () => {
     const { deps, reply, writeExecute } = makeDeps()
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'test' })
+    deps.metrics = metrics
     deps.authService.authenticate = async (username: string, password: string) =>
       password === 'correct'
         ? {
@@ -90,6 +93,13 @@ describe('web dispatcher adapters: auth and import', () => {
     })
     expect(JSON.stringify(writeExecute.mock.calls)).not.toContain('correct')
     expect(JSON.stringify(writeExecute.mock.calls)).not.toContain('wrong')
+    const text = metrics.metricsText()
+    expect(text).toContain(
+      'varlens_operation_events_total{app="varlens",environment="test",failure_class="none",operation="auth-login",result="success"} 1'
+    )
+    expect(text).toContain(
+      'varlens_operation_events_total{app="varlens",environment="test",failure_class="invalid-credentials",operation="auth-login",result="error"} 1'
+    )
   })
 
   test('auth.login records locked failures without leaking submitted usernames', async () => {

--- a/tests/web-gate/dispatcher-adapters-core.test.ts
+++ b/tests/web-gate/dispatcher-adapters-core.test.ts
@@ -237,6 +237,11 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
         async handle() {
           throw new Error('database unavailable')
         }
+      },
+      'import:start': {
+        async handle() {
+          return { error: 'upload-not-found' }
+        }
       }
     })
 
@@ -286,6 +291,7 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
   test('dispatcher records IPC metrics for overrides, autoroutes, errors, and unknown methods', async () => {
     const { deps, execute, writeExecute } = makeDeps()
     const metrics = new AppMetrics({ app: 'varlens', environment: 'dev' })
+    deps.metrics = metrics
     const app = fastify()
     app.setValidatorCompiler(validatorCompiler)
     app.setSerializerCompiler(serializerCompiler)
@@ -310,6 +316,11 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
         async handle() {
           throw new Error('database unavailable')
         }
+      },
+      'import:start': {
+        async handle() {
+          return { error: 'upload-not-found' }
+        }
       }
     })
 
@@ -333,6 +344,11 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
       url: '/api/variants/query',
       payload: { args: [1, {}] }
     })
+    const importError = await app.inject({
+      method: 'POST',
+      url: '/api/import/start',
+      payload: { args: ['web-upload:missing/case.vcf', 'Case A'] }
+    })
     const preHandlerError = await app.inject({
       method: 'POST',
       url: '/api/auth/isAccountsEnabled',
@@ -349,6 +365,7 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
     expect(read.statusCode).toBe(200)
     expect(write.statusCode).toBe(200)
     expect(error.statusCode).toBe(500)
+    expect(importError.statusCode).toBe(200)
     expect(preHandlerError.statusCode).toBe(401)
     expect(unknown.statusCode).toBe(404)
     expect(execute).toHaveBeenCalledWith({ type: 'tags:list', params: [] })
@@ -369,6 +386,9 @@ describe('web dispatcher adapters: variants, transcripts, and errors', () => {
     )
     expect(text).toContain(
       'varlens_ipc_requests_total{app="varlens",environment="dev",ipc="variants:query",status="error"} 1'
+    )
+    expect(text).toContain(
+      'varlens_operation_events_total{app="varlens",environment="dev",failure_class="upload-not-found",operation="import",result="error"} 1'
     )
     expect(text).toContain(
       'varlens_ipc_requests_total{app="varlens",environment="dev",ipc="auth:isAccountsEnabled",status="error"} 1'

--- a/tests/web-gate/integration/request-id.test.ts
+++ b/tests/web-gate/integration/request-id.test.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const isWebBuilt = existsSync(resolve(process.cwd(), 'out/web/server.cjs'))
+const hasPostgres =
+  typeof process.env.VARLENS_PG_URL === 'string' && process.env.VARLENS_PG_URL !== ''
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe.skipIf(!isWebBuilt || !hasPostgres)('web request IDs', () => {
+  test('generates a fresh UUID instead of trusting a client-supplied request ID', async () => {
+    const { buildApp } = await import('../../../src/web/server')
+    const app = await buildApp()
+    try {
+      const spoofed = 'x'.repeat(10_000)
+      const first = await app.inject({
+        method: 'GET',
+        url: '/healthz',
+        headers: { 'x-request-id': spoofed }
+      })
+      const firstId = first.headers['x-request-id']
+      expect(firstId).not.toBe(spoofed)
+      expect(firstId).toMatch(UUID_RE)
+
+      const second = await app.inject({ method: 'GET', url: '/healthz' })
+      expect(second.headers['x-request-id']).toMatch(UUID_RE)
+      expect(second.headers['x-request-id']).not.toBe(firstId)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/tests/web-gate/metrics-labels.test.ts
+++ b/tests/web-gate/metrics-labels.test.ts
@@ -71,6 +71,25 @@ describe('web metrics route labels', () => {
     )
   })
 
+  test('renders bounded operation metrics for support triage', () => {
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'test' })
+
+    metrics.recordOperationEvent({
+      operation: 'auth-login',
+      result: 'error',
+      failureClass: 'invalid-credentials'
+    })
+    metrics.recordOperationEvent({ operation: 'upload-stage', result: 'success' })
+
+    const text = metrics.metricsText()
+    expect(text).toContain(
+      'varlens_operation_events_total{app="varlens",environment="test",failure_class="invalid-credentials",operation="auth-login",result="error"} 1'
+    )
+    expect(text).toContain(
+      'varlens_operation_events_total{app="varlens",environment="test",failure_class="none",operation="upload-stage",result="success"} 1'
+    )
+  })
+
   test('escapes line breaks in label values', () => {
     const metrics = new AppMetrics({ app: 'varlens', environment: 'prod\ncanary' })
     metrics.beginRequest('POST', '/api/auth/login')

--- a/tests/web-gate/web-upload-boundary.test.ts
+++ b/tests/web-gate/web-upload-boundary.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path'
 import Fastify from 'fastify'
 import { describe, expect, test } from 'vitest'
 
+import { AppMetrics } from '../../src/web/server/metrics'
 import { registerImportUploadRoutes } from '../../src/web/server/routes/upload-staging'
 
 const ROOT = process.cwd()
@@ -94,6 +95,7 @@ describe('web upload boundary', () => {
     const uploadDir = mkdtempSync(join(tmpdir(), 'varlens-upload-boundary-'))
     process.env.VARLENS_WEB_UPLOAD_DIR = uploadDir
     process.env.VARLENS_WEB_MAX_UPLOAD_BYTES = '4'
+    const metrics = new AppMetrics({ app: 'varlens', environment: 'test' })
 
     const app = Fastify()
     app.addHook('preHandler', async (request) => {
@@ -102,7 +104,7 @@ describe('web upload boundary', () => {
         user: { id: 1 }
       }
     })
-    registerImportUploadRoutes(app)
+    registerImportUploadRoutes(app, { metrics } as never)
     await app.ready()
 
     try {
@@ -121,6 +123,9 @@ describe('web upload boundary', () => {
         error: 'upload-too-large',
         message: 'Upload exceeds the configured 4 byte limit'
       })
+      expect(metrics.metricsText()).toContain(
+        'varlens_operation_events_total{app="varlens",environment="test",failure_class="upload-too-large",operation="upload-stage",result="error"} 1'
+      )
     } finally {
       await app.close()
       if (previousUploadDir === undefined) delete process.env.VARLENS_WEB_UPLOAD_DIR


### PR DESCRIPTION
## Summary

- add bounded `varlens_operation_events_total` outcomes for login/password changes, upload staging, and import/batch-import operations
- attach server-generated UUID request IDs to logs and responses without trusting client-supplied values
- align the PostgreSQL migration integration expectation with the existing upstream 0015 migration

## Why

The existing request and IPC metrics show traffic and latency but not whether important web workflows succeed or fail. These bounded outcome labels support operational triage without exposing user data or introducing unbounded values.

## Compatibility

- web mode only; desktop behavior and default desktop CI paths are unchanged
- no new dependency or database schema change

## Validation

- `make ci`
- web build and static/integration web gates
- PostgreSQL migration integration against a fresh database
- `make agent-check`
