### PR TITLE
perf(ci): promote build.yml installers instead of rebuilding the tagged commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -446,8 +446,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev build-essential
 
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Rebuild native modules for Node.js
+        run: npm run rebuild:node
+
+      # `make web-ci` runs the web gate under Node (no Electron process
+      # involved), so assert the NODE ABI, not electron.
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs node
 
       - name: Run opt-in web gate
         run: make web-ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,12 +29,13 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      web: ${{ steps.filter.outputs.web }}
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.code }}
+      web: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # dorny/paths-filter@v4.0.2
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             code:
@@ -131,11 +133,32 @@ jobs:
       - name: Restore git mtimes
         run: git restore-mtime
 
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
 
       - name: Rebuild native modules for Node.js
         run: npm run rebuild:node
+
+      # checks runs Vitest under Node, so assert the NODE ABI, not electron.
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs node
 
       # Cache ESLint + Prettier results across CI runs. Key on lockfile +
       # lint/format config so stale caches auto-invalidate when rules change.
@@ -201,7 +224,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: win
+          - os: macos-latest
+            platform: mac
 
     steps:
       - name: Configure git line endings
@@ -220,29 +249,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev build-essential
 
-      - name: Install dependencies
-        run: npm ci
-
-      # Cache the Electron-ABI native binary. Key must include runner.os,
-      # runner.arch, the exact Electron version spec from package.json, and
-      # the lockfile hash — a partial match would leave a wrong-ABI `.node`
-      # on disk and silently corrupt the build. No restore-keys fallback
-      # for the same reason.
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
       - name: Extract Electron version
         id: electron-ver
         shell: bash
         run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
 
-      - name: Cache native module for Electron ABI
-        id: native-cache
+      - name: Restore native ABI cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
         with:
-          path: node_modules/better-sqlite3-multiple-ciphers/build/Release
-          key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
 
+      - name: Install dependencies
+        run: npm ci
+
+      # Unconditional: a warm cache makes this a ~0.1s restore, and a cold
+      # cache self-heals with a real compile. There is no cache-hit guard
+      # to fall out of sync with.
       - name: Rebuild native modules for Electron
-        if: steps.native-cache.outputs.cache-hit != 'true'
         run: npm run rebuild:electron
+
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs electron
 
       - name: Build Electron app
         run: npx electron-vite build
@@ -261,7 +295,7 @@ jobs:
             .planning/artifacts/perf/phase1/baseline/startup-smoke/
 
       - name: Package Electron app
-        run: npx electron-builder --publish never
+        run: npx electron-builder --${{ matrix.platform }} --publish never
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
@@ -284,6 +318,64 @@ jobs:
           path: |
             test-results/
             .planning/artifacts/perf/phase1/baseline/packaged-smoke/
