### PR TITLE
chore(deps): bump electron to 43.3.0 and fix the two build breaks it exposes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,23 @@ Current baseline (read the script for the authoritative list):
 - `OnlyLoadAppFromAsar: true` — refuses to launch the main app from any location other than `app.asar`.
 - `LoadBrowserProcessSpecificV8Snapshot: false` — current default preserved.
 - `GrantFileProtocolExtraPrivileges: true` — current default preserved; tightening this fuse is a separate, deliberate decision.
+- `WasmTrapHandlers: true` — current default preserved. Selects hardware trap handlers for WebAssembly bounds checks; a performance choice, not a security boundary.
 - `resetAdHocDarwinSignature: true` — re-ad-hoc-signs the macOS binary after fuse flipping so local ad-hoc builds remain launchable.
 
-`@electron/fuses` 2.x exposes `WasmTrapHandlers`, but Electron 40's fuse wire and electron-builder's bundled fuse implementation cannot configure it yet. Do not add it to the baseline until the packaged Electron binary supports that fuse.
+`WasmTrapHandlers` became configurable in **Electron 43**, whose fuse wire grew from 8 entries to 9. Under Electron 40 the fuse existed in `@electron/fuses` 2.x but could not be set, so the baseline deliberately omitted it; on Electron 43 `strictlyRequireAllFuses` fails the build until it is declared:
+
+```
+⨯ strictlyRequireAllFuses: The fuse wire in the Electron binary has 9 fuses
+  but you only provided a config for 8 fuses
+```
+
+This is the guardrail working as intended. When a future Electron major grows the wire again, read the pristine binary's shipped defaults before choosing a value rather than guessing:
+
+```bash
+node -e 'require("@electron/fuses").getCurrentFuseWire("./node_modules/electron/dist/electron").then(console.log)'
+```
+
+Values read back as ASCII bytes — `48` is `'0'` (disabled), `49` is `'1'` (enabled).
 
 The baseline lives only in `scripts/configure-fuses.mjs`. Do not reintroduce `build.electronFuses` in `package.json`; the hook owns the flip and `doAddElectronFuses` short-circuits when the declarative block is absent.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5627,37 +5627,6 @@
         "electron-builder-squirrel-windows": "26.15.3"
       }
     },
-    "node_modules/app-builder-lib/node_modules/@electron/fuses": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
-      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.1",
-        "fs-extra": "^9.0.1",
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "electron-fuses": "dist/bin.js"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/@electron/fuses/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@vitejs/plugin-vue": "^6.0.8",
         "@vitest/coverage-v8": "^4.1.10",
         "@vue/test-utils": "^2.4.11",
-        "electron": "^40.10.5",
+        "electron": "^43.3.0",
         "electron-builder": "^26.15.2",
         "electron-vite": "^5.0.0",
         "eslint": "^10.8.0",
@@ -8031,11 +8031,10 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
-      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
+      "version": "43.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.3.0.tgz",
+      "integrity": "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -8043,7 +8042,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"
@@ -12911,9 +12911,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.26.0.tgz",
-      "integrity": "sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14058,9 +14058,9 @@
       }
     },
     "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "@vitest/coverage-v8": "^4.1.10",
     "@vue/test-utils": "^2.4.11",
-    "electron": "^40.10.5",
+    "electron": "^43.3.0",
     "electron-builder": "^26.15.2",
     "electron-vite": "^5.0.0",
     "eslint": "^10.8.0",

