### PR TITLE
chore(deps): drop @types/nock stub and document the intentional vite import warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,15 @@ Values read back as ASCII bytes — `48` is `'0'` (disabled), `49` is `'1'` (ena
 
 The baseline lives only in `scripts/configure-fuses.mjs`. Do not reintroduce `build.electronFuses` in `package.json`; the hook owns the flip and `doAddElectronFuses` short-circuits when the declarative block is absent.
 
+### Vite "dynamically imported but also statically imported" warnings
+
+`npm run build` emits two of these. **Both are expected. Do not "fix" them by converting the dynamic import to a static one** — in both cases the `await import(...)` exists to defer _module evaluation at runtime_, not to split a chunk, so Vite's advice does not apply.
+
+- `src/main/storage/postgres/migrations/definitions.ts`, dynamically imported by `src/main/database/startup.ts`. That module reads migration SQL off disk at module scope, so importing it eagerly would do Postgres file I/O for every SQLite user. `tests/main/database/database-startup.test.ts` locks this in with _"does not load postgres migration definitions for the default sqlite database"_ — making the import static fails that test.
+- `src/main/ipc/handlers/import-logic.ts`, dynamically imported by `src/main/storage/sqlite/SqliteImportExecutor.ts`, so a test-injected delegate never drags the real import pipeline in.
+
+Vite still warns because other modules import each one statically; that only means no separate chunk is produced, which was never the goal.
+
 ## What NOT to do
 
 - Do not introduce `console.*` calls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "@types/d3": "^7.4.3",
         "@types/file-saver": "^2.0.7",
         "@types/markdown-it": "^14.1.2",
-        "@types/nock": "^11.1.0",
         "@types/node": "^26.1.2",
         "@types/pg": "^8.20.0",
         "@types/plotly.js": "^3.0.10",
@@ -4464,17 +4463,6 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
-    },
-    "node_modules/@types/nock": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
-      "integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
-      "deprecated": "This is a stub types definition. nock provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "nock": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "26.1.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/d3": "^7.4.3",
     "@types/file-saver": "^2.0.7",
     "@types/markdown-it": "^14.1.2",
-    "@types/nock": "^11.1.0",
     "@types/node": "^26.1.2",
     "@types/pg": "^8.20.0",
     "@types/plotly.js": "^3.0.10",


### PR DESCRIPTION
Follow-up to the dependency work in #356 / #359. Addresses the `npm ci` deprecation warnings and the two Vite build warnings.

## `@types/nock` removed

npm printed this on every install:

```
npm warn deprecated @types/nock@11.1.0: This is a stub types definition.
nock provides its own type definitions, so you do not need this installed.
```

It was a *direct* devDependency referenced nowhere outside `package.json`. `nock@14.0.17` ships `types/index.d.ts` and declares `types` in its manifest. Removed.

`make typecheck` passes and the full suite is unchanged at **4526 tests**.

## The other deprecation warnings are not safely fixable

All transitive under `electron-builder` / `electron-updater`:

| Package | Reached via |
|---|---|
| `glob@7.2.3` | `@electron/asar@3.4.1`, `rimraf@2.6.3` |
| `inflight@1.0.6` | `glob@7.2.3` |
| `rimraf@2.6.3` | `electron-winstaller@5.4.0` → `temp@0.9.4` |
| `boolean@3.2.0` | `@electron/get@3.1.0` → `global-agent@3.0.0` |
| `lodash.isequal@4.5.0` | `electron-updater@6.8.9` |

**None is flagged by `npm audit`** — these are deprecation notices with zero advisories against our tree.

Overriding the leaves would break packaging: glob v9+ removed the callback API `@electron/asar` 3.x uses, and rimraf v4+ is promise-only while `temp@0.9.4` calls it with callbacks. Upstream has not moved either — `electron-builder@26.15.3` is the latest release, and `electron-winstaller@5.4.4` still depends on `temp ^0.9.0`.

One avenue does exist and is deliberately **not** taken here: `@electron/asar@4.2.1` moved to `glob ^13`, which would drop both `glob@7` and `inflight`. That is a major bump of the component that produces `app.asar`, which pairs with the `EnableEmbeddedAsarIntegrityValidation` fuse. It deserves its own PR and a full `make ci-full`, not a ride-along on a cleanup.

## Vite warnings: both are intentional, and one is a trap

`npm run build` emits two "dynamically imported but also statically imported" warnings. They look like obvious cleanups. **Both should stay**, and this PR documents why in `AGENTS.md` instead of changing them.

I tried converting the `definitions.ts` one to a static import. The suite caught it immediately:

```
FAIL tests/main/database/database-startup.test.ts
  > does not load postgres migration definitions for the default sqlite database
Caused by: postgres migrations should not load for sqlite startup
```

`migrations/definitions.ts` reads migration SQL off disk at module scope, so an eager import performs Postgres file I/O for **every SQLite user** — and SQLite is the default backend. The `await import(...)` defers module *evaluation at runtime*; it was never about chunk splitting, so Vite's advice does not apply. `import-logic.ts` is the same shape: its dynamic import keeps a test-injected delegate from dragging in the real import pipeline.

Vite still warns because other modules import each one statically — that only means no separate chunk is produced, which was never the goal.

`AGENTS.md` now records both, with the failing test name, so the next reader does not spend the same time rediscovering it.

## Verification

- `make typecheck` — exit 0
- `npm run test` — **409 files / 4526 tests passed**, 91 skipped
- `npm run build` — exit 0
- web gate — 31 files / 201 tests passed

No source files change in this PR; the diff is `package.json`, `package-lock.json` and `AGENTS.md`.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PohiEWFT9CkCK4XNuhm9fR