+
+      # `-printf` is GNU-only, so it is avoided below — macOS runners ship
+      # BSD `find`. `sha256sum` is likewise absent on macOS; use
+      # `shasum -a 256`, which exists on all three runners (Git Bash
+      # provides it on Windows).
+      - name: Write provenance and checksums
+        if: github.event_name != 'pull_request'
+        shell: bash
+        working-directory: release
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          export VERSION="$(node -p "require('../package.json').version")"
+          export TREE_SHA="$(git -C .. rev-parse 'HEAD^{tree}')"
+          node -e "
+            const fs = require('fs')
+            fs.writeFileSync('provenance.json', JSON.stringify({
+              sha: process.env.GITHUB_SHA,
+              tree: process.env.TREE_SHA,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: process.env.GITHUB_RUN_ATTEMPT,
+              version: process.env.VERSION,
+              os: process.env.RUNNER_OS,
+              arch: process.env.RUNNER_ARCH,
+              platform: process.env.PLATFORM
+            }, null, 2) + '\n')
+          "
+          # Checksum every publishable asset, in the plain `<hex>  <name>` form
+          # verify-promoted-artifacts.mjs parses. Deliberately excludes
+          # provenance.json and SHA256SUMS itself. Portable across GNU/BSD find.
+          : > SHA256SUMS
+          for f in *.AppImage *.deb *.dmg *.exe *.zip latest*.yml; do
+            [ -e "$f" ] || continue
+            shasum -a 256 "$f" >> SHA256SUMS
+          done
+          # An empty SHA256SUMS means the packaging step produced nothing.
+          [ -s SHA256SUMS ] || { echo "::error::no publishable assets found in release/"; exit 1; }
+          cat SHA256SUMS
+
+      - name: Upload installers
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
+        with:
+          name: installers-${{ matrix.os }}
+          # Installers are already compressed; level 6 burns CPU for nothing.
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 90
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/*.dmg
+            release/*.exe
+            release/*.zip
+            release/latest*.yml
+            release/provenance.json
+            release/SHA256SUMS
 
   # ── 4. Web-mode required check for web app surfaces ────────────────
   # The standalone `Web CI` workflow stays for readability, but this

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,9 +194,16 @@ jobs:
       - name: Run type check
         run: npm run typecheck
 
-      # Coverage only on push-to-main — PRs run plain `vitest run` for speed.
-      - name: Run tests (PR)
-        if: github.event_name == 'pull_request'
+      # Coverage only on push-to-main — PRs and manual `workflow_dispatch`
+      # reruns (e.g. re-generating installers past the 30-day rerun window)
+      # run plain `vitest run` for speed. Gated on "not push" rather than an
+      # explicit pull_request/workflow_dispatch OR so a future event type
+      # defaults to running tests, not silently skipping them: release.yml
+      # selects the newest Build run on a SHA as its "CI passed" gate, so a
+      # test step that silently no-ops on some event would let an untested
+      # run satisfy that gate.
+      - name: Run tests
+        if: github.event_name != 'push'
         run: npm run test
 
       - name: Run tests with coverage (main)
@@ -249,17 +256,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev build-essential
 
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
       # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
       # postinstall restores a binary instead of compiling one. `.cache/native`
       # is a sibling of node_modules and survives `npm ci`.
       # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
       # sibling with a different key. No restore-keys: a partial match is
       # rejected by manifestIsFresh() anyway, and the absence documents intent.
-      - name: Extract Electron version
-        id: electron-ver
-        shell: bash
-        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
-
       - name: Restore native ABI cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
         with:
@@ -276,6 +283,7 @@ jobs:
         run: npm run rebuild:electron
 
       - name: Assert native ABI
+        shell: bash
         run: node scripts/native/assert-native-abi.mjs electron
 
       - name: Build Electron app
@@ -319,10 +327,11 @@ jobs:
             test-results/
             .planning/artifacts/perf/phase1/baseline/packaged-smoke/
 
-      # `-printf` is GNU-only, so it is avoided below — macOS runners ship
-      # BSD `find`. `sha256sum` is likewise absent on macOS; use
-      # `shasum -a 256`, which exists on all three runners (Git Bash
-      # provides it on Windows).
+      # macOS runners ship `shasum` but not `sha256sum`; Git-for-Windows ships
+      # coreutils' `sha256sum` but only has `shasum` if Perl is on PATH;
+      # Linux has both. Detect whichever is actually present rather than
+      # betting on one — both emit the identical `<64 hex><two spaces><name>`
+      # format that verify-promoted-artifacts.mjs parses, confirmed locally.
       - name: Write provenance and checksums
         if: github.event_name != 'pull_request'
         shell: bash
@@ -331,8 +340,16 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
-          export VERSION="$(node -p "require('../package.json').version")"
-          export TREE_SHA="$(git -C .. rev-parse 'HEAD^{tree}')"
+          # Split assignment from `export` — `export V="$(cmd)"` swallows a
+          # failing `cmd`'s exit status (only the bare `V="$(cmd)"` form trips
+          # `set -e`), which would otherwise let a failing `node -p` or
+          # `git rev-parse` write an empty/wrong value into provenance.json
+          # silently. `tree` in particular is never validated downstream, so
+          # a silently-empty value would ship unnoticed.
+          VERSION="$(node -p "require('../package.json').version")"
+          export VERSION
+          TREE_SHA="$(git -C .. rev-parse 'HEAD^{tree}')"
+          export TREE_SHA
           node -e "
             const fs = require('fs')
             fs.writeFileSync('provenance.json', JSON.stringify({
@@ -348,11 +365,12 @@ jobs:
           "
           # Checksum every publishable asset, in the plain `<hex>  <name>` form
           # verify-promoted-artifacts.mjs parses. Deliberately excludes
-          # provenance.json and SHA256SUMS itself. Portable across GNU/BSD find.
+          # provenance.json and SHA256SUMS itself.
+          SUM=$(command -v shasum >/dev/null 2>&1 && echo "shasum -a 256" || echo "sha256sum")
           : > SHA256SUMS
           for f in *.AppImage *.deb *.dmg *.exe *.zip latest*.yml; do
             [ -e "$f" ] || continue
-            shasum -a 256 "$f" >> SHA256SUMS
+            $SUM "$f" >> SHA256SUMS
           done
           # An empty SHA256SUMS means the packaging step produced nothing.
           [ -s SHA256SUMS ] || { echo "::error::no publishable assets found in release/"; exit 1; }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,8 +330,9 @@ jobs:
       # macOS runners ship `shasum` but not `sha256sum`; Git-for-Windows ships
       # coreutils' `sha256sum` but only has `shasum` if Perl is on PATH;
       # Linux has both. Detect whichever is actually present rather than
-      # betting on one — both emit the identical `<64 hex><two spaces><name>`
-      # format that verify-promoted-artifacts.mjs parses, confirmed locally.
+      # betting on one — both emit the identical `<64 hex> *<name>` binary-mode
+      # format (see the -b rationale below) that verify-promoted-artifacts.mjs
+      # parses, confirmed locally.
       - name: Write provenance and checksums
         if: github.event_name != 'pull_request'
         shell: bash
@@ -363,10 +364,20 @@ jobs:
               platform: process.env.PLATFORM
             }, null, 2) + '\n')
           "
-          # Checksum every publishable asset, in the plain `<hex>  <name>` form
-          # verify-promoted-artifacts.mjs parses. Deliberately excludes
-          # provenance.json and SHA256SUMS itself.
-          SUM=$(command -v shasum >/dev/null 2>&1 && echo "shasum -a 256" || echo "sha256sum")
+          # Checksum every publishable asset with -b (binary mode) on both tool
+          # branches, in the `<hex> *<name>` form verify-promoted-artifacts.mjs
+          # parses. Deliberately excludes provenance.json and SHA256SUMS itself.
+          #
+          # -b matters specifically for `shasum` on Git-for-Windows: it is a
+          # Perl script whose Digest::SHA::addfile only calls binmode() for
+          # 'b'/'0' modes, not the default text mode — without -b a CRLF
+          # translation on that Perl build could silently corrupt every
+          # .exe/.zip digest on the Windows leg. GNU sha256sum's default
+          # (text) mode is already binary-equivalent on POSIX, so -b there is
+          # a no-op in practice; it is applied to both branches anyway so the
+          # two tools always emit the identical asterisk-prefixed form rather
+          # than depending on which branch happened to run.
+          SUM=$(command -v shasum >/dev/null 2>&1 && echo "shasum -a 256 -b" || echo "sha256sum -b")
           : > SHA256SUMS
           for f in *.AppImage *.deb *.dmg *.exe *.zip latest*.yml; do
             [ -e "$f" ] || continue

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,16 @@ jobs:
             platform: win
           - os: macos-latest
             platform: mac
+    # app-builder-lib's getCacheDirectory() (electronGet.js:34-57) only honours
+    # ELECTRON_BUILDER_CACHE when it is an ABSOLUTE path (`path.parse(env).root`
+    # must be truthy). `${{ github.workspace }}` is absolute on every runner
+    # (Windows, macOS, Linux alike), so pinning it here gives one workspace-
+    # relative cache path instead of a three-way OS conditional over the
+    # default per-OS locations. Set at the job level so both the cache step
+    # below and the `Package Electron app` step (which invokes electron-builder
+    # itself) see the identical value.
+    env:
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 
     steps:
       - name: Configure git line endings
@@ -301,6 +311,38 @@ jobs:
           path: |
             test-results/
             .planning/artifacts/perf/phase1/baseline/startup-smoke/
+
+      # Content-addressed tool archives (nsis-resources, 7zip, winCodeSign, the
+      # Electron zip itself, …) re-verified by sha256 on use, so — unlike the
+      # native ABI cache above — a partial `restore-keys` match is safe and
+      # still saves a download. Path is `.cache/electron-builder`, workspace-
+      # relative and matching ELECTRON_BUILDER_CACHE above; never bare `.cache`
+      # — `.cache/native` and `.cache/tsbuildinfo` are siblings with different
+      # keys and lifetimes.
+      - name: Restore electron-builder toolset cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/electron-builder
+          key: ebtools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ebtools-${{ runner.os }}-${{ runner.arch }}-
+
+      # electron-builder's extracted-directory cache tier checks file COUNT,
+      # not content (cacheState.js:112-131), so a partial restore would be
+      # served silently. The `<extractDir>.state` files are SIBLINGS of the
+      # extracted directory, not files inside it (cacheState.js:24 —
+      # `${extractDir}.state`), so they must be found and removed explicitly.
+      # Dropping them forces re-extraction back through the sha256-verified
+      # archive path. Cheap; the download is what is actually being cached.
+      - name: Drop electron-builder extraction state so archives are re-verified
+        shell: bash
+        run: |
+          set -euo pipefail
+          DIR=".cache/electron-builder"
+          [ -d "$DIR" ] || { echo "no electron-builder cache to clean"; exit 0; }
+          find "$DIR" -name '*.state' -type f -delete
+          find "$DIR" -name '*.lock' -type f -delete
+          echo "cleared extraction state under $DIR"
 
       - name: Package Electron app
         run: npx electron-builder --${{ matrix.platform }} --publish never

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,11 +38,33 @@ jobs:
       - name: Allow Electron to use unprivileged user namespaces (Ubuntu 24.04)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
 
       - name: Rebuild native modules for Electron
         run: npm run rebuild:electron
+
+      # This job builds and drives the packaged Electron app (screenshots.e2e.ts
+      # launches it via Playwright), so assert the ELECTRON ABI, not node.
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs electron
 
       - name: Build Electron app
         run: npx electron-vite build
@@ -83,6 +105,13 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      # Deliberately no native ABI cache and no `assert-native-abi.mjs` check
+      # in this job. `--ignore-scripts` skips both the dependency's own
+      # install script and the root `postinstall`, so no `.node` binary is
+      # placed at all — this job only runs VitePress, which never touches the
+      # native module. An ABI assertion here would fail a perfectly correct
+      # job because there is nothing on disk to verify. Do not "fix" this
+      # inconsistency with the other jobs; it is intentional.
       - name: Install dependencies (skip native rebuild — only VitePress needed)
         run: npm ci --ignore-scripts
 

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -80,8 +80,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev build-essential
 
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Rebuild native modules for Node.js
+        run: npm run rebuild:node
+
+      # `make web-ci` runs the web gate under Node (no Electron process
+      # involved), so assert the NODE ABI, not electron.
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs node
 
       - name: Run opt-in web gate
         run: make web-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}
       version: ${{ steps.version.outputs.version }}
+      build_run_id: ${{ steps.build-gate.outputs.build_run_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
@@ -26,6 +27,20 @@ jobs:
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # Closes the force-moved-tag hole: refuses to release if the tag was
+      # moved to point at a different commit after this run started resolving
+      # refs/tags/*. The checkout above already uses fetch-depth: 0.
+      - name: Assert tag ref resolves to the commit being released
+        run: |
+          set -euo pipefail
+          TAG_COMMIT=$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")
+          if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} now resolves to $TAG_COMMIT but this run is for $GITHUB_SHA."
+            echo "::error::The tag was moved after this workflow started. Refusing to publish a mismatched release."
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} resolves to $GITHUB_SHA"
 
       - name: Assert tag matches package.json version
         run: |
@@ -59,33 +74,36 @@ jobs:
       # logic the check finds no "success" conclusion and fails
       # (race condition that broke v0.56.1's first release attempt).
       - name: Verify Build workflow passed on tagged SHA
+        id: build-gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           SHA="${GITHUB_SHA}"
-          WORKFLOW_NAME="Build"
           MAX_ATTEMPTS=20
           DELAY=30
-          STATUS="pending"
           for i in $(seq 1 $MAX_ATTEMPTS); do
-            STATUS=$(gh run list --workflow="$WORKFLOW_NAME" --commit="$SHA" \
-              --json conclusion --jq '.[0].conclusion // "pending"')
+            # `--commit` with a SHORT sha silently returns []; GITHUB_SHA is always full.
+            # Accept push and workflow_dispatch; exclude pull_request, whose head_sha
+            # is the PR HEAD and whose runs never upload installers.
+            RUN=$(gh run list --workflow="Build" --commit="$SHA" --limit 20 \
+              --json conclusion,databaseId,headSha,event \
+              --jq "[.[] | select(.headSha == \"$SHA\") | select(.event == \"push\" or .event == \"workflow_dispatch\")] | .[0] // empty")
+            STATUS=$(echo "$RUN" | jq -r '.conclusion // "pending"')
             if [ "$STATUS" = "success" ]; then
-              echo "$WORKFLOW_NAME passed on $SHA — proceeding with release"
-              break
+              RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
+              echo "build_run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+              echo "Build passed on $SHA in run $RUN_ID — promoting its artifacts"
+              exit 0
             elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
-              echo "::error::$WORKFLOW_NAME did not succeed on $SHA (got: $STATUS)"
-              echo "::error::Refusing to release a tag whose CI did not pass."
+              echo "::error::Build did not succeed on $SHA (got: $STATUS). Refusing to release."
               exit 1
-            else
-              echo "$WORKFLOW_NAME status: $STATUS (attempt $i/$MAX_ATTEMPTS, waiting ${DELAY}s...)"
-              sleep $DELAY
             fi
+            echo "Build status: $STATUS (attempt $i/$MAX_ATTEMPTS, waiting ${DELAY}s...)"
+            sleep $DELAY
           done
-          if [ "$STATUS" != "success" ]; then
-            echo "::error::$WORKFLOW_NAME did not complete within $((MAX_ATTEMPTS * DELAY))s on $SHA (last status: $STATUS)"
-            exit 1
-          fi
+          echo "::error::Build did not complete within $((MAX_ATTEMPTS * DELAY))s on $SHA"
+          exit 1
 
       - name: Generate release notes
         run: |
@@ -134,17 +152,14 @@ jobs:
       - name: Run gitleaks
         run: gitleaks git --no-banner --redact --report-format sarif --report-path gitleaks-results.sarif --exit-code 1 .
 
-  release-linux:
-    name: Release (Linux)
+  promote-unix:
+    name: Promote Linux + macOS installers
     needs: [create-release, secrets-scan]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-
+      contents: read
+      actions: read # required to read another workflow run's artifacts
     steps:
-      - name: Configure git line endings
-        run: git config --global core.autocrlf false
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
 
@@ -152,123 +167,68 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsqlite3-dev build-essential
-
-      - name: Install dependencies
-        run: npm ci
-
-      # lint/typecheck/test are validated by the Build workflow on the tagged SHA
-      # before the tag is pushed. The create-release gate above refuses to
-      # proceed when Build didn't succeed, so re-running those checks
-      # here would be pure duplication.
-
-      # Cache the Electron-ABI native binary. Key must include runner.os,
-      # runner.arch, the exact Electron version spec from package.json, and
-      # the lockfile hash — a partial match would leave a wrong-ABI `.node`
-      # on disk and silently corrupt the build. No restore-keys fallback
-      # for the same reason.
-      - name: Extract Electron version
-        id: electron-ver
-        shell: bash
-        run: echo "ver=$(node -p 'require("./package.json").devDependencies.electron')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache native module for Electron ABI
-        id: native-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+      - name: Download Linux installers from the verified Build run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
-          path: node_modules/better-sqlite3-multiple-ciphers/build/Release
-          key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+          name: installers-ubuntu-latest
+          path: promoted/linux
+          run-id: ${{ needs.create-release.outputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Rebuild native modules for Electron
-        if: steps.native-cache.outputs.cache-hit != 'true'
-        run: npm run rebuild:electron
+      - name: Download macOS installers from the verified Build run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
+        with:
+          name: installers-macos-latest
+          path: promoted/mac
+          run-id: ${{ needs.create-release.outputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        run: npx electron-vite build && npx electron-builder --linux --publish never
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+      - name: Verify promoted artifacts
+        run: |
+          set -euo pipefail
+          V="${{ needs.create-release.outputs.version }}"
+          node scripts/release/verify-promoted-artifacts.mjs promoted/linux linux "$V" "$GITHUB_SHA"
+          node scripts/release/verify-promoted-artifacts.mjs promoted/mac   mac   "$V" "$GITHUB_SHA"
+
+      - name: Verify auto-update metadata
+        run: |
+          set -euo pipefail
+          node scripts/release/verify-latest-yml.mjs promoted/linux/latest-linux.yml promoted/linux
+          node scripts/release/verify-latest-yml.mjs promoted/mac/latest-mac.yml     promoted/mac
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
         with:
           name: release-linux
+          compression-level: 0
+          if-no-files-found: error
           path: |
-            release/*.AppImage
-            release/*.deb
-            release/latest-linux.yml
+            promoted/linux/*.AppImage
+            promoted/linux/*.deb
+            promoted/linux/latest-linux.yml
 
-  release-macos:
-    name: Release (macOS)
-    needs: [create-release, secrets-scan]
-    runs-on: macos-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Configure git line endings
-        run: git config --global core.autocrlf false
-
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      # lint/typecheck/test already validated by the Build workflow on the tagged SHA.
-
-      - name: Extract Electron version
-        id: electron-ver
-        shell: bash
-        run: echo "ver=$(node -p 'require("./package.json").devDependencies.electron')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache native module for Electron ABI
-        id: native-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
-        with:
-          path: node_modules/better-sqlite3-multiple-ciphers/build/Release
-          key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Rebuild native modules for Electron
-        if: steps.native-cache.outputs.cache-hit != 'true'
-        run: npm run rebuild:electron
-
-      - name: Build
-        run: npx electron-vite build && npx electron-builder --mac --publish never
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
-
-      - name: Upload artifacts
+      - name: Upload macOS artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
         with:
           name: release-macos
+          compression-level: 0
+          if-no-files-found: error
           path: |
-            release/*.dmg
-            release/*.zip
-            release/latest-mac.yml
+            promoted/mac/*.dmg
+            promoted/mac/*.zip
+            promoted/mac/latest-mac.yml
 
-  release-windows:
-    name: Release (Windows)
+  sign-windows:
+    name: Sign Windows installer
     needs: [create-release, secrets-scan]
     runs-on: windows-latest
     environment: release
     permissions:
-      contents: write
+      contents: read
+      actions: read # required to read another workflow run's artifacts
 
     steps:
-      - name: Configure git line endings
-        run: git config --global core.autocrlf false
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
 
@@ -276,33 +236,25 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
-
-      # lint/typecheck/test already validated by build.yml on the tagged SHA.
-
-      - name: Extract Electron version
-        id: electron-ver
-        shell: bash
-        run: echo "ver=$(node -p 'require("./package.json").devDependencies.electron')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache native module for Electron ABI
-        id: native-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+      - name: Download Windows installers from the verified Build run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
-          path: node_modules/better-sqlite3-multiple-ciphers/build/Release
-          key: native-electron-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+          name: installers-windows-latest
+          path: promoted/win
+          run-id: ${{ needs.create-release.outputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Rebuild native modules for Electron
-        if: steps.native-cache.outputs.cache-hit != 'true'
-        run: npm run rebuild:electron
-
-      - name: Build
-        run: npx electron-vite build && npx electron-builder --win --publish never
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+      # Verifies build.yml's unsigned output. Signing happens below and
+      # rewrites the .exe bytes, so this has to run first — checking the
+      # signed bytes against a checksum manifest that describes the
+      # unsigned ones would always fail.
+      - name: Verify promoted artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/release/verify-promoted-artifacts.mjs promoted/win win \
+            "${{ needs.create-release.outputs.version }}" "$GITHUB_SHA"
 
       # --- SSL.com eSigner Code Signing (Windows) ---
       # Uses CodeSignTool v1.3.2 jar directly (not the buggy GitHub Action).
@@ -315,7 +267,7 @@ jobs:
         run: |
           $version = "${{ needs.create-release.outputs.version }}"
           $filesToSign = @("Varlens-Setup-${version}.exe", "Varlens-Portable-${version}.exe")
-          $found = ($filesToSign | Where-Object { Test-Path (Join-Path "release" $_) }).Count
+          $found = ($filesToSign | Where-Object { Test-Path (Join-Path "promoted/win" $_) }).Count
           Write-Host "::notice::Code signing: will sign $found of $($filesToSign.Count) files (monthly quota: 20 operations)"
 
       - name: Setup Java for CodeSignTool
@@ -379,7 +331,7 @@ jobs:
           # CodeSignTool reads ./conf/code_sign_tool.properties relative to CWD
           Push-Location $cstDir
           foreach ($fileName in $filesToSign) {
-            $filePath = Join-Path $workspace "release" $fileName
+            $filePath = Join-Path $workspace "promoted/win" $fileName
             if (-not (Test-Path $filePath)) {
               Write-Host "::warning::$fileName not found, skipping"
               continue
@@ -412,8 +364,8 @@ jobs:
         if: vars.ESIGNER_ENABLED == 'true'
         shell: pwsh
         run: |
-          $yml = Get-Content release/latest.yml -Raw
-          foreach ($exe in Get-ChildItem release/*.exe) {
+          $yml = Get-Content promoted/win/latest.yml -Raw
+          foreach ($exe in Get-ChildItem promoted/win/*.exe) {
             $hash = (Get-FileHash $exe.FullName -Algorithm SHA512).Hash.ToLower()
             $b64 = [Convert]::ToBase64String([byte[]] -split ($hash -replace '..', '0x$& '))
             $size = $exe.Length
@@ -425,25 +377,38 @@ jobs:
             $yml = $yml -replace "(?<=path: $([regex]::Escape($name))\s*\n\s*sha512: )\S+", $b64
             $yml = $yml -replace "(?<=path: $([regex]::Escape($name))\s*\n\s*sha512: \S+\s*\n\s*size: )\d+", $size
           }
-          Set-Content release/latest.yml $yml -NoNewline
+          Set-Content promoted/win/latest.yml $yml -NoNewline
+
+      # Runs unconditionally: latest.yml must describe the shipped bytes whether
+      # or not signing ran. This is the check the -replace regexes never had.
+      - name: Verify auto-update metadata matches the shipped binaries
+        shell: bash
+        run: node scripts/release/verify-latest-yml.mjs promoted/win/latest.yml promoted/win
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
         with:
           name: release-windows
+          compression-level: 0
+          if-no-files-found: error
           path: |
-            release/*.exe
-            release/*.zip
-            release/latest.yml
+            promoted/win/*.exe
+            promoted/win/*.zip
+            promoted/win/latest.yml
 
   publish-release:
     name: Publish Release
-    needs: [create-release, release-linux, release-macos, release-windows]
+    needs: [create-release, promote-unix, sign-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
@@ -458,6 +423,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh release upload "${{ github.ref_name }}" artifacts/* --clobber
+
+      # Last correctable moment: refuse to flip the release public if the tag
+      # moved during the promote/sign jobs above.
+      - name: Re-assert tag ref before publishing
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          TAG_COMMIT=$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")
+          if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} moved to $TAG_COMMIT during the release; assets are from $GITHUB_SHA."
+            exit 1
+          fi
 
       - name: Publish draft release and mark as latest
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,17 @@ jobs:
               # either way). Without this check the failure only surfaces one
               # job later as an opaque "Unable to find an artifact with the
               # name installers-<os>" from actions/download-artifact.
-              ARTIFACT_NAMES=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" --jq '[.artifacts[].name]')
+              # `--paginate` is required: the REST endpoint returns 30
+              # artifacts per page by default, and a run can produce more
+              # than that. `--jq` under `--paginate` runs once per page
+              # rather than merging pages first, so `[.artifacts[].name]`
+              # would print one JSON array per page instead of one combined
+              # array — using the flat `.artifacts[].name` form instead
+              # prints one name per line across all pages, which a plain
+              # line-match below can check without needing to merge JSON.
+              ARTIFACT_NAMES=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" --jq '.artifacts[].name')
               for NAME in installers-ubuntu-latest installers-macos-latest installers-windows-latest; do
-                if ! echo "$ARTIFACT_NAMES" | jq -e --arg n "$NAME" 'index($n) != null' > /dev/null; then
+                if ! grep -qxF "$NAME" <<< "$ARTIFACT_NAMES"; then
                   echo "::error::Build run $RUN_ID succeeded but has no '$NAME' artifact — its package job likely didn't run. Refusing to promote a partial artifact set."
                   exit 1
                 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read # gh run list / gh api .../artifacts read another workflow's runs
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}
       version: ${{ steps.version.outputs.version }}
@@ -90,8 +91,27 @@ jobs:
               --json conclusion,databaseId,headSha,event \
               --jq "[.[] | select(.headSha == \"$SHA\") | select(.event == \"push\" or .event == \"workflow_dispatch\")] | .[0] // empty")
             STATUS=$(echo "$RUN" | jq -r '.conclusion // "pending"')
+            # `echo "$RUN" | jq ...` on a genuinely empty $RUN (the `// empty`
+            # case, no matching run found yet) processes zero JSON values and
+            # produces an empty string rather than jq's own "pending"
+            # fallback — normalize it here so the poll log below is accurate.
+            STATUS="${STATUS:-pending}"
             if [ "$STATUS" = "success" ]; then
               RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
+              # A "success" Build run can still be missing installer artifacts
+              # if its package job was skipped (e.g. changes.outputs.code was
+              # false — not reachable for a real release commit since
+              # package.json is in the code filter, but this fails closed
+              # either way). Without this check the failure only surfaces one
+              # job later as an opaque "Unable to find an artifact with the
+              # name installers-<os>" from actions/download-artifact.
+              ARTIFACT_NAMES=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" --jq '[.artifacts[].name]')
+              for NAME in installers-ubuntu-latest installers-macos-latest installers-windows-latest; do
+                if ! echo "$ARTIFACT_NAMES" | jq -e --arg n "$NAME" 'index($n) != null' > /dev/null; then
+                  echo "::error::Build run $RUN_ID succeeded but has no '$NAME' artifact — its package job likely didn't run. Refusing to promote a partial artifact set."
+                  exit 1
+                fi
+              done
               echo "build_run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
               echo "Build passed on $SHA in run $RUN_ID — promoting its artifacts"
               exit 0
@@ -333,8 +353,13 @@ jobs:
           foreach ($fileName in $filesToSign) {
             $filePath = Join-Path $workspace "promoted/win" $fileName
             if (-not (Test-Path $filePath)) {
-              Write-Host "::warning::$fileName not found, skipping"
-              continue
+              # A missing file here means signing was requested (this step is
+              # gated on ESIGNER_ENABLED) but the expected artifact isn't on
+              # disk — e.g. a package.json artifactName rename or a path typo.
+              # Warn-and-continue would leave the file unsigned while the run
+              # stays green; that is the exact failure this gate exists to
+              # catch, so it must be fatal, not a warning.
+              throw "$fileName not found at $filePath — cannot sign a file that isn't there"
             }
             Write-Host "Signing $fileName ..."
             java -jar $jarPath sign `
@@ -357,6 +382,22 @@ jobs:
               if ($LASTEXITCODE -ne 0) { throw "Code signing failed for $fileName after retry" }
             }
             Write-Host "Successfully signed $fileName"
+
+            # CodeSignTool can exit 0 without actually attaching a signature
+            # (e.g. a silently-ignored API response). Assert a signature is
+            # physically present rather than trusting the exit code alone.
+            # `-ne 'NotSigned'` (not `-eq 'Valid'`) deliberately: 'Valid' also
+            # requires full chain validation on this runner, and a
+            # timestamping or intermediate-cert hiccup can return
+            # 'UnknownError' on a binary that is genuinely signed, which would
+            # block a legitimate release. 'NotSigned' is the unambiguous
+            # signal for the actual failure mode this guards against. Log the
+            # real status either way so a degraded-but-signed case is visible.
+            $sig = Get-AuthenticodeSignature $filePath
+            Write-Host "$fileName signature status: $($sig.Status)"
+            if ($sig.Status -eq 'NotSigned') {
+              throw "$fileName has no Authenticode signature after signing — refusing to ship an unsigned installer"
+            }
           }
           Pop-Location
 

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -62,8 +62,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev build-essential
 
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Rebuild native modules for Node.js
+        run: npm run rebuild:node
+
+      # `make web-ci` runs the web gate under Node (no Electron process
+      # involved), so assert the NODE ABI, not electron.
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs node
 
       - name: Run opt-in web gate
         run: make web-ci

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ node_modules/
 # Build output
 dist/
 out/
-release/
+# Anchored to repo root: an unanchored `release/` also matched
+# scripts/release/, which holds tracked release-tooling source.
+/release/
 
 # Tool caches
 .eslintcache

--- a/.planning/artifacts/perf/build/ci-cross-workflow-baseline.md
+++ b/.planning/artifacts/perf/build/ci-cross-workflow-baseline.md
@@ -1,0 +1,113 @@
+# CI cross-workflow baseline — 2026-08-06
+
+Baseline for spec `2026-08-05-build-ci-performance.md` **Phase 8** (cross-workflow rebuild
+elimination). Unlike the other artifacts in this directory, this one is **not** produced by
+`scripts/perf/measure-build.mjs` — that harness times *local* `make ci`-class stages, and Phase 8
+changes only GitHub Actions topology. The evidence here is therefore job/step timings read from
+the Actions API, which is the only instrument that can measure what Phase 8 changes.
+
+Source: `gh api repos/berntpopp/varlens/actions/runs/<id>/jobs`. All durations are
+`completed_at - started_at` per job/step. Release `v0.70.4`.
+
+## Runs measured
+
+| Role | Workflow | Run ID | Commit | Tree |
+|---|---|---|---|---|
+| PR head | `build.yml` | 31075896010 | `114ab762` | `2ba72e24` |
+| merge commit | `build.yml` | 31076728072 | `f0a898a5` | `2ba72e24` |
+| release commit | `build.yml` | 31076764351 | `4f220d8a` | `9818f592` |
+| release | `release.yml` | 31078255517 | `4f220d8a` | `9818f592` |
+
+The PR head and the merge commit have **identical trees**. The release commit does not — the
+three-line version bump changes `package.json`, so tree-hash keying can never dedupe the
+release-commit build. Recorded because the opposite was assumed at the outset.
+
+## Packaging ledger
+
+| Run | ubuntu | windows | macos | subtotal |
+|---|---:|---:|---:|---:|
+| PR head | 316 | 423 | 202 | 941 s |
+| merge commit | 307 | 418 | 219 | 944 s |
+| release commit | 350 | 450 | 234 | 1034 s |
+| `release.yml` | 344 | 528 | 193 | 1065 s |
+| | | | | **3984 s = 66.4 min** |
+
+Exactly one of these four produces artifacts that ship: the release commit's `build.yml` run.
+`release.yml` re-derives byte-equivalent installers from the same SHA whose `build.yml` success it
+explicitly polls for before starting.
+
+## Where the time goes
+
+### `release.yml` — `Release (Windows)`, 528 s total
+
+| Step | Cost |
+|---|---:|
+| Install dependencies (`npm ci`) | 217 s |
+| Build (`electron-vite build` + `electron-builder --win`) | 224 s |
+| Setup Java for CodeSignTool | 5 s |
+| Download and configure CodeSignTool | 7 s |
+| Sign 2 exes with CodeSignTool | 19 s |
+| Regenerate `latest.yml` | 3 s |
+| Upload artifacts | 14 s |
+
+**494 of 528 s is rebuild. 34 s is signing** — the only work in this job that `build.yml` cannot
+already have done.
+
+### `release.yml` — other legs
+
+| Step | Linux (344 s) | macOS (193 s) |
+|---|---:|---:|
+| Install dependencies | 112 s | 47 s |
+| Build | 186 s | 106 s |
+| Upload artifacts | 13 s | 14 s |
+
+### The native compile that no cache suppresses
+
+Every packaging job reports `Cache native module for Electron ABI: 1-5 s` followed by
+`Rebuild native modules for Electron: 0 s` — the `actions/cache` block **hits**, and the explicit
+rebuild is correctly skipped. Yet `npm ci` still costs:
+
+| Job | `npm ci` |
+|---|---:|
+| `build.yml` `Checks (Ubuntu)` | 121 s |
+| `build.yml` `Package (ubuntu)` | 119 s |
+| `build.yml` `Package (windows)` | 217 s |
+| `build.yml` `Package (macos)` | 140 s |
+| `release.yml` Linux | 112 s |
+| `release.yml` Windows | 217 s |
+| `release.yml` macOS | 47 s |
+
+This is the defect spec §2.4 predicted, now confirmed against fresh runs: `postinstall` compiles
+the Electron-ABI binary *before* the cache step can be consulted, and the cache restore then
+overwrites the freshly compiled result. The cache can only ever suppress the **second** compile.
+
+`Checks (Ubuntu)` is the sharpest case — it has **no native cache block at all** (`build.yml:134-138`
+is `npm ci` then `npm run rebuild:node`), so it compiles a full Electron-ABI binary in `postinstall`
+that it never loads, then re-targets the Node ABI in 2 s. That compile sits directly on the
+critical path, because `package` has `needs: checks`.
+
+**Caveat, stated rather than glossed:** the compile's exact share of each `npm ci` above is
+*inferred* from spec §2.1 (`npm ci --ignore-scripts` 3.32 s vs `npm ci` 45.50 s locally), not
+isolated in CI. The macOS figure (47 s total) is hard to reconcile with a ~42 s compile and may
+indicate something different is happening on that runner. Isolating this is a task in the Phase 8
+plan; no Phase 8 claim should rest on the inferred split until it is measured directly.
+
+### `build.yml` critical path, release-commit run
+
+`changes (6 s) → checks (315 s) → package/windows (450 s) → ci (3 s)` = **774 s**.
+`Checks (Ubuntu)` breakdown: `npm ci` 121 s · `test:coverage` 136 s · `format:check` 17 s ·
+`typecheck` 15 s · `lint` 2 s.
+
+## Targets for Phase 8
+
+| Metric | Baseline | Target | How it will be measured |
+|---|---:|---:|---|
+| `release.yml` Windows job | 528 s | ≤ 120 s | Actions API, first release after merge |
+| `release.yml` runner total | 1065 s | ≤ 250 s | Actions API |
+| Packaging runs per release | 12 | 9 | count of `package`/`release-*` jobs |
+| `npm ci` on jobs with a warm native cache | 112-217 s | report actual | Actions API |
+| `build.yml` critical path | 774 s | report actual | Actions API |
+| Packaging runner time per release | 3984 s | report actual | sum of the ledger above |
+
+Phase 8.2 (merge-commit dedupe, 944 s) is **deferred**, so the 12 → 9 figure is the honest one;
+12 → 6 was only ever reachable with 8.2 included.

--- a/.planning/artifacts/perf/build/ci-cross-workflow-baseline.md
+++ b/.planning/artifacts/perf/build/ci-cross-workflow-baseline.md
@@ -71,11 +71,19 @@ rebuild is correctly skipped. Yet `npm ci` still costs:
 |---|---:|
 | `build.yml` `Checks (Ubuntu)` | 121 s |
 | `build.yml` `Package (ubuntu)` | 119 s |
-| `build.yml` `Package (windows)` | 217 s |
-| `build.yml` `Package (macos)` | 140 s |
+| `build.yml` `Package (windows)` | 140 s |
+| `build.yml` `Package (macos)` | 73 s |
+| `build.yml` `Web CI` | 125 s |
 | `release.yml` Linux | 112 s |
 | `release.yml` Windows | 217 s |
 | `release.yml` macOS | 47 s |
+
+> **Correction, 2026-08-06.** An earlier revision of this file listed `build.yml`
+> `Package (windows)` as 217 s and `Package (macos)` as 140 s. Those were wrong: 217 s is
+> `release.yml`'s Windows leg, and the macOS figure was never measured. The values above are
+> re-read from run 31076764351 and are the ones the "after" comparison below uses. The error
+> would have inflated the measured improvement, which is why it is called out rather than
+> quietly amended.
 
 This is the defect spec §2.4 predicted, now confirmed against fresh runs: `postinstall` compiles
 the Electron-ABI binary *before* the cache step can be consulted, and the cache restore then
@@ -111,3 +119,82 @@ plan; no Phase 8 claim should rest on the inferred split until it is measured di
 
 Phase 8.2 (merge-commit dedupe, 944 s) is **deferred**, so the 12 → 9 figure is the honest one;
 12 → 6 was only ever reachable with 8.2 included.
+
+---
+
+## After — measured 2026-08-06
+
+Two `workflow_dispatch` runs of the implemented branch at `c7545773`: **31087288313** (cold caches,
+first run with these keys) and **31089098078** (warm). Both green on all 8 jobs. All three
+`installers-*` artifacts produced: ubuntu 354 MB, windows 543 MB, macos 390 MB.
+
+### `npm ci` — the clean, attributable measurement
+
+This is the one number with no confound: same command, same event, only the cache changed.
+
+| Job | Before | Warm after | Δ |
+|---|---:|---:|---:|
+| `Checks (Ubuntu)` | 121 s | **14 s** | −107 s |
+| `Package (ubuntu)` | 119 s | **14 s** | −105 s |
+| `Package (windows)` | 140 s | **38 s** | −102 s |
+| `Package (macos)` | 73 s | **22 s** | −51 s |
+| `Web CI` | 125 s | **17 s** | −108 s |
+
+Restoring `.cache/native` before `npm ci` does what §Phase 8.3 predicted: `postinstall` restores a
+binary instead of compiling one. `Rebuild native modules` is 0-1 s in every job.
+
+### Job totals — real, but partly confounded
+
+| Job | Before | Warm after | Δ |
+|---|---:|---:|---:|
+| `Checks (Ubuntu)` | 315 s | 187 s | −128 s |
+| `Package (ubuntu)` | 350 s | 272 s | −78 s |
+| `Package (windows)` | 450 s | 372 s | −78 s |
+| `Package (macos)` | 234 s | 219 s | −15 s |
+| `Web CI` | 254 s | 153 s | −101 s |
+| **`build.yml` critical path** | **774 s** | **568 s** | **−206 s (−27%)** |
+
+**Confound, stated rather than buried:** the baseline was a `push` run, which executes
+`test:coverage` (136 s); the after-runs are `workflow_dispatch`, which executes plain `npm run test`
+(107 s). So ~29 s of the `Checks` improvement is the cheaper test mode, not the cache. The
+cache-attributable part of that job is the −107 s `npm ci` line. The `Package` and `Web CI` jobs run
+identical work in both, so their deltas are clean — and the after-runs additionally upload ~1.3 GB
+of installers (3-8 s per job) that the baseline never produced.
+
+### The electron-builder toolset cache did NOT deliver a measurable win
+
+| `Package Electron app` step | Before | Warm after | Δ |
+|---|---:|---:|---:|
+| ubuntu | 164 s | 180 s | **+16 s** |
+| windows | 248 s | 243 s | −5 s |
+| macos | 104 s | 119 s | **+15 s** |
+
+The cache restores in 2-4 s and hits, but packaging did not speed up — two of three legs got
+slightly *slower*, which is most plausibly runner variance rather than a real regression.
+
+**The ~82 s attributed to the `nsis-resources` download in §Phase 8.4 is therefore not
+substantiated, and that figure should be treated as withdrawn** until someone measures it directly
+with `DEBUG=electron-builder`. Phase 8.4 is retained because it is correct and harmless — the
+`.state` purge closes a genuine unhashed-restore hazard — but it must not be cited as a
+performance win. This is a negative result and is recorded as one.
+
+### Targets: hit, missed, and untestable
+
+| Metric | Baseline | Target | Actual | Verdict |
+|---|---:|---:|---:|---|
+| `npm ci` on jobs with a warm native cache | 73-140 s | report actual | **14-38 s** | reported |
+| `build.yml` critical path | 774 s | report actual | **568 s** | reported |
+| Packaging runs per release | 12 | 9 | **9** | met |
+| `release.yml` Windows job | 528 s | ≤ 120 s | **not yet measurable** | untested |
+| `release.yml` runner total | 1065 s | ≤ 250 s | **not yet measurable** | untested |
+| Packaging runner time per release | 3984 s | report actual | **not yet measurable** | untested |
+
+**The three `release.yml` targets cannot be measured before merge.** `release.yml` triggers only on
+a `v*.*.*` tag push, so the promotion path is exercised for the first time on the next real release.
+What *was* verified pre-merge: the artifacts exist and are well-formed, and both verifier scripts
+pass against a genuinely downloaded `installers-ubuntu-latest` (correct 5-file contents, real
+`shasum -b` asterisk format, real `latest-linux.yml` including its `blockMapSize:` line), with
+negative controls failing as designed.
+
+The 528 s → ≤120 s estimate rests on the measured 34 s signing chain plus download; it remains an
+estimate. Re-measure on the first release after merge and update this file.

--- a/.planning/plans/2026-08-06-build-ci-cross-workflow-plan.md
+++ b/.planning/plans/2026-08-06-build-ci-cross-workflow-plan.md
@@ -1,0 +1,1407 @@
+# Build/CI Cross-Workflow Rebuild Elimination — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop packaging the same commit four times per release, and reduce the build warning
+inventory to zero-unexplained.
+
+**Architecture:** `build.yml`'s `package` job already produces shipping-quality installers and throws
+them away. It starts uploading them; `release.yml` stops rebuilding and promotes those artifacts
+instead, applying only the Windows signing that genuinely cannot happen anywhere else. Separately,
+the repo-local ABI-keyed native cache (`.cache/native`) becomes a GitHub Actions cache restored
+*before* `npm ci`, so `postinstall` restores a binary instead of compiling one. All promotion
+verification lives in tested Node scripts rather than inline YAML.
+
+**Tech Stack:** GitHub Actions, `actions/cache@v6.1.0`, `actions/upload-artifact@v7.0.1`,
+`actions/download-artifact@v8.0.1`, Node 24.15.0 ESM scripts, Vitest.
+
+**Spec:** `.planning/specs/2026-08-05-build-ci-performance.md` §Phase 8, §Phase 9.
+**Baseline:** `.planning/artifacts/perf/build/ci-cross-workflow-baseline.md`.
+
+## Global Constraints
+
+- Node `>=24.15.0 <25`, npm `>=11.11.0 <12` (`package.json` `engines`). Match `.nvmrc` (24.15.0).
+- **GitHub Actions must be pinned to full commit SHAs**, with the human-readable tag preserved as a
+  same-line comment: `uses: owner/repo@<full-sha> # owner/repo@vX.Y.Z`. Reuse the SHAs already
+  present in the repo rather than looking up new ones.
+- **No `console.*` in application code.** `scripts/**` is not application code and already uses
+  `process.stdout.write` / `process.stderr.write` — follow that, not `console.log`.
+- **Keep source files under 600 lines**; prefer 150-400.
+- **Never lower a coverage, lint, or typecheck threshold.** Add tests or fix the code.
+- **Do not re-enable ESLint `--concurrency=auto`**, un-serialize `typecheck`, add `$(MAKE) -jN`, or
+  change `vitest` `pool: 'forks'`. `tests/scripts/build-pipeline-guardrails.test.ts` enforces all
+  four and will fail you.
+- **Do not convert either of the two vite dynamic imports to static imports** (`definitions.ts`,
+  `import-logic.ts`). `tests/main/database/database-startup.test.ts` fails if you do.
+- **Never run `npm audit fix --force`** — it breaks `pdbe-molstar`.
+- Never commit to `main`. Branch, PR, green CI.
+- Conventional Commits: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `style`, `chore`, `ci`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `scripts/release/verify-promoted-artifacts.mjs` | **Create.** Validate a downloaded artifact set against expected sha, version, checksums and filenames. Pure function + thin CLI. |
+| `scripts/release/verify-latest-yml.mjs` | **Create.** Re-read a `latest*.yml`, recompute sha512 + size for every referenced file, fail on mismatch. |
+| `scripts/release/artifact-manifest.mjs` | **Create.** Single source of truth for the expected per-platform asset name list. Consumed by both scripts above and by the guardrail test. |
+| `tests/scripts/verify-promoted-artifacts.test.ts` | **Create.** Behaviour tests for the verifier. |
+| `tests/scripts/verify-latest-yml.test.ts` | **Create.** Behaviour tests for the yml assertion. |
+| `tests/scripts/build-pipeline-guardrails.test.ts` | **Modify.** Add workflow-YAML invariants (currently asserts nothing about workflows). |
+| `.github/workflows/build.yml` | **Modify.** `workflow_dispatch`; `.cache/native` cache; explicit platform flag; provenance + checksums + installer upload. |
+| `.github/workflows/release.yml` | **Modify.** Tag-ref assertions; `build_run_id` output; `promote-unix` + `sign-windows` replacing three build jobs. |
+| `.github/workflows/web-ci.yml`, `publish-web.yml`, `docs.yml` | **Modify.** `.cache/native` cache + per-job ABI assertion. |
+| `electron.vite.config.ts`, `vite.web-renderer.config.ts` | **Modify.** Delete the dead `zod` manualChunks entry. |
+| `eslint.config.js` → `eslint.config.mjs` | **Rename.** Plus its three functional references in `build.yml`. |
+| `.planning/docs/ACCEPTED-WARNINGS.md` | **Create.** The written ledger. |
+
+---
+
+# PART 1 — Phase 8 (branch `perf/ci-cross-workflow-dedupe`, one PR)
+
+## Task 1: Lock the new workflow invariants as failing guardrail assertions
+
+`tests/scripts/build-pipeline-guardrails.test.ts` currently asserts things about `package.json`,
+`rebuild-native.mjs` and the `Makefile`, but **nothing about workflow YAML**. Everything Phase 8
+changes is workflow YAML, so without this task the whole phase ships untested. Write the assertions
+first; they must fail before any YAML changes.
+
+**Files:**
+- Modify: `tests/scripts/build-pipeline-guardrails.test.ts`
+
+**Interfaces:**
+- Produces: nothing consumed by later tasks. This is the regression net all later tasks land against.
+
+- [ ] **Step 1: Read the existing file to match its style**
+
+Run: `cat tests/scripts/build-pipeline-guardrails.test.ts`
+
+Note how it reads files (repo-root-relative `readFileSync`) and how `describe`/`it` are nested.
+Follow that exactly — do not introduce a new helper style.
+
+- [ ] **Step 2: Add the failing workflow assertions**
+
+Append a new `describe` block. Read each workflow once at module scope alongside the existing reads.
+
+```ts
+const WORKFLOW_DIR = join(REPO_ROOT, '.github', 'workflows')
+const readWorkflow = (name: string): string =>
+  readFileSync(join(WORKFLOW_DIR, name), 'utf8')
+
+describe('cross-workflow rebuild elimination (spec Phase 8)', () => {
+  it('never caches the bare .cache root, which would collide with tsbuildinfo', () => {
+    for (const name of ['build.yml', 'web-ci.yml', 'publish-web.yml', 'docs.yml']) {
+      const yaml = readWorkflow(name)
+      expect(yaml, `${name} must not cache the bare .cache root`).not.toMatch(
+        /^\s*path:\s*\.cache\s*$/m
+      )
+    }
+  })
+
+  it('keys the native cache on os, arch, electron version and lockfile, with no restore-keys', () => {
+    const yaml = readWorkflow('build.yml')
+    const keys = [...yaml.matchAll(/key:\s*(native-[^\n]*)/g)].map((m) => m[1])
+    expect(keys.length, 'build.yml must declare at least one native cache key').toBeGreaterThan(0)
+    for (const key of keys) {
+      expect(key).toContain('runner.os')
+      expect(key).toContain('runner.arch')
+      expect(key).toContain('electron-ver.outputs.ver')
+      expect(key).toContain("hashFiles('package-lock.json')")
+    }
+    // A partial match would leave a wrong-ABI .node on disk. No fallback, ever.
+    const nativeBlocks = yaml.split('key: native-').slice(1)
+    for (const block of nativeBlocks) {
+      const untilNextStep = block.split(/\n\s*-\s/)[0]
+      expect(untilNextStep, 'native cache must not declare restore-keys').not.toContain(
+        'restore-keys'
+      )
+    }
+  })
+
+  it('release.yml no longer builds or packages the app', () => {
+    const yaml = readWorkflow('release.yml')
+    expect(yaml, 'release.yml must promote build.yml artifacts, not rebuild').not.toContain(
+      'electron-builder'
+    )
+    expect(yaml).not.toContain('electron-vite build')
+  })
+
+  it('release.yml grants actions:read so it can read another run’s artifacts', () => {
+    expect(readWorkflow('release.yml')).toContain('actions: read')
+  })
+
+  it('build.yml can be re-run against a ref, so expired artifacts are recoverable', () => {
+    // `gh run rerun` is only permitted for 30 days; artifacts are retained for 90.
+    expect(readWorkflow('build.yml')).toContain('workflow_dispatch:')
+  })
+
+  it('installer uploads fail loudly rather than producing an empty artifact', () => {
+    const yaml = readWorkflow('build.yml')
+    expect(yaml).toContain('installers-')
+    const uploadBlock = yaml.slice(yaml.indexOf('installers-'))
+    expect(uploadBlock).toContain('if-no-files-found: error')
+  })
+})
+```
+
+- [ ] **Step 3: Run the tests and confirm they fail**
+
+Run: `npx vitest run tests/scripts/build-pipeline-guardrails.test.ts`
+Expected: FAIL. The `release.yml no longer builds`, `actions: read`, `workflow_dispatch` and
+`installers-` assertions must all fail — nothing implements them yet. The `.cache` and `restore-keys`
+assertions may pass vacuously; that is correct, they are guarding against a future mistake.
+
+- [ ] **Step 4: Commit the failing net**
+
+```bash
+git add tests/scripts/build-pipeline-guardrails.test.ts
+git commit -m "test(ci): lock the Phase 8 workflow invariants before changing any YAML"
+```
+
+---
+
+## Task 2: The expected-artifact manifest
+
+One source of truth for what a release must contain, consumed by both verifier scripts. Derived from
+the published `v0.70.4` asset list and `package.json`'s `build` targets.
+
+**Files:**
+- Create: `scripts/release/artifact-manifest.mjs`
+
+**Interfaces:**
+- Produces: `expectedArtifacts(platform: 'linux'|'mac'|'win', version: string): string[]`
+  and `PLATFORMS: readonly ['linux','mac','win']`. Task 3 and Task 5 both consume these exact names.
+
+- [ ] **Step 1: Write the module**
+
+```js
+// Single source of truth for the asset set a release must contain.
+// Derived from package.json's build.{linux,mac,win}.target + artifactName
+// templates, and cross-checked against the published v0.70.4 release.
+export const PLATFORMS = Object.freeze(['linux', 'mac', 'win'])
+
+const PRODUCT = 'Varlens'
+
+// package.json build.mac pins arch to arm64 for both dmg and zip.
+const MAC_ARCH = 'arm64'
+
+export function expectedArtifacts(platform, version) {
+  if (!PLATFORMS.includes(platform)) {
+    throw new Error(`unknown platform "${platform}" (expected one of ${PLATFORMS.join(', ')})`)
+  }
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error('version must be a non-empty string')
+  }
+  switch (platform) {
+    case 'linux':
+      return [`${PRODUCT}-${version}.AppImage`, `${PRODUCT}-${version}.deb`, 'latest-linux.yml']
+    case 'mac':
+      return [
+        `${PRODUCT}-${version}-${MAC_ARCH}.dmg`,
+        `${PRODUCT}-${version}-${MAC_ARCH}.zip`,
+        'latest-mac.yml'
+      ]
+    case 'win':
+      // win.artifactName is "${productName}-Setup-${version}.${ext}", which the
+      // zip target also picks up; only `portable` overrides it.
+      return [
+        `${PRODUCT}-Setup-${version}.exe`,
+        `${PRODUCT}-Portable-${version}.exe`,
+        `${PRODUCT}-Setup-${version}.zip`,
+        'latest.yml'
+      ]
+  }
+}
+```
+
+- [ ] **Step 2: Verify it reproduces the real v0.70.4 asset set**
+
+Run:
+```bash
+node -e "
+import('./scripts/release/artifact-manifest.mjs').then(m => {
+  const all = m.PLATFORMS.flatMap(p => m.expectedArtifacts(p, '0.70.4')).sort()
+  process.stdout.write(all.join('\n') + '\n')
+})"
+gh release view v0.70.4 --json assets --jq '.assets[].name' | sort
+```
+Expected: the two lists are identical (10 names each).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/release/artifact-manifest.mjs
+git commit -m "feat(release): add the expected-artifact manifest"
+```
+
+---
+
+## Task 3: `verify-promoted-artifacts.mjs` — TDD
+
+The highest-risk logic in Phase 8. It must not live as inline YAML shell.
+
+**Files:**
+- Create: `scripts/release/verify-promoted-artifacts.mjs`
+- Test: `tests/scripts/verify-promoted-artifacts.test.ts`
+
+**Interfaces:**
+- Consumes: `expectedArtifacts`, `PLATFORMS` from Task 2.
+- Produces: `verifyPromotedArtifacts({ dir, platform, version, sha }): { ok: true } | never`
+  — throws `Error` with a specific message on any failure. The CLI wrapper maps a throw to exit 1.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { verifyPromotedArtifacts } from '../../scripts/release/verify-promoted-artifacts.mjs'
+
+const VERSION = '9.9.9'
+const SHA = 'a'.repeat(40)
+
+let dir: string
+
+const sha256 = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
+
+/** Write a complete, valid linux artifact set. Tests then corrupt one thing at a time. */
+function writeValidSet(): void {
+  const files = [`Varlens-${VERSION}.AppImage`, `Varlens-${VERSION}.deb`, 'latest-linux.yml']
+  const sums: string[] = []
+  for (const name of files) {
+    const body = Buffer.from(`payload-${name}`)
+    writeFileSync(join(dir, name), body)
+    sums.push(`${sha256(body)}  ${name}`)
+  }
+  writeFileSync(join(dir, 'SHA256SUMS'), sums.join('\n') + '\n')
+  writeFileSync(
+    join(dir, 'provenance.json'),
+    JSON.stringify({ sha: SHA, version: VERSION, os: 'ubuntu-latest', platform: 'linux' })
+  )
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'varlens-promote-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('verifyPromotedArtifacts', () => {
+  it('accepts a complete, self-consistent artifact set', () => {
+    writeValidSet()
+    expect(verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })).toEqual({
+      ok: true
+    })
+  })
+
+  it('rejects a set whose provenance names a different commit', () => {
+    writeValidSet()
+    writeFileSync(
+      join(dir, 'provenance.json'),
+      JSON.stringify({ sha: 'b'.repeat(40), version: VERSION })
+    )
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/provenance sha/i)
+  })
+
+  it('rejects a set whose provenance names a different version', () => {
+    writeValidSet()
+    writeFileSync(join(dir, 'provenance.json'), JSON.stringify({ sha: SHA, version: '0.0.1' }))
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/provenance version/i)
+  })
+
+  it('rejects a tampered payload whose checksum no longer matches', () => {
+    writeValidSet()
+    writeFileSync(join(dir, `Varlens-${VERSION}.deb`), Buffer.from('tampered'))
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/checksum mismatch/i)
+  })
+
+  it('rejects a set missing a required asset', () => {
+    writeValidSet()
+    rmSync(join(dir, 'latest-linux.yml'))
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/missing expected artifact.*latest-linux\.yml/i)
+  })
+
+  it('rejects an entirely empty directory rather than passing vacuously', () => {
+    mkdirSync(join(dir, 'empty'), { recursive: true })
+    expect(() =>
+      verifyPromotedArtifacts({ dir: join(dir, 'empty'), platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/provenance\.json/i)
+  })
+
+  it('rejects a SHA256SUMS that omits a file present on disk', () => {
+    writeValidSet()
+    writeFileSync(join(dir, 'SHA256SUMS'), `${sha256(Buffer.from('x'))}  nope.bin\n`)
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/not listed in SHA256SUMS|checksum mismatch|missing/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/scripts/verify-promoted-artifacts.test.ts`
+Expected: FAIL — cannot resolve `verify-promoted-artifacts.mjs`.
+
+- [ ] **Step 3: Implement**
+
+```js
+// Verifies one platform's promoted artifact set before it is published.
+// Every check here is the difference between shipping the right installer
+// and shipping a plausible-looking wrong one.
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { expectedArtifacts } from './artifact-manifest.mjs'
+
+function sha256File(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
+function parseChecksums(text) {
+  const map = new Map()
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) continue
+    // `sha256sum` format: "<hex>  <name>" (two spaces), tolerate one.
+    const match = /^([0-9a-f]{64})\s+\*?(.+)$/i.exec(trimmed)
+    if (!match) throw new Error(`malformed SHA256SUMS line: ${trimmed}`)
+    map.set(match[2], match[1].toLowerCase())
+  }
+  return map
+}
+
+export function verifyPromotedArtifacts({ dir, platform, version, sha }) {
+  const provenancePath = join(dir, 'provenance.json')
+  if (!existsSync(provenancePath)) {
+    throw new Error(`missing provenance.json in ${dir} — the artifact set is not promotable`)
+  }
+  const provenance = JSON.parse(readFileSync(provenancePath, 'utf8'))
+
+  if (provenance.sha !== sha) {
+    throw new Error(
+      `provenance sha mismatch: artifact was built from ${provenance.sha}, releasing ${sha}`
+    )
+  }
+  if (provenance.version !== version) {
+    throw new Error(
+      `provenance version mismatch: artifact declares ${provenance.version}, releasing ${version}`
+    )
+  }
+
+  const sumsPath = join(dir, 'SHA256SUMS')
+  if (!existsSync(sumsPath)) throw new Error(`missing SHA256SUMS in ${dir}`)
+  const sums = parseChecksums(readFileSync(sumsPath, 'utf8'))
+
+  for (const name of expectedArtifacts(platform, version)) {
+    const path = join(dir, name)
+    if (!existsSync(path)) throw new Error(`missing expected artifact: ${name}`)
+    const recorded = sums.get(name)
+    if (!recorded) throw new Error(`${name} is present but not listed in SHA256SUMS`)
+    const actual = sha256File(path)
+    if (actual !== recorded) {
+      throw new Error(`checksum mismatch for ${name}: expected ${recorded}, got ${actual}`)
+    }
+  }
+
+  return { ok: true }
+}
+
+// CLI: node verify-promoted-artifacts.mjs <dir> <platform> <version> <sha>
+// Compare resolved paths rather than matching basenames — a basename check
+// would also fire when this module is imported by a same-named test file.
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  const [dir, platform, version, sha] = process.argv.slice(2)
+  try {
+    verifyPromotedArtifacts({ dir, platform, version, sha })
+    process.stdout.write(`promoted artifacts verified: ${platform} ${version} @ ${sha}\n`)
+  } catch (error) {
+    process.stderr.write(`::error::${error.message}\n`)
+    process.exit(1)
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/scripts/verify-promoted-artifacts.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/verify-promoted-artifacts.mjs tests/scripts/verify-promoted-artifacts.test.ts
+git commit -m "feat(release): verify promoted artifacts before publishing"
+```
+
+---
+
+## Task 4: `verify-latest-yml.mjs` — TDD
+
+Closes spec 8.5. The existing regeneration step rewrites hashes with four PowerShell `-replace`
+calls and verifies nothing; a filename that stops matching silently ships auto-update metadata
+describing the *unsigned* binaries.
+
+**Files:**
+- Create: `scripts/release/verify-latest-yml.mjs`
+- Test: `tests/scripts/verify-latest-yml.test.ts`
+
+**Interfaces:**
+- Produces: `verifyLatestYml({ ymlPath, dir }): { ok: true, checked: string[] } | never`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`latest.yml` is electron-builder's update metadata. Its shape, from the real `v0.70.4` asset:
+a top-level `version`, a `files:` array of `{ url, sha512, size }`, and top-level `path` / `sha512`
+mirroring the primary file. sha512 values are **base64**, not hex.
+
+```ts
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { verifyLatestYml } from '../../scripts/release/verify-latest-yml.mjs'
+
+let dir: string
+const sha512b64 = (buf: Buffer): string => createHash('sha512').update(buf).digest('base64')
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'varlens-latestyml-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeSet(bodyText: string, ymlSha: string, ymlSize: number): string {
+  const body = Buffer.from(bodyText)
+  writeFileSync(join(dir, 'Varlens-Setup-9.9.9.exe'), body)
+  const yml = [
+    'version: 9.9.9',
+    'files:',
+    '  - url: Varlens-Setup-9.9.9.exe',
+    `    sha512: ${ymlSha}`,
+    `    size: ${ymlSize}`,
+    'path: Varlens-Setup-9.9.9.exe',
+    `sha512: ${ymlSha}`,
+    'releaseDate: 2026-08-06T00:00:00.000Z'
+  ].join('\n')
+  const ymlPath = join(dir, 'latest.yml')
+  writeFileSync(ymlPath, yml)
+  return ymlPath
+}
+
+describe('verifyLatestYml', () => {
+  it('accepts metadata whose hash and size match the file on disk', () => {
+    const body = Buffer.from('signed-installer-bytes')
+    const ymlPath = writeSet('signed-installer-bytes', sha512b64(body), body.length)
+    expect(verifyLatestYml({ ymlPath, dir })).toEqual({
+      ok: true,
+      checked: ['Varlens-Setup-9.9.9.exe']
+    })
+  })
+
+  it('rejects metadata describing the pre-signing bytes — the regex-no-op failure', () => {
+    const stale = Buffer.from('UNSIGNED-installer-bytes')
+    const signed = Buffer.from('signed-installer-bytes')
+    // yml still carries the unsigned hash; disk carries the signed file.
+    const ymlPath = writeSet('signed-installer-bytes', sha512b64(stale), signed.length)
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/sha512 mismatch/i)
+  })
+
+  it('rejects a stale size even when the hash was updated', () => {
+    const body = Buffer.from('signed-installer-bytes')
+    const ymlPath = writeSet('signed-installer-bytes', sha512b64(body), body.length + 4096)
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/size mismatch/i)
+  })
+
+  it('rejects metadata referencing a file that is not there', () => {
+    const body = Buffer.from('x')
+    const ymlPath = writeSet('x', sha512b64(body), body.length)
+    rmSync(join(dir, 'Varlens-Setup-9.9.9.exe'))
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/not found/i)
+  })
+
+  it('refuses to pass when the files array is empty, rather than vacuously succeeding', () => {
+    const ymlPath = join(dir, 'latest.yml')
+    writeFileSync(ymlPath, 'version: 9.9.9\nfiles:\n')
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/no files/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/scripts/verify-latest-yml.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Parse with a narrow line reader rather than adding a YAML dependency — the file shape is fixed and
+electron-builder-generated, and adding a parser dependency for this is not worth the surface.
+
+```js
+// Asserts that a latest*.yml actually describes the files sitting next to it.
+// The signing step rewrites sha512/size with regexes that silently no-op when a
+// filename stops matching; without this check that ships auto-update metadata
+// for the unsigned binaries and breaks updates for every user.
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+function sha512Base64(path) {
+  return createHash('sha512').update(readFileSync(path)).digest('base64')
+}
+
+// Reads the `files:` array entries. electron-builder emits a fixed two-space
+// indented list of `- url:` / `sha512:` / `size:` triples.
+export function parseFileEntries(yml) {
+  const entries = []
+  let current = null
+  for (const raw of yml.split('\n')) {
+    const urlMatch = /^\s*-\s*url:\s*(.+?)\s*$/.exec(raw)
+    if (urlMatch) {
+      if (current) entries.push(current)
+      current = { url: urlMatch[1], sha512: null, size: null }
+      continue
+    }
+    if (!current) continue
+    const shaMatch = /^\s+sha512:\s*(.+?)\s*$/.exec(raw)
+    if (shaMatch) {
+      current.sha512 = shaMatch[1]
+      continue
+    }
+    const sizeMatch = /^\s+size:\s*(\d+)\s*$/.exec(raw)
+    if (sizeMatch) {
+      current.size = Number.parseInt(sizeMatch[1], 10)
+      continue
+    }
+    // A non-indented key ends the files array.
+    if (/^\S/.test(raw)) {
+      entries.push(current)
+      current = null
+    }
+  }
+  if (current) entries.push(current)
+  return entries
+}
+
+export function verifyLatestYml({ ymlPath, dir }) {
+  const yml = readFileSync(ymlPath, 'utf8')
+  const entries = parseFileEntries(yml)
+  if (entries.length === 0) {
+    throw new Error(`${ymlPath} lists no files — refusing to treat that as verified`)
+  }
+
+  const checked = []
+  for (const entry of entries) {
+    const path = join(dir, entry.url)
+    if (!existsSync(path)) {
+      throw new Error(`${entry.url} is referenced by ${ymlPath} but not found in ${dir}`)
+    }
+    const actualSize = statSync(path).size
+    if (entry.size !== actualSize) {
+      throw new Error(`size mismatch for ${entry.url}: yml says ${entry.size}, file is ${actualSize}`)
+    }
+    const actualSha = sha512Base64(path)
+    if (entry.sha512 !== actualSha) {
+      throw new Error(
+        `sha512 mismatch for ${entry.url} — the metadata does not describe the file on disk`
+      )
+    }
+    checked.push(entry.url)
+  }
+  return { ok: true, checked }
+}
+
+// CLI: node verify-latest-yml.mjs <ymlPath> <dir>
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  const [ymlPath, dir] = process.argv.slice(2)
+  try {
+    const { checked } = verifyLatestYml({ ymlPath, dir })
+    process.stdout.write(`latest.yml verified against ${checked.length} file(s)\n`)
+  } catch (error) {
+    process.stderr.write(`::error::${error.message}\n`)
+    process.exit(1)
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/scripts/verify-latest-yml.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/verify-latest-yml.mjs tests/scripts/verify-latest-yml.test.ts
+git commit -m "feat(release): assert latest.yml describes the files it ships with"
+```
+
+---
+
+## Task 5: `build.yml` — native cache, dispatch trigger, installer upload
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: artifacts named `installers-ubuntu-latest`, `installers-windows-latest`,
+  `installers-macos-latest`, each containing that platform's assets plus `provenance.json` and
+  `SHA256SUMS`. Task 6 downloads exactly these names.
+
+- [ ] **Step 1: Add the `workflow_dispatch` trigger**
+
+In the `on:` block (currently `push` to `main` + `pull_request`), add:
+
+```yaml
+  workflow_dispatch:
+```
+
+This is the 30-90 day artifact-recovery path (`gh run rerun` only works for 30 days).
+
+- [ ] **Step 2: Force `code=true` for dispatch runs**
+
+`dorny/paths-filter` has no base ref on `workflow_dispatch` and cannot compute a diff. In the
+`changes` job, make the outputs account for it:
+
+```yaml
+    outputs:
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.code }}
+      web: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.web }}
+```
+
+and guard the filter step itself so it does not run on dispatch:
+
+```yaml
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # dorny/paths-filter@v4.0.2
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+```
+
+- [ ] **Step 3: Add the `.cache/native` restore to the `checks` job**
+
+The `checks` job has **no** native cache today. Insert *before* `- name: Install dependencies`, and
+move the existing `Extract Electron version` step up so the key can reference it:
+
+```yaml
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      # Restore the repo-owned ABI-keyed native cache BEFORE npm ci, so
+      # postinstall restores a binary instead of compiling one. `.cache/native`
+      # is a sibling of node_modules and survives `npm ci`.
+      # Path is `.cache/native`, never bare `.cache` — `.cache/tsbuildinfo` is a
+      # sibling with a different key. No restore-keys: a partial match is
+      # rejected by manifestIsFresh() anyway, and the absence documents intent.
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules for Node.js
+        run: npm run rebuild:node
+
+      # checks runs Vitest under Node, so assert the NODE ABI, not electron.
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs node
+```
+
+- [ ] **Step 4: Replace the `package` job's cache block**
+
+Delete the `Cache native module for Electron ABI` step (which caches
+`node_modules/better-sqlite3-multiple-ciphers/build/Release` *after* `npm ci`) and the
+`if: steps.native-cache.outputs.cache-hit != 'true'` guard on the rebuild. Replace with the same
+pre-install pattern, asserting `electron`:
+
+```yaml
+      - name: Extract Electron version
+        id: electron-ver
+        shell: bash
+        run: echo "ver=$(node -p "require('./package.json').devDependencies.electron")" >> "$GITHUB_OUTPUT"
+
+      - name: Restore native ABI cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: .cache/native
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules for Electron
+        run: npm run rebuild:electron
+
+      - name: Assert native ABI
+        run: node scripts/native/assert-native-abi.mjs electron
+```
+
+`rebuild:electron` is now unconditional because it is a cache-restore no-op when warm — that is the
+point of the change, and it means a cold cache still self-heals.
+
+- [ ] **Step 5: Make the packaging platform explicit**
+
+Replace `run: npx electron-builder --publish never` with a matrix-driven flag so the promoted set is
+defined by configuration rather than inferred from the runner. Add to the matrix entries:
+
+```yaml
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: win
+          - os: macos-latest
+            platform: mac
+```
+
+and the step:
+
+```yaml
+      - name: Package Electron app
+        run: npx electron-builder --${{ matrix.platform }} --publish never
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+```
+
+- [ ] **Step 6: Emit provenance and checksums, then upload**
+
+After the packaged-smoke steps. `shell: bash` everywhere so Windows uses Git Bash and one script
+covers all three runners.
+
+```yaml
+`-printf` is GNU-only, so it is avoided below — macOS runners ship BSD `find`. `sha256sum` is
+likewise absent on macOS; use `shasum -a 256`, which exists on all three runners (Git Bash provides
+it on Windows).
+
+```yaml
+      - name: Write provenance and checksums
+        if: github.event_name != 'pull_request'
+        shell: bash
+        working-directory: release
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          export VERSION="$(node -p "require('../package.json').version")"
+          export TREE_SHA="$(git -C .. rev-parse 'HEAD^{tree}')"
+          node -e "
+            const fs = require('fs')
+            fs.writeFileSync('provenance.json', JSON.stringify({
+              sha: process.env.GITHUB_SHA,
+              tree: process.env.TREE_SHA,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: process.env.GITHUB_RUN_ATTEMPT,
+              version: process.env.VERSION,
+              os: process.env.RUNNER_OS,
+              arch: process.env.RUNNER_ARCH,
+              platform: process.env.PLATFORM
+            }, null, 2) + '\n')
+          "
+          # Checksum every publishable asset, in the plain `<hex>  <name>` form
+          # verify-promoted-artifacts.mjs parses. Deliberately excludes
+          # provenance.json and SHA256SUMS itself. Portable across GNU/BSD find.
+          : > SHA256SUMS
+          for f in *.AppImage *.deb *.dmg *.exe *.zip latest*.yml; do
+            [ -e "$f" ] || continue
+            shasum -a 256 "$f" >> SHA256SUMS
+          done
+          # An empty SHA256SUMS means the packaging step produced nothing.
+          [ -s SHA256SUMS ] || { echo "::error::no publishable assets found in release/"; exit 1; }
+          cat SHA256SUMS
+```
+
+Then the upload:
+
+```yaml
+      - name: Upload installers
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
+        with:
+          name: installers-${{ matrix.os }}
+          # Installers are already compressed; level 6 burns CPU for nothing.
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 90
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/*.dmg
+            release/*.exe
+            release/*.zip
+            release/latest*.yml
+            release/provenance.json
+            release/SHA256SUMS
+```
+
+- [ ] **Step 7: Verify the workflow parses and the guardrails pass**
+
+Run:
+```bash
+node -e "require('js-yaml')" 2>/dev/null && echo "js-yaml available" || echo "no js-yaml — use actionlint or gh"
+npx vitest run tests/scripts/build-pipeline-guardrails.test.ts
+```
+Expected: the `workflow_dispatch`, `installers-`, `.cache` and `restore-keys` assertions PASS. The
+`release.yml` assertions still FAIL — Task 6 implements those.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci(build): cache the native ABI before npm ci and upload installers on push"
+```
+
+---
+
+## Task 6: `release.yml` — promote instead of rebuild
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: `installers-<os>` artifacts from Task 5; `verifyPromotedArtifacts` CLI from Task 3;
+  `verifyLatestYml` CLI from Task 4.
+- Produces: `release-linux` / `release-macos` / `release-windows` artifacts — **the same names
+  `publish-release` already downloads**, so that job needs no change at all.
+
+- [ ] **Step 1: Assert the tag ref still points at the commit being released**
+
+In `create-release`, immediately after `Extract version from tag`. Closes the force-moved-tag hole
+(pre-existing, but this is the moment to close it). The checkout already uses `fetch-depth: 0`.
+
+```yaml
+      - name: Assert tag ref resolves to the commit being released
+        run: |
+          set -euo pipefail
+          TAG_COMMIT=$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")
+          if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} now resolves to $TAG_COMMIT but this run is for $GITHUB_SHA."
+            echo "::error::The tag was moved after this workflow started. Refusing to publish a mismatched release."
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} resolves to $GITHUB_SHA"
+```
+
+- [ ] **Step 2: Capture and export `build_run_id` from the existing gate**
+
+Modify the `Verify Build workflow passed on tagged SHA` step. Add `id: build-gate`, widen the event
+filter to `push` **or** `workflow_dispatch` (the recovery path from Task 5 produces the latter), and
+assert `headSha` rather than trusting `--commit`:
+
+```yaml
+      - name: Verify Build workflow passed on tagged SHA
+        id: build-gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SHA="${GITHUB_SHA}"
+          MAX_ATTEMPTS=20
+          DELAY=30
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            # `--commit` with a SHORT sha silently returns []; GITHUB_SHA is always full.
+            # Accept push and workflow_dispatch; exclude pull_request, whose head_sha
+            # is the PR HEAD and whose runs never upload installers.
+            RUN=$(gh run list --workflow="Build" --commit="$SHA" --limit 20 \
+              --json conclusion,databaseId,headSha,event \
+              --jq "[.[] | select(.headSha == \"$SHA\") | select(.event == \"push\" or .event == \"workflow_dispatch\")] | .[0] // empty")
+            STATUS=$(echo "$RUN" | jq -r '.conclusion // "pending"')
+            if [ "$STATUS" = "success" ]; then
+              RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
+              echo "build_run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+              echo "Build passed on $SHA in run $RUN_ID — promoting its artifacts"
+              exit 0
+            elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
+              echo "::error::Build did not succeed on $SHA (got: $STATUS). Refusing to release."
+              exit 1
+            fi
+            echo "Build status: $STATUS (attempt $i/$MAX_ATTEMPTS, waiting ${DELAY}s...)"
+            sleep $DELAY
+          done
+          echo "::error::Build did not complete within $((MAX_ATTEMPTS * DELAY))s on $SHA"
+          exit 1
+```
+
+Add to the job's `outputs:` block:
+
+```yaml
+      build_run_id: ${{ steps.build-gate.outputs.build_run_id }}
+```
+
+- [ ] **Step 3: Replace `release-linux` and `release-macos` with one `promote-unix` job**
+
+Delete both jobs entirely. Add:
+
+```yaml
+  promote-unix:
+    name: Promote Linux + macOS installers
+    needs: [create-release, secrets-scan]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read          # required to read another workflow run's artifacts
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download Linux installers from the verified Build run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
+        with:
+          name: installers-ubuntu-latest
+          path: promoted/linux
+          run-id: ${{ needs.create-release.outputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download macOS installers from the verified Build run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
+        with:
+          name: installers-macos-latest
+          path: promoted/mac
+          run-id: ${{ needs.create-release.outputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify promoted artifacts
+        run: |
+          set -euo pipefail
+          V="${{ needs.create-release.outputs.version }}"
+          node scripts/release/verify-promoted-artifacts.mjs promoted/linux linux "$V" "$GITHUB_SHA"
+          node scripts/release/verify-promoted-artifacts.mjs promoted/mac   mac   "$V" "$GITHUB_SHA"
+
+      - name: Verify auto-update metadata
+        run: |
+          set -euo pipefail
+          node scripts/release/verify-latest-yml.mjs promoted/linux/latest-linux.yml promoted/linux
+          node scripts/release/verify-latest-yml.mjs promoted/mac/latest-mac.yml     promoted/mac
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
+        with:
+          name: release-linux
+          compression-level: 0
+          if-no-files-found: error
+          path: |
+            promoted/linux/*.AppImage
+            promoted/linux/*.deb
+            promoted/linux/latest-linux.yml
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7.0.1
+        with:
+          name: release-macos
+          compression-level: 0
+          if-no-files-found: error
+          path: |
+            promoted/mac/*.dmg
+            promoted/mac/*.zip
+            promoted/mac/latest-mac.yml
+```
+
+**Do not** upload `provenance.json` or `SHA256SUMS` — `publish-release` uses `merge-multiple: true`
+and `gh release upload artifacts/*`, so anything uploaded here becomes a published release asset.
+
+- [ ] **Step 4: Turn `release-windows` into `sign-windows`**
+
+Keep every existing signing step **byte-for-byte**: `Log signing quota usage`, `Setup Java for
+CodeSignTool`, `Download and configure CodeSignTool`, `Sign Windows installer with CodeSignTool`,
+`Regenerate latest.yml with signed artifact hashes`. Replace only the preamble (checkout / node /
+`npm ci` / native cache / build) with download + verify, and keep the `environment: release`
+declaration so the signing secrets remain available. Rename the job key to `sign-windows` and add
+`actions: read`.
+
+The working directory changes from `release/` to `promoted/win/`, so update the paths inside the
+signing steps:
+- `$filePath = Join-Path $workspace "release" $fileName` → `Join-Path $workspace "promoted/win" $fileName`
+- `Get-Content release/latest.yml` → `Get-Content promoted/win/latest.yml`
+- `Get-ChildItem release/*.exe` → `Get-ChildItem promoted/win/*.exe`
+- `Set-Content release/latest.yml` → `Set-Content promoted/win/latest.yml`
+- the `Test-Path (Join-Path "release" $_)` quota probe → `Join-Path "promoted/win" $_`
+
+Verify **after** regeneration, so the assertion covers the signed bytes:
+
+```yaml
+      - name: Verify promoted artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/release/verify-promoted-artifacts.mjs promoted/win win \
+            "${{ needs.create-release.outputs.version }}" "$GITHUB_SHA"
+
+      # ... existing signing + latest.yml regeneration steps ...
+
+      # Runs unconditionally: latest.yml must describe the shipped bytes whether
+      # or not signing ran. This is the check the -replace regexes never had.
+      - name: Verify auto-update metadata matches the shipped binaries
+        shell: bash
+        run: node scripts/release/verify-latest-yml.mjs promoted/win/latest.yml promoted/win
+```
+
+Note the ordering: `verify-promoted-artifacts` runs *before* signing (checksums describe the
+unsigned build.yml output), `verify-latest-yml` runs *after* (metadata must match the final bytes).
+
+Update the upload step's paths to `promoted/win/*` and keep the artifact name `release-windows`.
+
+- [ ] **Step 5: Update `publish-release`'s `needs` and re-assert the tag**
+
+```yaml
+  publish-release:
+    name: Publish Release
+    needs: [create-release, promote-unix, sign-windows]
+```
+
+Add a checkout (it currently has none) plus a final tag assertion immediately before the draft is
+flipped — the last correctable moment:
+
+```yaml
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Re-assert tag ref before publishing
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          TAG_COMMIT=$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")
+          if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} moved to $TAG_COMMIT during the release; assets are from $GITHUB_SHA."
+            exit 1
+          fi
+```
+
+Place the checkout **first** in the job, before `Download all artifacts`, and confirm the download
+path (`artifacts/`) does not collide with the checkout.
+
+- [ ] **Step 6: Run the guardrails**
+
+Run: `npx vitest run tests/scripts/build-pipeline-guardrails.test.ts`
+Expected: PASS, all assertions including `release.yml no longer builds` and `actions: read`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): promote build.yml installers instead of rebuilding the tagged commit"
+```
+
+---
+
+## Task 7: Native cache for the remaining workflows
+
+**Files:**
+- Modify: `.github/workflows/web-ci.yml`, `.github/workflows/publish-web.yml`,
+  `.github/workflows/docs.yml`
+
+- [ ] **Step 1: Apply the pre-`npm ci` cache to the three remaining sites**
+
+Same block as Task 5 Step 3. Assertion targets, per the spec's per-job table:
+- `web-ci.yml:66` → assert `node`
+- `publish-web.yml:84` → assert `node`
+- `docs.yml:42` (the leg that runs `npm run rebuild:electron`) → assert `electron`
+- `build.yml`'s `web-ci` job (`:329`) → assert `node`
+
+- [ ] **Step 2: Leave `docs.yml`'s deploy leg alone**
+
+`docs.yml:87` uses `npm ci --ignore-scripts`. It gets **no cache and no assertion** — with scripts
+skipped, neither the dependency's `install` nor the root `postinstall` places a binary, so an
+assertion there would fail a correct job. Add a comment saying so, so the next person does not
+"fix" the inconsistency.
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `npx vitest run tests/scripts/build-pipeline-guardrails.test.ts`
+Expected: PASS.
+
+```bash
+git add .github/workflows/web-ci.yml .github/workflows/publish-web.yml .github/workflows/docs.yml
+git commit -m "ci: restore the native ABI cache before npm ci in the remaining workflows"
+```
+
+---
+
+## Task 8: electron-builder toolset cache, archive tier only
+
+**Files:**
+- Modify: `.github/workflows/build.yml` (the `package` job)
+
+- [ ] **Step 1: Add the cache with a post-restore `.state` purge**
+
+The extracted-directory tier validates file *count*, not content (`cacheState.js:112-131`), so a
+corrupt restore would be served silently. Deleting the `${extractDir}.state` sidecars
+(`cacheState.js:24` — they are **sibling files**, not inside the directory) forces re-extraction
+through the sha256-checked archive path.
+
+```yaml
+      - name: Restore electron-builder toolset cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: ${{ runner.os == 'Windows' && 'C:\Users\runneradmin\AppData\Local\electron-builder\Cache' || (runner.os == 'macOS' && '~/Library/Caches/electron-builder' || '~/.cache/electron-builder') }}
+          key: ebtools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ebtools-${{ runner.os }}-${{ runner.arch }}-
+
+      # electron-builder's extracted-directory cache tier checks file COUNT, not
+      # content (cacheState.js:112-131), so a partial restore would be served
+      # silently. Dropping the `<dir>.state` sidecars forces re-extraction back
+      # through the sha256-verified archive path. Cheap; the download is what we
+      # are actually caching.
+      - name: Drop electron-builder extraction state so archives are re-verified
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$RUNNER_OS" in
+            Windows) DIR="$LOCALAPPDATA/electron-builder/Cache" ;;
+            macOS)   DIR="$HOME/Library/Caches/electron-builder" ;;
+            *)       DIR="$HOME/.cache/electron-builder" ;;
+          esac
+          [ -d "$DIR" ] || { echo "no electron-builder cache to clean"; exit 0; }
+          find "$DIR" -name '*.state' -type f -delete
+          find "$DIR" -name '*.lock' -type f -delete
+          echo "cleared extraction state under $DIR"
+```
+
+Note `restore-keys` **is** appropriate here, unlike the native cache: these are content-addressed
+tool archives re-verified by sha256 on use, so a partial match is safe and useful.
+
+- [ ] **Step 2: Measure it rather than assuming**
+
+The ~82 s figure for `nsis-resources` is quoted, not measured. Add `DEBUG: electron-builder` to the
+`Package Electron app` step's `env:` for one run, capture the per-download timings from the Windows
+job log, then remove the debug flag. Record the real number in the spec's §6 table.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci(build): cache electron-builder's hash-verified toolset archives"
+```
+
+---
+
+## Task 9: Dry-run the promotion path before trusting it
+
+The promotion path cannot be validated by a PR run, because the installer upload is gated on
+`github.event_name != 'pull_request'`. The `workflow_dispatch` trigger added in Task 5 is the
+mechanism — one trigger serving both recovery and rehearsal.
+
+- [ ] **Step 1: Push the branch and dispatch a build against it**
+
+```bash
+git push -u origin perf/ci-cross-workflow-dedupe
+gh workflow run build.yml --ref perf/ci-cross-workflow-dedupe
+gh run list --workflow=build.yml --limit 3
+```
+
+- [ ] **Step 2: Confirm the artifacts exist and are well-formed**
+
+```bash
+RUN_ID=$(gh run list --workflow=build.yml --branch=perf/ci-cross-workflow-dedupe \
+  --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID"
+gh api "repos/berntpopp/varlens/actions/runs/$RUN_ID/artifacts" \
+  --jq '.artifacts[] | "\(.name)\t\(.size_in_bytes)"'
+```
+Expected: three `installers-*` artifacts, each non-trivial in size.
+
+- [ ] **Step 3: Run the verifier against a real downloaded set**
+
+```bash
+gh run download "$RUN_ID" -n installers-ubuntu-latest -D /tmp/promote-check
+node scripts/release/verify-promoted-artifacts.mjs /tmp/promote-check linux \
+  "$(node -p "require('./package.json').version")" \
+  "$(git rev-parse HEAD)"
+node scripts/release/verify-latest-yml.mjs /tmp/promote-check/latest-linux.yml /tmp/promote-check
+```
+Expected: both print their success line and exit 0. **If either fails, stop and fix before the PR** —
+this is the rehearsal that stands in for an actual release.
+
+- [ ] **Step 4: Record the measured CI deltas**
+
+```bash
+gh api "repos/berntpopp/varlens/actions/runs/$RUN_ID/jobs" \
+  --jq '.jobs[] | "\(.name)\t\((((.completed_at|fromdateiso8601) - (.started_at|fromdateiso8601))))s"'
+```
+Append the real numbers to `.planning/artifacts/perf/build/ci-cross-workflow-baseline.md` under a
+new "After" section. Report every target that was missed, with its actual number.
+
+---
+
+# PART 2 — Phase 9 (branch `chore/build-warning-ledger`, separate PR)
+
+Branch from `main`, not from Part 1 — these changes are independent and should be reviewable alone.
+
+## Task 10: Delete the dead `zod` manualChunks
+
+**Files:**
+- Modify: `electron.vite.config.ts:56-59`, `vite.web-renderer.config.ts:83-86`
+
+- [ ] **Step 1: Confirm the warning exists before touching anything**
+
+Run: `npm run build 2>&1 | grep -n "empty chunk"`
+Expected: `Generated an empty chunk: "zod".`
+
+- [ ] **Step 2: Delete the `zod` entry in both files, keeping `vuetify`**
+
+```ts
+          manualChunks: {
+            vuetify: ['vuetify']
+          }
+```
+
+- [ ] **Step 3: Confirm the warning is gone and nothing else changed**
+
+Run: `npm run build 2>&1 | grep -c "empty chunk" || echo "0 empty chunks"`
+Expected: `0 empty chunks`. Also confirm a `vuetify-*.js` chunk is still emitted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add electron.vite.config.ts vite.web-renderer.config.ts
+git commit -m "perf(build): drop the dead zod manualChunks group"
+```
+
+## Task 11: Rename `eslint.config.js` → `eslint.config.mjs`
+
+**Files:**
+- Rename: `eslint.config.js` → `eslint.config.mjs`
+- Modify: `.github/workflows/build.yml:56`, `:148`, `:150`; `.prettierignore:1`
+
+- [ ] **Step 1: Confirm the warning fires**
+
+Run: `npm run lint:check 2>&1 | head -5`
+Expected: a `MODULE_TYPELESS_PACKAGE_JSON` warning naming `eslint.config.js`.
+
+- [ ] **Step 2: Rename with git so history follows**
+
+```bash
+git mv eslint.config.js eslint.config.mjs
+```
+
+**Do not** add `"type": "module"` to `package.json`. Node suggests it; this is a mixed CJS/ESM
+Electron app and it would change module resolution for every untyped `.js` in the repo.
+
+- [ ] **Step 3: Update the three functional references**
+
+`build.yml:56` — the paths-filter entry: `- 'eslint.config.mjs'`
+`build.yml:148` and `:150` — both `hashFiles(...)` calls. A file that does not exist contributes
+nothing to `hashFiles` **without failing**, so a missed rename here silently weakens the cache key
+rather than erroring. Change both to `hashFiles('package-lock.json', 'eslint.config.mjs', '.prettierignore')`.
+
+Also fix the stale comment at `.prettierignore:1`.
+
+- [ ] **Step 4: Confirm ESLint still resolves the config**
+
+Run:
+```bash
+rm -f .eslintcache
+npm run lint:check 2>&1 | head -5
+```
+Expected: no `MODULE_TYPELESS_PACKAGE_JSON` warning, and lint completes. If ESLint reports "could
+not find config", the rename broke resolution — ESLint 10.8.0 lists `eslint.config.mjs` at
+`eslint/lib/config/config-loader.js:45`, so investigate rather than reverting blindly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A eslint.config.mjs .github/workflows/build.yml .prettierignore
+git commit -m "chore(lint): rename eslint config to .mjs to stop the reparse warning"
+```
+
+## Task 12: Resolve the `h264-mp4-encoder` question
+
+Not a warning to accept until it is understood. Three builtins (`path`, `fs`, `crypto`) are being
+externalized into the renderer bundle, which turns them into runtime no-ops.
+
+- [ ] **Step 1: Find what pulls it in**
+
+```bash
+grep -rn "h264-mp4-encoder" src/ package.json
+npm ls h264-mp4-encoder --all 2>/dev/null | head -20
+```
+
+- [ ] **Step 2: Determine whether the import is reachable at runtime**
+
+Establish whether the importing module is statically imported from the renderer entry, lazily
+imported behind a user action, or dead. Read the importing file and trace to `src/renderer/src/main.ts`.
+
+- [ ] **Step 3: Rule, and record the ruling**
+
+- If **reachable**: this is a latent renderer defect, not a warning. Do not fix it in this PR —
+  open an issue with the trace, and record it in the ledger as a known defect with the issue link.
+- If **unreachable**: record it in the ledger as accepted, with the evidence that made it safe.
+
+Either way the outcome is written down, not silently dropped.
+
+## Task 13: Write the accepted-warnings ledger
+
+**Files:**
+- Create: `.planning/docs/ACCEPTED-WARNINGS.md`
+
+- [ ] **Step 1: Write the ledger**
+
+One row per warning: what it is, where it surfaces, why it is accepted, and what would change the
+ruling. Cover all four groups:
+
+1. 2× vite "dynamically imported but also statically imported" — reason already in `AGENTS.md`;
+   link rather than restate. Include that `tests/main/database/database-startup.test.ts` fails if
+   the `definitions.ts` import is made static.
+2. 5× `npm audit` low (elliptic via `pdbe-molstar`) — out of scope; **never**
+   `npm audit fix --force`.
+3. 2× Rollup `#__PURE__` from `@vueuse/core` (`dist/index.js` 3362:0, 5780:22) — upstream
+   annotation placement; nothing in this repo to change.
+4. 5× npm deprecations — the full table from spec Phase 9 item 3, including *why* an `overrides`
+   entry is unsafe for four of them and impossible for `lodash.isequal` (already latest).
+
+Add the operational note: `MODULE_TYPELESS_PACKAGE_JSON` and the npm deprecations do **not** appear
+in `npm run build`; a warning inventory must run `npm run build`, `npm run lint:check` and
+`npm install`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .planning/docs/ACCEPTED-WARNINGS.md
+git commit -m "docs(planning): record the accepted-warnings ledger"
+```
+
+---
+
+## Final verification (both parts)
+
+- [ ] `make ci` — expected green, ~28 s warm.
+- [ ] `make ci-full` — expected green. Run **once**, at the end; it is several minutes.
+- [ ] `make perf-build LABEL=post-phase8 ONLY=lint,build` then
+      `make perf-build-compare BEFORE=<existing-baseline-label> AFTER=post-phase8` — **only Part 2**
+      changes local stage timings (the eslint rename touches `lint`, the zod deletion touches
+      `build`). Part 1 is CI-only and is measured from the Actions API, per the spec's §6 note.
+- [ ] Codex adversarial review of the finished branch (`gpt-5.6-terra`, high reasoning effort)
+      before opening either PR.
+- [ ] Report every missed target with its actual number. Do not round in our favour.

--- a/.planning/specs/2026-08-05-build-ci-performance.md
+++ b/.planning/specs/2026-08-05-build-ci-performance.md
@@ -571,9 +571,33 @@ uploading 1.29 GB per PR is pure cost), the `package` job emits and uploads its 
 5. Expected-filename assertion for this version. A silently empty or partial artifact must fail
    here, not at `gh release upload`.
 
-**Missing or expired artifacts: hard fail, no fallback build path.** The error names the recovery
-(`gh run rerun <build_run_id>`, then re-run the release). Chosen deliberately over auto-fallback: a
-fallback that never executes rots, and its rotting stays invisible until the day it is needed.
+**Missing or expired artifacts: hard fail, no fallback build path.** Chosen deliberately over
+auto-fallback: a fallback that never executes rots, and its rotting stays invisible until the day it
+is needed.
+
+The recovery path needs `build.yml` to gain a **`workflow_dispatch` trigger**. `gh run rerun` is
+only permitted for **30 days** after the initial run, while artifacts are retained for 90 — so for a
+run aged 30-90 days there would otherwise be no supported way to regenerate artifacts for that exact
+SHA, since `build.yml` triggers only on `push` and `pull_request` today (`build.yml:3-7`). With
+`workflow_dispatch`, `gh workflow run build.yml --ref <tag>` checks out the tag's commit and
+regenerates. Consequences:
+
+- The promotion lookup must accept `push` **or** `workflow_dispatch`, not `--event push` alone. The
+  `headSha == $GITHUB_SHA` assertion remains the real guard; the event filter exists only to exclude
+  `pull_request` runs, whose `head_sha` is the PR HEAD.
+- `changes`'s `dorny/paths-filter` has no base ref on a `workflow_dispatch` event. Force
+  `code=true` for that event rather than relying on filter behaviour.
+- Recovery instruction in the failure message: `gh run rerun <build_run_id>` if under 30 days,
+  otherwise `gh workflow run build.yml --ref <tag>`.
+
+**Assert the tag ref still resolves to the commit being promoted.** `create-release` binds its gate
+to `$GITHUB_SHA` (`release.yml:65`) but creates the release by **mutable `tag_name`**
+(`release.yml:106`). If the tag is force-moved between the event and publication, the release
+resolves to the new commit while the assets came from the old one. **This hazard exists today** —
+the current `release.yml` builds from `$GITHUB_SHA` too — so promotion does not introduce it, but it
+is the right moment to close it. Add a `git rev-parse refs/tags/<tag>^{commit} == $GITHUB_SHA`
+assertion in `create-release`, and repeat it in `publish-release` immediately before flipping
+`draft: false`, which is the last moment the mismatch is still correctable.
 
 #### 8.2 Merge-commit dedupe — deferred, recorded, not dropped
 
@@ -611,8 +635,23 @@ compiling (`rebuild-native.mjs:71` `if (restore(target))` → `:75 return 0`, ne
     path: .cache/native          # NOT bare `.cache` — `.cache/tsbuildinfo` is a sibling
     key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
 - run: npm ci                    # postinstall becomes a file copy
-- run: node scripts/native/assert-native-abi.mjs electron
+- run: node scripts/native/assert-native-abi.mjs <target>
 ```
+
+**The assertion target is per-job, not uniformly `electron`.** Asserting the wrong ABI would fail a
+correct job. Each site asserts the ABI it actually loads:
+
+| Site | Loads | Assert |
+|---|---|---|
+| `build.yml` `checks` | Node (runs Vitest after `rebuild:node`) | `node`, **after** `rebuild:node` |
+| `build.yml` `package` ×3 | Electron (packages the app) | `electron` |
+| `build.yml` `web-ci`, `web-ci.yml`, `publish-web.yml` | Node | `node` |
+| `docs.yml:42` leg | Electron (runs `rebuild:electron`, then `electron-vite build`) | `electron` |
+| `docs.yml:87` deploy leg | nothing — `npm ci --ignore-scripts`, no native module | **no cache, no assert** |
+
+That last row is load-bearing: adding the restore-and-assert pattern there would fail, because
+`--ignore-scripts` skips both the dependency's own `install` and the root `postinstall`, so no
+binary is ever placed for the assertion to check.
 
 This **replaces** the `build/Release` cache block rather than adding to it: one cache step instead
 of two, covering both ABIs in one entry and covering `checks`, which has none today.
@@ -637,11 +676,31 @@ Install sites in scope (9 `npm ci` invocations across 5 workflows): `build.yml:1
 `docs.yml:87` already uses `--ignore-scripts`. **`release.yml`'s three sites need no cache — 8.1
 deletes them.**
 
-**Effect on Phase 2.** Not superseded, but its justification shrinks and must be re-derived against
-post-8.3 numbers. With 8.3 in place the residual win from `--ignore-scripts` is the cold-cache case
-plus the `checks`/`web-ci` jobs' unnecessary Electron-ABI *copy* (~0.1 s, not ~98 s). It also
-carries a repo-specific trap worth restating: `--ignore-scripts` skips `electron`'s own
+**Effect on Phase 2 — stated precisely, because a looser wording contradicts it.**
+
+8.3 does **not** deliver Phase 2's rule that "`checks` and `web-ci` must never build for the Electron
+ABI at all" (§Phase 2). On a **cold** cache — first run after any lockfile change, once per OS —
+`checks` still runs an ordinary `npm ci` whose `postinstall` compiles a full Electron-ABI binary it
+never loads, then re-targets Node. 8.3 removes that cost on the **warm** path only, which is the
+common case but not the invariant Phase 2 asserts.
+
+So: Phase 2 is **not superseded, and its rule still stands unmet until it ships.** What changes is
+the size of its remaining prize, which must be re-derived against post-PR-3 numbers rather than the
+pre-8.3 ones. Note also its repo-specific trap: `--ignore-scripts` skips `electron`'s own
 `install.js`, which downloads the Electron binary.
+
+The two phases compose rather than conflict; the end-state ordering once both have shipped is:
+
+```yaml
+- uses: actions/cache@<sha>        # restore .cache/native            (8.3)
+- run: npm ci --ignore-scripts     # no compile at all                (Phase 2)
+- run: npm run rebuild:<target>    # cache-restore, or compile if cold (8.3 + Phase 2)
+- run: node scripts/native/assert-native-abi.mjs <target>
+```
+
+Phase 2's originally specified `--ignore-scripts → restore → conditional rebuild → assert` ordering
+is preserved; 8.3 only moves the cache restore earlier, which is a no-op for Phase 2's semantics and
+is what lets the interim state (before Phase 2 lands) benefit at all.
 
 #### 8.4 electron-builder toolset cache — archive tier only
 
@@ -734,6 +793,36 @@ warnings. Phases 5.3 and 5.5 **move here** rather than being duplicated — see 
 Recorded for whoever next audits warnings: `MODULE_TYPELESS_PACKAGE_JSON` and the npm deprecations
 do **not** appear in `npm run build` — they surface via `eslint` and `npm install` respectively. A
 warning inventory must run all three commands.
+
+### Phase 8 design review — independent adversarial pass
+
+Reviewed 2026-08-06 by Codex CLI (`gpt-5.6-terra`, `model_reasoning_effort = high`), prompted to
+**refute** rather than assess. Four findings, all accepted; no finding was parked.
+
+| # | Finding | Ruling |
+|---|---|---|
+| 1 | A force-moved tag publishes commit A's binaries under a tag that now resolves to commit B. `create-release` gates on `$GITHUB_SHA` (`release.yml:65`) but creates by mutable `tag_name` (`release.yml:106`). | **Accepted, with a correction to its framing.** Real, and now closed by the tag-ref assertion in 8.1. But it is **pre-existing** — today's `release.yml` also builds from `$GITHUB_SHA` while publishing to a mutable tag name — so promotion does not introduce it. Codex rated it Critical on the assumption it was new. |
+| 2 | "Hard fail, `gh run rerun`" has no viable recovery for a run aged 30-90 days: reruns are permitted for 30 days, artifacts retained for 90, and `build.yml` has no `workflow_dispatch`. | **Accepted in full.** The recovery instruction was simply wrong. Fixed by adding `workflow_dispatch` to `build.yml`, widening the promotion lookup to `push` or `workflow_dispatch`, and forcing `code=true` for that event in `changes`. |
+| 3 | Applying 8.3's restore-and-assert to `docs.yml`'s deploy job would fail: it runs `npm ci --ignore-scripts`, so no binary exists for the assertion. | **Accepted in substance, though the literal case was already excluded** — the site list explicitly exempts `docs.yml:87`. It exposed a real error underneath: the assertion target was specified uniformly as `electron` when `checks` and `web-ci` load the **node** ABI. Fixed with the per-job target table in 8.3. |
+| 4 | 8.3 contradicts Phase 2's rule that "`checks` and `web-ci` must never build for the Electron ABI", because a cold cache still compiles one in `postinstall`. Calling Phase 2 "not superseded" does not reconcile it. | **Accepted.** The wording was glib. 8.3 fixes the warm path only; Phase 2's invariant stands unmet until Phase 2 ships. 8.3 now states this explicitly and gives the composed end-state ordering. |
+
+Attacks Codex ran and **could not** break — recorded because a failed refutation is evidence:
+
+- **The native-cache correctness chain.** No wrong-ABI path was found under the proposed required
+  assertion: `manifestIsFresh()` covers target/ABI/platform/arch/moduleVersion/lockfileHash,
+  `restore()` checks sha256, restored binaries are independently ABI-probed, and the compile-path
+  "undetermined" success branch (`rebuild-native.mjs:135`) is caught by the post-`npm ci` assertion.
+  Also confirmed: the dependency's own `install` script result is overwritten by the root
+  `postinstall`, so it does not leave the final Electron binary behind.
+- **The tree-hash claim.** Confirmed against real git data, and sharpened: because installer names
+  embed `${version}` (`package.json:149`, `:158`), reusing PR-head or merge-commit artifacts for the
+  release commit would produce wrongly-named files even if the trees had matched. Deferring 8.2 is
+  justified on that narrower ground too.
+- **Artifact-set equivalence.** The proposed globs match today's Linux/macOS/Windows upload globs
+  exactly, and explicit `--linux`/`--mac`/`--win` matches the current per-platform invocations.
+- **`ESIGNER_ENABLED != 'true'`.** Windows binaries remain unsigned exactly as today — signing and
+  `latest.yml` regeneration are both skipped while upload stays unconditional (`release.yml:303`,
+  `:357`, `:430`). Promotion does not change this behaviour.
 
 ---
 
@@ -850,7 +939,9 @@ Ordering constraints that are not negotiable:
 | **Promotion ships installers built from the wrong commit** (8.1) | `build_run_id` comes from the same gate that verified CI green, so there is one identity, not two. Plus `--event push`, an explicit `headSha == $GITHUB_SHA` assertion, and a `provenance.sha` check on the artifact itself. |
 | **Promotion ships a partial or corrupt artifact set** (8.1) | `download-artifact`'s `digest-mismatch: error` default, `sha256sum -c SHA256SUMS`, and an expected-filename assertion against the 10-asset set. `if-no-files-found: error` on the upload side so an empty artifact fails at creation. |
 | **A signed release ships a `latest.yml` describing the unsigned binaries** (8.5) | Exists today and is unverified. The new post-regeneration assertion recomputes sha512 + size for every referenced file and fails on mismatch. This is the failure mode promotion makes load-bearing, so it is a prerequisite, not a follow-up. |
-| **A tag whose `build.yml` run has expired or skipped `package` cannot be released** (8.1) | Accepted, deliberately. Hard fail naming `gh run rerun <id>` as the recovery, chosen over an auto-fallback build path that would rot unexercised and fail exactly when needed. |
+| **A tag whose `build.yml` run has expired or skipped `package` cannot be released** (8.1) | Accepted, deliberately. Hard fail chosen over an auto-fallback build path that would rot unexercised and fail exactly when needed. Recovery is `gh run rerun <id>` under 30 days, or `gh workflow run build.yml --ref <tag>` beyond it — which is why 8.1 adds `workflow_dispatch` to `build.yml`. |
+| **A force-moved tag publishes the previous commit's binaries** (8.1) | **Pre-existing, not introduced by promotion** — today's `release.yml` builds from `$GITHUB_SHA` while publishing to a mutable `tag_name`. Closed by asserting `refs/tags/<tag>^{commit} == $GITHUB_SHA` in `create-release` and again in `publish-release` immediately before flipping `draft: false`. |
+| **A cold native cache still compiles an Electron-ABI binary in `checks`** (8.3) | Accepted and stated rather than glossed: 8.3 fixes the warm path only. Phase 2's "never build for the Electron ABI" invariant remains unmet until Phase 2 ships. Cost is bounded to once per lockfile change per OS. |
 | **A corrupted electron-builder tool cache is served silently** (8.4) | Real: the extracted-directory tier validates file *count*, not content (`cacheState.js:112-131`). Mitigated by caching only hash-verified tiers and deleting `${extractDir}.state` sidecars after restore, forcing re-extraction through the sha256-checked archive path. |
 | A stale `.cache/native` GitHub cache entry installs a wrong-ABI binary (8.3) | Cannot: `manifestIsFresh` checks moduleVersion + lockfileHash + ABI + platform + arch, `restore()` sha256-checks against the manifest, and `restoreDecision()` re-derives the ABI from the binary on disk — resolving *undetermined* to `purge-and-compile`. Degrades to a recompile, never a wrong binary. Keep no `restore-keys`. |
 

--- a/.planning/specs/2026-08-05-build-ci-performance.md
+++ b/.planning/specs/2026-08-05-build-ci-performance.md
@@ -1,8 +1,12 @@
 # Build & CI Performance
 
-**Date:** 2026-08-05
-**Status:** Draft — awaiting review
-**Scope:** Build/CI pipeline wall clock, local and GitHub Actions. One correctness defect found en route.
+**Date:** 2026-08-05 · Phases 8-9 added 2026-08-06
+**Status:** In progress — PRs 1-2 merged; PRs 3-5 (Phase 8, Phase 9) in flight
+**Scope:** Build/CI pipeline wall clock, local and GitHub Actions. Phases 1-7 address redundancy
+*within* a single `build.yml` run; Phase 8 addresses redundancy *across* workflows, where one
+release packages the same code four times. One correctness defect found en route, plus three more
+found while designing Phase 8 (8.4's unhashed cache tier, 8.5's unverified `latest.yml` rewrite, and
+two build warnings that were never inventoried).
 
 ---
 
@@ -487,6 +491,250 @@ Required rewrites, all documented in the Vite 8 migration guide:
 
 Expected saving is small (build is 11.2 s). Included at explicit user request.
 
+### Phase 8 — Cross-workflow rebuild elimination
+
+Phases 1-7 address redundancy **within** one `build.yml` run. They do not touch the fact that one
+release of VarLens packages the same code **four times across two workflows**.
+
+Baseline artifact: `.planning/artifacts/perf/build/ci-cross-workflow-baseline.md` (measured from the
+Actions API for `v0.70.4`; the local `measure-build.mjs` harness cannot instrument Actions topology).
+
+| Run | ubuntu | windows | macos | subtotal |
+|---|---:|---:|---:|---:|
+| PR head `build.yml` (31075896010, tree `2ba72e24`) | 316 | 423 | 202 | 941 s |
+| merge commit `build.yml` (31076728072, tree `2ba72e24`) | 307 | 418 | 219 | 944 s |
+| release commit `build.yml` (31076764351, tree `9818f592`) | 350 | 450 | 234 | 1034 s |
+| `release.yml` (31078255517, tree `9818f592`) | 344 | 528 | 193 | 1065 s |
+| | | | | **3984 s = 66.4 min** |
+
+Exactly **one** of these four produces artifacts that ship: the release commit's `build.yml` run.
+
+Two corrections to assumptions held at the outset, both verified:
+
+- **Tree-hash keying cannot dedupe the release-commit build.** The PR head and merge commit do share
+  tree `2ba72e24`, but the release commit is `9818f592` — the three-line version bump changes
+  `package.json` and therefore the tree.
+- **`ELECTRON_CACHE` is read nowhere** in the installed dependency tree. It is not "not honoured by
+  Electron 43"; it does not exist as an input. Two distinct caches are routinely conflated — see 8.4.
+
+#### 8.1 Build once, promote
+
+`build.yml`'s `package` job already produces working installers on all three OS and **discards
+them** — it uploads only smoke reports, and `build.yml` contains no `download-artifact` anywhere.
+`release.yml` then rebuilds the identical commit, whose `build.yml` success it explicitly polls for
+before starting. Per-step evidence from `Release (Windows)` (528 s): `npm ci` 217 s + build/package
+224 s = **494 s of rebuild**, against **34 s of signing** that genuinely cannot happen anywhere else.
+
+**`build.yml` changes.** On `push` events only (not PRs — PR validation does not need the bytes, and
+uploading 1.29 GB per PR is pure cost), the `package` job emits and uploads its installers:
+
+- `provenance.json` — `{ sha, tree, run_id, run_attempt, version, os, arch }`.
+- `SHA256SUMS` over every uploaded installer.
+- `upload-artifact` as `installers-${{ matrix.os }}`, with `compression-level: 0` (installers are
+  already compressed; the default level 6 burns CPU on both ends for nothing),
+  `if-no-files-found: error`, `retention-days: 90`.
+- Path globs mirror what `release.yml` uploads today so the published asset set is unchanged. The
+  authoritative set, read from the published `v0.70.4` release, is 10 assets:
+  `Varlens-<v>.AppImage`, `Varlens-<v>.deb`, `latest-linux.yml`, `Varlens-<v>-arm64.dmg`,
+  `Varlens-<v>-arm64.zip`, `latest-mac.yml`, `Varlens-Setup-<v>.exe`, `Varlens-Portable-<v>.exe`,
+  `Varlens-Setup-<v>.zip`, `latest.yml`.
+- Replace the bare `npx electron-builder --publish never` with an explicit `--linux` / `--mac` /
+  `--win`, so the promoted set is defined by configuration rather than inferred from the runner.
+
+**`release.yml` changes.**
+
+- `create-release`'s existing "Verify Build workflow passed on tagged SHA" step gains a
+  `build_run_id` output. **The run we verified green is by construction the run we promote from** —
+  one lookup, one identity, with no second search that could disagree with the gate.
+  Harden that lookup while there: add `--event push` (a `pull_request` run reports the PR HEAD as
+  `head_sha`, so tagging a commit still open in a PR could otherwise select a run that never
+  uploaded installers), and assert the returned run's `headSha == $GITHUB_SHA` rather than trusting
+  the `--commit` filter. Verified quirk: `gh run list --commit=<short-sha>` returns empty while
+  `--commit=<full-sha>` works. The gate passes `$GITHUB_SHA`, always full, so this is latent rather
+  than live — the assertion makes it non-latent.
+- `release-linux` + `release-macos` collapse into one `promote-unix` job on an ubuntu runner.
+- `release-windows` becomes `sign-windows`: download, verify, then the **existing, unchanged**
+  Java / CodeSignTool / regenerate steps.
+- Both re-upload under the existing `release-linux` / `release-macos` / `release-windows` artifact
+  names, so `publish-release` needs no change at all.
+- Both need `permissions: actions: read` for the cross-run download.
+
+**Verification gate — five checks before any promoted artifact is trusted:**
+
+1. `actions/download-artifact@v8.0.1` verifies the recorded upload digest and fails on mismatch
+   (`digest-mismatch` defaults to `error`). Do not weaken it.
+2. `provenance.sha == github.sha`.
+3. `provenance.version == ${GITHUB_REF_NAME#v}` — belt-and-braces against the existing
+   "Assert tag matches package.json version" gate, but checked against the *artifact* rather than
+   the checkout.
+4. `sha256sum -c SHA256SUMS`.
+5. Expected-filename assertion for this version. A silently empty or partial artifact must fail
+   here, not at `gh release upload`.
+
+**Missing or expired artifacts: hard fail, no fallback build path.** The error names the recovery
+(`gh run rerun <build_run_id>`, then re-run the release). Chosen deliberately over auto-fallback: a
+fallback that never executes rots, and its rotting stays invisible until the day it is needed.
+
+#### 8.2 Merge-commit dedupe — deferred, recorded, not dropped
+
+The merge-commit rebuild (944 s) is genuinely redundant — identical tree to the PR-head run that
+just passed. Eliminating it needs a tree-keyed stamp **plus artifact copy-forward**, because a
+skipped `package` job uploads nothing, which would break 8.1's invariant if that commit were ever
+tagged.
+
+Deferred until 8.3 is measured, for two reasons stated plainly: runner time is **not billed** on
+this public repo (§2.4: `duration_ms: 0`), and this is a push nobody waits on — so the 944 s is real
+waste that costs neither money nor wall clock. And 8.3 removes ~100 s from each of these jobs
+anyway. Decide with the post-8.3 number, not this one.
+
+#### 8.3 Cache `.cache/native`, restored *before* `npm ci`
+
+The `actions/cache` block added for the native binary caches
+`node_modules/better-sqlite3-multiple-ciphers/build/Release` **after** `npm ci`, so it can never
+suppress the compile `postinstall` already ran. §2.4 predicted this; the fresh runs confirm it.
+Every packaging job reports `Cache native module: 1-5 s` then `Rebuild native modules: 0 s` — the
+cache **hits** — while `npm ci` still costs 112-217 s.
+
+`Checks (Ubuntu)` is the sharpest case: it has **no native cache block at all**
+(`build.yml:134-138`), so it compiles a full Electron-ABI binary in `postinstall` that it never
+loads, then re-targets the Node ABI in 2 s — directly on the critical path, since `package` has
+`needs: checks`.
+
+`.cache/native` (the ABI-keyed cache from PR #361) is local-only and cached by nothing. It is a
+sibling of `node_modules`, so `npm ci` does not remove it, and `postinstall` consults it **before**
+compiling (`rebuild-native.mjs:71` `if (restore(target))` → `:75 return 0`, never reaching
+`compile()` at `:105`).
+
+```yaml
+- uses: actions/cache@<sha>
+  with:
+    path: .cache/native          # NOT bare `.cache` — `.cache/tsbuildinfo` is a sibling
+    key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-ver.outputs.ver }}-${{ hashFiles('package-lock.json') }}
+- run: npm ci                    # postinstall becomes a file copy
+- run: node scripts/native/assert-native-abi.mjs electron
+```
+
+This **replaces** the `build/Release` cache block rather than adding to it: one cache step instead
+of two, covering both ABIs in one entry and covering `checks`, which has none today.
+
+Safe to make load-bearing because the cache self-verifies three independent ways:
+`manifestIsFresh()` (`native-abi.mjs:136-154`) requires target, abi, platform, arch, **moduleVersion**
+and **lockfileHash** to match; `restore()` (`:164-172`) recomputes sha256 over the cached binary and
+compares it to the manifest; `restoreDecision()` (`:196-199`) re-derives the ABI from the binary
+actually on disk, and resolves anything other than an exact match — *including "could not
+determine"* — to `purge-and-compile`. A stale or corrupt entry therefore degrades to a recompile,
+never to a wrong binary.
+
+Keep **no `restore-keys`**, matching the existing precedent. They would add nothing here (a
+lockfile-mismatched entry is rejected by `manifestIsFresh` regardless) and their absence documents
+the intent.
+
+Wiring `assert-native-abi.mjs` in as a required step also **closes the residual Phase 2 was carrying**
+— it fails loud (exit 1) on *undetermined*, where `rebuild-native.mjs` deliberately does not.
+
+Install sites in scope (9 `npm ci` invocations across 5 workflows): `build.yml:135` (checks),
+`:224` (package ×3 OS), `:329` (web-ci); `web-ci.yml:66`; `publish-web.yml:84`; `docs.yml:42`.
+`docs.yml:87` already uses `--ignore-scripts`. **`release.yml`'s three sites need no cache — 8.1
+deletes them.**
+
+**Effect on Phase 2.** Not superseded, but its justification shrinks and must be re-derived against
+post-8.3 numbers. With 8.3 in place the residual win from `--ignore-scripts` is the cold-cache case
+plus the `checks`/`web-ci` jobs' unnecessary Electron-ABI *copy* (~0.1 s, not ~98 s). It also
+carries a repo-specific trap worth restating: `--ignore-scripts` skips `electron`'s own
+`install.js`, which downloads the Electron binary.
+
+#### 8.4 electron-builder toolset cache — archive tier only
+
+Corrects Phase 4.9. Verified from installed source (`electron-builder@26.15.3` /
+`app-builder-lib@26.15.3`, `@electron/get@5.0.0`, `electron@43.3.0`):
+
+- **`ELECTRON_CACHE` is read nowhere** in the tree.
+- `electron_config_cache` (lower-case, `electron/install.js:46`) controls the **Electron binary
+  download** cache → `~/.cache/electron` · `%LOCALAPPDATA%\electron\Cache` · `~/Library/Caches/electron`.
+- The nsis / nsis-resources / winCodeSign / fpm / appimage / dmgbuild bundles are a **different
+  cache** under `ELECTRON_BUILDER_CACHE` (`app-builder-lib/out/util/electronGet.js:34-57`) →
+  `~/.cache/electron-builder` · `%LOCALAPPDATA%\electron-builder\Cache` ·
+  `~/Library/Caches/electron-builder`. An override is honoured only if **absolute** (`:38`).
+
+**Correctness hazard, and it changes the design.** electron-builder's *extracted-directory* tier
+short-circuits on a `.state` sidecar plus a file-count check with **no content hashing**
+(`electronGet.js:336-341` → `cacheState.js:112-131`, which verifies only that the directory is
+non-empty and the file count is `>=` expected). A corrupted or partial `actions/cache` restore of an
+already-`complete` extracted tool directory would be **silently served** — the archive-tier sha256
+check (`electronGet.js:292-316`) and `@electron/get`'s `sumchecker` pass both sit inside a branch
+the fast path never enters.
+
+**Therefore cache the hash-verified tiers only.** After restore, delete the `.state` sidecars —
+verified to be **sibling files**, `${extractDir}.state` (`cacheState.js:24`), not files inside the
+directory — so `readCacheStateFile` returns null and extraction is forced back through the
+sha256-checked archive path. Costs seconds of re-extraction; buys the download.
+
+Magnitude is **unverified**: the ~82 s figure for `nsis-resources` is quoted, not measured here.
+Measure with `DEBUG=electron-builder` before and after; electron-builder's docs state no magnitude
+for any option.
+
+#### 8.5 `latest.yml` integrity assertion
+
+`release.yml`'s "Regenerate latest.yml with signed artifact hashes" step rewrites sha512 and size
+through four PowerShell `-replace` regexes, and **nothing verifies the result**. If a filename ever
+stops matching, the regexes silently no-op and the release ships a `latest.yml` whose hashes
+describe the *unsigned* binaries — auto-update then fails at checksum verification for every user.
+
+The risk exists today; 8.1 makes it load-bearing. Add a step after regeneration that re-reads
+`latest.yml`, recomputes sha512 and size for every referenced file, and fails on any mismatch.
+
+### Phase 9 — Warning ledger
+
+Goal: every warning is either fixed or written down as accepted with a reason. No unexplained
+warnings. Phases 5.3 and 5.5 **move here** rather than being duplicated — see §7.
+
+1. **Delete the dead `zod` `manualChunks`** (was 5.5). `electron.vite.config.ts:56-59` and
+   `vite.web-renderer.config.ts:83-86`. Proven dead: zero zod imports under `src/renderer`; the sole
+   grep hit is the substring "benzodiazepine" in `hpo-terms.json`; every renderer→shared edge
+   reaching a zod-importing module is `import type`. The build emits
+   `Generated an empty chunk: "zod"` and a 0.00 kB asset. Keep the `vuetify` entry.
+2. **Rename `eslint.config.js` → `eslint.config.mjs`** (was 5.3). Do **not** add `"type": "module"`
+   to `package.json` — Node suggests it, but this is a mixed CJS/ESM Electron app. ESLint 10.8.0
+   lists `eslint.config.mjs` as a candidate (`eslint/lib/config/config-loader.js:45`). Three
+   functional references move in the same commit: `build.yml:56` (paths-filter), `build.yml:148` and
+   `:150` (`hashFiles` cache-key inputs — a missing file silently drops from the key rather than
+   failing the run). Plus a stale comment at `.prettierignore:1`. Confirm ESLint still resolves the
+   config after the rename.
+3. **npm deprecation triage — outcome: all five accepted, none actionable.**
+
+   | Package | Path | Ruling |
+   |---|---|---|
+   | `rimraf@2.6.3` | electron-builder → app-builder-lib → electron-builder-squirrel-windows → electron-winstaller → temp → rimraf | accepted |
+   | `glob@7.2.3` | electron-builder → app-builder-lib → @electron/asar → glob | accepted |
+   | `inflight@1.0.6` | … → @electron/asar → glob@7 → inflight | accepted |
+   | `boolean@3.2.0` | electron-builder → app-builder-lib → @electron/get@3 → global-agent → boolean | accepted |
+   | `lodash.isequal@4.5.0` | electron-updater → lodash.isequal | accepted |
+
+   Four of five sit inside `app-builder-lib`; overriding them would force majors electron-builder was
+   never tested against, breaking `.asar` packaging or Squirrel generation only at `npm run dist`
+   time, invisible to unit tests. `glob` additionally has two unrelated consumers at different majors
+   (`@fastify/static` → glob@13, `@vue/test-utils` → glob@10), so a top-level override would collide.
+   `lodash.isequal@4.5.0` is **already the latest published version** — the deprecation is permanent
+   ("use `node:util.isDeepStrictEqual`"), so no override exists that could silence it; it needs an
+   upstream change in `electron-updater`. **No `overrides` entries are added.**
+4. **Write the accepted-warnings ledger.** One place, each entry with its reason:
+   - 2× vite "dynamically imported but also statically imported" (`definitions.ts`,
+     `import-logic.ts`) — already reasoned in `AGENTS.md`; both defer *module evaluation*, not
+     chunking, and `tests/main/database/database-startup.test.ts` fails if the first is made static.
+   - 5× `npm audit` low (elliptic, via `pdbe-molstar`) — out of scope; never `npm audit fix --force`.
+   - 2× Rollup `/* #__PURE__ */` annotation from `@vueuse/core` (`dist/index.js` 3362:0, 5780:22) —
+     **not previously inventoried**; upstream annotation placement, nothing here to change.
+   - the 5 npm deprecations above.
+5. **Investigate — `h264-mp4-encoder` externalises `path`, `fs` and `crypto` for the browser** (3
+   warnings). **Also not previously inventoried, and not assumed benign.** A node-only module is
+   reachable from the renderer graph and those builtins become runtime no-ops. Determine whether that
+   import path can execute at runtime. If it can, this is a latent renderer defect, not a warning. If
+   it cannot, accept and record. Ruling deferred to the investigation, not pre-decided.
+
+Recorded for whoever next audits warnings: `MODULE_TYPELESS_PACKAGE_JSON` and the npm deprecations
+do **not** appear in `npm run build` — they surface via `eslint` and `npm install` respectively. A
+warning inventory must run all three commands.
+
 ---
 
 ## 6. Verification
@@ -519,6 +767,25 @@ baseline + comparison artifacts under `.planning/artifacts/perf/<topic>/`, gitig
 | ESLint peak RSS | 3.4 GB | no regression |
 | `typecheck` | 5.2 s warm | **expected to INCREASE** — Phase 4.2 adds `src/web/**` (71 files) and Phase 4.1 drops an unsound flag. Both are correctness wins; do not treat the increase as a regression. |
 
+Phase 8 targets. **These are measured from the GitHub Actions API, not from `compare-build.mjs`** —
+the local harness times local `make ci`-class stages and cannot instrument Actions topology.
+Baseline: `.planning/artifacts/perf/build/ci-cross-workflow-baseline.md`.
+
+| Metric | Baseline | Target |
+|---|---:|---:|
+| `release.yml` Windows job | 528 s | **≤ 120 s** (signing chain alone measures 34 s) |
+| `release.yml` runner total | 1065 s | **≤ 250 s** |
+| Packaging runs per release | 12 | **9** (12 → 6 was only reachable with 8.2, which is deferred) |
+| `npm ci` on jobs with a warm native cache | 112–217 s | report actual |
+| `build.yml` critical path | 774 s | report actual |
+| Packaging runner time per release | 3984 s | report actual |
+
+Two honesty constraints on Phase 8 claims. The compile's share of each `npm ci` above is **inferred**
+from §2.1, not isolated in CI — and the macOS figure (47 s total, against a ~42 s expected compile)
+does not reconcile cleanly. Isolate it before any claim rests on the split. And the ~82 s attributed
+to the `nsis-resources` download in 8.4 is **quoted, not measured**; get a real number from
+`DEBUG=electron-builder` before and after.
+
 Renderer bundle context for Phase 5/7 claims: `out/` is 23 MB, renderer 21 MB, of which the Mol*
 chunk is **9,140,442 B** and `plotly-basic` 1,692,371 B. Both are correctly code-split for runtime,
 but rollup + esbuild reprocess all 9 MB on every build — and today that build happens twice in
@@ -535,25 +802,38 @@ This spec is deliberately larger than one PR. `AGENTS.md` requires splitting wor
 boundaries, and these phases touch native tooling, workflows, tsconfigs, Vite configs and the
 Makefile. Ship as follows, each independently revertable, each with a before/after from §6:
 
-| PR | Contents | Gate |
-|---|---|---|
-| 1 | Verification harness only (`scripts/perf/compare-build.mjs`, `.planning/artifacts/perf/build/`) + committed baseline | `make ci` |
-| 2 | Phase 1 (native ABI cache, drop `-f`, ABI assertion, `--jobs`) | `make ci-full` |
-| 3 | Phase 2 (`--ignore-scripts` + cache ordering across 6 sites) + Phase 4.11 composite action | `make ci-full` + a real CI run |
-| 4 | Phase 3 (local `ci-full` dedupe) + Phase 4.12 guardrail test extension | `make ci-full` |
-| 5 | Phase 4.1–4.4 (typecheck correctness: unsound flag, `src/web/**`, dead references, program narrowing) | `make ci` |
-| 6 | Phase 4.5–4.10 (workflow hygiene: timeouts, `.nvmrc`, de-dupe web gate, caches) | CI run |
-| 7 | Phase 5 (cheap config wins) | `make ci-full` |
-| 8 | Phase 6 (TypeScript 7 / TNB) — **blocked on PR 5** | `make ci-full` |
-| 9 | Phase 7 (Vite 8 + electron-vite 6) — **blocked on PR 7** | `make ci-full` |
+| PR | Contents | Gate | Status |
+|---|---|---|---|
+| 1 | Verification harness only (`scripts/perf/compare-build.mjs`, `.planning/artifacts/perf/build/`) + committed baseline | `make ci` | **merged** |
+| 2 | Phase 1 (native ABI cache, drop `-f`, ABI assertion, `--jobs`) | `make ci-full` | **merged** |
+| 3 | Phase 8.3 + 8.4 (`.cache/native` CI cache restored pre-`npm ci`, `assert-native-abi` as a required step, electron-builder archive-tier cache) | real CI run | |
+| 4 | Phase 8.1 + 8.5 (build once, promote; `latest.yml` integrity assertion) | real CI run + a dry-run promote before it is trusted | |
+| 5 | Phase 9 (warning ledger) — absorbs former Phase 5.3 and 5.5 | `make ci` | |
+| 6 | Phase 2 (`--ignore-scripts` + cache ordering) + Phase 4.11 composite action — **scope re-derived against post-PR-3 numbers** | `make ci-full` + a real CI run | |
+| 7 | Phase 3 (local `ci-full` dedupe) + Phase 4.12 guardrail test extension | `make ci-full` | |
+| 8 | Phase 4.1–4.4 (typecheck correctness: unsound flag, `src/web/**`, dead references, program narrowing) | `make ci` | |
+| 9 | Phase 4.5–4.10 (workflow hygiene: timeouts, `.nvmrc`, de-dupe web gate, caches) | CI run | |
+| 10 | Phase 5 (cheap config wins) — **minus 5.3 and 5.5, which moved to PR 5** | `make ci-full` | |
+| 11 | Phase 6 (TypeScript 7 / TNB) — **blocked on PR 8** | `make ci-full` | |
+| 12 | Phase 7 (Vite 8 + electron-vite 6) — **blocked on PR 10** | `make ci-full` | |
 
 PR 1 must land first. Without a committed baseline, no later PR can substantiate its claim, and this
 spec's entire argument rests on measurement rather than intuition.
 
+Phase 8 was inserted at PRs 3-4 rather than appended, because it is the largest measured item in the
+document (3984 s per release) and because PR 3's native cache captures most of what Phase 2 was
+going to win — so Phase 2 should be re-justified against the post-PR-3 numbers rather than shipped
+on its original rationale. The former PRs 3-9 shift to 6-12 accordingly.
+
 Ordering constraints that are not negotiable:
 - Phase 1's ABI assertion **precedes** Phase 2, which makes the cache load-bearing.
 - Phase 4.1 (drop the unsound flag) **precedes** Phase 6 (TS 7). They must not ship together.
-- Phase 5.5 (delete dead `manualChunks`) **precedes** Phase 7 (which removes that API).
+- Phase 9 item 1 (delete dead `manualChunks`) **precedes** Phase 7 (which removes that API). This
+  constraint used to name Phase 5.5; the item moved, the constraint did not.
+- **Phase 8.3 precedes Phase 8.1.** Not a correctness constraint — 8.1's measurements are simply
+  cleaner once the native-cache noise is out of the `package` jobs.
+- **Phase 8.2 must not ship before 8.1.** A tree-stamp skip that suppresses artifact upload would
+  break the invariant that every main-push SHA has promotable installers.
 
 ## 8. Risks
 
@@ -567,6 +847,12 @@ Ordering constraints that are not negotiable:
 | Re-introducing parallelism near the quality gates re-triggers the June OOM | Explicitly out of scope (§4); guardrail clamps kept and extended |
 | **npm 12 silently ships an app with no native binary** (§3.5) | Keep the `<12` ceiling; adopt `npm approve-scripts` + `strict-allow-scripts=true` before raising it; assert the ceiling in the guardrail test; rely on the Phase 1.3 ABI assertion to fail loud rather than at runtime |
 | A fork release adding ABI 148 makes part of this work look redundant (§3.6) | It does not — the cache is what makes the *repeat* cost zero. A prebuild would only remove the first compile. |
+| **Promotion ships installers built from the wrong commit** (8.1) | `build_run_id` comes from the same gate that verified CI green, so there is one identity, not two. Plus `--event push`, an explicit `headSha == $GITHUB_SHA` assertion, and a `provenance.sha` check on the artifact itself. |
+| **Promotion ships a partial or corrupt artifact set** (8.1) | `download-artifact`'s `digest-mismatch: error` default, `sha256sum -c SHA256SUMS`, and an expected-filename assertion against the 10-asset set. `if-no-files-found: error` on the upload side so an empty artifact fails at creation. |
+| **A signed release ships a `latest.yml` describing the unsigned binaries** (8.5) | Exists today and is unverified. The new post-regeneration assertion recomputes sha512 + size for every referenced file and fails on mismatch. This is the failure mode promotion makes load-bearing, so it is a prerequisite, not a follow-up. |
+| **A tag whose `build.yml` run has expired or skipped `package` cannot be released** (8.1) | Accepted, deliberately. Hard fail naming `gh run rerun <id>` as the recovery, chosen over an auto-fallback build path that would rot unexercised and fail exactly when needed. |
+| **A corrupted electron-builder tool cache is served silently** (8.4) | Real: the extracted-directory tier validates file *count*, not content (`cacheState.js:112-131`). Mitigated by caching only hash-verified tiers and deleting `${extractDir}.state` sidecars after restore, forcing re-extraction through the sha256-checked archive path. |
+| A stale `.cache/native` GitHub cache entry installs a wrong-ABI binary (8.3) | Cannot: `manifestIsFresh` checks moduleVersion + lockfileHash + ABI + platform + arch, `restore()` sha256-checks against the manifest, and `restoreDecision()` re-derives the ABI from the binary on disk — resolving *undetermined* to `purge-and-compile`. Degrades to a recompile, never a wrong binary. Keep no `restore-keys`. |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,9 +81,10 @@ Correctness is enforced automatically by the ABI verification built into
 `scripts/native/rebuild-native.mjs` itself — every restore and every compile is checked against
 the binary that actually ends up on disk, never trusted from a manifest. `node
 scripts/native/assert-native-abi.mjs <node|electron>` is a separate, required CI step: it runs
-after every install across five jobs in four workflows (`build.yml`'s checks and package jobs,
-`web-ci.yml`, `publish-web.yml`, and `docs.yml`'s screenshot job), each asserting the ABI that job
-actually loads (`node` for test/web jobs, `electron` for packaging and the docs screenshot job).
+after every install at six job call-sites across four workflows — `build.yml` alone has three
+(`checks`, `package`, and its own `web-ci` job, distinct from the standalone `web-ci.yml`
+workflow) — plus one each in `web-ci.yml`, `publish-web.yml`, and `docs.yml`'s screenshot job,
+asserting `node` for test/web jobs and `electron` for packaging and the docs screenshot job.
 It exists alongside `rebuild-native.mjs`'s internal check because it fails loud on "undetermined",
 where `rebuild-native.mjs` deliberately does not.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ The target user is a clinical geneticist or researcher working with case-level v
 
 | Layer         | Choice                                                              |
 | ------------- | ------------------------------------------------------------------- |
-| Runtime       | Electron 40 (main + preload + renderer)                             |
-| Renderer      | Vue 3.5 + Vuetify 4 + Pinia 3 + Vue Router                          |
+| Runtime       | Electron 43 (main + preload + renderer)                             |
+| Renderer      | Vue 3.5 + Vuetify 4 + Pinia 4 + Vue Router                          |
 | Build         | electron-vite 5 + Vite 7                                            |
 | Language      | TypeScript 6, strict mode                                           |
 | Database      | `better-sqlite3-multiple-ciphers` (encrypted SQLite, synchronous)   |
@@ -81,10 +81,12 @@ Correctness is enforced automatically by the ABI verification built into
 `scripts/native/rebuild-native.mjs` itself — every restore and every compile is checked against
 the binary that actually ends up on disk, never trusted from a manifest. `node
 scripts/native/assert-native-abi.mjs <node|electron>` is a separate, required CI step: it runs
-after every install at six job call-sites across four workflows — `build.yml` alone has three
-(`checks`, `package`, and its own `web-ci` job, distinct from the standalone `web-ci.yml`
-workflow) — plus one each in `web-ci.yml`, `publish-web.yml`, and `docs.yml`'s screenshot job,
-asserting `node` for test/web jobs and `electron` for packaging and the docs screenshot job.
+after every install that builds the native module, at six job call-sites across four workflows —
+`build.yml` alone has three (`checks`, `package`, and its own `web-ci` job, distinct from the
+standalone `web-ci.yml` workflow) — plus one each in `web-ci.yml`, `publish-web.yml`, and
+`docs.yml`'s screenshot job, asserting `node` for test/web jobs and `electron` for packaging and
+the docs screenshot job (`docs.yml`'s `deploy` job is the deliberate exception — its
+`npm ci --ignore-scripts` skips the native rebuild, so there is no binary to assert against).
 It exists alongside `rebuild-native.mjs`'s internal check because it fails loud on "undetermined",
 where `rebuild-native.mjs` deliberately does not.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,12 @@ deliberately **not** passed `-f`, because `-f` disables both its skip logic and 
 Correctness is enforced automatically by the ABI verification built into
 `scripts/native/rebuild-native.mjs` itself — every restore and every compile is checked against
 the binary that actually ends up on disk, never trusted from a manifest. `node
-scripts/native/assert-native-abi.mjs <node|electron>` is a separate, on-demand check of whatever
-binary is currently installed; nothing invokes it automatically today — wiring it into CI is
-Phase 2.
+scripts/native/assert-native-abi.mjs <node|electron>` is a separate, required CI step: it runs
+after every install across five jobs in four workflows (`build.yml`'s checks and package jobs,
+`web-ci.yml`, `publish-web.yml`, and `docs.yml`'s screenshot job), each asserting the ABI that job
+actually loads (`node` for test/web jobs, `electron` for packaging and the docs screenshot job).
+It exists alongside `rebuild-native.mjs`'s internal check because it fails loud on "undetermined",
+where `rebuild-native.mjs` deliberately does not.
 
 Upstream publishes no prebuild for Electron 43's ABI 148 (published range 121-146), which is why
 this compile exists at all. **When bumping Electron, check whether the new ABI has a published
@@ -245,7 +248,7 @@ Test data lives at `tests/test-data/vcf/` (GIAB Chinese Trio, chr22:29M–30.5M,
   - Use git worktrees when useful or when the current checkout should stay clean.
   - Only documentation/archive housekeeping may be committed directly to `main` if explicitly requested.
 - **Conventional Commits.** Types used in this repo: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `style`, `chore`, `ci`, `merge`. Optional scope in parentheses: `refactor(ipc): …`, `fix(renderer): …`. Read `git log --oneline -30` before opening a PR if you're unsure of current phrasing.
-- **Release flow.** Versions are tagged `vX.Y.Z`. `.github/workflows/release.yml` **refuses to publish** if `build.yml` has not passed on the exact tagged SHA. Do not tag until CI is green on the commit you're tagging.
+- **Release flow.** Versions are tagged `vX.Y.Z`. `.github/workflows/release.yml` **refuses to publish** if `build.yml` has not passed on the exact tagged SHA. Do not tag until CI is green on the commit you're tagging. Release no longer rebuilds that commit: it downloads `build.yml`'s installers for that exact SHA, verifies provenance, checksums, and expected filenames, applies Windows signing, and publishes.
 - **PRs.** Small, focused, green CI. If a change spans shell + IPC + database, split it unless the atomicity is load-bearing. Reference the `.planning/` plan or review that motivates the change.
 
 ## Workflow Maintenance

--- a/scripts/release/artifact-manifest.mjs
+++ b/scripts/release/artifact-manifest.mjs
@@ -1,0 +1,49 @@
+// Single source of truth for the asset set a release must contain.
+//
+// Derived from package.json's build.{linux,mac,win} target + artifactName
+// templates, and cross-checked (see Task 2 Step 2 of the cross-workflow
+// dedupe plan) against the actually published v0.70.4 release assets —
+// 10 names across the three platforms. Both the promotion verifier
+// (verify-promoted-artifacts.mjs) and the workflow that generates the
+// build matrix consume `expectedArtifacts` and `PLATFORMS` directly, so
+// keep both names stable.
+export const PLATFORMS = Object.freeze(['linux', 'mac', 'win'])
+
+const PRODUCT = 'Varlens'
+
+// package.json's build.mac target pins arch to arm64 for both dmg and zip.
+const MAC_ARCH = 'arm64'
+
+export function expectedArtifacts(platform, version) {
+  if (!PLATFORMS.includes(platform)) {
+    throw new Error(`unknown platform "${platform}" (expected one of ${PLATFORMS.join(', ')})`)
+  }
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error('version must be a non-empty string')
+  }
+
+  switch (platform) {
+    case 'linux':
+      return [`${PRODUCT}-${version}.AppImage`, `${PRODUCT}-${version}.deb`, 'latest-linux.yml']
+    case 'mac':
+      return [
+        `${PRODUCT}-${version}-${MAC_ARCH}.dmg`,
+        `${PRODUCT}-${version}-${MAC_ARCH}.zip`,
+        'latest-mac.yml'
+      ]
+    case 'win':
+      // win.artifactName is "${productName}-Setup-${version}.${ext}", which
+      // the zip target also picks up; only the `portable` target overrides it.
+      return [
+        `${PRODUCT}-Setup-${version}.exe`,
+        `${PRODUCT}-Portable-${version}.exe`,
+        `${PRODUCT}-Setup-${version}.zip`,
+        'latest.yml'
+      ]
+    default:
+      // Unreachable: the PLATFORMS.includes() guard above already rejected
+      // anything not in PLATFORMS. Kept so an exhaustive switch reads as
+      // exhaustive rather than silently falling through to `undefined`.
+      throw new Error(`unhandled platform "${platform}"`)
+  }
+}

--- a/scripts/release/verify-latest-yml.mjs
+++ b/scripts/release/verify-latest-yml.mjs
@@ -77,6 +77,14 @@ export function verifyLatestYml({ ymlPath, dir }) {
     throw new Error(`${ymlPath} lists no files — refusing to treat that as verified`)
   }
 
+  // Deliberately not checked: the top-level `path:`/`sha512:` pair that
+  // mirrors the primary file outside the `files:` array. electron-updater's
+  // Provider.getFileList() (node_modules/electron-updater/out/providers/
+  // Provider.js:104-123) prefers `updateInfo.files` and only falls back to
+  // top-level `path`/`sha512` when `files` is empty or absent — which never
+  // happens for electron-builder output, so that fallback is inert today.
+  // This ruling depends on electron-updater's fallback behaviour and should
+  // be re-checked on its next major bump.
   const checked = []
   for (const entry of entries) {
     assertFileMatchesEntry(dir, entry)

--- a/scripts/release/verify-latest-yml.mjs
+++ b/scripts/release/verify-latest-yml.mjs
@@ -1,0 +1,101 @@
+// Asserts that a latest*.yml (electron-builder's auto-update metadata) actually
+// describes the files sitting next to it. The signing step rewrites sha512/size
+// with four PowerShell `-replace` regexes and verifies nothing; if a filename
+// ever stops matching, those calls silently no-op and the release ships
+// auto-update metadata describing the *unsigned* binaries — every user's
+// auto-update then fails checksum verification. This is the check that closes
+// that gap. Prefer failing loudly: an ambiguous or incomplete input must throw,
+// never pass by omission.
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+function sha512Base64(path) {
+  return createHash('sha512').update(readFileSync(path)).digest('base64')
+}
+
+// Reads the `files:` array entries out of a latest*.yml. electron-builder
+// emits a fixed two-space indented list of `- url:` / `sha512:` / `size:`
+// triples (plus, on Linux AppImage entries, an extra `blockMapSize:` line —
+// deliberately ignored below: it's indented, so it neither matches one of
+// the three known keys nor looks like the non-indented top-level key that
+// ends the array). A narrow line reader is used instead of a YAML dependency
+// because the file shape is fixed and electron-builder-generated.
+export function parseFileEntries(yml) {
+  const entries = []
+  let current = null
+  for (const raw of yml.split('\n')) {
+    const urlMatch = /^\s*-\s*url:\s*(.+?)\s*$/.exec(raw)
+    if (urlMatch) {
+      if (current) entries.push(current)
+      current = { url: urlMatch[1], sha512: null, size: null }
+      continue
+    }
+    if (!current) continue
+    const shaMatch = /^\s+sha512:\s*(.+?)\s*$/.exec(raw)
+    if (shaMatch) {
+      current.sha512 = shaMatch[1]
+      continue
+    }
+    const sizeMatch = /^\s+size:\s*(\d+)\s*$/.exec(raw)
+    if (sizeMatch) {
+      current.size = Number.parseInt(sizeMatch[1], 10)
+      continue
+    }
+    // A non-indented key (path:, sha512:, releaseDate:, ...) ends the files array.
+    if (/^\S/.test(raw)) {
+      entries.push(current)
+      current = null
+    }
+  }
+  if (current) entries.push(current)
+  return entries
+}
+
+function assertFileMatchesEntry(dir, entry) {
+  const path = join(dir, entry.url)
+  if (!existsSync(path)) {
+    throw new Error(`${entry.url} is referenced by latest.yml but not found in ${dir}`)
+  }
+  const actualSize = statSync(path).size
+  if (entry.size !== actualSize) {
+    throw new Error(`size mismatch for ${entry.url}: yml says ${entry.size}, file is ${actualSize}`)
+  }
+  const actualSha = sha512Base64(path)
+  if (entry.sha512 !== actualSha) {
+    throw new Error(
+      `sha512 mismatch for ${entry.url} — the metadata does not describe the file on disk`
+    )
+  }
+}
+
+export function verifyLatestYml({ ymlPath, dir }) {
+  const yml = readFileSync(ymlPath, 'utf8')
+  const entries = parseFileEntries(yml)
+  if (entries.length === 0) {
+    throw new Error(`${ymlPath} lists no files — refusing to treat that as verified`)
+  }
+
+  const checked = []
+  for (const entry of entries) {
+    assertFileMatchesEntry(dir, entry)
+    checked.push(entry.url)
+  }
+  return { ok: true, checked }
+}
+
+// CLI: node verify-latest-yml.mjs <ymlPath> <dir>
+function main() {
+  const [ymlPath, dir] = process.argv.slice(2)
+  try {
+    const { checked } = verifyLatestYml({ ymlPath, dir })
+    process.stdout.write(`latest.yml verified against ${checked.length} file(s)\n`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`::error::${message}\n`)
+    process.exit(1)
+  }
+}
+
+if (process.argv[1] === import.meta.filename) main()

--- a/scripts/release/verify-promoted-artifacts.mjs
+++ b/scripts/release/verify-promoted-artifacts.mjs
@@ -32,7 +32,14 @@ function parseChecksums(text) {
     if (trimmed.length === 0) continue
     const match = /^([0-9a-f]{64})\s+\*?(.+)$/i.exec(trimmed)
     if (!match) throw new Error(`malformed SHA256SUMS line: ${trimmed}`)
-    map.set(match[2], match[1].toLowerCase())
+    const [, digest, name] = match
+    // A repeated filename makes the manifest ambiguous, even if the
+    // surviving entry (last-one-wins on a plain Map.set) happens to be
+    // correct — SHA256SUMS must unambiguously describe what shipped.
+    if (map.has(name)) {
+      throw new Error(`duplicate SHA256SUMS entry for ${name}`)
+    }
+    map.set(name, digest.toLowerCase())
   }
   return map
 }

--- a/scripts/release/verify-promoted-artifacts.mjs
+++ b/scripts/release/verify-promoted-artifacts.mjs
@@ -5,11 +5,15 @@
 // Prefer failing loudly: an ambiguous or incomplete input must throw, never
 // pass by omission.
 import { createHash } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
 
 import { expectedArtifacts } from './artifact-manifest.mjs'
+
+// The only two files in a promoted-artifact directory that are not
+// themselves shipped artifacts. Anything else on disk is unexpected.
+const NON_ARTIFACT_FILES = new Set(['provenance.json', 'SHA256SUMS'])
 
 function sha256File(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex')
@@ -60,6 +64,38 @@ function readChecksums(dir) {
   return parseChecksums(readFileSync(sumsPath, 'utf8'))
 }
 
+// Enforces an EXACT set, not a superset check. Both enumerations below are
+// required, not redundant: Task 6's upload step re-globs the promoted
+// directory by extension rather than reading SHA256SUMS, so a planted file
+// that is present on disk but never entered into SHA256SUMS would still ship
+// — checking SHA256SUMS alone cannot see it. Conversely, a phantom entry
+// added to SHA256SUMS for a file that was never written to disk doesn't get
+// uploaded by the glob, but it does mean SHA256SUMS no longer accurately
+// describes what shipped, which is its entire purpose — checking the
+// directory alone cannot see that either.
+
+// Every file physically present (other than the two metadata files) must be
+// one this platform/version is actually expecting.
+function assertNoUnexpectedFilesOnDisk(dir, expectedSet) {
+  for (const name of readdirSync(dir)) {
+    if (NON_ARTIFACT_FILES.has(name)) continue
+    if (!expectedSet.has(name)) {
+      throw new Error(`unexpected file in promoted artifact set: ${name}`)
+    }
+  }
+}
+
+// Every checksum entry must name an expected artifact — an entry for a file
+// this platform/version was never supposed to produce is unexpected even if
+// no such file exists on disk right now.
+function assertNoUnexpectedChecksumEntries(sums, expectedSet) {
+  for (const name of sums.keys()) {
+    if (!expectedSet.has(name)) {
+      throw new Error(`unexpected entry in SHA256SUMS: ${name}`)
+    }
+  }
+}
+
 function assertArtifactMatchesChecksum(dir, name, sums) {
   const path = join(dir, name)
   if (!existsSync(path)) throw new Error(`missing expected artifact: ${name}`)
@@ -76,7 +112,13 @@ export function verifyPromotedArtifacts({ dir, platform, version, sha }) {
   assertProvenanceMatches(provenance, { version, sha })
 
   const sums = readChecksums(dir)
-  for (const name of expectedArtifacts(platform, version)) {
+  const expected = expectedArtifacts(platform, version)
+  const expectedSet = new Set(expected)
+
+  assertNoUnexpectedFilesOnDisk(dir, expectedSet)
+  assertNoUnexpectedChecksumEntries(sums, expectedSet)
+
+  for (const name of expected) {
     assertArtifactMatchesChecksum(dir, name, sums)
   }
 

--- a/scripts/release/verify-promoted-artifacts.mjs
+++ b/scripts/release/verify-promoted-artifacts.mjs
@@ -1,0 +1,99 @@
+// Verifies one platform's promoted artifact set before it is published as a
+// signed release. This is the gate between "a set of downloaded binaries"
+// and "what users install" — every check here is the difference between
+// shipping the right installer and shipping a plausible-looking wrong one.
+// Prefer failing loudly: an ambiguous or incomplete input must throw, never
+// pass by omission.
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+import { expectedArtifacts } from './artifact-manifest.mjs'
+
+function sha256File(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
+// Tolerates real sha256sum/shasum output: one-or-more whitespace between the
+// hex digest and the filename (canonical `sha256sum` emits exactly two
+// spaces for text mode), and an optional leading `*` binary-mode marker on
+// the filename. A later task generates this file with `shasum -a 256` on
+// Linux, macOS and Windows-Git-Bash runners, so the parser has to accept
+// whatever those actually produce, not just the two-space case.
+function parseChecksums(text) {
+  const map = new Map()
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) continue
+    const match = /^([0-9a-f]{64})\s+\*?(.+)$/i.exec(trimmed)
+    if (!match) throw new Error(`malformed SHA256SUMS line: ${trimmed}`)
+    map.set(match[2], match[1].toLowerCase())
+  }
+  return map
+}
+
+function readProvenance(dir) {
+  const provenancePath = join(dir, 'provenance.json')
+  if (!existsSync(provenancePath)) {
+    throw new Error(`missing provenance.json in ${dir} — the artifact set is not promotable`)
+  }
+  return JSON.parse(readFileSync(provenancePath, 'utf8'))
+}
+
+function assertProvenanceMatches(provenance, { version, sha }) {
+  if (provenance.sha !== sha) {
+    throw new Error(
+      `provenance sha mismatch: artifact was built from ${String(provenance.sha)}, releasing ${sha}`
+    )
+  }
+  if (provenance.version !== version) {
+    throw new Error(
+      `provenance version mismatch: artifact declares ${String(provenance.version)}, releasing ${version}`
+    )
+  }
+}
+
+function readChecksums(dir) {
+  const sumsPath = join(dir, 'SHA256SUMS')
+  if (!existsSync(sumsPath)) throw new Error(`missing SHA256SUMS in ${dir}`)
+  return parseChecksums(readFileSync(sumsPath, 'utf8'))
+}
+
+function assertArtifactMatchesChecksum(dir, name, sums) {
+  const path = join(dir, name)
+  if (!existsSync(path)) throw new Error(`missing expected artifact: ${name}`)
+  const recorded = sums.get(name)
+  if (!recorded) throw new Error(`${name} is present but not listed in SHA256SUMS`)
+  const actual = sha256File(path)
+  if (actual !== recorded) {
+    throw new Error(`checksum mismatch for ${name}: expected ${recorded}, got ${actual}`)
+  }
+}
+
+export function verifyPromotedArtifacts({ dir, platform, version, sha }) {
+  const provenance = readProvenance(dir)
+  assertProvenanceMatches(provenance, { version, sha })
+
+  const sums = readChecksums(dir)
+  for (const name of expectedArtifacts(platform, version)) {
+    assertArtifactMatchesChecksum(dir, name, sums)
+  }
+
+  return { ok: true }
+}
+
+// CLI: node verify-promoted-artifacts.mjs <dir> <platform> <version> <sha>
+function main() {
+  const [dir, platform, version, sha] = process.argv.slice(2)
+  try {
+    verifyPromotedArtifacts({ dir, platform, version, sha })
+    process.stdout.write(`promoted artifacts verified: ${platform} ${version} @ ${sha}\n`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`::error::${message}\n`)
+    process.exit(1)
+  }
+}
+
+if (process.argv[1] === import.meta.filename) main()

--- a/tests/scripts/build-pipeline-guardrails.test.ts
+++ b/tests/scripts/build-pipeline-guardrails.test.ts
@@ -10,6 +10,9 @@ const scripts = (
   }
 ).scripts
 
+const WORKFLOW_DIR = resolve(ROOT, '.github', 'workflows')
+const readWorkflow = (name: string): string => readFileSync(resolve(WORKFLOW_DIR, name), 'utf8')
+
 describe('native rebuild stays cacheable', () => {
   // `-f` disables @electron/rebuild's own skip logic AND its module-state
   // cache, which is what made the binary recompile on every install, every
@@ -104,5 +107,62 @@ describe('memory clamps from the June 2026 incident stay in place', () => {
     // regardless of what follows it.
     const makefile = readFileSync(resolve(ROOT, 'Makefile'), 'utf8')
     expect(makefile).not.toMatch(/\$\(MAKE\)\s+-j/)
+  })
+})
+
+describe('cross-workflow rebuild elimination (spec Phase 8)', () => {
+  test('never caches the bare .cache root, which would collide with tsbuildinfo', () => {
+    for (const name of ['build.yml', 'web-ci.yml', 'publish-web.yml', 'docs.yml']) {
+      const yaml = readWorkflow(name)
+      expect(yaml, `${name} must not cache the bare .cache root`).not.toMatch(
+        /^\s*path:\s*\.cache\s*$/m
+      )
+    }
+  })
+
+  test('keys the native cache on os, arch, electron version and lockfile, with no restore-keys', () => {
+    const yaml = readWorkflow('build.yml')
+    const keys = [...yaml.matchAll(/key:\s*(native-[^\n]*)/g)].map((m) => m[1])
+    expect(keys.length, 'build.yml must declare at least one native cache key').toBeGreaterThan(0)
+    for (const key of keys) {
+      expect(key).toContain('runner.os')
+      expect(key).toContain('runner.arch')
+      expect(key).toContain('electron-ver.outputs.ver')
+      expect(key).toContain("hashFiles('package-lock.json')")
+    }
+    // A partial match would leave a wrong-ABI .node on disk. No fallback, ever.
+    // Scoped to `native-` keys only — a later phase adds an `ebtools-` cache
+    // that legitimately uses restore-keys, and must not trip this assertion.
+    const nativeBlocks = yaml.split('key: native-').slice(1)
+    for (const block of nativeBlocks) {
+      const untilNextStep = block.split(/\n\s*-\s/)[0]
+      expect(untilNextStep, 'native cache must not declare restore-keys').not.toContain(
+        'restore-keys'
+      )
+    }
+  })
+
+  test('release.yml no longer builds or packages the app', () => {
+    const yaml = readWorkflow('release.yml')
+    expect(yaml, 'release.yml must promote build.yml artifacts, not rebuild').not.toContain(
+      'electron-builder'
+    )
+    expect(yaml).not.toContain('electron-vite build')
+  })
+
+  test('release.yml grants actions:read so it can read another run’s artifacts', () => {
+    expect(readWorkflow('release.yml')).toContain('actions: read')
+  })
+
+  test('build.yml can be re-run against a ref, so expired artifacts are recoverable', () => {
+    // `gh run rerun` is only permitted for 30 days; artifacts are retained for 90.
+    expect(readWorkflow('build.yml')).toContain('workflow_dispatch:')
+  })
+
+  test('installer uploads fail loudly rather than producing an empty artifact', () => {
+    const yaml = readWorkflow('build.yml')
+    expect(yaml).toContain('installers-')
+    const uploadBlock = yaml.slice(yaml.indexOf('installers-'))
+    expect(uploadBlock).toContain('if-no-files-found: error')
   })
 })

--- a/tests/scripts/build-pipeline-guardrails.test.ts
+++ b/tests/scripts/build-pipeline-guardrails.test.ts
@@ -112,11 +112,38 @@ describe('memory clamps from the June 2026 incident stay in place', () => {
 
 describe('cross-workflow rebuild elimination (spec Phase 8)', () => {
   test('never caches the bare .cache root, which would collide with tsbuildinfo', () => {
+    // Catches every spelling of "cache the whole .cache root" that YAML
+    // allows: unquoted, single-quoted, double-quoted, with-or-without a
+    // trailing slash — and the block-scalar `path: |` form (build.yml's own
+    // "Restore lint caches" step already uses that style for a multi-path
+    // cache list, so it is the most realistic way a future author would
+    // accidentally cache the whole root instead of a scoped subdirectory).
+    const bareCacheEntry = /^[ \t]*(['"]?)\.cache\/?\1[ \t]*$/m
+
     for (const name of ['build.yml', 'web-ci.yml', 'publish-web.yml', 'docs.yml']) {
       const yaml = readWorkflow(name)
+
+      // Single-line form: `path: .cache`, `path: '.cache'`, `path: ".cache"`,
+      // `path: .cache/`, and quoted-with-slash variants.
       expect(yaml, `${name} must not cache the bare .cache root`).not.toMatch(
-        /^\s*path:\s*\.cache\s*$/m
+        /^[ \t]*path:[ \t]*(['"]?)\.cache\/?\1[ \t]*$/m
       )
+
+      // Block-scalar form: `path: |` (or `>`, with optional chomping
+      // indicator) followed by one or more indented entries, one per line.
+      // A block entry qualifies only while it is indented deeper than the
+      // `path:` key itself — that is how YAML delimits the scalar block, and
+      // it is also what stops this capture at the next mapping key (e.g.
+      // `key:`) which sits back at the `path:` key's own indentation.
+      for (const match of yaml.matchAll(
+        /^([ \t]*)path:[ \t]*[|>][+-]?[ \t]*\n((?:\1[ \t]+\S.*\n?)*)/gm
+      )) {
+        const block = match[2]
+        expect(
+          block,
+          `${name} must not cache the bare .cache root in a block-scalar path list`
+        ).not.toMatch(bareCacheEntry)
+      }
     }
   })
 

--- a/tests/scripts/build-pipeline-guardrails.test.ts
+++ b/tests/scripts/build-pipeline-guardrails.test.ts
@@ -161,8 +161,24 @@ describe('cross-workflow rebuild elimination (spec Phase 8)', () => {
 
   test('installer uploads fail loudly rather than producing an empty artifact', () => {
     const yaml = readWorkflow('build.yml')
-    expect(yaml).toContain('installers-')
-    const uploadBlock = yaml.slice(yaml.indexOf('installers-'))
-    expect(uploadBlock).toContain('if-no-files-found: error')
+    // Bounded the same way the native-cache assertion above bounds its
+    // per-key block: split on the marker, then cut each resulting chunk off
+    // at the next step so an unrelated later upload-artifact step (build.yml
+    // already has several, and will gain more) can't satisfy this by
+    // coincidence. `.length` is asserted explicitly rather than relying on
+    // a `for` loop over zero blocks to fail — an empty array would otherwise
+    // pass vacuously, which is exactly the silent defeat this guards against.
+    const installerUploads = yaml.split('installers-').slice(1)
+    expect(
+      installerUploads.length,
+      'build.yml must declare at least one installers- artifact upload'
+    ).toBeGreaterThan(0)
+    for (const upload of installerUploads) {
+      const untilNextStep = upload.split(/\n\s*-\s/)[0]
+      expect(
+        untilNextStep,
+        'installers- upload step must set if-no-files-found: error'
+      ).toContain('if-no-files-found: error')
+    }
   })
 })

--- a/tests/scripts/build-pipeline-guardrails.test.ts
+++ b/tests/scripts/build-pipeline-guardrails.test.ts
@@ -120,26 +120,55 @@ describe('cross-workflow rebuild elimination (spec Phase 8)', () => {
     }
   })
 
-  test('keys the native cache on os, arch, electron version and lockfile, with no restore-keys', () => {
-    const yaml = readWorkflow('build.yml')
-    const keys = [...yaml.matchAll(/key:\s*(native-[^\n]*)/g)].map((m) => m[1])
-    expect(keys.length, 'build.yml must declare at least one native cache key').toBeGreaterThan(0)
-    for (const key of keys) {
-      expect(key).toContain('runner.os')
-      expect(key).toContain('runner.arch')
-      expect(key).toContain('electron-ver.outputs.ver')
-      expect(key).toContain("hashFiles('package-lock.json')")
+  test('keys the native cache on os, arch, electron version and lockfile, with no restore-keys, across every workflow that declares one', () => {
+    // Task 7 (build.yml, web-ci.yml, publish-web.yml, docs.yml) and release.yml
+    // (which must have none — it promotes build.yml's artifacts, it never
+    // rebuilds) are all scanned. A per-file "at least one" minimum would be
+    // wrong here because release.yml legitimately has zero; the vacuous-pass
+    // guard below is instead "at least one across the whole set", with
+    // release.yml's zero asserted separately and explicitly further down.
+    const workflowNames = ['build.yml', 'web-ci.yml', 'publish-web.yml', 'docs.yml', 'release.yml']
+    let totalKeys = 0
+
+    for (const name of workflowNames) {
+      const yaml = readWorkflow(name)
+      const keys = [...yaml.matchAll(/key:\s*(native-[^\n]*)/g)].map((m) => m[1])
+      totalKeys += keys.length
+
+      for (const key of keys) {
+        expect(key, `${name}: native- key must pin runner.os`).toContain('runner.os')
+        expect(key, `${name}: native- key must pin runner.arch`).toContain('runner.arch')
+        expect(key, `${name}: native- key must pin the electron version`).toContain(
+          'electron-ver.outputs.ver'
+        )
+        expect(key, `${name}: native- key must pin the lockfile hash`).toContain(
+          "hashFiles('package-lock.json')"
+        )
+      }
+
+      // A partial match would leave a wrong-ABI .node on disk. No fallback,
+      // ever. Scoped to `native-` keys only — the `ebtools-` toolset cache
+      // legitimately uses restore-keys, and must not trip this assertion.
+      const nativeBlocks = yaml.split('key: native-').slice(1)
+      for (const block of nativeBlocks) {
+        const untilNextStep = block.split(/\n\s*-\s/)[0]
+        expect(untilNextStep, `${name}: native cache must not declare restore-keys`).not.toContain(
+          'restore-keys'
+        )
+      }
     }
-    // A partial match would leave a wrong-ABI .node on disk. No fallback, ever.
-    // Scoped to `native-` keys only — a later phase adds an `ebtools-` cache
-    // that legitimately uses restore-keys, and must not trip this assertion.
-    const nativeBlocks = yaml.split('key: native-').slice(1)
-    for (const block of nativeBlocks) {
-      const untilNextStep = block.split(/\n\s*-\s/)[0]
-      expect(untilNextStep, 'native cache must not declare restore-keys').not.toContain(
-        'restore-keys'
-      )
-    }
+
+    expect(
+      totalKeys,
+      'at least one scanned workflow must declare a native- cache key'
+    ).toBeGreaterThan(0)
+
+    // Explicit, not just relying on the loop above passing vacuously on zero
+    // keys: proves release.yml staying rebuild-free (see the "no longer
+    // builds or packages" test below) also stays cache-free, so a future
+    // regression that reintroduces a native rebuild there is caught here too.
+    const releaseKeys = [...readWorkflow('release.yml').matchAll(/key:\s*(native-[^\n]*)/g)]
+    expect(releaseKeys.length, 'release.yml must not declare any native- cache key').toBe(0)
   })
 
   test('release.yml no longer builds or packages the app', () => {

--- a/tests/scripts/build-pipeline-guardrails.test.ts
+++ b/tests/scripts/build-pipeline-guardrails.test.ts
@@ -175,10 +175,9 @@ describe('cross-workflow rebuild elimination (spec Phase 8)', () => {
     ).toBeGreaterThan(0)
     for (const upload of installerUploads) {
       const untilNextStep = upload.split(/\n\s*-\s/)[0]
-      expect(
-        untilNextStep,
-        'installers- upload step must set if-no-files-found: error'
-      ).toContain('if-no-files-found: error')
+      expect(untilNextStep, 'installers- upload step must set if-no-files-found: error').toContain(
+        'if-no-files-found: error'
+      )
     }
   })
 })

--- a/tests/scripts/verify-latest-yml.test.ts
+++ b/tests/scripts/verify-latest-yml.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHash } from 'crypto'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { verifyLatestYml } from '../../scripts/release/verify-latest-yml.mjs'
+
+let dir: string
+const sha512b64 = (buf: Buffer): string => createHash('sha512').update(buf).digest('base64')
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'varlens-latestyml-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeSet(bodyText: string, ymlSha: string, ymlSize: number): string {
+  const body = Buffer.from(bodyText)
+  writeFileSync(join(dir, 'Varlens-Setup-9.9.9.exe'), body)
+  const yml = [
+    'version: 9.9.9',
+    'files:',
+    '  - url: Varlens-Setup-9.9.9.exe',
+    `    sha512: ${ymlSha}`,
+    `    size: ${ymlSize}`,
+    'path: Varlens-Setup-9.9.9.exe',
+    `sha512: ${ymlSha}`,
+    'releaseDate: 2026-08-06T00:00:00.000Z'
+  ].join('\n')
+  const ymlPath = join(dir, 'latest.yml')
+  writeFileSync(ymlPath, yml)
+  return ymlPath
+}
+
+describe('verifyLatestYml', () => {
+  it('accepts metadata whose hash and size match the file on disk', () => {
+    const body = Buffer.from('signed-installer-bytes')
+    const ymlPath = writeSet('signed-installer-bytes', sha512b64(body), body.length)
+    expect(verifyLatestYml({ ymlPath, dir })).toEqual({
+      ok: true,
+      checked: ['Varlens-Setup-9.9.9.exe']
+    })
+  })
+
+  it('rejects metadata describing the pre-signing bytes — the regex-no-op failure', () => {
+    const stale = Buffer.from('UNSIGNED-installer-bytes')
+    const signed = Buffer.from('signed-installer-bytes')
+    // yml still carries the unsigned hash; disk carries the signed file.
+    const ymlPath = writeSet('signed-installer-bytes', sha512b64(stale), signed.length)
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/sha512 mismatch/i)
+  })
+
+  it('rejects a stale size even when the hash was updated', () => {
+    const body = Buffer.from('signed-installer-bytes')
+    const ymlPath = writeSet('signed-installer-bytes', sha512b64(body), body.length + 4096)
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/size mismatch/i)
+  })
+
+  it('rejects metadata referencing a file that is not there', () => {
+    const body = Buffer.from('x')
+    const ymlPath = writeSet('x', sha512b64(body), body.length)
+    rmSync(join(dir, 'Varlens-Setup-9.9.9.exe'))
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/not found/i)
+  })
+
+  it('refuses to pass when the files array is empty, rather than vacuously succeeding', () => {
+    const ymlPath = join(dir, 'latest.yml')
+    writeFileSync(ymlPath, 'version: 9.9.9\nfiles:\n')
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/no files/i)
+  })
+})

--- a/tests/scripts/verify-latest-yml.test.ts
+++ b/tests/scripts/verify-latest-yml.test.ts
@@ -5,7 +5,7 @@ import { createHash } from 'crypto'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { verifyLatestYml } from '../../scripts/release/verify-latest-yml.mjs'
+import { parseFileEntries, verifyLatestYml } from '../../scripts/release/verify-latest-yml.mjs'
 
 let dir: string
 const sha512b64 = (buf: Buffer): string => createHash('sha512').update(buf).digest('base64')
@@ -34,6 +34,58 @@ function writeSet(bodyText: string, ymlSha: string, ymlSize: number): string {
   writeFileSync(ymlPath, yml)
   return ymlPath
 }
+
+interface FileEntryFixture {
+  name: string
+  body: Buffer
+  sha: string
+  size: number
+}
+
+// Two-entry files: array, shaped exactly like the real, downloaded v0.70.4
+// latest-mac.yml (two `- url:`/`sha512:`/`size:` blocks, no blockMapSize —
+// that only appears on the Linux AppImage entry, covered separately below).
+// Every macOS and Linux release has this multi-entry shape; the single-entry
+// writeSet() above never exercises it.
+function writeTwoEntrySet(entries: [FileEntryFixture, FileEntryFixture]): string {
+  for (const entry of entries) writeFileSync(join(dir, entry.name), entry.body)
+  const fileLines = entries.flatMap((entry) => [
+    `  - url: ${entry.name}`,
+    `    sha512: ${entry.sha}`,
+    `    size: ${entry.size}`
+  ])
+  const yml = [
+    'version: 9.9.9',
+    'files:',
+    ...fileLines,
+    `path: ${entries[0].name}`,
+    `sha512: ${entries[0].sha}`,
+    "releaseDate: '2026-08-06T00:00:00.000Z'"
+  ].join('\n')
+  const ymlPath = join(dir, 'latest-mac.yml')
+  writeFileSync(ymlPath, yml)
+  return ymlPath
+}
+
+// Copied verbatim from the real v0.70.4 latest-linux.yml release asset
+// (`gh release download v0.70.4 -p 'latest*.yml'`). The AppImage entry
+// carries an extra `blockMapSize:` line between `size:` and the next
+// `- url:` that electron-builder emits for differential-update-capable
+// Linux builds; the .deb entry has none, same as the real file.
+const REAL_LATEST_LINUX_YML = [
+  'version: 0.70.4',
+  'files:',
+  '  - url: Varlens-0.70.4.AppImage',
+  '    sha512: nxtWcGumqh/cJyxhoHPPznIPqbagVoFij4r9CrmOF7OEMBeeu2DqxPzMMLga5Kc+iWBsszW4wjOIV6tYLyofWQ==',
+  '    size: 202168940',
+  '    blockMapSize: 211584',
+  '  - url: Varlens-0.70.4.deb',
+  '    sha512: TJ2nDIAOiqZqPo0AwkyMli4bvYtZZk6Yppb/KgMd+rnDPzFNJGvdtTQmFZQgFHBC/4vFuuAz2SuRralm4HHHeQ==',
+  '    size: 154097136',
+  'path: Varlens-0.70.4.AppImage',
+  'sha512: nxtWcGumqh/cJyxhoHPPznIPqbagVoFij4r9CrmOF7OEMBeeu2DqxPzMMLga5Kc+iWBsszW4wjOIV6tYLyofWQ==',
+  "releaseDate: '2026-08-06T06:49:16.725Z'"
+].join('\n')
 
 describe('verifyLatestYml', () => {
   it('accepts metadata whose hash and size match the file on disk', () => {
@@ -70,5 +122,48 @@ describe('verifyLatestYml', () => {
     const ymlPath = join(dir, 'latest.yml')
     writeFileSync(ymlPath, 'version: 9.9.9\nfiles:\n')
     expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(/no files/i)
+  })
+
+  it('checks every entry in a multi-entry files array, not just the first — the real two-entry latest-mac.yml shape', () => {
+    const zipBody = Buffer.from('signed-zip-bytes')
+    const dmgBody = Buffer.from('signed-dmg-bytes')
+    const ymlPath = writeTwoEntrySet([
+      {
+        name: 'Varlens-9.9.9-arm64.zip',
+        body: zipBody,
+        sha: sha512b64(zipBody),
+        size: zipBody.length
+      },
+      // The SECOND entry is the bad one: its recorded hash is stale even
+      // though its size line matches. A parser or checker that stops after
+      // entries[0] would pass this vacuously — the first entry alone is
+      // fully valid.
+      {
+        name: 'Varlens-9.9.9-arm64.dmg',
+        body: dmgBody,
+        sha: sha512b64(Buffer.from('UNSIGNED-dmg-bytes')),
+        size: dmgBody.length
+      }
+    ])
+    expect(() => verifyLatestYml({ ymlPath, dir })).toThrow(
+      /sha512 mismatch for Varlens-9\.9\.9-arm64\.dmg/i
+    )
+  })
+
+  it('parses the real latest-linux.yml blockMapSize: line without corrupting the entry or leaking into the next one', () => {
+    expect(parseFileEntries(REAL_LATEST_LINUX_YML)).toEqual([
+      {
+        url: 'Varlens-0.70.4.AppImage',
+        sha512:
+          'nxtWcGumqh/cJyxhoHPPznIPqbagVoFij4r9CrmOF7OEMBeeu2DqxPzMMLga5Kc+iWBsszW4wjOIV6tYLyofWQ==',
+        size: 202168940
+      },
+      {
+        url: 'Varlens-0.70.4.deb',
+        sha512:
+          'TJ2nDIAOiqZqPo0AwkyMli4bvYtZZk6Yppb/KgMd+rnDPzFNJGvdtTQmFZQgFHBC/4vFuuAz2SuRralm4HHHeQ==',
+        size: 154097136
+      }
+    ])
   })
 })

--- a/tests/scripts/verify-promoted-artifacts.test.ts
+++ b/tests/scripts/verify-promoted-artifacts.test.ts
@@ -127,6 +127,23 @@ describe('verifyPromotedArtifacts', () => {
     ).toThrow(/unexpected/i)
   })
 
+  it('rejects a SHA256SUMS with a duplicate entry for the same filename', () => {
+    // The map-based parser used to overwrite on a repeated filename, so a
+    // manifest listing the same file twice (e.g. a wrong digest followed by
+    // the correct one) silently passed on the surviving entry. Wrong bytes
+    // still couldn't get through, but an ambiguous manifest violated this
+    // script's fail-closed contract. A duplicate must be rejected outright,
+    // regardless of whether either digest is correct.
+    writeValidSet()
+    const appImageName = `Varlens-${VERSION}.AppImage`
+    const existingSums = readFileSync(join(dir, 'SHA256SUMS'), 'utf8')
+    const wrongDigest = '0'.repeat(64)
+    writeFileSync(join(dir, 'SHA256SUMS'), `${wrongDigest}  ${appImageName}\n${existingSums}`)
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/duplicate/i)
+  })
+
   it('rejects a phantom SHA256SUMS entry for a file that was never written to disk', () => {
     // Covers the checksum-entries check independently of the on-disk check:
     // no extra file exists here, only an extra checksum line naming one that

--- a/tests/scripts/verify-promoted-artifacts.test.ts
+++ b/tests/scripts/verify-promoted-artifacts.test.ts
@@ -1,0 +1,104 @@
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHash } from 'crypto'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { verifyPromotedArtifacts } from '../../scripts/release/verify-promoted-artifacts.mjs'
+
+const VERSION = '9.9.9'
+const SHA = 'a'.repeat(40)
+
+let dir: string
+
+const sha256 = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
+
+/** Write a complete, valid linux artifact set. Tests then corrupt one thing at a time. */
+function writeValidSet(): void {
+  const files = [`Varlens-${VERSION}.AppImage`, `Varlens-${VERSION}.deb`, 'latest-linux.yml']
+  const sums: string[] = []
+  for (const name of files) {
+    const body = Buffer.from(`payload-${name}`)
+    writeFileSync(join(dir, name), body)
+    sums.push(`${sha256(body)}  ${name}`)
+  }
+  writeFileSync(join(dir, 'SHA256SUMS'), sums.join('\n') + '\n')
+  writeFileSync(
+    join(dir, 'provenance.json'),
+    JSON.stringify({ sha: SHA, version: VERSION, os: 'ubuntu-latest', platform: 'linux' })
+  )
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'varlens-promote-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('verifyPromotedArtifacts', () => {
+  it('accepts a complete, self-consistent artifact set', () => {
+    writeValidSet()
+    expect(verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })).toEqual(
+      {
+        ok: true
+      }
+    )
+  })
+
+  it('rejects a set whose provenance names a different commit', () => {
+    writeValidSet()
+    writeFileSync(
+      join(dir, 'provenance.json'),
+      JSON.stringify({ sha: 'b'.repeat(40), version: VERSION })
+    )
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/provenance sha/i)
+  })
+
+  it('rejects a set whose provenance names a different version', () => {
+    writeValidSet()
+    writeFileSync(join(dir, 'provenance.json'), JSON.stringify({ sha: SHA, version: '0.0.1' }))
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/provenance version/i)
+  })
+
+  it('rejects a tampered payload whose checksum no longer matches', () => {
+    writeValidSet()
+    writeFileSync(join(dir, `Varlens-${VERSION}.deb`), Buffer.from('tampered'))
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/checksum mismatch/i)
+  })
+
+  it('rejects a set missing a required asset', () => {
+    writeValidSet()
+    rmSync(join(dir, 'latest-linux.yml'))
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/missing expected artifact.*latest-linux\.yml/i)
+  })
+
+  it('rejects an entirely empty directory rather than passing vacuously', () => {
+    mkdirSync(join(dir, 'empty'), { recursive: true })
+    expect(() =>
+      verifyPromotedArtifacts({
+        dir: join(dir, 'empty'),
+        platform: 'linux',
+        version: VERSION,
+        sha: SHA
+      })
+    ).toThrow(/provenance\.json/i)
+  })
+
+  it('rejects a SHA256SUMS that omits a file present on disk', () => {
+    writeValidSet()
+    writeFileSync(join(dir, 'SHA256SUMS'), `${sha256(Buffer.from('x'))}  nope.bin\n`)
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/not listed in SHA256SUMS|checksum mismatch|missing/i)
+  })
+})