--- a/package.json
+++ b/package.json
@@ -213,7 +213,8 @@
   "overrides": {
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "@xmldom/xmldom": "^0.8.13",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "@electron/fuses": "^2.1.3"
   },
   "prettier": {
     "semi": false,

--- a/scripts/configure-fuses.mjs
+++ b/scripts/configure-fuses.mjs
@@ -22,7 +22,15 @@ export const FUSE_BASELINE = {
   [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
   [FuseV1Options.OnlyLoadAppFromAsar]: true,
   [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
-  [FuseV1Options.GrantFileProtocolExtraPrivileges]: true
+  [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
+  // Electron 43 is the first release whose fuse wire exposes this fuse (the
+  // wire grew from 8 to 9 entries), so `strictlyRequireAllFuses` now demands
+  // an explicit value. Electron ships it enabled; the pristine 43.3.0 binary
+  // reads back `1`. Kept at the shipped default: it selects hardware trap
+  // handlers for WebAssembly bounds checks, which is a performance choice
+  // rather than a security boundary, and disabling it would slow WASM without
+  // hardening anything.
+  [FuseV1Options.WasmTrapHandlers]: true
 }
 
 export default async function configureFuses(context) {

--- a/tests/main/scripts/configure-fuses.test.ts
+++ b/tests/main/scripts/configure-fuses.test.ts
@@ -3,8 +3,6 @@ import { FuseV1Options, FuseVersion } from '@electron/fuses'
 import { FUSE_BASELINE } from '../../../scripts/configure-fuses.mjs'
 
 describe('FUSE_BASELINE', () => {
-  const unsupportedByElectron40 = new Set<number>([FuseV1Options.WasmTrapHandlers])
-
   it('targets fuse wire version V1', () => {
     expect(FUSE_BASELINE.version).toBe(FuseVersion.V1)
   })
@@ -18,7 +16,6 @@ describe('FUSE_BASELINE', () => {
       (v): v is number => typeof v === 'number'
     )
     for (const fuseKey of numericFuseKeys) {
-      if (unsupportedByElectron40.has(fuseKey)) continue
       expect(
         FUSE_BASELINE,
         `FUSE_BASELINE is missing a declaration for FuseV1Options=${FuseV1Options[fuseKey]} (${fuseKey})`
@@ -26,8 +23,12 @@ describe('FUSE_BASELINE', () => {
     }
   })
 
-  it('does not configure fuses absent from the Electron 40 fuse wire', () => {
-    expect(FUSE_BASELINE).not.toHaveProperty(String(FuseV1Options.WasmTrapHandlers))
+  // Electron 43 was the first release whose fuse wire exposed WasmTrapHandlers,
+  // growing the wire from 8 entries to 9. Under Electron 40 the baseline
+  // deliberately omitted it because the binary could not configure it; that
+  // carve-out is gone, so every fuse above is now required unconditionally.
+  it('declares WasmTrapHandlers at the default Electron ships it with', () => {
+    expect(FUSE_BASELINE[FuseV1Options.WasmTrapHandlers]).toBe(true)
   })
 
   it('enables OnlyLoadAppFromAsar', () => {


### PR DESCRIPTION
Bumps Electron 40.10.6 → 43.3.0, closing the **last open Dependabot security alert** and resolving #357.

Supersedes #358.

## Why this could not just be merged

#358 bumps `electron` and nothing else. Merged as-is it **breaks the build in two independent ways** — neither is visible from the dependency diff, and both are release blockers.

### 1. `node-abi` cannot resolve Electron 43 → native module never compiles

`postinstall` runs `@electron/rebuild`, which resolves the native ABI through `node-abi`. The pinned `node-abi@4.26.0` predates Electron 43:

```
Error: Could not detect abi for version 43.3.0 and runtime electron
  at getAbi (node_modules/node-abi/index.js:32:9)
npm error command failed
npm error command sh -c npx @electron/rebuild -f -w better-sqlite3-multiple-ciphers
```

`npm install` exits non-zero, `better-sqlite3-multiple-ciphers` is never built, and neither the app nor the test suite can run.

Fixed by bumping `node-abi` 4.26.0 → 4.33.0, which maps Electron 43 → **ABI 148** (Electron 40 was **143** — the ABI genuinely changed, so the dual-rebuild path had to be revalidated). `@electron/rebuild@4.2.0` declares `node-abi: ^4.2.0`, so no override was needed.

### 2. Electron 43's fuse wire grew from 8 entries to 9 → packaging fails

`scripts/configure-fuses.mjs` sets `strictlyRequireAllFuses: true` deliberately, so an Electron upgrade that adds a fuse fails loudly instead of silently shipping an unconfigured one. It did its job:

```
⨯ strictlyRequireAllFuses: The fuse wire in the Electron binary has 9 fuses
  but you only provided a config for 8 fuses
  failedTask=build
```

The 9th fuse is `WasmTrapHandlers`. `AGENTS.md` previously said **not** to declare it, because Electron 40's wire could not configure it. Electron 43's can, so the note is updated rather than worked around.

**Declaring it was necessary but not sufficient.** The flip is executed by `app-builder-lib`, which bundles its *own* `@electron/fuses@1.8.0` whose `FuseV1Options` enum stops at index 7. Our baseline keys the new fuse at index 8 (from the root `@electron/fuses@2.1.3`), so 1.8.0 could not see it and packaging failed with the identical 9-vs-8 error. `electron-builder@26.15.3` is the latest release and still declares `@electron/fuses: ^1.8.0`, so there is no version to upgrade into.

Resolved with an override aligning `app-builder-lib` onto the 2.1.3 the repo already depends on directly, leaving exactly one fuse implementation in the tree. This is the sanctioned path — `app-builder-lib`'s own `platformPackager` source documents the `afterPack` hook as *"an alternative approach if one wants to override electron-builder's @electron/fuses version"*. The `flipFuses` signature is byte-identical across both versions:

```ts
(pathToElectron: string, fuseConfig: FuseConfig) => Promise<number>
```

## Choosing the `WasmTrapHandlers` value

Read from the pristine binary rather than guessed:

```bash
node -e 'require("@electron/fuses").getCurrentFuseWire("./node_modules/electron/dist/electron").then(console.log)'
```

Electron 43.3.0 ships it as `49` — ASCII `'1'`, i.e. **enabled** — so the baseline preserves the shipped default, consistent with how `LoadBrowserProcessSpecificV8Snapshot` and `GrantFileProtocolExtraPrivileges` are handled. The fuse selects hardware trap handlers for WebAssembly bounds checks: a performance choice, not a security boundary. Disabling it would slow WASM without hardening anything.

## Verified fuse state in the packaged binary

Read back from `release/linux-unpacked/varlens` after packaging — not merely asserted against the config object:

```
OK   RunAsNode                                want=false got=false
OK   EnableCookieEncryption                   want=true  got=true
OK   EnableNodeOptionsEnvironmentVariable     want=false got=false
OK   EnableNodeCliInspectArguments            want=false got=false
OK   EnableEmbeddedAsarIntegrityValidation    want=true  got=true
OK   OnlyLoadAppFromAsar                      want=true  got=true
OK   LoadBrowserProcessSpecificV8Snapshot     want=false got=false
OK   GrantFileProtocolExtraPrivileges         want=true  got=true
OK   WasmTrapHandlers                         want=true  got=true

ALL 9 FUSES MATCH BASELINE
```

Every hardening fuse survives the upgrade unchanged.

## Test change

`tests/main/scripts/configure-fuses.test.ts` carried an Electron 40 carve-out: `WasmTrapHandlers` was exempted from the "declares every fuse" check, and a dedicated test asserted the baseline must **not** declare it.

That premise is now obsolete. The assertion was **tightened, not removed**:

- the exemption set is deleted, so "declares every fuse exposed by the pinned `@electron/fuses` version" now covers all 9 unconditionally
- the negative test becomes a positive one pinning `WasmTrapHandlers` to Electron's shipped default

Net effect is stricter than before: previously one fuse could be silently absent; now none can.

## Security

Closes Dependabot alert [#96](https://github.com/berntpopp/VarLens/security/dependabot/96) — [GHSA-9f4c-93c8-jc8g](https://github.com/advisories/GHSA-9f4c-93c8-jc8g) (high, CVSS 7.2): a sandboxed iframe could bypass the `allow-popups` restriction via the OpenURL navigation path. Vulnerable range `>= 40.0.0-alpha.1 < 41.10.3`. Electron 40 is EOL and never received a backport, so a major bump was the only remedy.

`npm audit`: **6 vulnerabilities → 5**. The remaining 5 are the known low `elliptic` → `pdbe-molstar` residual, whose only "fix" is a semver-major *downgrade* of `pdbe-molstar` that breaks the molecular viewer.

**This leaves zero open Dependabot alerts on the repository.**

## Verification

`make ci-full` — the full local mirror of the GitHub Actions pipeline — passed end to end (exit 0):

```
=== Checks (Ubuntu) PASSED ===          lint, format-check, typecheck x3
                                        Test Files  409 passed | 4 skipped (413)
                                        Tests      4526 passed | 91 skipped (4617)
=== Startup Smoke (Linux) PASSED ===
=== Package (ubuntu-latest) PASSED ===
=== Packaged Smoke (Linux) PASSED ===
=== GitHub Actions parity pipeline PASSED ===
```

Web gate (`make web-gate-static`, exit 0):

```
Test Files  31 passed | 13 skipped (44)
Tests      201 passed | 1 expected fail | 32 skipped (234)
```

Both packaging and packaged smoke are load-bearing here: they are what exercises the fuse flip, and they are exactly what failed before the `@electron/fuses` override.

Note `.github/dependabot.yml` still ignores `electron` `version-update:semver-major`. That is left as-is deliberately: it correctly suppresses routine major churn for a dependency whose upgrades need this much validation, and it did **not** prevent the security PR from being raised.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PohiEWFT9CkCK4XNuhm9fR
