### PR TITLE
fix(ci): repair the docs pipeline — Node engine violation, Pages stall resilience, Playwright cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -147,6 +147,19 @@ jobs:
         with:
           path: docs/.vitepress/dist
 
+      # `timeout` is the action's own budget for waiting on the Pages API to
+      # move a created deployment out of `deployment_queued`; the default is
+      # 600000 ms. On 2026-08-06 four consecutive deploys sat queued for the
+      # full ten minutes and aborted, while the artifact, the workflow and the
+      # Pages configuration were all verified correct — i.e. the stall was on
+      # the Pages side, not ours. Twenty minutes gives a slow-but-working
+      # backend room to finish instead of burning the whole docs build.
+      #
+      # This is resilience, not a root-cause fix. If deploys still time out,
+      # the problem is server-side and belongs in a GitHub support ticket —
+      # do not keep raising this number.
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # actions/deploy-pages@v5.0.0
+        with:
+          timeout: 1200000

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install system dependencies
@@ -84,6 +84,23 @@ jobs:
       - name: Build Electron app
         run: npx electron-vite build
 
+      # Cache the downloaded browser binaries. Keyed on the resolved Playwright
+      # version, because browser builds are pinned per Playwright release — a
+      # stale browser against a newer Playwright is exactly the mismatch this
+      # key prevents. The `--with-deps` system packages are NOT cached (they
+      # install into /usr/lib, outside the cache path), so the install step
+      # still runs; on a hit it skips only the browser download.
+      - name: Resolve Playwright version
+        id: pw
+        shell: bash
+        run: echo "ver=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.pw.outputs.ver }}
+
       - name: Install Playwright
         run: npx playwright install --with-deps
 
@@ -117,7 +134,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # actions/setup-node@v7.0.0
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       # Deliberately no native ABI cache and no `assert-native-abi.mjs` check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,9 +8,24 @@ on:
 permissions:
   contents: read
 
+# Deliberately diverges from GitHub's Pages starter template, which sets
+# `cancel-in-progress: false` to let production deployments finish.
+#
+# That is the wrong trade for a docs site rebuilt from `main` on every push.
+# GitHub Pages serialises deployments API-side, so several pushes in quick
+# succession leave every run sitting in `deployment_queued` until
+# `actions/deploy-pages` gives up with "Timeout reached, aborting!". Observed
+# 2026-08-06: three pushes to `main` within ~25 minutes (two PR merges plus a
+# release version bump) produced three queued deploys; two timed out after
+# 10 minutes each having built the whole Electron app and screenshot suite
+# first.
+#
+# Superseding is also semantically right here: the docs site only ever reflects
+# the tip of `main`, so an in-flight deploy of an older commit has no value once
+# a newer one exists. Nothing is lost by cancelling it.
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-screenshots:


### PR DESCRIPTION
Closes the failing Pages deploys, fixes an engine violation found while diagnosing, and cuts ~135 s off every docs run.

## 1. `docs.yml` ran Node 20 — an engine violation costing ~99 s

Both jobs pinned `node-version: '20'` while `package.json` declares `"node": ">=24.15.0 <25"` and every other workflow reads `.nvmrc` (24.15.0). The docs job built and screenshotted the Electron app under a **different Node major than the CI that gates it**.

It also cost real time. Under Node 20 the native module's own install script finds no matching prebuild and falls through to a full `node-gyp` compile:

| Job, same commit, same warm cache | `Install dependencies` |
|---|---:|
| `build.yml` (Node 24) | **14 s** |
| `docs.yml` (Node 20) | **114 s** |

Worth stating precisely, because I initially misread it: the repo-owned `.cache/native` restore was working correctly the whole time. It serves the **Electron** ABI; this compile was the dependency rebuilding for **Node 20's own** ABI, which no cache in this repo covers.

## 2. Playwright browsers are now cached (38 s)

Keyed on the resolved Playwright version (`1.62.1`), since browser builds are pinned per release — a stale browser against a newer Playwright is exactly the mismatch that key prevents. The `--with-deps` system packages install into `/usr/lib`, outside the cache path, so that step still runs; a hit skips only the download.

**Measured baseline** for `Build & Screenshots`: 336 s total — `npm ci` 114 s, screenshots 131 s, Playwright install 38 s, `electron-vite build` 28 s. Items 1+2 target ~135 s of that.

## 3. Pages deploy resilience

Four consecutive deploys created successfully then sat in `deployment_queued` for the full 600 s budget and aborted. Ruled out with evidence, each checked rather than assumed:

| Hypothesis | Verdict |
|---|---|
| The native-ABI cache added to `docs.yml` in #362 | **No.** `Build & Screenshots` passed on all four |
| Wrong artifact (`Found 2 artifact(s)`) | **No.** Correct `github-pages` artifact; the last *successful* run also had 2 |
| Artifact corrupt/oversized | **No.** 5,369,244 B vs 5,370,151 B on the last success |
| GitHub Pages incident | **No.** Status API: Pages + Actions `operational` |
| Environment protection rule | **No.** `custom_branch_policies` contains exactly `main` |
| Contention between concurrent deploys | **No.** A clean `workflow_dispatch` run against an empty queue failed identically |

The stall is server-side. Two changes make the workflow resilient to it:

- **`cancel-in-progress: true`** — independently justified: three pushes to `main` within ~25 min each queued a full deploy, having already built the whole app and screenshot suite first. The site only reflects the tip of `main`, so superseding an older in-flight deploy loses nothing. Deliberately diverges from GitHub's starter template, whose `false` protects long production deployments; the comment records why that doesn't apply here.
- **`timeout: 1200000`** (from the 600000 default) — lets a slow-but-working backend finish instead of discarding a complete build.

**Neither claims to fix the Pages backend.** If deploys still time out at 20 minutes it is server-side and belongs in a GitHub support ticket — the comment says so, so nobody keeps ratcheting the number.

**No outage at any point** — the site served HTTP 200 throughout; a failed deploy leaves the previous one live.

## Operational note

`gh run rerun --failed` on a Pages workflow **can never succeed**. It re-executes `upload-pages-artifact`, leaving two artifacts named `github-pages`, and `deploy-pages` hard-errors: `Multiple artifacts named "github-pages" were unexpectedly found`. `upload-pages-artifact@v5` exposes no `overwrite` input, so this is not fixable in the workflow — a Pages run must be re-triggered fresh, never re-run. I hit this while diagnosing and it briefly sent me down the wrong path.

## Verification

`docs.yml` parses (`js-yaml`) · `npm run format:check` clean · guardrails 17/17 · `@playwright/test` resolves to 1.62.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PohiEWFT9CkCK4XNuhm9fR