--- a/tests/scripts/verify-promoted-artifacts.test.ts
+++ b/tests/scripts/verify-promoted-artifacts.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createHash } from 'crypto'
@@ -95,10 +95,50 @@ describe('verifyPromotedArtifacts', () => {
   })
 
   it('rejects a SHA256SUMS that omits a file present on disk', () => {
+    // Tightened to a genuine single-file omission (the original body
+    // replaced SHA256SUMS wholesale, omitting all three files at once,
+    // which didn't match what the test name claimed). Drop only the .deb
+    // entry; the AppImage and latest-linux.yml entries stay intact.
     writeValidSet()
-    writeFileSync(join(dir, 'SHA256SUMS'), `${sha256(Buffer.from('x'))}  nope.bin\n`)
+    const debName = `Varlens-${VERSION}.deb`
+    const remaining = readFileSync(join(dir, 'SHA256SUMS'), 'utf8')
+      .trim()
+      .split('\n')
+      .filter((line) => !line.includes(debName))
+    writeFileSync(join(dir, 'SHA256SUMS'), remaining.join('\n') + '\n')
     expect(() =>
       verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
-    ).toThrow(/not listed in SHA256SUMS|checksum mismatch|missing/i)
+    ).toThrow(/not listed in SHA256SUMS/i)
+  })
+
+  it('rejects a superset: an extra file present on disk and correctly checksummed in SHA256SUMS, but not in the expected artifact set', () => {
+    // Regression for the critical finding: Task 6's upload step re-globs
+    // promoted/<plat>/*.<ext> rather than reading SHA256SUMS, so a planted
+    // file that is present, checksummed, and self-consistent would still
+    // reach a published release unless this is checked as an exact set.
+    writeValidSet()
+    const evilName = `Varlens-${VERSION}-EVIL-backdoor.exe`
+    const evilBody = Buffer.from('evil-payload')
+    writeFileSync(join(dir, evilName), evilBody)
+    const existingSums = readFileSync(join(dir, 'SHA256SUMS'), 'utf8')
+    writeFileSync(join(dir, 'SHA256SUMS'), `${existingSums}${sha256(evilBody)}  ${evilName}\n`)
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/unexpected/i)
+  })
+
+  it('rejects a phantom SHA256SUMS entry for a file that was never written to disk', () => {
+    // Covers the checksum-entries check independently of the on-disk check:
+    // no extra file exists here, only an extra checksum line naming one that
+    // was never produced. SHA256SUMS must accurately describe what shipped.
+    writeValidSet()
+    const existingSums = readFileSync(join(dir, 'SHA256SUMS'), 'utf8')
+    writeFileSync(
+      join(dir, 'SHA256SUMS'),
+      `${existingSums}${sha256(Buffer.from('phantom'))}  Varlens-${VERSION}-phantom.exe\n`
+    )
+    expect(() =>
+      verifyPromotedArtifacts({ dir, platform: 'linux', version: VERSION, sha: SHA })
+    ).toThrow(/unexpected entry in SHA256SUMS/i)
   })
 })


### PR DESCRIPTION
Implements **Phase 8** of `.planning/specs/2026-08-05-build-ci-performance.md` (added in this PR), executed from `.planning/plans/2026-08-06-build-ci-cross-workflow-plan.md`.

## The problem

One release of VarLens packaged the same code **four times across two workflows** — 3984 s (66.4 min) of runner time, measured from the Actions API for v0.70.4:

| Run | ubuntu | windows | macos |
|---|---:|---:|---:|
| PR head `build.yml` | 316 | 423 | 202 |
| merge commit `build.yml` | 307 | 418 | 219 |
| release commit `build.yml` | 350 | 450 | 234 |
| `release.yml` | 344 | 528 | 193 |

Exactly one of those produces artifacts anyone ships. `release.yml` re-derived byte-equivalent installers from the same SHA whose `build.yml` success it explicitly polls for before starting. Of its 528 s Windows leg, **494 s was rebuild and 34 s was signing** — and signing is the only part that genuinely cannot happen anywhere else.

## What changes

**Build once, promote.** `build.yml`'s `package` job already produced working installers and discarded them. It now uploads them (plus `provenance.json` and `SHA256SUMS`) on push and dispatch. `release.yml` downloads those for the exact tagged SHA, verifies them, signs on Windows, and publishes. `build_run_id` comes from the *same gate* that already verified CI green, so promotion has one identity rather than two.

Five checks before any artifact is trusted: `download-artifact`'s digest check, `provenance.sha == github.sha`, `provenance.version == tag`, `sha256sum -c`, and an exact-filename-set assertion. Missing artifacts **hard-fail** with a named recovery path rather than falling back to a build path that would rot unexercised.

**Native cache, restored before `npm ci`.** The existing cache block sat *after* `npm ci`, so it could only ever suppress the second compile — every packaging job showed a cache hit while `npm ci` still cost 73-140 s. `.cache/native` is now a GitHub Actions cache restored first, so `postinstall` restores a binary instead of compiling one.

**`latest.yml` integrity assertion.** The signing step rewrites sha512/size with four PowerShell regexes and nothing verified the result. If a filename stopped matching, they silently no-op and the release shipped auto-update metadata describing the *unsigned* binaries.

## Measured

Two `workflow_dispatch` runs of this branch, both green on all 8 jobs, all three installer artifacts produced. Full detail in `.planning/artifacts/perf/build/ci-cross-workflow-baseline.md`.

| `npm ci` | Before | Warm after |
|---|---:|---:|
| `Checks (Ubuntu)` | 121 s | **14 s** |
| `Package (ubuntu)` | 119 s | **14 s** |
| `Package (windows)` | 140 s | **38 s** |
| `Package (macos)` | 73 s | **22 s** |
| `Web CI` | 125 s | **17 s** |

`build.yml` critical path: **774 s → 568 s (−27%)**. Packaging runs per release: **12 → 9**.

### Reported against interest

- **The electron-builder toolset cache delivered no measurable win.** It restores in 2-4 s and hits, but packaging did not speed up — two of three legs got slightly slower. The ~82 s attributed to the `nsis-resources` download is **withdrawn as unsubstantiated**. The change is kept because its `.state` purge closes a genuine unhashed-restore hazard, not because it is fast.
- **The `Checks` job comparison is partly confounded** — the baseline was a `push` run (`test:coverage`, 136 s) and the after-runs are dispatches (plain test, 107 s), so ~29 s of that job's improvement is the cheaper test mode. The clean number for that job is the −107 s `npm ci` line.
- **The three `release.yml` targets could not be measured before merge.** That workflow triggers only on a version tag, so promotion runs for the first time on the next real release. The 528 s → ≤120 s figure remains an estimate built on the measured 34 s signing chain.
- **Phase 8.2 (merge-commit dedupe, 944 s) is deferred**, so 12 → 9 is the honest count; 12 → 6 was only reachable with it.

## Correctness work found along the way

- `.gitignore`'s bare `release/` matched `scripts/release/` at any depth, silently making the new tooling directory unstageable. Anchored to `/release/`; the 1.3 GB output directory is still ignored.
- A `workflow_dispatch` run ran **neither** test step, yet would have satisfied the release gate — a hole in the recovery path this PR itself added. Fixed.
- `shasum` is absent on some runners and `sha256sum` on others; both now selected at runtime with `-b` so digests are binary-mode.
- `export VAR="$(...)"` defeats `set -e`, so a failed `git rev-parse` would have shipped `provenance.tree=""` silently.
- Windows signing soft-skipped a missing file with a warning, then regenerated `latest.yml` from whatever bytes were on disk — shipping unsigned installers with self-consistent metadata and a green run. Now throws, and asserts each file carries a signature.
- A tag force-moved mid-release would publish the previous commit's binaries. Pre-existing; now asserted in `create-release` and again immediately before the draft is published.

## Verification

- `make ci-full` — **green** ("GitHub Actions parity pipeline PASSED")
- `tests/scripts/` — 92 tests passing, including new coverage for the two verifier scripts
- Two full CI dry-runs green on all 8 jobs; both verifier scripts run against a genuinely downloaded artifact, with negative controls failing as designed
- The manifest is set-identical to the 10 actually-published v0.70.4 assets

## Reviews

Independently reviewed at two checkpoints by Codex (`gpt-5.6-terra`, high reasoning effort), prompted to refute rather than assess, plus a per-task review loop and a whole-branch review. Findings and rulings are recorded in the spec's "Phase 8 design review" section.

**Two findings surfaced but deliberately NOT fixed here** — both real, both pre-existing, both out of scope for a promotion change:

1. Signing fails open when `vars.ESIGNER_ENABLED` is not exactly `true`: unsigned EXEs are published with no warning. That gate exists deliberately to conserve a 20/month signing quota. Behaviour is unchanged from `main`.
2. The published `Varlens-Setup-<v>.zip` contains an **unsigned** `Varlens.exe` — electron-builder's ZIP target archives the pre-signing `appOutDir`, and the signer only touches the two outer EXEs. This is new information and a genuine gap in the signed-release contract, but closing it means signing inside the archive and repacking, which deserves its own spec.

Both warrant a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PohiEWFT9CkCK4XNuhm9fR
